### PR TITLE
perf(rust): Restore sampler performance via cheap per-row RNG + add Rust tests and benchmark CI

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -73,6 +73,25 @@ jobs:
       - name: cargo clippy
         run: cargo clippy --all-features --all-targets -- -D warnings
 
+  rust-test:
+    name: test / cargo test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      # `extension-module` is disabled below, so the test binary links libpython
+      # itself rather than expecting a host interpreter; setup-python provides it.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install pinned Rust toolchain
+        run: rustup show
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: rust-test
+      - name: cargo test
+        run: cargo test --no-default-features
+
   # Build the extension once as an abi3 wheel. The `abi3-py39` pyo3 feature
   # means a single wheel runs on every CPython >= 3.9, so downstream
   # typing / test jobs just download and pip-install it.
@@ -156,6 +175,56 @@ jobs:
         run: uv export --no-annotate --no-hashes --group testing
       - name: Run tests
         run: uv run --no-sync pytest tests
+
+  benchmark:
+    name: benchmark
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+          enable-cache: true
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheel
+          path: dist
+      - name: Sync project dependencies
+        run: uv sync --group benchmark --no-install-project
+      - name: Install built wheel
+        run: uv pip install dist/*.whl
+      # Persist prior results so pytest-benchmark can compare against the last run.
+      # `restore-keys` pulls the most recent cache; the run-id key writes a fresh one.
+      - name: Restore benchmark baseline
+        uses: actions/cache@v4
+        with:
+          path: .benchmarks
+          key: benchmarks-${{ github.run_id }}
+          restore-keys: benchmarks-
+      # `min` is the noise-robust statistic (noise only adds time). GitHub runners use
+      # heterogeneous hardware, so absolute timings drift run-to-run: the gate is set
+      # to trip only on catastrophic (>3x) regressions like the ChaCha20-per-row one.
+      # A deterministic instruction-count gate (CodSpeed) should replace this once the
+      # repo is public and CI minutes are unconstrained. First run has no baseline to
+      # compare against and simply records one.
+      - name: Run benchmarks
+        run: >
+          uv run --no-sync pytest benchmarks
+          -o filterwarnings=default
+          --benchmark-only
+          --benchmark-autosave
+          --benchmark-compare
+          --benchmark-compare-fail=min:200%
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: .benchmarks
+          if-no-files-found: warn
+          retention-days: 30
 
   test-oldest:
     name: test-oldest / py${{ matrix.python-version }} polars-${{ needs.setup.outputs.polars-oldest }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -195,34 +195,22 @@ jobs:
         run: uv sync --group benchmark --no-install-project
       - name: Install built wheel
         run: uv pip install dist/*.whl
-      # Persist prior results so pytest-benchmark can compare against the last run.
-      # `restore-keys` pulls the most recent cache; the run-id key writes a fresh one.
-      - name: Restore benchmark baseline
-        uses: actions/cache@v4
-        with:
-          path: .benchmarks
-          key: benchmarks-${{ github.run_id }}
-          restore-keys: benchmarks-
-      # `min` is the noise-robust statistic (noise only adds time). GitHub runners use
-      # heterogeneous hardware, so absolute timings drift run-to-run: the gate is set
-      # to trip only on catastrophic (>3x) regressions like the ChaCha20-per-row one.
-      # A deterministic instruction-count gate (CodSpeed) should replace this once the
-      # repo is public and CI minutes are unconstrained. First run has no baseline to
-      # compare against and simply records one.
+      # Just run the benchmarks and record the numbers as an artifact. Cross-run
+      # comparison on heterogeneous GitHub runners is too noisy to gate on; a
+      # deterministic instruction-count gate (CodSpeed) is the intended replacement
+      # once the repo is public and CI minutes are unconstrained.
       - name: Run benchmarks
         run: >
           uv run --no-sync pytest benchmarks
           -o filterwarnings=default
           --benchmark-only
-          --benchmark-autosave
-          --benchmark-compare
-          --benchmark-compare-fail=min:200%
+          --benchmark-json=benchmark.json
       - name: Upload benchmark results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results
-          path: .benchmarks
+          path: benchmark.json
           if-no-files-found: warn
           retention-days: 30
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ venv
 
 *__pycache__/
 .benchmarks/
+benchmark.json

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ venv
 *.pyd
 
 *__pycache__/
+.benchmarks/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,7 +1845,7 @@ dependencies = [
  "pyo3",
  "pyo3-polars",
  "rand 0.8.6",
- "rand_chacha 0.3.1",
+ "rand_pcg",
  "serde",
  "statrs",
 ]
@@ -2260,6 +2260,15 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.4",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,19 @@ edition = "2021"
 name = "polars_stats"
 crate-type = ["cdylib"]
 
+[features]
+# `extension-module` tells pyo3 not to link libpython (the host interpreter provides the symbols at runtime).
+# That is required for the wheel but breaks a standalone `cargo test` binary on Linux,
+# so it is a default feature that the Rust test job turns off via `--no-default-features`.
+default = ["extension-module"]
+extension-module = ["pyo3/extension-module"]
+
 [dependencies]
-pyo3 = { version = "0.26.0", features = ["extension-module", "abi3-py39"] }
+pyo3 = { version = "0.26.0", features = ["abi3-py39"] }
 pyo3-polars = { version = "0.25.0", features = ["derive", "dtype-struct", "dtype-array"] }
 serde = { version = "1", features = ["derive"] }
 polars = { version = "0.52.0", default-features = false, features = ["dtype-u8"] }
 polars-arrow = { version = "0.52.0", default-features = false }
 statrs = "0.18.0"
 rand = "0.8"
-rand_chacha = "0.3"
+rand_pcg = "0.3"

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,14 @@ lint:
 test:
 	POLARS_MAX_THREADS=4 uv run --group testing pytest tests
 
+test-rust:
+	# `extension-module` is disabled so the test binary links libpython itself;
+	# point pyo3 at the project interpreter for that link step.
+	PYO3_PYTHON=$$(uv run python -c "import sys; print(sys.executable)") cargo test --no-default-features
+
+benchmark:
+	uv run --group benchmark pytest benchmarks -o filterwarnings=default --benchmark-only --benchmark-autosave
+
 typing:
 	uv run --group typing pyrefly check polars_stats tests
 	uv run --group typing pyright polars_stats tests

--- a/benchmarks/sample_bench_test.py
+++ b/benchmarks/sample_bench_test.py
@@ -1,0 +1,56 @@
+"""Performance benchmarks for the Bernoulli sampler hot paths.
+
+Written against the ``pytest-benchmark`` ``benchmark`` fixture so the runner can be
+swapped for ``pytest-codspeed`` (instruction-count, deterministic) once CI allows it,
+without touching the benchmark bodies.
+
+These guard the per-row RNG construction cost: it scales with the number of rows, so a
+single wide column is enough to surface a regression like the ChaCha20-per-row one.
+
+Run with: ``pytest benchmarks --benchmark-only`` (see the ``benchmark`` Make target).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+
+from polars_stats import Bernoulli
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+N_ROWS = 1_000_000
+ARRAY_SIZE = 50
+SEED = 0
+
+
+@pytest.fixture(scope="module")
+def frame() -> pl.DataFrame:
+    # Materialised once: each benchmark times only the sampling, not frame construction.
+    return pl.DataFrame(
+        {
+            "x": range(N_ROWS),
+            "p": [0.3] * N_ROWS,
+        }
+    )
+
+
+def test_sample_scalar_p(benchmark: Callable[..., object], frame: pl.DataFrame) -> None:
+    # Scalar p expands to pl.repeat(p, n=pl.len()); the common path.
+    expr = Bernoulli(p=0.3).sample(seed=SEED)
+    benchmark(lambda: frame.with_columns(b=expr))
+
+
+def test_sample_column_p(benchmark: Callable[..., object], frame: pl.DataFrame) -> None:
+    # Column p skips the repeat and feeds a real per-row probability series.
+    expr = Bernoulli(p=pl.col("p")).sample(seed=SEED)
+    benchmark(lambda: frame.with_columns(b=expr))
+
+
+def test_samples_array(benchmark: Callable[..., object], frame: pl.DataFrame) -> None:
+    # Array path: ARRAY_SIZE independent draws per row.
+    expr = Bernoulli(p=0.3).samples(ARRAY_SIZE, seed=SEED)
+    benchmark(lambda: frame.with_columns(b=expr))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,10 @@ testing = [
     "numpy>=2.2.6",
     "pytest>=8.3.5",
 ]
+benchmark = [
+    "pytest>=8.3.5",
+    "pytest-benchmark>=5.1.0",
+]
 typing = [
     "mypy>=1.14.1",
     "pyrefly>=0.62.0",

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -3,11 +3,10 @@ use polars::prelude::arity::try_binary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distributions::Distribution;
-use rand::rngs::OsRng;
-use rand::{RngCore, SeedableRng};
-use rand_chacha::ChaCha20Rng;
 use serde::Deserialize;
 use statrs::distribution::Bernoulli;
+
+use crate::rng::{resolve_root_seed, row_rng};
 
 #[derive(Deserialize)]
 struct BernoulliSampleKwargs {
@@ -18,15 +17,6 @@ fn build_dist(proba: f64) -> PolarsResult<Bernoulli> {
     Bernoulli::new(proba).map_err(|e| {
         PolarsError::InvalidOperation(format!("p must be in [0, 1], got {proba}: {e}").into())
     })
-}
-
-/// Per-row RNG seeded by (root_seed, row_index). Identical pairs always yield identical streams,
-/// so output is independent of how Polars chunks or threads the input.
-fn row_rng(root_seed: u64, index: u64) -> ChaCha20Rng {
-    let mut seed_bytes = [0u8; 32];
-    seed_bytes[..8].copy_from_slice(&root_seed.to_le_bytes());
-    seed_bytes[8..16].copy_from_slice(&index.to_le_bytes());
-    ChaCha20Rng::from_seed(seed_bytes)
 }
 
 /// Element-wise Bernoulli sampler.
@@ -49,7 +39,7 @@ fn bernoulli_sample(inputs: &[Series], kwargs: BernoulliSampleKwargs) -> PolarsR
     let index_ca = index.u64()?;
     let name = inputs[0].name().clone();
 
-    let root_seed = kwargs.seed.unwrap_or_else(|| OsRng.next_u64());
+    let root_seed = resolve_root_seed(kwargs.seed);
 
     let ca: BooleanChunked = try_binary_elementwise(
         proba_ca,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod distributions;
+mod rng;
 
 use pyo3::prelude::*;
 use pyo3_polars::PolarsAllocator;

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,0 +1,119 @@
+//! Shared per-row RNG foundation for all distribution samplers.
+//!
+//! Every sampler needs the same property: a deterministic, independent random stream
+//! per row, derived only from `(root_seed, row_index)`. Because the seed is a function
+//! of the row index (not of position within a chunk), the output is invariant to how
+//! Polars chunks or threads the input.
+//!
+//! The generator is [`Pcg64Mcg`]: construction is a handful of integer ops (no key
+//! schedule, no keystream block), it passes TestU01 BigCrush, and its output is stable
+//! across `rand_pcg` releases and platforms (so seeded results stay reproducible). That
+//! makes it a safe default for any distribution, including rejection/Ziggurat samplers
+//! that consume an unbounded number of words per draw.
+//!
+//! Contrast with a one-shot hash-to-uniform: that only serves distributions needing a
+//! single uniform per draw (e.g. Bernoulli) and cannot back the general case, so it is
+//! deliberately not the foundation here.
+
+use rand::rngs::OsRng;
+use rand::RngCore;
+use rand_pcg::Pcg64Mcg;
+
+/// splitmix64 finalizer: full-avalanche mixing of a single 64-bit word.
+///
+/// Used to decorrelate adjacent `(root_seed, index)` pairs before they seed the
+/// generator, so neighbouring rows get well-separated states rather than nearly
+/// identical ones.
+#[inline]
+fn splitmix64(mut z: u64) -> u64 {
+    z = z.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// Resolve the root seed for a sampler call: the caller's seed if given, otherwise a
+/// fresh OS-entropy draw. Called once per plugin invocation, never per row.
+#[inline]
+pub(crate) fn resolve_root_seed(seed: Option<u64>) -> u64 {
+    seed.unwrap_or_else(|| OsRng.next_u64())
+}
+
+/// Per-row RNG seeded by `(root_seed, index)`.
+///
+/// Identical inputs always yield identical streams, so a sampler built on this is
+/// genuinely elementwise: chunking and thread scheduling cannot change its output.
+#[inline]
+pub(crate) fn row_rng(root_seed: u64, index: u64) -> Pcg64Mcg {
+    // Fold both inputs into a 128-bit state via two splitmix64 draws. The low bit is
+    // forced odd to give the MCG its full period.
+    let lo = splitmix64(root_seed ^ index.wrapping_mul(0x9E37_79B9_7F4A_7C15));
+    let hi = splitmix64(lo);
+    let state = (((hi as u128) << 64) | lo as u128) | 1;
+    Pcg64Mcg::new(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use rand::RngCore;
+
+    use super::*;
+
+    fn stream(root_seed: u64, index: u64, n: usize) -> Vec<u64> {
+        let mut rng = row_rng(root_seed, index);
+        (0..n).map(|_| rng.next_u64()).collect()
+    }
+
+    #[test]
+    fn same_seed_and_index_give_identical_stream() {
+        assert_eq!(stream(42, 7, 8), stream(42, 7, 8));
+    }
+
+    #[test]
+    fn distinct_index_gives_distinct_stream() {
+        assert_ne!(stream(42, 7, 8), stream(42, 8, 8));
+    }
+
+    #[test]
+    fn distinct_root_seed_gives_distinct_stream() {
+        assert_ne!(stream(1, 7, 8), stream(2, 7, 8));
+    }
+
+    #[test]
+    fn adjacent_indices_do_not_alias() {
+        // The first word of each per-row stream across a contiguous index block must be
+        // unique. A collision would mean two rows share a stream, i.e. the per-row
+        // seeding failed to decorrelate adjacent indices. Collisions in 100k draws from
+        // a 64-bit space are otherwise astronomically unlikely.
+        let n: u64 = 100_000;
+        let mut seen = HashSet::with_capacity(n as usize);
+        for index in 0..n {
+            let first = row_rng(123, index).next_u64();
+            assert!(seen.insert(first), "stream collision at index {index}");
+        }
+    }
+
+    #[test]
+    fn resolve_root_seed_passes_through_explicit_seed() {
+        assert_eq!(resolve_root_seed(Some(99)), 99);
+    }
+
+    #[test]
+    fn resolve_root_seed_draws_entropy_when_absent() {
+        // Two OS-entropy draws coinciding is astronomically unlikely.
+        assert_ne!(resolve_root_seed(None), resolve_root_seed(None));
+    }
+
+    #[test]
+    fn splitmix64_diffuses_adjacent_inputs() {
+        // Strong avalanche is what lets neighbouring (root_seed, index) pairs seed
+        // well-separated states rather than near-identical ones.
+        let diff_bits = (splitmix64(0) ^ splitmix64(1)).count_ones();
+        assert!(
+            diff_bits >= 16,
+            "weak avalanche: only {diff_bits} bits differ"
+        );
+    }
+}

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -440,30 +440,30 @@ wheels = [
 
 [[package]]
 name = "polars"
-version = "1.41.0"
+version = "1.41.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "polars-runtime-32" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/13/fe30b3e2f9ab54a27d82af04fb2edc51c7342cbaa88815e175769a9f5901/polars-1.41.0.tar.gz", hash = "sha256:7cb5465eb66eb868fde779bf5c41c9f2f244481d72c52133e8ed10ba64372e4f", size = 737530, upload-time = "2026-05-22T20:20:56.209Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/f9/aeda46259b0669247a160315d2d51269de9504b9dd2f70acadbcb22f46b7/polars-1.41.2.tar.gz", hash = "sha256:256d6731162371b77f3f29a55eacb8c0fc740ddb1a293a01d2ef5b5393c5c708", size = 737996, upload-time = "2026-05-29T17:39:15.604Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/c8/5807714256c5f3de08593113df17f14f99417a451cb2d91530ad94785003/polars-1.41.0-py3-none-any.whl", hash = "sha256:35dcd24de88a198dc50929924f064ba12a0a0a4a3e77e116689491b4b3ab58ac", size = 832953, upload-time = "2026-05-22T20:19:30.958Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/22/28f62d24f7db56ac4343588f9362d49b7b4177e55ac47a466fe696b0099b/polars-1.41.2-py3-none-any.whl", hash = "sha256:23ce9a2910b6e3e8d4258770bf44aa17170958df7af6e85feedf4458a04d8d29", size = 833445, upload-time = "2026-05-29T17:37:05.576Z" },
 ]
 
 [[package]]
 name = "polars-runtime-32"
-version = "1.41.0"
+version = "1.41.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1e/8f/30dc715ea1135b4b80397edf33fe7b1bb124850e96e38d9918e2b3d6d0b0/polars_runtime_32-1.41.0.tar.gz", hash = "sha256:37ffbe5414f14bf43bcc8e08a0386c97c692e3fd4e87af74529d7f14b1b2d1cb", size = 2985826, upload-time = "2026-05-22T20:20:57.622Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/56/54e3ea0e9b64f327179049e4742241cc6b1d3e8fa414b05a057dd26df367/polars_runtime_32-1.41.2.tar.gz", hash = "sha256:7af09ec1ab053da2c9669e8d15f809a4083a29be05db57111688b8051062af56", size = 2989474, upload-time = "2026-05-29T17:39:17.257Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/e7/9d1630d666eca6a67e2096c0ed2c0e18f1355fe440043fd0830de1b71ab6/polars_runtime_32-1.41.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:766b60c74550382731b604ed62a385a8403b341bf18282d3fd2f746fa3c4cafd", size = 52163350, upload-time = "2026-05-22T20:19:34.431Z" },
-    { url = "https://files.pythonhosted.org/packages/11/b3/01538d51cd2790729ae13c23db44bc787bdfe20867faeb1087afc390c53b/polars_runtime_32-1.41.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:bee0d294daca79cedd5749e1bf3373c2d4107eb849fe544a60df6c08abc972ce", size = 46474331, upload-time = "2026-05-22T20:19:37.936Z" },
-    { url = "https://files.pythonhosted.org/packages/79/29/efa82e1b3e6711f254df3793f3d3fd99f26ef1bcaffa6533266fa6522de4/polars_runtime_32-1.41.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08b3f915468bf00d327b4a1236935a4ec3174dcb163785fcd98185ad1319a503", size = 50358997, upload-time = "2026-05-22T20:19:42.209Z" },
-    { url = "https://files.pythonhosted.org/packages/53/18/5a04b06b773047cbf43912ab802eef3c1d50ef7e66d51a41b16726f9bc62/polars_runtime_32-1.41.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e72269f768c57229190dba0cb5abb8a1b228e96cc6331273a77a7957576885bd", size = 56332032, upload-time = "2026-05-22T20:19:45.928Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/d5/d728ce7a39ea925555db7d2c9f7b5df3ca17568e483db6501783f653e0b9/polars_runtime_32-1.41.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1532c7560a5c0fd06943080ee42aade721f186becdfbb1baafa622e3199c3b62", size = 50529017, upload-time = "2026-05-22T20:19:49.489Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/92/6b2092dfed4278f636499217767204fce19ed72695690e2c4eba99e2892e/polars_runtime_32-1.41.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:43368d8a754ee274f1e1099a7c09aae59cd69d22b8a6f83c0f782a00cd3a6662", size = 54244707, upload-time = "2026-05-22T20:19:52.852Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/6e/46b43be0f5becbef65843f438de3950ac6f8d0fa0008d7de0025eed00097/polars_runtime_32-1.41.0-cp310-abi3-win_amd64.whl", hash = "sha256:a9bd6095ecadc6799d166b9e8f7183a7ca8ba0a5aef8a426ec41df8ed8b09df7", size = 51918379, upload-time = "2026-05-22T20:19:55.832Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/da/30f15f0c3959b70e7a6583eccd37140a30b5c643ca374792d150b3a357df/polars_runtime_32-1.41.0-cp310-abi3-win_arm64.whl", hash = "sha256:ed922400f0eb393345fd7b6874b150eb943af2b816297a3dde03735cb5f3de08", size = 45921961, upload-time = "2026-05-22T20:19:59.525Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/9b/fe72a3811c0357cdb06c67bdc7695fa1623ad47948fc523195f5ac31037f/polars_runtime_32-1.41.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:95a08346dac337357cdb825c8076df7d36da54c4caa59a5cb41d0a30691c5edd", size = 52265283, upload-time = "2026-05-29T17:37:09.407Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/93/fab9da803fd80d9e83ef88c20932f637a10bc611b20415fc322eec84bc44/polars_runtime_32-1.41.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:dedfaeec2c7f995298da7319dd9431d662e5dd1d0ec51b1459df4a0234ceff52", size = 46571222, upload-time = "2026-05-29T17:37:13.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2a/8843f34a8ac57acd058a39b87b03b580dd352a490e9dae0415e02033bdd4/polars_runtime_32-1.41.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18eea22c5cc34e27f8a60950458ad81e6a9ea75e89363ca1367e14e7e7f781fc", size = 50409372, upload-time = "2026-05-29T17:37:17.875Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c6/92b352fe88cf51bd0a19fb99e1c0cbe46aa26c14dcf7995b89869cd932ae/polars_runtime_32-1.41.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2630540dfdfb0f36f9b04a07c7c2e3f50bf2ad384113263c1c812007ee9141e0", size = 56405484, upload-time = "2026-05-29T17:37:22.684Z" },
+    { url = "https://files.pythonhosted.org/packages/74/c4/bae3174c3b02f6b441d2e58594387abcd509f67a098f682a83b195f08966/polars_runtime_32-1.41.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:20e969e08f9b137e233c04cc04de73d9795f89eb77d34854e40a025965a43763", size = 50603512, upload-time = "2026-05-29T17:37:27.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ed/f2d26ae02d92c2689056838ed59e2a626326ad23c2831d58637d25f6c82a/polars_runtime_32-1.41.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e7016a3deb641b64a31447abbbee0f34bd020a6a9ae34ee6b743837def15e2a4", size = 54328561, upload-time = "2026-05-29T17:37:32.587Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/c4/9c3831cc885dc7769e59abf8f583821a5fb4403fd0e4eba0ccc6d47a3d4b/polars_runtime_32-1.41.2-cp310-abi3-win_amd64.whl", hash = "sha256:1e5e5377c315e0dcafdfb2a31adc546abbaeb3f9cb1864e6536523d2af473265", size = 51978643, upload-time = "2026-05-29T17:37:37.443Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c6/79e9f3f270270d7ed5575d92b7bfef49f01abd9275447161275b23b553a8/polars_runtime_32-1.41.2-cp310-abi3-win_arm64.whl", hash = "sha256:843d96f69d18eca53429c1198e58891db7f18111f83b9c419bb45ad9d73eaed5", size = 46006901, upload-time = "2026-05-29T17:37:42.522Z" },
 ]
 
 [[package]]
@@ -474,6 +474,10 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+benchmark = [
+    { name = "pytest" },
+    { name = "pytest-benchmark" },
+]
 dev = [
     { name = "maturin" },
 ]
@@ -492,6 +496,10 @@ typing = [
 requires-dist = [{ name = "polars", specifier = ">=1.15.0" }]
 
 [package.metadata.requires-dev]
+benchmark = [
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-benchmark", specifier = ">=5.1.0" },
+]
 dev = [{ name = "maturin", specifier = ">=1.13.1" }]
 testing = [
     { name = "numpy", specifier = ">=2.2.6" },
@@ -501,6 +509,15 @@ typing = [
     { name = "mypy", specifier = ">=1.14.1" },
     { name = "pyrefly", specifier = ">=0.62.0" },
     { name = "pyright", specifier = ">=1.1.409" },
+]
+
+[[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
 ]
 
 [[package]]
@@ -558,6 +575,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

#6  made `Bernoulli.sample` 10-20x slower by constructing a fresh `ChaCha20Rng` per row (~100M times on a 1M×100 workload). This swaps the per-row generator for a cheap PCG, restoring pre-regression speed while keeping the chunk/thread-independence guarantee.

## Fix

New shared `src/rng.rs`: `row_rng(root_seed, index) -> Pcg64Mcg`, seeded via splitmix64-folded state, used by every distribution's sampler. PCG generalises to stream-consuming samplers (rejection/Ziggurat), passes BigCrush, and is value-stable. Local: ~5.9s → ~0.29s (from ~5x slower than scipy to ~3.3x faster).

## Tests & CI

7 Rust unit tests; new `rust-test` job (`cargo test --no-default-features`; `extension-module` now a default feature, wheel unchanged); new `pytest-benchmark` job with a `min:200%` regression gate (CodSpeed-swappable). `make test-rust` / `make benchmark` added.

## Behaviour change

⚠️ Seeded output **values** change (different RNG); contract unchanged and verified (determinism, chunk/thread invariance, nulls, errors, mean≈p). All 252 Python tests pass.
