### PR TITLE
test: scipy-parity harness, hypothesis property suite, `register_plugin` shim

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           key: build-wheel
       - name: Build abi3 wheel
-        run: uvx maturin build --release --uv --out dist
+        run: uvx maturin build --release --out dist
       - name: Upload wheel
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           key: build-wheel
       - name: Build abi3 wheel
-        run: uvx maturin build --release --out dist
+        run: uvx maturin build --release --uv --out dist
       - name: Upload wheel
         uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ venv
 *__pycache__/
 .benchmarks/
 benchmark.json
+.hypothesis/

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -6,6 +6,9 @@ from itertools import repeat
 from typing import TYPE_CHECKING, ClassVar
 
 import polars as pl
+from polars.plugins import register_plugin_function
+
+from polars_stats._lib import LIB
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -40,6 +43,33 @@ def coerce_param(value: float | IntoExprColumn, *, name: str) -> pl.Expr:
         return pl.col(value)
     msg = f"{name} should be a float or IntoExprColumn (pl.Expr, str, pl.Series), found {type(value)}"
     raise TypeError(msg)
+
+
+def register_plugin(
+    function_name: str,
+    args: IntoExprColumn | Iterable[IntoExprColumn],
+    *,
+    kwargs: dict[str, int | None] | None = None,
+) -> pl.Expr:
+    """Register a polars-stats Rust plugin call, fixing the defaults every distribution shares.
+
+    Wraps `register_plugin_function` so each call site spells only what varies (the function name, its input exprs,
+    and an optional sampler `seed`). `plugin_path=LIB`, `is_elementwise` is fixed to `True`: every distribution plugin
+    is per-row by contract (see `coerce_param`), and an aggregating plugin would break `over` / `group_by`, so this is a
+    guard rather than a default.
+
+    Arguments:
+        function_name: The `#[polars_expr]` function exported by the Rust crate.
+        args: One expr or an iterable of exprs forming the plugin's positional inputs.
+        kwargs: Static keyword arguments serialised to Rust (only a sampler `seed` today).
+    """
+    return register_plugin_function(
+        plugin_path=LIB,
+        function_name=function_name,
+        args=args,
+        kwargs=kwargs,
+        is_elementwise=True,
+    )
 
 
 def as_expr(value: float | pl.Expr) -> pl.Expr:

--- a/polars_stats/distributions/_bernoulli.py
+++ b/polars_stats/distributions/_bernoulli.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, ClassVar
 
 import polars as pl
-from polars.plugins import register_plugin_function
 
-from polars_stats._lib import LIB
-from polars_stats.distributions._base import DiscreteDistribution, coerce_param, row_index_expr
+from polars_stats.distributions._base import DiscreteDistribution, coerce_param, register_plugin, row_index_expr
 
 if TYPE_CHECKING:
     from polars_stats._typing import IntoExprColumn, PolarsDataType
@@ -33,12 +31,7 @@ class Bernoulli(DiscreteDistribution):
         Computed in Rust so the closed-form methods report an invalid ``p`` consistently with
         ``sample`` rather than silently computing a negative probability. Null propagates.
         """
-        return register_plugin_function(
-            args=self._p,
-            plugin_path=LIB,
-            function_name="bernoulli_proba",
-            is_elementwise=True,
-        )
+        return register_plugin("bernoulli_proba", self._p)
 
     def _valid_mask(self) -> pl.Expr:
         # Only null p is masked to a null array here; an out-of-range p raises via `_checked_p`.
@@ -56,13 +49,7 @@ class Bernoulli(DiscreteDistribution):
         sub-seed mixed from ``seed`` and the row's position in the surrounding context,
         so the result is independent of Polars chunking and thread scheduling.
         """
-        return register_plugin_function(
-            args=(self._p, row_index_expr()),
-            plugin_path=LIB,
-            function_name="bernoulli_sample",
-            kwargs={"seed": seed},
-            is_elementwise=True,
-        )
+        return register_plugin("bernoulli_sample", (self._p, row_index_expr()), kwargs={"seed": seed})
 
     def _pmf(self, value: pl.Expr) -> pl.Expr:
         """``1 - p`` at 0, ``p`` at 1, ``0`` elsewhere."""

--- a/polars_stats/distributions/_normal.py
+++ b/polars_stats/distributions/_normal.py
@@ -4,10 +4,8 @@ import math
 from typing import TYPE_CHECKING, ClassVar
 
 import polars as pl
-from polars.plugins import register_plugin_function
 
-from polars_stats._lib import LIB
-from polars_stats.distributions._base import ContinuousDistribution, coerce_param, row_index_expr
+from polars_stats.distributions._base import ContinuousDistribution, coerce_param, register_plugin, row_index_expr
 
 if TYPE_CHECKING:
     from polars_stats._typing import IntoExprColumn, PolarsDataType
@@ -52,12 +50,7 @@ class Normal(ContinuousDistribution):
         Validation of ``std_dev`` happens inside the plugin, so every value-keyed method reports an
         invalid scale consistently; null inputs propagate per row.
         """
-        return register_plugin_function(
-            args=(value, self._mean, self._std_dev),
-            plugin_path=LIB,
-            function_name=function_name,
-            is_elementwise=True,
-        )
+        return register_plugin(function_name, (value, self._mean, self._std_dev))
 
     @property
     def _checked_std_dev(self) -> pl.Expr:
@@ -66,12 +59,7 @@ class Normal(ContinuousDistribution):
         # single FFI round-trip, so they report an invalid parameterisation (``std_dev <= 0``, or a
         # non-finite parameter) as a ``ComputeError`` consistently with the value-keyed methods. Null in
         # either parameter propagates to null, so a moment built on this nulls when either input is null.
-        return register_plugin_function(
-            args=(self._mean, self._std_dev),
-            plugin_path=LIB,
-            function_name="normal_std_dev",
-            is_elementwise=True,
-        )
+        return register_plugin("normal_std_dev", (self._mean, self._std_dev))
 
     def _valid_mask(self) -> pl.Expr:
         # Only null parameters are masked to a null array here; an invalid `std_dev` raises in the plugin.
@@ -86,13 +74,7 @@ class Normal(ContinuousDistribution):
         independent of Polars chunking and thread scheduling. Rows with an invalid ``std_dev`` raise;
         rows with a null parameter yield null.
         """
-        return register_plugin_function(
-            args=(self._mean, self._std_dev, row_index_expr()),
-            plugin_path=LIB,
-            function_name="normal_sample",
-            kwargs={"seed": seed},
-            is_elementwise=True,
-        )
+        return register_plugin("normal_sample", (self._mean, self._std_dev, row_index_expr()), kwargs={"seed": seed})
 
     def _pdf(self, value: pl.Expr) -> pl.Expr:
         """Density via native ``statrs`` ``Continuous::pdf``."""

--- a/polars_stats/distributions/_uniform.py
+++ b/polars_stats/distributions/_uniform.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, ClassVar
 
 import polars as pl
-from polars.plugins import register_plugin_function
 
-from polars_stats._lib import LIB
-from polars_stats.distributions._base import ContinuousDistribution, coerce_param, row_index_expr
+from polars_stats.distributions._base import ContinuousDistribution, coerce_param, register_plugin, row_index_expr
 
 if TYPE_CHECKING:
     from polars_stats._typing import IntoExprColumn, PolarsDataType
@@ -46,12 +44,7 @@ class Uniform(ContinuousDistribution):
         rather than silently yielding a non-positive width. Every closed-form method derives from this,
         so they all validate consistently. Null bounds propagate.
         """
-        return register_plugin_function(
-            args=(self._min, self._max),
-            plugin_path=LIB,
-            function_name="uniform_range",
-            is_elementwise=True,
-        )
+        return register_plugin("uniform_range", (self._min, self._max))
 
     def _valid_mask(self) -> pl.Expr:
         # Only null bounds are masked to a null array here; `max <= min` raises via `range`.
@@ -66,13 +59,7 @@ class Uniform(ContinuousDistribution):
         independent of Polars chunking and thread scheduling. Rows with ``max <= min`` or a null bound
         yield null.
         """
-        return register_plugin_function(
-            args=(self._min, self._max, row_index_expr()),
-            plugin_path=LIB,
-            function_name="uniform_sample",
-            kwargs={"seed": seed},
-            is_elementwise=True,
-        )
+        return register_plugin("uniform_sample", (self._min, self._max, row_index_expr()), kwargs={"seed": seed})
 
     def _pdf(self, value: pl.Expr) -> pl.Expr:
         """``1 / (max - min)`` on ``[min, max]``, ``0`` outside."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "maturin>=1.13.1",
 ]
 testing = [
+    "hypothesis>=6.100.0",
     "numpy>=2.2.6",
     "pytest>=8.3.5",
     "scipy>=1.13.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,12 @@ include = ["polars_stats", "tests"]
 
 [tool.pyrefly]
 project-includes = ["polars_stats", "tests"]
-search_path = ["polars_stats", "tests"]
+# Resolve first-party imports from the project root so module names match their full dotted path
+# (`polars_stats.*`, `tests.*`), the same way mypy/pyright and pytest's importlib mode see them. Listing
+# `polars_stats` / `tests` as roots instead would name `tests/property/_specs.py` as `property._specs`,
+# so the cross-test `from tests.property._specs import ...` only resolves via the editable `.pth` on a
+# local dev machine and breaks under CI's wheel-only install.
+search_path = ["."]
 
 [tool.coverage.run]
 plugins = ["covdefaults"]

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,49 @@
+# Test layout convention
+
+Tests for the distribution surface live in three places, split by what they assert.
+A new distribution adds tests by following the existing files, not by writing fixtures from scratch.
+
+## 1. Per-method behavioural tests — `tests/distributions/<name>/`
+
+One directory per distribution, mirroring [`distributions/bernoulli/`](distributions/bernoulli),
+one file per public method (`cdf_test.py`, `ppf_test.py`, `sample_test.py`, ...).
+These assert *behaviour that is specific to the distribution* and is not captured by a numeric match against SciPy:
+
+* support handling (clamping outside `[min, max]`, the `{0, 1}` mass points, infinite `ppf` endpoints);
+* the three parameter modes — scalar, `pl.Expr`, mixed/`str` column — produce the right result;
+* null propagation: a null in any input position yields a null output;
+* invalid parameters raise `ComputeError` rather than silently computing a wrong value;
+* sampler contracts: reproducibility under a fixed seed, per-row independence, `over` / `group_by`.
+
+Shared inputs (a `seed`, a `frame` factory, a `value_grid`, parameter grids) live in the directory's `conftest.py` so
+no test file redeclares them. Keep these files focused on *edges*, not on numeric parity — that is covered once, below.
+
+## 2. SciPy parity — `tests/scipy_parity/<name>_test.py`
+
+One table-driven module per distribution. Each lists its methods as `Case` rows and runs them through the shared harness
+in [`_harness.py`](scipy_parity/_harness.py), which compares every method against the matching `scipy.stats` attribute
+across a parameter grid.
+
+Adding a method is one row; the comparison mechanics (grid selection, Boolean→float casting, tolerance)
+are not re-implemented.
+
+Tolerances follow the *upstream implementation*, not aspiration: closed-form methods hold the default `1e-12`;
+methods routed through `erf`/`erfc` or a binary-search `inverse_cdf` pass a relaxed per-`Case` tolerance
+(e.g. the normal cdf/sf family at `1e-9`). Document any exception inline on the `Case`.
+
+## 3. Property tests — `tests/property/`
+
+Distribution-agnostic invariants, written once and parametrised across every distribution via the `DistSpec` registry in
+[`_specs.py`](property/_specs.py). A new distribution adds one `DistSpec` entry and inherits the whole suite:
+
+* `0 <= cdf(x) <= 1` and `cdf` non-decreasing in `x`;
+* `cdf(ppf(q)) ~= q` for `q` in the open unit interval (continuous);
+* `pdf(x) >= 0` (continuous) / `pmf(x) >= 0` (discrete);
+* trapezoidal integral of `pdf` over the (truncated) support `~= 1` (continuous);
+* sum of `pmf` over the finite support `~= 1` (discrete);
+* `sample(seed=N)` is reproducible across two calls.
+
+These use [`hypothesis`](https://hypothesis.readthedocs.io).
+
+The capped profile in [`conftest.py`](property/conftest.py) (`max_examples`, `deadline=None`) keeps the suite under the
+CI budget and non-flaky; raise `max_examples` locally when investigating a failure.

--- a/tests/property/_specs.py
+++ b/tests/property/_specs.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from hypothesis import strategies as st
+
+from polars_stats import Bernoulli, Normal, Uniform
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import polars as pl
+    from hypothesis.strategies import SearchStrategy
+
+    from polars_stats.distributions._base import _UnivariateDistribution
+
+
+def _finite(min_value: float, max_value: float) -> SearchStrategy[float]:
+    """Bounded, non-degenerate floats (no NaN/inf), the only inputs a parameter sweep should explore."""
+    return st.floats(min_value=min_value, max_value=max_value, allow_nan=False, allow_infinity=False)
+
+
+@dataclass(frozen=True)
+class DistSpec:
+    """Describes one distribution for the property suite: how to build it and where it is defined.
+
+    A single `DistSpec` lets each property be written once and parametrised across every distribution.
+    `params` draws a *valid* parameterisation (samplers and closed forms never raise on these), `make`
+    turns that tuple into an instance, and `density` selects `pdf` (continuous) or `pmf` (discrete) so
+    the non-negativity / normalisation properties read the same for both families.
+
+    Arguments:
+        name: Test id.
+        continuous: `True` for a continuous distribution (has `pdf`, finite-grid integral), `False` for
+            a discrete one (has `pmf`, finite-support sum).
+        params: Strategy yielding a valid parameter tuple.
+        make: Builds an instance from a parameter tuple.
+        density: `pdf` or `pmf` as `(dist, expr) -> expr`. Typed loosely because the method differs by family;
+            the concrete distribution is fixed per spec.
+        eval_range: `(lo, hi)` finite window for evaluating cdf / density on a grid.
+        integration_bounds: `(lo, hi)` over which the pdf integrates to ~1 (continuous only);
+            the normal is truncated to a wide multiple of `std`. `None` for discrete.
+        support: Finite list of mass points summing to ~1 (discrete only). `None` for continuous.
+    """
+
+    name: str
+    continuous: bool
+    params: SearchStrategy[tuple[float, ...]]
+    make: Callable[[tuple[float, ...]], _UnivariateDistribution]
+    density: Callable[[Any, pl.Expr], pl.Expr]
+    eval_range: Callable[[tuple[float, ...]], tuple[float, float]]
+    integration_bounds: Callable[[tuple[float, ...]], tuple[float, float]] | None = None
+    support: Callable[[tuple[float, ...]], list[float]] | None = None
+
+
+_BERNOULLI = DistSpec(
+    name="bernoulli",
+    continuous=False,
+    params=st.tuples(_finite(0.0, 1.0)),
+    make=lambda p: Bernoulli(p=p[0]),
+    density=lambda d, c: d.pmf(c),
+    eval_range=lambda _: (-1.0, 2.0),
+    support=lambda _: [0.0, 1.0],
+)
+
+_NORMAL = DistSpec(
+    name="normal",
+    continuous=True,
+    params=st.tuples(_finite(-10.0, 10.0), _finite(1e-2, 10.0)),
+    make=lambda p: Normal(mean=p[0], std_dev=p[1]),
+    density=lambda d, c: d.pdf(c),
+    eval_range=lambda p: (p[0] - 6.0 * p[1], p[0] + 6.0 * p[1]),
+    integration_bounds=lambda p: (p[0] - 12.0 * p[1], p[0] + 12.0 * p[1]),
+)
+
+_UNIFORM = DistSpec(
+    name="uniform",
+    continuous=True,
+    # Draw `(min, width)` with `width > 0`, then expose `(min, max)`; this guarantees `max > min`
+    # without rejection, so every drawn parameterisation is valid.
+    params=st.tuples(_finite(-10.0, 10.0), _finite(1e-2, 20.0)).map(lambda mw: (mw[0], mw[0] + mw[1])),
+    make=lambda p: Uniform(min=p[0], max=p[1]),
+    density=lambda d, c: d.pdf(c),
+    eval_range=lambda p: (p[0] - 0.5 * (p[1] - p[0]), p[1] + 0.5 * (p[1] - p[0])),
+    integration_bounds=lambda p: (p[0], p[1]),
+)
+
+ALL_SPECS = [_BERNOULLI, _NORMAL, _UNIFORM]
+CONTINUOUS_SPECS = [s for s in ALL_SPECS if s.continuous]
+DISCRETE_SPECS = [s for s in ALL_SPECS if not s.continuous]

--- a/tests/property/cdf_test.py
+++ b/tests/property/cdf_test.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import polars as pl
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from tests.property._specs import ALL_SPECS, CONTINUOUS_SPECS
+
+if TYPE_CHECKING:
+    from tests.property._specs import DistSpec
+
+_GRID_SIZE = 64
+# cdf/ppf on the normal go through `erf`/`erfc` and a closed-form `inverse_cdf`, so the round-trip
+# recovers `q` only to ~1e-9. 1e-6 is the padded bound covering every distribution uniformly.
+_ROUNDTRIP_TOL = 1e-6
+# Float-noise slack on strict monotonicity: a genuine cdf decrease must still fail.
+_MONOTONE_SLACK = 1e-12
+
+
+def _eval(expr: pl.Expr, xs: list[float]) -> np.ndarray:
+    return pl.DataFrame({"x": xs}).select(r=expr)["r"].to_numpy()
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@given(data=st.data())
+def test_cdf_bounded_and_monotone(spec: DistSpec, data: st.DataObject) -> None:
+    """`0 <= cdf(x) <= 1` and `cdf` is non-decreasing in `x`, across the parameter space."""
+    params = data.draw(spec.params)
+    dist = spec.make(params)
+    lo, hi = spec.eval_range(params)
+    xs = np.linspace(lo, hi, _GRID_SIZE).tolist()
+
+    cdf = _eval(dist.cdf(pl.col("x")), xs)
+
+    assert not np.isnan(cdf).any()
+    assert cdf.min() >= 0.0
+    assert cdf.max() <= 1.0
+    # Allow only float noise against strict monotonicity, not a real decrease.
+    assert np.all(np.diff(cdf) >= -_MONOTONE_SLACK)
+
+
+@pytest.mark.parametrize("spec", CONTINUOUS_SPECS, ids=lambda s: s.name)
+@given(q=st.floats(min_value=1e-3, max_value=1.0 - 1e-3), data=st.data())
+def test_cdf_ppf_round_trip(spec: DistSpec, q: float, data: st.DataObject) -> None:
+    """`cdf(ppf(q)) ~= q` for `q` in the open unit interval (continuous distributions)."""
+    params = data.draw(spec.params)
+    dist = spec.make(params)
+
+    recovered = _eval(dist.cdf(dist.ppf(pl.col("x"))), [q])
+    np.testing.assert_allclose(recovered, [q], atol=_ROUNDTRIP_TOL, rtol=0)

--- a/tests/property/conftest.py
+++ b/tests/property/conftest.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from hypothesis import HealthCheck, settings
+
+# A single capped profile keeps the whole property suite well under the 60s CI budget, while staying high enough to
+# exercise the parameter space. `deadline=None` removes per-example timing assertions: a plugin call's first invocation
+# pays a one-off cost that would otherwise flake the deadline.
+# `function_scoped_fixture` is suppressed because every property combines `@pytest.mark.parametrize("spec", ...)`
+# (a function-scoped argument) with `@given`, which is intentional and not the bug that health check guards against.
+settings.register_profile(
+    "polars_stats",
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+settings.load_profile("polars_stats")

--- a/tests/property/pdf_test.py
+++ b/tests/property/pdf_test.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import polars as pl
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from tests.property._specs import ALL_SPECS, CONTINUOUS_SPECS, DISCRETE_SPECS
+
+if TYPE_CHECKING:
+    from tests.property._specs import DistSpec
+
+_GRID_SIZE = 64
+# Dense grid for the trapezoidal mass check. A coarser grid understates the gaussian tails; finer adds
+# little. The integral is an approximation, so `1e-3` is the honest tolerance (exact for uniform).
+_INTEGRATION_GRID_SIZE = 4096
+_INTEGRATION_TOL = 1e-3
+
+
+def _eval(expr: pl.Expr, xs: list[float]) -> np.ndarray:
+    return pl.DataFrame({"x": xs}).select(r=expr)["r"].to_numpy()
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@given(data=st.data())
+def test_density_non_negative(spec: DistSpec, data: st.DataObject) -> None:
+    """`pdf(x) >= 0` (continuous) / `pmf(x) >= 0` (discrete), across the parameter space."""
+    params = data.draw(spec.params)
+    dist = spec.make(params)
+    lo, hi = spec.eval_range(params)
+    xs = np.linspace(lo, hi, _GRID_SIZE).tolist()
+
+    density = _eval(spec.density(dist, pl.col("x")), xs)
+
+    assert not np.isnan(density).any()
+    assert density.min() >= 0.0
+
+
+@pytest.mark.parametrize("spec", CONTINUOUS_SPECS, ids=lambda s: s.name)
+@settings(max_examples=25)
+@given(data=st.data())
+def test_pdf_integrates_to_one(spec: DistSpec, data: st.DataObject) -> None:
+    """Trapezoidal integral of the pdf over the (truncated) support is ~1."""
+    assert spec.integration_bounds is not None  # invariant for continuous specs
+    params = data.draw(spec.params)
+    dist = spec.make(params)
+    lo, hi = spec.integration_bounds(params)
+    xs = np.linspace(lo, hi, _INTEGRATION_GRID_SIZE)
+
+    density = _eval(spec.density(dist, pl.col("x")), xs.tolist())
+    mass = float(np.trapezoid(density, xs))
+
+    assert mass == pytest.approx(1.0, abs=_INTEGRATION_TOL)
+
+
+@pytest.mark.parametrize("spec", DISCRETE_SPECS, ids=lambda s: s.name)
+@given(data=st.data())
+def test_pmf_sums_to_one(spec: DistSpec, data: st.DataObject) -> None:
+    """Sum of the pmf over the finite support is ~1."""
+    assert spec.support is not None  # invariant for discrete specs
+    params = data.draw(spec.params)
+    dist = spec.make(params)
+    support = spec.support(params)
+
+    mass = float(_eval(spec.density(dist, pl.col("x")), support).sum())
+
+    assert mass == pytest.approx(1.0, abs=1e-12)

--- a/tests/property/sample_test.py
+++ b/tests/property/sample_test.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from polars.testing import assert_series_equal
+
+from tests.property._specs import ALL_SPECS
+
+if TYPE_CHECKING:
+    from tests.property._specs import DistSpec
+
+_N_ROWS = 64
+_SEED = 12345
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@given(data=st.data())
+def test_sample_seeded_is_reproducible(spec: DistSpec, data: st.DataObject) -> None:
+    """`sample(seed=N)` returns identical draws across two calls in the same process."""
+    params = data.draw(spec.params)
+    dist = spec.make(params)
+    frame = pl.DataFrame({"_": range(_N_ROWS)})
+
+    first = frame.select(s=dist.sample(seed=_SEED))["s"]
+    second = frame.select(s=dist.sample(seed=_SEED))["s"]
+
+    assert_series_equal(first, second)

--- a/tests/scipy_parity/_harness.py
+++ b/tests/scipy_parity/_harness.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Generic, Literal, TypeVar
+
+import numpy as np
+import polars as pl
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+# Default absolute tolerance for closed-form methods. `statrs` and the pure-polars closed forms agree
+# with scipy to ~1e-13; 1e-12 is the padded bound. Methods routed through `erf`/`erfc` (e.g. the
+# normal cdf/sf family) agree only to ~1e-10 and pass their own relaxed tolerance per `Case`.
+DEFAULT_TOL = 1e-12
+
+DistT = TypeVar("DistT")
+
+Kind = Literal["value", "quantile", "scalar"]
+"""Selects the evaluation grid for a `Case`:
+
+* `"value"` evaluates `pl_fn` over the distribution's `value_grid` (pdf/pmf, cdf, sf, and their logs);
+* `"quantile"` evaluates over `quantiles` (ppf, isf);
+* `"scalar"` takes no input and compares a single number (mean, variance, std, median, entropy).
+"""
+
+
+@dataclass(frozen=True)
+class Case(Generic[DistT]):
+    """One polars-stats method paired with the `scipy.stats` attribute it must reproduce.
+
+    Parametrising a parity test over a list of `Case` makes "add a method" one row rather than a new
+    test. Per-distribution numeric grids stay in the test module; this type owns only the mapping from
+    a method to its scipy oracle and the tolerance it must hold.
+
+    Arguments:
+        name: Method name, used only as the test id.
+        kind: Which grid drives the comparison (see `Kind`).
+        pl_fn: Builds the polars-stats expression from a distribution instance and an evaluation expr.
+            For `kind="scalar"` the expr argument is unused (pass `pl.lit(0.0)`).
+        scipy_attr: Attribute on the frozen scipy distribution producing the reference values.
+        tol: Absolute tolerance for the comparison; defaults to `DEFAULT_TOL`.
+    """
+
+    name: str
+    kind: Kind
+    pl_fn: Callable[[DistT, pl.Expr], pl.Expr]
+    scipy_attr: str
+    tol: float = DEFAULT_TOL
+
+
+def assert_case_matches_scipy(
+    case: Case[DistT],
+    *,
+    dist: DistT,
+    scipy_frozen: object,
+    value_grid: Sequence[float],
+    quantiles: Sequence[float],
+) -> None:
+    """Assert one `Case` reproduces its scipy oracle across the grid selected by `case.kind`.
+
+    Boolean outputs (a discrete `ppf`/`isf`/`median`) are cast to `0.0`/`1.0` before comparison, so the
+    same helper serves discrete and continuous distributions. `value_grid` / `quantiles` are owned by
+    the calling test module because their support spans are distribution-specific.
+    """
+    if case.kind == "scalar":
+        result = pl.DataFrame({"_": [0]}).select(r=case.pl_fn(dist, pl.lit(0.0)))["r"].to_numpy()
+        expected = np.asarray([getattr(scipy_frozen, case.scipy_attr)()], dtype=float)
+    else:
+        xs = list(value_grid if case.kind == "value" else quantiles)
+        result = pl.DataFrame({"x": xs}).select(r=case.pl_fn(dist, pl.col("x")))["r"].to_numpy()
+        expected = np.asarray(getattr(scipy_frozen, case.scipy_attr)(xs), dtype=float)
+
+    np.testing.assert_allclose(np.asarray(result, dtype=float), expected, atol=case.tol, rtol=0)

--- a/tests/scipy_parity/bernoulli_test.py
+++ b/tests/scipy_parity/bernoulli_test.py
@@ -1,17 +1,10 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
-
-import numpy as np
-import polars as pl
 import pytest
 from scipy.stats import bernoulli as scipy_bernoulli
 
 from polars_stats import Bernoulli
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
+from tests.scipy_parity._harness import Case, assert_case_matches_scipy
 
 # Parameter and evaluation grids for the parity sweep. Owned by this test category and independent
 # of the per-method functional tests under `tests/distributions/bernoulli`.
@@ -24,40 +17,26 @@ _QUANTILES = [0.1, 0.25, 0.5, 0.75, 0.9]
 _VALUE_GRID = [-1.0, 0.0, 0.5, 1.0, 2.0]
 
 
-@dataclass(frozen=True)
-class _Case:
-    """One `Bernoulli` method paired with the `scipy.stats.bernoulli` attribute it must reproduce.
-
-    `kind` selects the input grid: `"value"` evaluates over `_VALUE_GRID`, `"quantile"` over the
-    interior `_QUANTILES`, `"scalar"` takes no input (moments / entropy).
-    """
-
-    name: str
-    kind: str
-    pl_fn: Callable[[Bernoulli, pl.Expr], pl.Expr]
-    scipy_attr: str
-
-
-_CASES = [
-    _Case("pmf", "value", lambda b, c: b.pmf(c), "pmf"),
-    _Case("log_pmf", "value", lambda b, c: b.log_pmf(c), "logpmf"),
-    _Case("cdf", "value", lambda b, c: b.cdf(c), "cdf"),
-    _Case("log_cdf", "value", lambda b, c: b.log_cdf(c), "logcdf"),
-    _Case("sf", "value", lambda b, c: b.sf(c), "sf"),
-    _Case("log_sf", "value", lambda b, c: b.log_sf(c), "logsf"),
-    _Case("ppf", "quantile", lambda b, c: b.ppf(c), "ppf"),
-    _Case("isf", "quantile", lambda b, c: b.isf(c), "isf"),
-    _Case("mean", "scalar", lambda b, _: b.mean(), "mean"),
-    _Case("variance", "scalar", lambda b, _: b.variance(), "var"),
-    _Case("std", "scalar", lambda b, _: b.std(), "std"),
-    _Case("median", "scalar", lambda b, _: b.median(), "median"),
-    _Case("entropy", "scalar", lambda b, _: b.entropy(), "entropy"),
+_CASES: list[Case[Bernoulli]] = [
+    Case("pmf", "value", lambda b, c: b.pmf(c), "pmf"),
+    Case("log_pmf", "value", lambda b, c: b.log_pmf(c), "logpmf"),
+    Case("cdf", "value", lambda b, c: b.cdf(c), "cdf"),
+    Case("log_cdf", "value", lambda b, c: b.log_cdf(c), "logcdf"),
+    Case("sf", "value", lambda b, c: b.sf(c), "sf"),
+    Case("log_sf", "value", lambda b, c: b.log_sf(c), "logsf"),
+    Case("ppf", "quantile", lambda b, c: b.ppf(c), "ppf"),
+    Case("isf", "quantile", lambda b, c: b.isf(c), "isf"),
+    Case("mean", "scalar", lambda b, _: b.mean(), "mean"),
+    Case("variance", "scalar", lambda b, _: b.variance(), "var"),
+    Case("std", "scalar", lambda b, _: b.std(), "std"),
+    Case("median", "scalar", lambda b, _: b.median(), "median"),
+    Case("entropy", "scalar", lambda b, _: b.entropy(), "entropy"),
 ]
 
 
 @pytest.mark.parametrize("p", _PROBS, ids=[f"p={p}" for p in _PROBS])
 @pytest.mark.parametrize("case", _CASES, ids=lambda c: c.name)
-def test_method_matches_scipy(case: _Case, p: float) -> None:
+def test_method_matches_scipy(case: Case[Bernoulli], p: float) -> None:
     """Every closed-form method matches `scipy.stats.bernoulli` across `_PROBS`.
 
     Table-driven: adding a method is one row in `_CASES`. `ppf`/`isf` use interior quantiles only,
@@ -65,16 +44,10 @@ def test_method_matches_scipy(case: _Case, p: float) -> None:
     the Boolean-valued `ppf` here does not reproduce. Method-specific behaviour (support handling,
     null propagation) is asserted in the per-method test files.
     """
-    b = Bernoulli(p=p)
-    frozen = scipy_bernoulli(p)
-
-    if case.kind == "scalar":
-        result = pl.DataFrame({"_": [0]}).select(r=case.pl_fn(b, pl.lit(0.0)))["r"].to_numpy()
-        expected = np.asarray([getattr(frozen, case.scipy_attr)()], dtype=float)
-    else:
-        xs = _VALUE_GRID if case.kind == "value" else _QUANTILES
-        result = pl.DataFrame({"x": xs}).select(r=case.pl_fn(b, pl.col("x")))["r"].to_numpy()
-        expected = np.asarray(getattr(frozen, case.scipy_attr)(xs), dtype=float)
-
-    # Cast `result` to float so Boolean outputs (ppf / isf / median) compare as 0.0 / 1.0.
-    np.testing.assert_allclose(np.asarray(result, dtype=float), expected, atol=1e-12, rtol=0)
+    assert_case_matches_scipy(
+        case,
+        dist=Bernoulli(p=p),
+        scipy_frozen=scipy_bernoulli(p),
+        value_grid=_VALUE_GRID,
+        quantiles=_QUANTILES,
+    )

--- a/tests/scipy_parity/normal_test.py
+++ b/tests/scipy_parity/normal_test.py
@@ -1,17 +1,10 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
-
-import numpy as np
-import polars as pl
 import pytest
 from scipy.stats import norm as scipy_norm
 
 from polars_stats import Normal
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
+from tests.scipy_parity._harness import Case, assert_case_matches_scipy
 
 # Parameter and evaluation grids for the parity sweep. Owned by this test category and independent
 # of the per-method functional tests under `tests/distributions/normal`.
@@ -20,43 +13,26 @@ _QUANTILES = [0.01, 0.1, 0.25, 0.5, 0.75, 0.9, 0.99]
 
 # Tolerance split, by upstream implementation rather than by aspiration:
 #   * `statrs` evaluates pdf / ln_pdf / inverse_cdf and the moments to ~1e-13 against scipy,
-#     so they hold the 1e-12 target the issue asks for;
+#     so they hold the default 1e-12 target;
 #   * cdf / sf (and their logs) go through `erfc`, while scipy uses the Cephes `ndtr`; the two
-#     agree only to ~1e-10. 1e-9 is the honest, comfortably-padded bound for that family. See the
-#     PR description for the measured worst case.
-_TOL_EXACT = 1e-12
+#     agree only to ~1e-10. 1e-9 is the honest, comfortably-padded bound for that family.
 _TOL_ERF = 1e-9
 
 
-@dataclass(frozen=True)
-class _Case:
-    """One `Normal` method paired with the `scipy.stats.norm` attribute it must reproduce.
-
-    `kind` selects the input grid: `"value"` evaluates over `value_grid`, `"quantile"` over
-    `_QUANTILES`, `"scalar"` takes no input (moments / entropy). `tol` is the absolute tolerance.
-    """
-
-    name: str
-    kind: str
-    pl_fn: Callable[[Normal, pl.Expr], pl.Expr]
-    scipy_attr: str
-    tol: float
-
-
-_CASES = [
-    _Case("pdf", "value", lambda n, c: n.pdf(c), "pdf", _TOL_EXACT),
-    _Case("log_pdf", "value", lambda n, c: n.log_pdf(c), "logpdf", _TOL_EXACT),
-    _Case("cdf", "value", lambda n, c: n.cdf(c), "cdf", _TOL_ERF),
-    _Case("log_cdf", "value", lambda n, c: n.log_cdf(c), "logcdf", _TOL_ERF),
-    _Case("sf", "value", lambda n, c: n.sf(c), "sf", _TOL_ERF),
-    _Case("log_sf", "value", lambda n, c: n.log_sf(c), "logsf", _TOL_ERF),
-    _Case("ppf", "quantile", lambda n, c: n.ppf(c), "ppf", _TOL_EXACT),
-    _Case("isf", "quantile", lambda n, c: n.isf(c), "isf", _TOL_EXACT),
-    _Case("mean", "scalar", lambda n, _: n.mean(), "mean", _TOL_EXACT),
-    _Case("variance", "scalar", lambda n, _: n.variance(), "var", _TOL_EXACT),
-    _Case("std", "scalar", lambda n, _: n.std(), "std", _TOL_EXACT),
-    _Case("median", "scalar", lambda n, _: n.median(), "median", _TOL_EXACT),
-    _Case("entropy", "scalar", lambda n, _: n.entropy(), "entropy", _TOL_EXACT),
+_CASES: list[Case[Normal]] = [
+    Case("pdf", "value", lambda n, c: n.pdf(c), "pdf"),
+    Case("log_pdf", "value", lambda n, c: n.log_pdf(c), "logpdf"),
+    Case("cdf", "value", lambda n, c: n.cdf(c), "cdf", _TOL_ERF),
+    Case("log_cdf", "value", lambda n, c: n.log_cdf(c), "logcdf", _TOL_ERF),
+    Case("sf", "value", lambda n, c: n.sf(c), "sf", _TOL_ERF),
+    Case("log_sf", "value", lambda n, c: n.log_sf(c), "logsf", _TOL_ERF),
+    Case("ppf", "quantile", lambda n, c: n.ppf(c), "ppf"),
+    Case("isf", "quantile", lambda n, c: n.isf(c), "isf"),
+    Case("mean", "scalar", lambda n, _: n.mean(), "mean"),
+    Case("variance", "scalar", lambda n, _: n.variance(), "var"),
+    Case("std", "scalar", lambda n, _: n.std(), "std"),
+    Case("median", "scalar", lambda n, _: n.median(), "median"),
+    Case("entropy", "scalar", lambda n, _: n.entropy(), "entropy"),
 ]
 
 
@@ -67,21 +43,16 @@ def _value_grid(mean: float, std: float) -> list[float]:
 
 @pytest.mark.parametrize(("mean", "std"), _PARAMS, ids=[f"mean={m},std={s}" for m, s in _PARAMS])
 @pytest.mark.parametrize("case", _CASES, ids=lambda c: c.name)
-def test_method_matches_scipy(case: _Case, mean: float, std: float) -> None:
+def test_method_matches_scipy(case: Case[Normal], mean: float, std: float) -> None:
     """Every closed-form method matches `scipy.stats.norm` across the `(mean, std)` grid.
 
     Table-driven: adding a method is one row in `_CASES`. Method-specific behaviour (null
     propagation, out-of-range quantiles, infinite ppf endpoints) is asserted in the per-method files.
     """
-    n = Normal(mean=mean, std_dev=std)
-    frozen = scipy_norm(loc=mean, scale=std)
-
-    if case.kind == "scalar":
-        result = pl.DataFrame({"_": [0]}).select(r=case.pl_fn(n, pl.lit(0.0)))["r"].to_numpy()
-        expected = np.asarray([getattr(frozen, case.scipy_attr)()], dtype=float)
-    else:
-        xs = _value_grid(mean, std) if case.kind == "value" else _QUANTILES
-        result = pl.DataFrame({"x": xs}).select(r=case.pl_fn(n, pl.col("x")))["r"].to_numpy()
-        expected = np.asarray(getattr(frozen, case.scipy_attr)(xs), dtype=float)
-
-    np.testing.assert_allclose(result, expected, atol=case.tol, rtol=0)
+    assert_case_matches_scipy(
+        case,
+        dist=Normal(mean=mean, std_dev=std),
+        scipy_frozen=scipy_norm(loc=mean, scale=std),
+        value_grid=_value_grid(mean, std),
+        quantiles=_QUANTILES,
+    )

--- a/tests/scipy_parity/uniform_test.py
+++ b/tests/scipy_parity/uniform_test.py
@@ -1,22 +1,32 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
-
-import numpy as np
-import polars as pl
 import pytest
 from scipy.stats import uniform as scipy_uniform
 
 from polars_stats import Uniform
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
+from tests.scipy_parity._harness import Case, assert_case_matches_scipy
 
 # Parameter and evaluation grids for the parity sweep. Owned by this test category and independent
 # of the per-method functional tests under `tests/distributions/uniform`.
 _PARAMS = [(0.0, 1.0), (-2.0, 3.0), (2.0, 5.0), (-5.0, -1.0), (0.0, 1e-3)]
 _QUANTILES = [0.0, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0]
+
+
+_CASES: list[Case[Uniform]] = [
+    Case("pdf", "value", lambda u, c: u.pdf(c), "pdf"),
+    Case("log_pdf", "value", lambda u, c: u.log_pdf(c), "logpdf"),
+    Case("cdf", "value", lambda u, c: u.cdf(c), "cdf"),
+    Case("log_cdf", "value", lambda u, c: u.log_cdf(c), "logcdf"),
+    Case("sf", "value", lambda u, c: u.sf(c), "sf"),
+    Case("log_sf", "value", lambda u, c: u.log_sf(c), "logsf"),
+    Case("ppf", "quantile", lambda u, c: u.ppf(c), "ppf"),
+    Case("isf", "quantile", lambda u, c: u.isf(c), "isf"),
+    Case("mean", "scalar", lambda u, _: u.mean(), "mean"),
+    Case("variance", "scalar", lambda u, _: u.variance(), "var"),
+    Case("std", "scalar", lambda u, _: u.std(), "std"),
+    Case("median", "scalar", lambda u, _: u.median(), "median"),
+    Case("entropy", "scalar", lambda u, _: u.entropy(), "entropy"),
+]
 
 
 def _value_grid(mn: float, mx: float) -> list[float]:
@@ -25,54 +35,18 @@ def _value_grid(mn: float, mx: float) -> list[float]:
     return [mn - width, mn, mn + 0.25 * width, (mn + mx) / 2, mn + 0.75 * width, mx, mx + width]
 
 
-@dataclass(frozen=True)
-class _Case:
-    """One `Uniform` method paired with the `scipy.stats.uniform` attribute it must reproduce.
-
-    `kind` selects the input grid: `"value"` evaluates over `_value_grid`, `"quantile"` over
-    `_QUANTILES`, `"scalar"` takes no input (moments / entropy).
-    """
-
-    name: str
-    kind: str
-    pl_fn: Callable[[Uniform, pl.Expr], pl.Expr]
-    scipy_attr: str
-
-
-_CASES = [
-    _Case("pdf", "value", lambda u, c: u.pdf(c), "pdf"),
-    _Case("log_pdf", "value", lambda u, c: u.log_pdf(c), "logpdf"),
-    _Case("cdf", "value", lambda u, c: u.cdf(c), "cdf"),
-    _Case("log_cdf", "value", lambda u, c: u.log_cdf(c), "logcdf"),
-    _Case("sf", "value", lambda u, c: u.sf(c), "sf"),
-    _Case("log_sf", "value", lambda u, c: u.log_sf(c), "logsf"),
-    _Case("ppf", "quantile", lambda u, c: u.ppf(c), "ppf"),
-    _Case("isf", "quantile", lambda u, c: u.isf(c), "isf"),
-    _Case("mean", "scalar", lambda u, _: u.mean(), "mean"),
-    _Case("variance", "scalar", lambda u, _: u.variance(), "var"),
-    _Case("std", "scalar", lambda u, _: u.std(), "std"),
-    _Case("median", "scalar", lambda u, _: u.median(), "median"),
-    _Case("entropy", "scalar", lambda u, _: u.entropy(), "entropy"),
-]
-
-
 @pytest.mark.parametrize(("mn", "mx"), _PARAMS, ids=[f"min={mn},max={mx}" for mn, mx in _PARAMS])
 @pytest.mark.parametrize("case", _CASES, ids=lambda c: c.name)
-def test_method_matches_scipy(case: _Case, mn: float, mx: float) -> None:
+def test_method_matches_scipy(case: Case[Uniform], mn: float, mx: float) -> None:
     """Every closed-form method matches `scipy.stats.uniform` across the `(min, max)` grid.
 
     Table-driven: adding a method is one row in `_CASES`. Method-specific behaviour (support
     clamping, null propagation, out-of-range quantiles) is asserted in the per-method test files.
     """
-    u = Uniform(min=mn, max=mx)
-    frozen = scipy_uniform(loc=mn, scale=mx - mn)
-
-    if case.kind == "scalar":
-        result = pl.DataFrame({"_": [0]}).select(r=case.pl_fn(u, pl.lit(0.0)))["r"].to_numpy()
-        expected = np.asarray([getattr(frozen, case.scipy_attr)()], dtype=float)
-    else:
-        xs = _value_grid(mn, mx) if case.kind == "value" else _QUANTILES
-        result = pl.DataFrame({"x": xs}).select(r=case.pl_fn(u, pl.col("x")))["r"].to_numpy()
-        expected = np.asarray(getattr(frozen, case.scipy_attr)(xs), dtype=float)
-
-    np.testing.assert_allclose(result, expected, atol=1e-12, rtol=0)
+    assert_case_matches_scipy(
+        case,
+        dist=Uniform(min=mn, max=mx),
+        scipy_frozen=scipy_uniform(loc=mn, scale=mx - mn),
+        value_grid=_value_grid(mn, mx),
+        quantiles=_QUANTILES,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -69,6 +69,19 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.155.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/ef/4a94c12429986a90076057513e084bf32106a9bdc62c8e29f58673dd85a2/hypothesis-6.155.1.tar.gz", hash = "sha256:07c102031612b98d7c1be15ca3608c43e1234d9d07e3a190a53fa01536700196", size = 477300, upload-time = "2026-05-29T23:12:57.515Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/6e/8c9cf32201238617454303b1605dfa667d90cd1ef51226f92d9c2b3b8f7c/hypothesis-6.155.1-py3-none-any.whl", hash = "sha256:2753f469df3ba3c483b08e0c37dbcbc41d8316ebb921abcc07493ee9c8a7d187", size = 543715, upload-time = "2026-05-29T23:12:54.77Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -531,6 +544,7 @@ dev = [
     { name = "maturin" },
 ]
 testing = [
+    { name = "hypothesis" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pytest" },
@@ -538,6 +552,7 @@ testing = [
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 typing = [
+    { name = "hypothesis" },
     { name = "mypy" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -560,11 +575,13 @@ benchmark = [
 ]
 dev = [{ name = "maturin", specifier = ">=1.13.1" }]
 testing = [
+    { name = "hypothesis", specifier = ">=6.100.0" },
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "scipy", specifier = ">=1.13.0" },
 ]
 typing = [
+    { name = "hypothesis", specifier = ">=6.100.0" },
     { name = "mypy", specifier = ">=1.14.1" },
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "pyrefly", specifier = ">=0.62.0" },
@@ -816,6 +833,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/30/7a2e621918d1317ab972f797161131f2635648ad5d92baf0695dd009e4f9/scipy_stubs-1.17.1.5.tar.gz", hash = "sha256:284b1dd1dd46107a614971d170030d310cd88b2ac6b483f85285ee0ff87720bd", size = 399933, upload-time = "2026-05-25T21:34:33.6Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/26/d4bc2ba3427a623f79a6c10c8f427c7a55b56eb8b3eddc369319d97f741b/scipy_stubs-1.17.1.5-py3-none-any.whl", hash = "sha256:58ebf054a86c000c72e8982e121c4ead0d3d9ba7a6c38aa5fa71b07f96a427fd", size = 607388, upload-time = "2026-05-25T21:34:32.073Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
1. Extracts the three copy-pasted scipy-parity drivers into a shared `tests/scipy_parity/_harness.py` and adds a `tests/property/` hypothesis suite where six invariants (cdf bounds/monotonicity, cdf(ppf(q))≈q, density≥0, pdf integral≈1, pmf sum≈1, seeded reproducibility) are written once and parametrised across all distributions. Plus a tests/README.md documenting the three-tier layout and the hypothesis dev dep.

2. Lands the `register_plugin` shim (fixes `plugin_path=LIB` and a per-row `is_elementwise=True` guard) across all seven plugin call sites, behaviour unchanged.