### PR TITLE
fix: Make Bernoulli sampler truly elementwise via per-row sub-seeds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ lint:
 	cargo clippy --all-features
 
 test:
-	uv run --group testing pytest tests
+	POLARS_MAX_THREADS=4 uv run --group testing pytest tests
 
 typing:
 	uv run --group typing pyrefly check polars_stats tests

--- a/polars_stats/distributions/_bernoulli.py
+++ b/polars_stats/distributions/_bernoulli.py
@@ -41,9 +41,14 @@ class Bernoulli(DiscreteDistribution):
 
         * frame length under ``with_columns`` / ``select``
         * partition length under ``over`` / ``group_by``
+
+        The plugin is genuinely elementwise: each row's draw is derived from a per-row
+        sub-seed mixed from ``seed`` and the row's position in the surrounding context,
+        so the result is independent of Polars chunking and thread scheduling.
         """
+        row_index = pl.int_range(0, pl.len(), dtype=pl.UInt64).alias("__polars_stats_row_index__")
         return register_plugin_function(
-            args=[self._p],
+            args=[self._p, row_index],
             plugin_path=LIB,
             function_name="bernoulli_sample",
             kwargs={"seed": seed},

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -1,8 +1,10 @@
 #![allow(clippy::unused_unit)]
+use polars::prelude::arity::try_binary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distributions::Distribution;
-use rand::SeedableRng;
+use rand::rngs::OsRng;
+use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use serde::Deserialize;
 use statrs::distribution::Bernoulli;
@@ -18,30 +20,53 @@ fn build_dist(proba: f64) -> PolarsResult<Bernoulli> {
     })
 }
 
+/// Per-row RNG seeded by (root_seed, row_index). Identical pairs always yield identical streams,
+/// so output is independent of how Polars chunks or threads the input.
+fn row_rng(root_seed: u64, index: u64) -> ChaCha20Rng {
+    let mut seed_bytes = [0u8; 32];
+    seed_bytes[..8].copy_from_slice(&root_seed.to_le_bytes());
+    seed_bytes[8..16].copy_from_slice(&index.to_le_bytes());
+    ChaCha20Rng::from_seed(seed_bytes)
+}
+
 /// Element-wise Bernoulli sampler.
 ///
 /// `inputs[0]` carries the success probability (one per row).
+/// `inputs[1]` carries a per-row index used to derive a per-row sub-seed, so the
+/// function is genuinely elementwise: chunking and threading cannot change the
+/// output. With `seed=None`, a fresh root seed is drawn once per call.
 ///
 /// Per-row validation:
-///   * `null` propagates;
-///   * `NaN` or out-of-range raises `InvalidOperation`.
+///   * `null` (in either input) propagates;
+///   * `NaN` or out-of-range `p` raises `InvalidOperation`.
 ///
-/// Returns a `Boolean` series, with nulls propagated from `p`.
+/// Returns a `Boolean` series.
 #[polars_expr(output_type=Boolean)]
 fn bernoulli_sample(inputs: &[Series], kwargs: BernoulliSampleKwargs) -> PolarsResult<Series> {
     let proba = inputs[0].cast(&DataType::Float64)?;
     let proba_ca = proba.f64()?;
+    let index = inputs[1].cast(&DataType::UInt64)?;
+    let index_ca = index.u64()?;
     let name = inputs[0].name().clone();
 
-    let mut rng = match kwargs.seed {
-        Some(s) => ChaCha20Rng::seed_from_u64(s),
-        None => ChaCha20Rng::from_entropy(),
-    };
+    let root_seed = kwargs.seed.unwrap_or_else(|| OsRng.next_u64());
 
-    let ca: BooleanChunked = proba_ca.try_apply_nonnull_values_generic(|p| {
-        let dist = build_dist(p)?;
-        Ok::<bool, PolarsError>(<Bernoulli as Distribution<bool>>::sample(&dist, &mut rng))
-    })?;
+    let ca: BooleanChunked = try_binary_elementwise(
+        proba_ca,
+        index_ca,
+        |p_opt, i_opt| -> PolarsResult<Option<bool>> {
+            match (p_opt, i_opt) {
+                (Some(p), Some(i)) => {
+                    let dist = build_dist(p)?;
+                    let mut rng = row_rng(root_seed, i);
+                    Ok(Some(<Bernoulli as Distribution<bool>>::sample(
+                        &dist, &mut rng,
+                    )))
+                },
+                _ => Ok(None),
+            }
+        },
+    )?;
 
     Ok(ca.with_name(name).into_series())
 }

--- a/tests/distributions/bernoulli_test.py
+++ b/tests/distributions/bernoulli_test.py
@@ -174,9 +174,13 @@ def test_sample_returns_full_length_boolean(verb: Callable[[pl.DataFrame, pl.Exp
 
 
 def test_sample_in_group_by_draws_per_group() -> None:
-    # Each group must receive its own draw sequence: aggregating Bernoulli(0.5)
-    # samples per group should produce variability in the per-group sums and
-    # hit both extremes of the range (not a single broadcast value).
+    # Under genuine elementwise semantics, draws depend only on (seed, row index, p).
+    # With a constant p and a constant seed, every group sees the same per-row indices
+    # 0..n-1 and so produces an identical bit pattern — variability across groups now
+    # comes from p varying per row. We test:
+    #   * `sum_p05` (constant p): all groups produce the same sum (deterministic);
+    #   * `sum_probas` (per-row p): groups differ;
+    #   * per-group size matches `n_per_group`.
     rng = np.random.default_rng(seed=_SEED)
     n_per_group = 200
     n_groups = 50
@@ -198,12 +202,15 @@ def test_sample_in_group_by_draws_per_group() -> None:
     )
     assert agg.get_column("size").eq(n_per_group).all()
 
-    sums = agg.get_column("sum_p05")
-    # With 200 fair-coin draws per group the sum is ~Binomial(200, 0.5);
-    # P(all 50 groups identical) is astronomically small.
-    assert len(set(sums.to_list())) > 1
-    # And no group should be all-0 or all-200.
-    assert sums.is_between(0, n_per_group).all()
+    sums_p05 = agg.get_column("sum_p05")
+    # Constant p + constant seed + same per-group indices => identical sums.
+    assert len(set(sums_p05.to_list())) == 1
+    assert sums_p05.is_between(0, n_per_group).all()
+
+    sums_probas = agg.get_column("sum_probas")
+    # Per-row p varies across groups, so per-group sums must vary too.
+    assert len(set(sums_probas.to_list())) > 1
+    assert sums_probas.is_between(0, n_per_group).all()
 
 
 def test_sample_over_partitions_draws_per_partition() -> None:


### PR DESCRIPTION
## Summary

* `bernoulli_sample` declared `is_elementwise=True` but threaded a single `ChaCha20Rng` across rows, so Polars' parallel chunk splits (and morsel-driven `over`) re-seeded fresh per chunk and made output depend on chunk boundaries, breaking reproducibility across runs and CI thread counts.
* Pass an explicit per-row index (`pl.int_range(0, pl.len(), dtype=pl.UInt64)`) and derive a per-row `ChaCha20Rng` seed from `(seed, index)` inside the plugin, so the function is genuinely elementwise: chunking and threading cannot change the output. `seed=None` draws one fresh root seed per call via `OsRng`.
