### PR TITLE
feat: Add `LogNormal` distribution

### DIFF
--- a/polars_stats/__init__.py
+++ b/polars_stats/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from polars_stats._internal import __version__ as __version__
 from polars_stats.distributions._base import ContinuousDistribution, DiscreteDistribution
 from polars_stats.distributions._bernoulli import Bernoulli
+from polars_stats.distributions._lognormal import LogNormal
 from polars_stats.distributions._normal import Normal
 from polars_stats.distributions._uniform import Uniform
 
@@ -10,6 +11,7 @@ __all__ = (
     "Bernoulli",
     "ContinuousDistribution",
     "DiscreteDistribution",
+    "LogNormal",
     "Normal",
     "Uniform",
     "__version__",

--- a/polars_stats/distributions/_lognormal.py
+++ b/polars_stats/distributions/_lognormal.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, ClassVar
+
+import polars as pl
+
+from polars_stats.distributions._base import ContinuousDistribution, coerce_param, register_plugin, row_index_expr
+
+if TYPE_CHECKING:
+    from polars_stats._typing import IntoExprColumn, PolarsDataType
+
+
+_TWO_PI_E = math.tau * math.e
+"""2 * pi * e, the constant inside the log-normal's differential entropy `mu + 0.5 * log(2 * pi * e * sigma^2)`."""
+
+
+class LogNormal(ContinuousDistribution):
+    """Log-normal distribution: ``X`` such that ``ln(X)`` is ``Normal(mu, sigma)``.
+
+    Parameterised by the underlying normal's location ``mu`` and scale ``sigma`` (``sigma > 0``).
+
+    Equivalent to ``scipy.stats.lognorm(s=sigma, scale=exp(mu))`` (with ``loc=0``):
+    scipy's shape ``s`` is ``sigma`` and its ``scale`` is ``exp(mu)``.
+
+    The support is ``x > 0``; ``pdf`` and ``cdf`` are ``0`` and ``sf`` is ``1`` for ``x <= 0``, matching scipy.
+
+    Arguments:
+        mu: Location of the underlying normal (mean of ``ln(X)``). Either a Python ``float`` or an
+            ``IntoExprColumn`` (``pl.Expr``, ``pl.Series`` or column name ``str``) carrying one value per row.
+        sigma: Scale of the underlying normal (std-dev of ``ln(X)``), with ``sigma > 0``. Same accepted types as ``mu``.
+
+    An invalid parameterisation (``sigma <= 0`` or a non-finite parameter) is not checked at construction;
+    it raises ``InvalidOperation`` (a ``ComputeError``) when any method is evaluated.
+
+    Null parameters propagate to null.
+    """
+
+    _mu: pl.Expr
+    _sigma: pl.Expr
+    _sample_dtype: ClassVar[PolarsDataType] = pl.Float64()
+
+    def __init__(self, mu: float | IntoExprColumn = 0.0, sigma: float | IntoExprColumn = 1.0) -> None:
+        self._mu = coerce_param(mu, name="mu")
+        self._sigma = coerce_param(sigma, name="sigma")
+
+    def _value_plugin(self, function_name: str, value: pl.Expr) -> pl.Expr:
+        """Register a value-keyed Rust plugin call ``f(value, mu, sigma)``.
+
+        Validation of ``sigma`` happens inside the plugin, so every value-keyed method reports an
+        invalid parameterisation consistently; null inputs propagate per row.
+        """
+        return register_plugin(function_name, (value, self._mu, self._sigma))
+
+    @property
+    def _checked_sigma(self) -> pl.Expr:
+        """``sigma`` validated in Rust against the full ``(mu, sigma)`` parameterisation."""
+        # Mirrors ``Normal._checked_std_dev`` / ``Uniform.range``: the closed-form moments derive from
+        # this single FFI round-trip, so they report an invalid parameterisation (``sigma <= 0``, or a
+        # non-finite parameter) as a ``ComputeError`` consistently with the value-keyed methods. Null in
+        # either parameter propagates to null, so a moment built on this nulls when either input is null.
+        return register_plugin("lognormal_sigma", (self._mu, self._sigma))
+
+    def _valid_mask(self) -> pl.Expr:
+        # Only null parameters are masked to a null array here; an invalid `sigma` raises in the plugin.
+        return self._mu.is_not_null() & self._sigma.is_not_null()
+
+    def sample(self, seed: int | None = None) -> pl.Expr:
+        """Draw one LogNormal sample per row, returning a ``Float64`` column.
+
+        Output length follows the surrounding context (frame length under ``select`` / ``with_columns``, partition
+        length under ``over`` / ``group_by``). Each row's draw is derived from a per-row sub-seed mixed from ``seed``
+        and the row's position, so the result is independent of Polars chunking and thread scheduling.
+        Rows with an invalid ``sigma`` raise; rows with a null parameter yield null.
+        """
+        return register_plugin("lognormal_sample", (self._mu, self._sigma, row_index_expr()), kwargs={"seed": seed})
+
+    def _pdf(self, value: pl.Expr) -> pl.Expr:
+        """Density via native ``statrs`` ``Continuous::pdf`` (``0`` for ``value <= 0``)."""
+        return self._value_plugin("lognormal_pdf", value)
+
+    def _log_pdf(self, value: pl.Expr) -> pl.Expr:
+        """Log-density via native ``Continuous::ln_pdf`` (more accurate than ``pdf().log()``)."""
+        return self._value_plugin("lognormal_ln_pdf", value)
+
+    def _cdf(self, value: pl.Expr) -> pl.Expr:
+        """Cumulative distribution via native ``ContinuousCDF::cdf`` (``0`` for ``value <= 0``)."""
+        return self._value_plugin("lognormal_cdf", value)
+
+    def _sf(self, value: pl.Expr) -> pl.Expr:
+        """Survival function via native ``ContinuousCDF::sf`` (accurate in the upper tail).
+
+        ``log_sf`` and ``isf`` inherit the base-class defaults, which compose this native ``sf`` and
+        ``ppf`` rather than the generic ``1 - cdf`` fallback.
+        """
+        return self._value_plugin("lognormal_sf", value)
+
+    def _ppf(self, quantile: pl.Expr) -> pl.Expr:
+        """Inverse cdf via the closed-form ``ContinuousCDF::inverse_cdf``.
+
+        A quantile outside ``[0, 1]`` yields null; the endpoints map to the support boundaries
+        (``ppf(0) = 0``, ``ppf(1) = +inf``), matching scipy.
+        """
+        return self._value_plugin("lognormal_ppf", quantile)
+
+    def _moment(self, value: pl.Expr) -> pl.Expr:
+        """Gate a closed-form moment on a non-null, valid ``(mu, sigma)`` parameterisation.
+
+        Evaluating ``_checked_sigma`` validates ``sigma`` in Rust (raising on ``sigma <= 0`` or a non-finite parameter)
+        and is null when ``sigma`` is null; the ``mu`` term propagates a null ``mu``. So every moment nulls on either
+        null input and raises identically on an invalid parameterisation, matching ``Normal._moment``.
+        Validation lives in the gate, so ``value`` can read the raw ``self._mu`` / ``self._sigma`` without
+        re-validating.
+        """
+        return pl.when(self._checked_sigma.is_not_null() & self._mu.is_not_null()).then(value)
+
+    def mean(self) -> pl.Expr:
+        """Expected value, ``exp(mu + sigma ** 2 / 2)``."""
+        return self._moment((self._mu + self._sigma**2 / 2).exp())
+
+    def variance(self) -> pl.Expr:
+        """Variance, ``(exp(sigma ** 2) - 1) * exp(2 * mu + sigma ** 2)``."""
+        return self._moment(((self._sigma**2).exp() - 1) * (2 * self._mu + self._sigma**2).exp())
+
+    def median(self) -> pl.Expr:
+        """Median, ``exp(mu)``."""
+        return self._moment(self._mu.exp())
+
+    def entropy(self) -> pl.Expr:
+        """Differential entropy, ``mu + 0.5 * log(2 * pi * e * sigma ** 2)``."""
+        return self._moment(self._mu + 0.5 * (_TWO_PI_E * self._sigma**2).log())

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -1,0 +1,178 @@
+#![allow(clippy::unused_unit)]
+use polars::prelude::arity::{try_binary_elementwise, try_ternary_elementwise};
+use polars::prelude::*;
+use pyo3_polars::derive::polars_expr;
+use rand::distributions::Distribution as RandDistribution;
+use statrs::distribution::{Continuous, ContinuousCDF, LogNormal};
+
+use crate::rng::SampleKwargs;
+
+/// Construct a `statrs::LogNormal`, mapping the invalid-parameter case to a `ComputeError`.
+///
+/// `statrs::LogNormal::new` rejects a `NaN` `mu`, a `NaN` `sigma`, or `sigma <= 0`. We surface that
+/// as `InvalidOperation` so an invalid parameterisation fails the whole evaluation, rather than
+/// silently nulling the row. Validation lives here so every method that builds a distribution
+/// reports it identically.
+fn build_dist(mu: f64, sigma: f64) -> PolarsResult<LogNormal> {
+    LogNormal::new(mu, sigma).map_err(|e| {
+        PolarsError::InvalidOperation(
+            format!(
+                "sigma must be finite and strictly positive (mu must be finite), got mu={mu}, sigma={sigma}: {e}"
+            )
+            .into(),
+        )
+    })
+}
+
+/// Apply a value-keyed function `f(dist, value)` element-wise over `(value, mu, sigma)`.
+///
+/// `inputs[0]` is the evaluation point, `inputs[1]` is `mu`, `inputs[2]` is `sigma`. `null` in any
+/// input propagates to `null`; an invalid parameterisation raises via [`build_dist`]. `f` returns an
+/// `Option` so a method can null a row on its own terms (e.g. `ppf` outside `[0, 1]`). Shared by
+/// `pdf`, `ln_pdf`, `cdf`, `sf`, `ppf`.
+fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
+where
+    F: Fn(&LogNormal, f64) -> Option<f64>,
+{
+    let value = inputs[0].cast(&DataType::Float64)?;
+    let value_ca = value.f64()?;
+    let mu = inputs[1].cast(&DataType::Float64)?;
+    let mu_ca = mu.f64()?;
+    let sigma = inputs[2].cast(&DataType::Float64)?;
+    let sigma_ca = sigma.f64()?;
+    let name = inputs[0].name().clone();
+
+    let ca: Float64Chunked = try_ternary_elementwise(
+        value_ca,
+        mu_ca,
+        sigma_ca,
+        |value_opt, mu_opt, sigma_opt| -> PolarsResult<Option<f64>> {
+            match (value_opt, mu_opt, sigma_opt) {
+                (Some(v), Some(m), Some(s)) => {
+                    let dist = build_dist(m, s)?;
+                    Ok(f(&dist, v))
+                },
+                _ => Ok(None),
+            }
+        },
+    )?;
+
+    Ok(ca.with_name(name).into_series())
+}
+
+/// Validate the `(mu, sigma)` parameterisation and return the validated `sigma`.
+///
+/// `inputs[0]` is `mu`, `inputs[1]` is `sigma`. Mirrors `normal_std_dev` / `uniform_range`: the
+/// closed-form moments (`mean`, `variance`, `median`, `entropy`) are computed in Python and all
+/// derive from this single FFI round-trip, so they report an invalid parameterisation identically to
+/// the value-keyed methods that build the distribution directly. `null` in either input propagates;
+/// a `NaN` `mu` or a non-positive / `NaN` `sigma` raises `InvalidOperation` via [`build_dist`].
+#[polars_expr(output_type=Float64)]
+fn lognormal_sigma(inputs: &[Series]) -> PolarsResult<Series> {
+    let mu = inputs[0].cast(&DataType::Float64)?;
+    let mu_ca = mu.f64()?;
+    let sigma = inputs[1].cast(&DataType::Float64)?;
+    let sigma_ca = sigma.f64()?;
+    let name = inputs[1].name().clone();
+
+    let ca: Float64Chunked = try_binary_elementwise(
+        mu_ca,
+        sigma_ca,
+        |mu_opt, sigma_opt| -> PolarsResult<Option<f64>> {
+            match (mu_opt, sigma_opt) {
+                (Some(m), Some(s)) => {
+                    build_dist(m, s)?;
+                    Ok(Some(s))
+                },
+                _ => Ok(None),
+            }
+        },
+    )?;
+
+    Ok(ca.with_name(name).into_series())
+}
+
+/// Element-wise LogNormal sampler.
+///
+/// `inputs[0]` carries `mu`, `inputs[1]` `sigma`, and `inputs[2]` a per-row index used to derive a
+/// per-row sub-seed, so the function is genuinely element-wise: chunking and threading cannot change
+/// the output. With `seed=None`, a fresh root seed is drawn once per call.
+///
+/// Per-row validation:
+///   * `null` (in any input) propagates;
+///   * a `NaN` `mu`, or a non-positive / `NaN` `sigma`, raises `InvalidOperation`.
+///
+/// Returns a `Float64` series.
+#[polars_expr(output_type=Float64)]
+fn lognormal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
+    let mu = inputs[0].cast(&DataType::Float64)?;
+    let mu_ca = mu.f64()?;
+    let sigma = inputs[1].cast(&DataType::Float64)?;
+    let sigma_ca = sigma.f64()?;
+    let index = inputs[2].cast(&DataType::UInt64)?;
+    let index_ca = index.u64()?;
+    let name = inputs[0].name().clone();
+
+    let rngs = kwargs.row_rngs();
+
+    let ca: Float64Chunked = try_ternary_elementwise(
+        mu_ca,
+        sigma_ca,
+        index_ca,
+        |mu_opt, sigma_opt, i_opt| -> PolarsResult<Option<f64>> {
+            match (mu_opt, sigma_opt, i_opt) {
+                (Some(m), Some(s), Some(i)) => {
+                    let dist = build_dist(m, s)?;
+                    let mut rng = rngs.rng(i);
+                    let draw: f64 = RandDistribution::sample(&dist, &mut rng);
+                    Ok(Some(draw))
+                },
+                _ => Ok(None),
+            }
+        },
+    )?;
+
+    Ok(ca.with_name(name).into_series())
+}
+
+/// Element-wise pdf via `statrs` `Continuous::pdf`; `0` for `value <= 0` (outside the support).
+/// See [`value_keyed`] for the null/error contract.
+#[polars_expr(output_type=Float64)]
+fn lognormal_pdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, |dist, v| Some(dist.pdf(v)))
+}
+
+/// Element-wise log-pdf via native `Continuous::ln_pdf` (more accurate than `pdf().ln()`);
+/// `-inf` for `value <= 0`.
+#[polars_expr(output_type=Float64)]
+fn lognormal_ln_pdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, |dist, v| Some(dist.ln_pdf(v)))
+}
+
+/// Element-wise cdf via `statrs` `ContinuousCDF::cdf`; `0` for `value <= 0`.
+#[polars_expr(output_type=Float64)]
+fn lognormal_cdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, |dist, v| Some(dist.cdf(v)))
+}
+
+/// Element-wise survival function via native `ContinuousCDF::sf` (accurate in the upper tail);
+/// `1` for `value <= 0`.
+#[polars_expr(output_type=Float64)]
+fn lognormal_sf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, |dist, v| Some(dist.sf(v)))
+}
+
+/// Element-wise ppf (inverse cdf) via the closed-form `ContinuousCDF::inverse_cdf`.
+///
+/// A quantile outside `[0, 1]` yields `null` (guarding the `statrs` panic). The closed endpoints map
+/// to the support boundaries (`ppf(0) = 0`, `ppf(1) = +inf`), matching `scipy.stats.lognorm.ppf`.
+#[polars_expr(output_type=Float64)]
+fn lognormal_ppf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, |dist, q| {
+        if !(0.0..=1.0).contains(&q) {
+            None
+        } else {
+            Some(dist.inverse_cdf(q))
+        }
+    })
+}

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -1,3 +1,4 @@
 pub mod bernoulli;
+pub mod lognormal;
 pub mod normal;
 pub mod uniform;

--- a/tests/distributions/lognormal/cdf_test.py
+++ b/tests/distributions/lognormal/cdf_test.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import LogNormal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def test_cdf_is_half_at_median(params: tuple[float, float]) -> None:
+    mu, sigma = params
+    median = math.exp(mu)
+    result = pl.DataFrame({"x": [median]}).select(r=LogNormal(mu=mu, sigma=sigma).cdf(pl.col("x")))["r"].item()
+    assert result == pytest.approx(0.5, abs=1e-12)
+
+
+def test_cdf_is_monotone_non_decreasing(
+    params: tuple[float, float], value_grid: Callable[[float, float], list[float]]
+) -> None:
+    mu, sigma = params
+    xs = value_grid(mu, sigma)
+    result = pl.DataFrame({"x": xs}).select(r=LogNormal(mu=mu, sigma=sigma).cdf(pl.col("x")))["r"]
+    assert result.is_sorted()
+    assert result.is_between(0.0, 1.0).all()
+
+
+def test_cdf_column_params() -> None:
+    # x = exp(mu) is the median, so cdf = 0.5 regardless of sigma.
+    df = pl.DataFrame({"mu": [0.0, 1.0], "sigma": [1.0, 0.5], "x": [1.0, math.e]})
+    result = df.select(r=LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")).cdf(pl.col("x")))["r"]
+    expected = pl.Series("r", [0.5, 0.5], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_cdf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"x": [1.0, None]}, schema={"x": pl.Float64})
+    result = df.select(r=LogNormal().cdf(pl.col("x")))["r"]
+    expected = pl.Series("r", [0.5, None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/lognormal/conftest.py
+++ b/tests/distributions/lognormal/conftest.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import polars as pl
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+SEED = 42
+DEFAULT_SIZE = 1000
+
+# `(mu, sigma)` grid exposed through the `params` fixture so no test file redeclares it. `sigma` is
+# kept moderate: the LogNormal mean/variance grow exponentially in `sigma` and lose absolute
+# precision against scipy past `sigma > 5` (see the issue caveat).
+PARAMS = [(0.0, 1.0), (0.5, 0.5), (-1.0, 0.25), (1.0, 0.75), (0.0, 0.1)]
+
+
+@pytest.fixture(scope="session")
+def seed() -> int:
+    return SEED
+
+
+@pytest.fixture(params=PARAMS, ids=[f"mu={m},sigma={s}" for m, s in PARAMS])
+def params(request: pytest.FixtureRequest) -> tuple[float, float]:
+    """A `(mu, sigma)` pair. Requesting this fixture parametrises the test over `PARAMS`."""
+    return request.param  # type: ignore[no-any-return]
+
+
+@pytest.fixture
+def frame() -> Callable[..., pl.DataFrame]:
+    """Factory for a frame with an `x` column and per-row `mu` / `sigma` (`sigma > 0`) parameters.
+
+    Seeds a fresh generator on every call, so the data is reproducible regardless of test execution
+    order, selection (`-k`) or sharding, rather than depending on a shared session-scoped stream.
+    """
+
+    def _make(size: int = DEFAULT_SIZE) -> pl.DataFrame:
+        local_rng = np.random.default_rng(seed=SEED)
+        mu = local_rng.uniform(-2.0, 2.0, size=size)
+        sigma = local_rng.uniform(0.25, 2.0, size=size)
+        return pl.DataFrame({"x": list(range(size)), "mu": mu, "sigma": sigma})
+
+    return _make
+
+
+@pytest.fixture
+def value_grid() -> Callable[[float, float], list[float]]:
+    """Evaluation points on the positive support of a `(mu, sigma)` LogNormal, spanning both tails.
+
+    Geometric around the median `exp(mu)`, so the grid tracks the distribution's scale.
+    """
+
+    def _make(mu: float, sigma: float) -> list[float]:
+        return [float(np.exp(mu + k * sigma)) for k in (-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0)]
+
+    return _make

--- a/tests/distributions/lognormal/conftest.py
+++ b/tests/distributions/lognormal/conftest.py
@@ -54,7 +54,7 @@ def value_grid() -> Callable[[float, float], list[float]]:
     """
 
     def _make(mu: float, sigma: float) -> list[float]:
-        ks = np.array([-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0])
-        return np.exp(mu + ks * sigma).tolist()
+        ks = pl.Series([-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0])
+        return (mu + ks * sigma).exp().to_list()
 
     return _make

--- a/tests/distributions/lognormal/conftest.py
+++ b/tests/distributions/lognormal/conftest.py
@@ -54,6 +54,7 @@ def value_grid() -> Callable[[float, float], list[float]]:
     """
 
     def _make(mu: float, sigma: float) -> list[float]:
-        return [float(np.exp(mu + k * sigma)) for k in (-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0)]
+        ks = np.array([-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0])
+        return np.exp(mu + ks * sigma).tolist()
 
     return _make

--- a/tests/distributions/lognormal/construct_test.py
+++ b/tests/distributions/lognormal/construct_test.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from polars_stats import LogNormal
+
+
+@pytest.mark.parametrize("bad", [None, True, False, 1, 0, [0.0, 1.0], (0.0,), {"mu": 0.0}])
+def test_construct_invalid_mu_type_raises(bad: object) -> None:
+    with pytest.raises(TypeError, match="mu should be a float or IntoExprColumn"):
+        LogNormal(mu=bad, sigma=1.0)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("bad", [None, True, False, 1, 0, [1.0], (1.0,), {"sigma": 1.0}])
+def test_construct_invalid_sigma_type_raises(bad: object) -> None:
+    with pytest.raises(TypeError, match="sigma should be a float or IntoExprColumn"):
+        LogNormal(mu=0.0, sigma=bad)  # type: ignore[arg-type]
+
+
+def test_construct_defaults_to_standard_lognormal() -> None:
+    # Default mu=0, sigma=1: median is exp(0) = 1, so cdf(1) = 0.5.
+    result = pl.DataFrame({"x": [1.0]}).select(r=LogNormal().cdf(pl.col("x")))["r"].item()
+    assert result == pytest.approx(0.5, abs=1e-12)
+
+
+@pytest.mark.parametrize("bad_sigma", [0.0, -1.0, -1e-9])
+def test_construct_scalar_non_positive_sigma_defers_to_eval(bad_sigma: float) -> None:
+    # No early Python validation (matching Bernoulli / Uniform / Normal): construction succeeds; the
+    # invalid scale surfaces as a ComputeError when a method is evaluated, not a ValueError here.
+    LogNormal(mu=0.0, sigma=bad_sigma)
+    with pytest.raises(pl.exceptions.ComputeError, match="sigma must be finite and strictly positive"):
+        pl.DataFrame({"x": [0.5]}).select(r=LogNormal(mu=0.0, sigma=bad_sigma).pdf(pl.col("x")))
+
+
+def test_construct_column_params_defers_validation() -> None:
+    # A non-positive sigma on a column is not knowable at construction; it must not raise here.
+    LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma"))
+    LogNormal(mu="mu", sigma="sigma")

--- a/tests/distributions/lognormal/entropy_test.py
+++ b/tests/distributions/lognormal/entropy_test.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+from polars.testing import assert_series_equal
+
+from polars_stats import LogNormal
+
+
+def _entropy(mu: float, sigma: float) -> float:
+    # Differential entropy of a LogNormal: mu + 0.5 * log(2 * pi * e * sigma^2).
+    return mu + 0.5 * math.log(2.0 * math.pi * math.e * sigma**2)
+
+
+def test_entropy_is_log_form_column_params() -> None:
+    mus = [0.0, -1.0, 1.0]
+    sigmas = [1.0, 0.25, 0.75]
+    df = pl.DataFrame({"mu": mus, "sigma": sigmas})
+    result = df.select(r=LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")).entropy())["r"]
+    expected = pl.Series("r", [_entropy(m, s) for m, s in zip(mus, sigmas, strict=True)], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_entropy_propagates_null_params() -> None:
+    df = pl.DataFrame(
+        {"mu": [0.0, None, 1.0], "sigma": [1.0, 2.0, None]}, schema={"mu": pl.Float64, "sigma": pl.Float64}
+    )
+    result = df.select(r=LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")).entropy())["r"]
+    expected = pl.Series("r", [_entropy(0.0, 1.0), None, None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/lognormal/isf_test.py
+++ b/tests/distributions/lognormal/isf_test.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+from polars.testing import assert_series_equal
+
+from polars_stats import LogNormal
+
+
+def test_isf_equals_ppf_of_complement(params: tuple[float, float]) -> None:
+    mu, sigma = params
+    qs = [0.05, 0.25, 0.5, 0.75, 0.95]
+    d = LogNormal(mu=mu, sigma=sigma)
+    isf = pl.DataFrame({"q": qs}).select(r=d.isf(pl.col("q")))["r"].to_numpy()
+    ppf_comp = pl.DataFrame({"q": [1 - q for q in qs]}).select(r=d.ppf(pl.col("q")))["r"].to_numpy()
+    np.testing.assert_allclose(isf, ppf_comp, atol=1e-12, rtol=0)
+
+
+def test_isf_endpoints_map_to_support_boundaries() -> None:
+    # isf(0) = ppf(1) = +inf, isf(1) = ppf(0) = 0.
+    df = pl.DataFrame({"q": [0.0, 1.0]})
+    result = df.select(r=LogNormal().isf(pl.col("q")))["r"]
+    expected = pl.Series("r", [float("inf"), 0.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_isf_out_of_range_is_null() -> None:
+    df = pl.DataFrame({"q": [-0.1, 0.0, 1.0, 1.1]})
+    result = df.select(r=LogNormal().isf(pl.col("q")))["r"]
+    expected = pl.Series("r", [None, float("inf"), 0.0, None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/lognormal/log_cdf_test.py
+++ b/tests/distributions/lognormal/log_cdf_test.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+import polars as pl
+from polars.testing import assert_series_equal
+
+from polars_stats import LogNormal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def test_log_cdf_equals_log_of_cdf(value_grid: Callable[[float, float], list[float]]) -> None:
+    mu, sigma = 0.5, 1.0
+    xs = value_grid(mu, sigma)
+    d = LogNormal(mu=mu, sigma=sigma)
+    out = pl.DataFrame({"x": xs}).select(diff=d.log_cdf(pl.col("x")) - d.cdf(pl.col("x")).log())["diff"]
+    np.testing.assert_allclose(out.to_numpy(), 0.0, atol=1e-12, rtol=0)
+
+
+def test_log_cdf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"x": [1.0, None]}, schema={"x": pl.Float64})
+    result = df.select(r=LogNormal().log_cdf(pl.col("x")))["r"]
+    expected = pl.Series("r", [math.log(0.5), None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/lognormal/log_pdf_test.py
+++ b/tests/distributions/lognormal/log_pdf_test.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+import polars as pl
+from polars.testing import assert_series_equal
+
+from polars_stats import LogNormal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def test_log_pdf_equals_log_of_pdf(value_grid: Callable[[float, float], list[float]]) -> None:
+    mu, sigma = 0.5, 1.0
+    xs = value_grid(mu, sigma)
+    d = LogNormal(mu=mu, sigma=sigma)
+    out = pl.DataFrame({"x": xs}).select(diff=d.log_pdf(pl.col("x")) - d.pdf(pl.col("x")).log())["diff"]
+    np.testing.assert_allclose(out.to_numpy(), 0.0, atol=1e-12, rtol=0)
+
+
+def test_log_pdf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"x": [1.0, None]}, schema={"x": pl.Float64})
+    result = df.select(r=LogNormal().log_pdf(pl.col("x")))["r"]
+    expected = pl.Series("r", [math.log(1.0 / math.sqrt(2.0 * math.pi)), None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/lognormal/log_sf_test.py
+++ b/tests/distributions/lognormal/log_sf_test.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+import polars as pl
+from polars.testing import assert_series_equal
+
+from polars_stats import LogNormal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def test_log_sf_equals_log_of_sf(value_grid: Callable[[float, float], list[float]]) -> None:
+    mu, sigma = 0.5, 1.0
+    xs = value_grid(mu, sigma)
+    d = LogNormal(mu=mu, sigma=sigma)
+    out = pl.DataFrame({"x": xs}).select(diff=d.log_sf(pl.col("x")) - d.sf(pl.col("x")).log())["diff"]
+    np.testing.assert_allclose(out.to_numpy(), 0.0, atol=1e-12, rtol=0)
+
+
+def test_log_sf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"x": [1.0, None]}, schema={"x": pl.Float64})
+    result = df.select(r=LogNormal().log_sf(pl.col("x")))["r"]
+    expected = pl.Series("r", [math.log(0.5), None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/lognormal/mean_test.py
+++ b/tests/distributions/lognormal/mean_test.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+from polars.testing import assert_series_equal
+
+from polars_stats import LogNormal
+
+
+def test_mean_is_exp_formula_column_params() -> None:
+    mus = [0.0, -1.0, 1.0]
+    sigmas = [1.0, 0.25, 0.75]
+    df = pl.DataFrame({"mu": mus, "sigma": sigmas})
+    result = df.select(r=LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")).mean())["r"]
+    expected = pl.Series("r", [math.exp(m + s**2 / 2.0) for m, s in zip(mus, sigmas, strict=True)], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_mean_propagates_null_params() -> None:
+    df = pl.DataFrame(
+        {"mu": [0.0, None, 1.0], "sigma": [1.0, 2.0, None]}, schema={"mu": pl.Float64, "sigma": pl.Float64}
+    )
+    result = df.select(r=LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")).mean())["r"]
+    expected = pl.Series("r", [math.exp(0.5), None, None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/lognormal/median_test.py
+++ b/tests/distributions/lognormal/median_test.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+from polars.testing import assert_series_equal
+
+from polars_stats import LogNormal
+
+
+def test_median_is_exp_mu_column_params() -> None:
+    mus = [0.0, -1.0, 1.0]
+    df = pl.DataFrame({"mu": mus, "sigma": [1.0, 0.25, 0.75]})
+    result = df.select(r=LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")).median())["r"]
+    expected = pl.Series("r", [math.exp(m) for m in mus], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_median_propagates_null_params() -> None:
+    df = pl.DataFrame(
+        {"mu": [0.0, None, 1.0], "sigma": [1.0, 2.0, None]}, schema={"mu": pl.Float64, "sigma": pl.Float64}
+    )
+    result = df.select(r=LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")).median())["r"]
+    expected = pl.Series("r", [1.0, None, None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/lognormal/pdf_test.py
+++ b/tests/distributions/lognormal/pdf_test.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import LogNormal
+
+
+def test_pdf_standard_lognormal_at_one() -> None:
+    # For LogNormal(0, 1): pdf(1) = 1 / (1 * sqrt(2*pi) * 1) = 1 / sqrt(2*pi).
+    result = pl.DataFrame({"x": [1.0]}).select(r=LogNormal().pdf(pl.col("x")))["r"].item()
+    assert result == pytest.approx(1.0 / math.sqrt(2.0 * math.pi), abs=1e-12)
+
+
+def test_pdf_column_params() -> None:
+    df = pl.DataFrame({"mu": [0.0, 0.0], "sigma": [1.0, 0.5], "x": [1.0, 1.0]})
+    result = df.select(r=LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")).pdf(pl.col("x")))["r"]
+    # At x = exp(mu) = 1 the density is 1 / (sigma * sqrt(2*pi)).
+    expected = pl.Series(
+        "r",
+        [1.0 / math.sqrt(2.0 * math.pi), 1.0 / (0.5 * math.sqrt(2.0 * math.pi))],
+        dtype=pl.Float64,
+    )
+    assert_series_equal(result, expected)
+
+
+def test_pdf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"x": [1.0, None, math.e]}, schema={"x": pl.Float64})
+    result = df.select(r=LogNormal().pdf(pl.col("x")))["r"]
+    expected = pl.Series(
+        "r",
+        [1.0 / math.sqrt(2.0 * math.pi), None, math.exp(-0.5) / (math.e * math.sqrt(2.0 * math.pi))],
+        dtype=pl.Float64,
+    )
+    assert_series_equal(result, expected)

--- a/tests/distributions/lognormal/ppf_test.py
+++ b/tests/distributions/lognormal/ppf_test.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import LogNormal
+
+
+def test_ppf_at_half_is_median(params: tuple[float, float]) -> None:
+    mu, sigma = params
+    result = pl.DataFrame({"q": [0.5]}).select(r=LogNormal(mu=mu, sigma=sigma).ppf(pl.col("q")))["r"].item()
+    assert result == pytest.approx(math.exp(mu), abs=1e-12)
+
+
+def test_ppf_is_cdf_inverse(params: tuple[float, float]) -> None:
+    mu, sigma = params
+    interior = [0.05, 0.25, 0.5, 0.75, 0.95]
+    d = LogNormal(mu=mu, sigma=sigma)
+    out = pl.DataFrame({"q": interior}).select(r=d.cdf(d.ppf(pl.col("q"))))["r"]
+    np.testing.assert_allclose(out.to_numpy(), interior, atol=1e-9, rtol=0)
+
+
+def test_ppf_endpoints_map_to_support_boundaries() -> None:
+    # The support is (0, inf): ppf(0) = 0, ppf(1) = +inf (matching scipy.stats.lognorm.ppf).
+    df = pl.DataFrame({"q": [0.0, 1.0]})
+    result = df.select(r=LogNormal().ppf(pl.col("q")))["r"]
+    expected = pl.Series("r", [0.0, float("inf")], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_ppf_out_of_range_is_null() -> None:
+    df = pl.DataFrame({"q": [-0.1, 0.0, 0.5, 1.0, 1.1]})
+    result = df.select(r=LogNormal().ppf(pl.col("q")))["r"]
+    expected = pl.Series("r", [None, 0.0, 1.0, float("inf"), None], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_ppf_propagates_null_in_quantile() -> None:
+    df = pl.DataFrame({"q": [0.5, None]}, schema={"q": pl.Float64})
+    result = df.select(r=LogNormal(mu=2.0, sigma=1.0).ppf(pl.col("q")))["r"]
+    expected = pl.Series("r", [math.exp(2.0), None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/lognormal/sample_test.py
+++ b/tests/distributions/lognormal/sample_test.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal, assert_series_not_equal
+
+from polars_stats import LogNormal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@pytest.mark.parametrize("size", [0, 100, 1_000])
+def test_sample_basic_properties(size: int, frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    result = frame(size=size).lazy().with_columns(z=LogNormal().sample(seed=seed))
+    assert result.collect_schema()["z"] == pl.Float64
+    assert result.collect().height == size
+
+
+def test_sample_is_positive(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    # The LogNormal support is (0, inf): every draw is strictly positive.
+    s = frame(size=10_000).with_columns(z=LogNormal(mu=0.0, sigma=1.5).sample(seed=seed))["z"]
+    assert s.min() > 0.0  # type: ignore[operator]
+
+
+def test_sample_seed_reproducible(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    dframe = frame()
+    s1 = dframe.with_columns(z=LogNormal(mu=1.0, sigma=2.0).sample(seed=seed))["z"]
+    s2 = dframe.with_columns(z=LogNormal(mu=1.0, sigma=2.0).sample(seed=seed))["z"]
+    assert_series_equal(s1, s2)
+
+
+def test_sample_different_seeds_differ(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    dframe = frame()
+    s1 = dframe.with_columns(z=LogNormal().sample(seed=123))["z"]
+    s2 = dframe.with_columns(z=LogNormal().sample(seed=seed))["z"]
+    assert_series_not_equal(s1, s2)
+
+
+@pytest.mark.parametrize(("mu", "sigma"), [(0.0, 1.0), (-1.0, 0.5), (1.0, 0.75)])
+def test_sample_log_moments_close_for_large_n(
+    mu: float, sigma: float, frame: Callable[..., pl.DataFrame], seed: int
+) -> None:
+    # ln(X) is Normal(mu, sigma); checking the log-space moments avoids the heavy-tailed convergence
+    # of the raw LogNormal mean / std.
+    s = frame(size=200_000).with_columns(z=LogNormal(mu=mu, sigma=sigma).sample(seed=seed))["z"]
+    logs = s.log()
+    observed_mean = logs.mean()
+    observed_std = logs.std()
+    assert isinstance(observed_mean, float)
+    assert isinstance(observed_std, float)
+    assert abs(observed_mean - mu) < 0.02 * sigma
+    assert abs(observed_std - sigma) < 0.02 * sigma
+
+
+def test_sample_column_params_log_moments_per_row(seed: int) -> None:
+    size = 200_000
+    mu, sigma = 0.5, 0.75
+    dframe = pl.DataFrame({"mu": [mu] * size, "sigma": [sigma] * size})
+    s = dframe.with_columns(z=LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")).sample(seed=seed))["z"]
+    logs = s.log()
+    assert abs(logs.mean() - mu) < 0.02 * sigma  # type: ignore[operator]
+    assert abs(logs.std() - sigma) < 0.02 * sigma  # type: ignore[operator]
+
+
+def test_sample_str_params_match_col(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    dframe = frame()
+    s_str = dframe.with_columns(z=LogNormal(mu="mu", sigma="sigma").sample(seed=seed))["z"]
+    s_col = dframe.with_columns(z=LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")).sample(seed=seed))["z"]
+    assert_series_equal(s_str, s_col)
+
+
+def test_sample_null_param_row_is_null(seed: int) -> None:
+    dframe = pl.DataFrame(
+        {"mu": [0.0, None, -1.0], "sigma": [1.0, 2.0, None]},
+        schema={"mu": pl.Float64, "sigma": pl.Float64},
+    )
+    result = dframe.with_columns(z=LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")).sample(seed=seed))["z"]
+    assert_series_equal(result.is_null(), pl.Series("z", [False, True, True]))
+
+
+def test_sample_non_positive_sigma_row_raises(seed: int) -> None:
+    # An invalid scale on a row raises (no early Python validation). Plugin errors surface as `ComputeError`.
+    dframe = pl.DataFrame({"mu": [0.0, 1.0, -1.0], "sigma": [1.0, -2.0, 3.0]})  # row 1: sigma = -2.0
+    with pytest.raises(pl.exceptions.ComputeError, match="sigma must be finite and strictly positive"):
+        dframe.with_columns(z=LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")).sample(seed=seed))
+
+
+def test_sample_in_group_by_draws_per_group(seed: int) -> None:
+    n_per_group, n_groups = 200, 20
+    dframe = pl.DataFrame({"group": np.repeat(np.arange(n_groups), n_per_group)})
+    agg = (
+        dframe.group_by("group", maintain_order=True)
+        .agg(mean_z=LogNormal().sample(seed=seed).mean(), size=pl.len())
+        .sort("group")
+    )
+    assert agg["size"].eq(n_per_group).all()
+    # Constant params + constant seed + same per-group indices => identical per-group means.
+    assert len(set(agg["mean_z"].to_list())) == 1
+
+
+def test_sample_over_partitions_full_length(seed: int) -> None:
+    n_per_group, n_groups = 200, 10
+    dframe = pl.DataFrame({"group": np.repeat(np.arange(n_groups), n_per_group)})
+    s1 = dframe.with_columns(z=LogNormal().sample(seed=seed).over("group"))["z"]
+    s2 = dframe.with_columns(z=LogNormal().sample(seed=seed).over("group"))["z"]
+    assert s1.len() == n_groups * n_per_group
+    assert_series_equal(s1, s2)
+
+
+def test_sample_unseeded_produces_variability(frame: Callable[..., pl.DataFrame]) -> None:
+    dframe = frame(size=512)
+    s1 = dframe.with_columns(z=LogNormal().sample(seed=None))["z"]
+    s2 = dframe.with_columns(z=LogNormal().sample(seed=None))["z"]
+    assert_series_not_equal(s1, s2)
+
+
+def test_sample_rows_are_independent_no_aliasing(seed: int) -> None:
+    # Each row derives its stream from `(seed, row_index)`, so even with constant params and a fixed
+    # seed every row must draw an independent value.
+    size = 50_000
+    s = pl.DataFrame({"x": range(size)}).with_columns(z=LogNormal().sample(seed=seed))["z"]
+    assert s.n_unique() == size

--- a/tests/distributions/lognormal/samples_test.py
+++ b/tests/distributions/lognormal/samples_test.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import LogNormal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@pytest.mark.parametrize("size", [1, 4, 16])
+def test_samples_shape_and_dtype(size: int, frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    n = 32
+    result = frame(size=n).select(s=LogNormal().samples(size=size, seed=seed))
+    assert result.height == n
+    assert result.schema["s"] == pl.Array(pl.Float64, size)
+
+
+def test_samples_seed_reproducible(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    dframe = frame(size=128)
+    s1 = dframe.select(s=LogNormal().samples(size=8, seed=seed))["s"]
+    s2 = dframe.select(s=LogNormal().samples(size=8, seed=seed))["s"]
+    assert_series_equal(s1, s2)
+
+
+def test_samples_columns_are_not_all_equal(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    size = 8
+    dframe = frame(size=512)
+    result = dframe.select(s=LogNormal().samples(size=size, seed=seed))["s"]
+    columns = [result.arr.get(i) for i in range(size)]
+    distinct = {tuple(c.to_list()) for c in columns}
+    assert len(distinct) == size
+
+
+def test_samples_log_moments_close(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    mu, sigma = 0.5, 0.75
+    flat = np.asarray(
+        frame(size=4_000).select(s=LogNormal(mu=mu, sigma=sigma).samples(size=16, seed=seed))["s"].to_list(),
+        dtype=float,
+    ).ravel()
+    logs = np.log(flat)
+    assert abs(logs.mean() - mu) < 0.05 * sigma
+    assert abs(logs.std() - sigma) < 0.05 * sigma
+
+
+@pytest.mark.parametrize("bad_size", [0, -1])
+def test_samples_rejects_non_positive_size(bad_size: int) -> None:
+    with pytest.raises(ValueError, match="size must be a positive integer"):
+        LogNormal().samples(size=bad_size, seed=0)
+
+
+def test_samples_null_param_row_is_null_array(seed: int) -> None:
+    size = 4
+    dframe = pl.DataFrame(
+        {"mu": [0.0, None, 1.0], "sigma": [1.0, 2.0, 3.0]},
+        schema={"mu": pl.Float64, "sigma": pl.Float64},
+    )
+    result = dframe.select(s=LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")).samples(size=size, seed=seed))["s"]
+    assert result.dtype == pl.Array(pl.Float64, size)
+    # A null param row yields a null array, not an array of inner-null elements.
+    assert_series_equal(result.is_null(), pl.Series("s", [False, True, False]))
+
+
+def test_samples_non_positive_sigma_raises(seed: int) -> None:
+    dframe = pl.DataFrame({"mu": [0.0, 1.0], "sigma": [1.0, -2.0]})  # row 1: sigma = -2.0
+    with pytest.raises(pl.exceptions.ComputeError, match="sigma must be finite and strictly positive"):
+        dframe.select(s=LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")).samples(size=4, seed=seed))

--- a/tests/distributions/lognormal/sf_test.py
+++ b/tests/distributions/lognormal/sf_test.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import LogNormal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def test_sf_is_half_at_median(params: tuple[float, float]) -> None:
+    mu, sigma = params
+    median = math.exp(mu)
+    result = pl.DataFrame({"x": [median]}).select(r=LogNormal(mu=mu, sigma=sigma).sf(pl.col("x")))["r"].item()
+    assert result == pytest.approx(0.5, abs=1e-12)
+
+
+def test_sf_complements_cdf(params: tuple[float, float], value_grid: Callable[[float, float], list[float]]) -> None:
+    mu, sigma = params
+    xs = value_grid(mu, sigma)
+    d = LogNormal(mu=mu, sigma=sigma)
+    out = pl.DataFrame({"x": xs}).select(total=d.cdf(pl.col("x")) + d.sf(pl.col("x")))["total"]
+    np.testing.assert_allclose(out.to_numpy(), 1.0, atol=1e-12, rtol=0)
+
+
+def test_sf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"x": [1.0, None]}, schema={"x": pl.Float64})
+    result = df.select(r=LogNormal().sf(pl.col("x")))["r"]
+    expected = pl.Series("r", [0.5, None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/lognormal/std_test.py
+++ b/tests/distributions/lognormal/std_test.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+from polars.testing import assert_series_equal
+
+from polars_stats import LogNormal
+
+
+def test_std_is_sqrt_variance_column_params() -> None:
+    mus = [0.0, -1.0, 1.0]
+    sigmas = [1.0, 0.25, 0.75]
+    df = pl.DataFrame({"mu": mus, "sigma": sigmas})
+    result = df.select(r=LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")).std())["r"]
+    expected = pl.Series(
+        "r",
+        [math.sqrt((math.exp(s**2) - 1.0) * math.exp(2.0 * m + s**2)) for m, s in zip(mus, sigmas, strict=True)],
+        dtype=pl.Float64,
+    )
+    assert_series_equal(result, expected)
+
+
+def test_std_propagates_null_params() -> None:
+    df = pl.DataFrame(
+        {"mu": [0.0, None, 1.0], "sigma": [1.0, 2.0, None]}, schema={"mu": pl.Float64, "sigma": pl.Float64}
+    )
+    result = df.select(r=LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")).std())["r"]
+    expected = pl.Series("r", [math.sqrt((math.exp(1.0) - 1.0) * math.exp(1.0)), None, None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/lognormal/support_test.py
+++ b/tests/distributions/lognormal/support_test.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import polars as pl
+from polars.testing import assert_series_equal
+
+from polars_stats import LogNormal
+
+# The LogNormal support is `x > 0`. For `x <= 0` the density and cdf are 0 and the survival function
+# is 1, matching `scipy.stats.lognorm`. The boundary `x == 0` is included in the "outside" branch.
+
+
+def test_pdf_is_zero_at_or_below_zero() -> None:
+    df = pl.DataFrame({"x": [-2.0, -1e-9, 0.0]})
+    result = df.select(r=LogNormal().pdf(pl.col("x")))["r"]
+    assert_series_equal(result, pl.Series("r", [0.0, 0.0, 0.0], dtype=pl.Float64))
+
+
+def test_cdf_is_zero_at_or_below_zero() -> None:
+    df = pl.DataFrame({"x": [-2.0, -1e-9, 0.0]})
+    result = df.select(r=LogNormal().cdf(pl.col("x")))["r"]
+    assert_series_equal(result, pl.Series("r", [0.0, 0.0, 0.0], dtype=pl.Float64))
+
+
+def test_sf_is_one_at_or_below_zero() -> None:
+    df = pl.DataFrame({"x": [-2.0, -1e-9, 0.0]})
+    result = df.select(r=LogNormal().sf(pl.col("x")))["r"]
+    assert_series_equal(result, pl.Series("r", [1.0, 1.0, 1.0], dtype=pl.Float64))
+
+
+def test_log_pdf_is_neg_inf_at_or_below_zero() -> None:
+    df = pl.DataFrame({"x": [-2.0, 0.0]})
+    result = df.select(r=LogNormal().log_pdf(pl.col("x")))["r"]
+    assert_series_equal(result, pl.Series("r", [float("-inf"), float("-inf")], dtype=pl.Float64))

--- a/tests/distributions/lognormal/validation_test.py
+++ b/tests/distributions/lognormal/validation_test.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+
+from polars_stats import LogNormal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Every public method must report an invalid scale (`sigma <= 0`) as a ComputeError, not silently
+# compute garbage or null the row. Each method builds the distribution in Rust via `statrs`, which is
+# what enforces this consistently across the surface, and identically for scalar and column inputs.
+_METHODS: dict[str, Callable[[LogNormal], pl.Expr]] = {
+    "pdf": lambda d: d.pdf(pl.col("x")),
+    "log_pdf": lambda d: d.log_pdf(pl.col("x")),
+    "cdf": lambda d: d.cdf(pl.col("x")),
+    "log_cdf": lambda d: d.log_cdf(pl.col("x")),
+    "sf": lambda d: d.sf(pl.col("x")),
+    "log_sf": lambda d: d.log_sf(pl.col("x")),
+    "ppf": lambda d: d.ppf(pl.col("q")),
+    "isf": lambda d: d.isf(pl.col("q")),
+    "mean": lambda d: d.mean(),
+    "variance": lambda d: d.variance(),
+    "std": lambda d: d.std(),
+    "median": lambda d: d.median(),
+    "entropy": lambda d: d.entropy(),
+    "sample": lambda d: d.sample(seed=0),
+    "samples": lambda d: d.samples(size=4, seed=0),
+}
+
+
+@pytest.mark.parametrize("expr_fn", _METHODS.values(), ids=list(_METHODS))
+def test_method_raises_on_non_positive_sigma_column(expr_fn: Callable[[LogNormal], pl.Expr]) -> None:
+    df = pl.DataFrame({"mu": [0.0, 1.0], "sigma": [1.0, -2.0], "x": [1.5, 1.5], "q": [0.5, 0.5]})
+    d = LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma"))  # row 1: sigma = -2.0
+    with pytest.raises(pl.exceptions.ComputeError, match="sigma must be finite and strictly positive"):
+        df.select(r=expr_fn(d))
+
+
+@pytest.mark.parametrize("expr_fn", _METHODS.values(), ids=list(_METHODS))
+def test_method_raises_on_non_positive_sigma_scalar(expr_fn: Callable[[LogNormal], pl.Expr]) -> None:
+    df = pl.DataFrame({"x": [1.5], "q": [0.5]})
+    d = LogNormal(mu=0.0, sigma=-1.0)
+    with pytest.raises(pl.exceptions.ComputeError, match="sigma must be finite and strictly positive"):
+        df.select(r=expr_fn(d))

--- a/tests/distributions/lognormal/variance_test.py
+++ b/tests/distributions/lognormal/variance_test.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+from polars.testing import assert_series_equal
+
+from polars_stats import LogNormal
+
+
+def test_variance_is_exp_formula_column_params() -> None:
+    mus = [0.0, -1.0, 1.0]
+    sigmas = [1.0, 0.25, 0.75]
+    df = pl.DataFrame({"mu": mus, "sigma": sigmas})
+    result = df.select(r=LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")).variance())["r"]
+    expected = pl.Series(
+        "r",
+        [(math.exp(s**2) - 1.0) * math.exp(2.0 * m + s**2) for m, s in zip(mus, sigmas, strict=True)],
+        dtype=pl.Float64,
+    )
+    assert_series_equal(result, expected)
+
+
+def test_variance_propagates_null_params() -> None:
+    df = pl.DataFrame(
+        {"mu": [0.0, None, 1.0], "sigma": [1.0, 2.0, None]}, schema={"mu": pl.Float64, "sigma": pl.Float64}
+    )
+    result = df.select(r=LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")).variance())["r"]
+    expected = pl.Series("r", [(math.exp(1.0) - 1.0) * math.exp(1.0), None, None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/normal/cdf_test.py
+++ b/tests/distributions/normal/cdf_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import numpy as np
 import polars as pl
 import pytest
 from polars.testing import assert_series_equal
@@ -24,10 +23,9 @@ def test_cdf_is_monotone_non_decreasing(
 ) -> None:
     mean, std = params
     xs = value_grid(mean, std)
-    result = pl.DataFrame({"x": xs}).select(r=Normal(mean=mean, std_dev=std).cdf(pl.col("x")))["r"].to_numpy()
-    assert np.all(np.diff(result) >= 0.0)
-    assert result.min() >= 0.0
-    assert result.max() <= 1.0
+    result = pl.DataFrame({"x": xs}).select(r=Normal(mean=mean, std_dev=std).cdf(pl.col("x")))["r"]
+    assert result.is_sorted()
+    assert result.is_between(0.0, 1.0).all()
 
 
 def test_cdf_column_params() -> None:

--- a/tests/distributions/normal/entropy_test.py
+++ b/tests/distributions/normal/entropy_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import numpy as np
+import math
+
 import polars as pl
 from polars.testing import assert_series_equal
 
@@ -12,7 +13,7 @@ def test_entropy_is_log_form_column_params() -> None:
     df = pl.DataFrame({"mu": [0.0, -3.0, 10.0], "sigma": sigmas})
     result = df.select(r=Normal(mean=pl.col("mu"), std_dev=pl.col("sigma")).entropy())["r"]
     # Differential entropy of a normal: 0.5 * log(2*pi*e*sigma^2), independent of the mean.
-    expected = pl.Series("r", [0.5 * np.log(2.0 * np.pi * np.e * s**2) for s in sigmas], dtype=pl.Float64)
+    expected = pl.Series("r", [0.5 * math.log(2.0 * math.pi * math.e * s**2) for s in sigmas], dtype=pl.Float64)
     assert_series_equal(result, expected)
 
 
@@ -22,5 +23,5 @@ def test_entropy_propagates_null_params() -> None:
         {"mu": [0.0, None, 1.0], "sigma": [1.0, 2.0, None]}, schema={"mu": pl.Float64, "sigma": pl.Float64}
     )
     result = df.select(r=Normal(mean=pl.col("mu"), std_dev=pl.col("sigma")).entropy())["r"]
-    expected = pl.Series("r", [0.5 * np.log(2.0 * np.pi * np.e), None, None], dtype=pl.Float64)
+    expected = pl.Series("r", [0.5 * math.log(2.0 * math.pi * math.e), None, None], dtype=pl.Float64)
     assert_series_equal(result, expected)

--- a/tests/distributions/normal/log_cdf_test.py
+++ b/tests/distributions/normal/log_cdf_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -23,5 +24,5 @@ def test_log_cdf_equals_log_of_cdf(value_grid: Callable[[float, float], list[flo
 def test_log_cdf_propagates_null_in_value() -> None:
     df = pl.DataFrame({"x": [0.0, None]}, schema={"x": pl.Float64})
     result = df.select(r=Normal().log_cdf(pl.col("x")))["r"]
-    expected = pl.Series("r", [float(np.log(0.5)), None], dtype=pl.Float64)
+    expected = pl.Series("r", [math.log(0.5), None], dtype=pl.Float64)
     assert_series_equal(result, expected)

--- a/tests/distributions/normal/log_pdf_test.py
+++ b/tests/distributions/normal/log_pdf_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -23,5 +24,5 @@ def test_log_pdf_equals_log_of_pdf(value_grid: Callable[[float, float], list[flo
 def test_log_pdf_propagates_null_in_value() -> None:
     df = pl.DataFrame({"x": [0.0, None]}, schema={"x": pl.Float64})
     result = df.select(r=Normal().log_pdf(pl.col("x")))["r"]
-    expected = pl.Series("r", [float(np.log(1.0 / np.sqrt(2.0 * np.pi))), None], dtype=pl.Float64)
+    expected = pl.Series("r", [math.log(1.0 / math.sqrt(2.0 * math.pi)), None], dtype=pl.Float64)
     assert_series_equal(result, expected)

--- a/tests/distributions/normal/log_sf_test.py
+++ b/tests/distributions/normal/log_sf_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -23,5 +24,5 @@ def test_log_sf_equals_log_of_sf(value_grid: Callable[[float, float], list[float
 def test_log_sf_propagates_null_in_value() -> None:
     df = pl.DataFrame({"x": [0.0, None]}, schema={"x": pl.Float64})
     result = df.select(r=Normal().log_sf(pl.col("x")))["r"]
-    expected = pl.Series("r", [float(np.log(0.5)), None], dtype=pl.Float64)
+    expected = pl.Series("r", [math.log(0.5), None], dtype=pl.Float64)
     assert_series_equal(result, expected)

--- a/tests/distributions/normal/pdf_test.py
+++ b/tests/distributions/normal/pdf_test.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import math
 
-import numpy as np
 import polars as pl
 import pytest
 from polars.testing import assert_series_equal
@@ -41,7 +40,7 @@ def test_pdf_propagates_null_in_value() -> None:
     result = df.select(r=Normal().pdf(pl.col("x")))["r"]
     expected = pl.Series(
         "r",
-        [1.0 / math.sqrt(2.0 * math.pi), None, float(np.exp(-0.5) / math.sqrt(2.0 * math.pi))],
+        [1.0 / math.sqrt(2.0 * math.pi), None, math.exp(-0.5) / math.sqrt(2.0 * math.pi)],
         dtype=pl.Float64,
     )
     assert_series_equal(result, expected)

--- a/tests/distributions/normal/ppf_test.py
+++ b/tests/distributions/normal/ppf_test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 import polars as pl
+import pytest
 from polars.testing import assert_series_equal
 
 from polars_stats import Normal
@@ -10,7 +11,7 @@ from polars_stats import Normal
 def test_ppf_at_half_is_mean(params: tuple[float, float]) -> None:
     mean, std = params
     result = pl.DataFrame({"q": [0.5]}).select(r=Normal(mean=mean, std_dev=std).ppf(pl.col("q")))["r"].item()
-    np.testing.assert_allclose(result, mean, atol=1e-12, rtol=0)
+    assert result == pytest.approx(mean, abs=1e-12)
 
 
 def test_ppf_is_cdf_inverse(params: tuple[float, float]) -> None:

--- a/tests/distributions/uniform/entropy_test.py
+++ b/tests/distributions/uniform/entropy_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import numpy as np
+import math
+
 import polars as pl
 from polars.testing import assert_series_equal
 
@@ -10,5 +11,5 @@ from polars_stats import Uniform
 def test_entropy_is_log_width_column_bounds() -> None:
     df = pl.DataFrame({"lo": [0.0, -2.0], "hi": [1.0, 3.0]})
     result = df.select(r=Uniform(min=pl.col("lo"), max=pl.col("hi")).entropy())["r"]
-    expected = pl.Series("r", [float(np.log(1.0)), float(np.log(5.0))], dtype=pl.Float64)
+    expected = pl.Series("r", [math.log(1.0), math.log(5.0)], dtype=pl.Float64)
     assert_series_equal(result, expected)

--- a/tests/distributions/uniform/log_cdf_test.py
+++ b/tests/distributions/uniform/log_cdf_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import numpy as np
+import math
+
 import polars as pl
 from polars.testing import assert_series_equal
 
@@ -17,5 +18,5 @@ def test_log_cdf_is_neg_inf_at_or_below_min() -> None:
 def test_log_cdf_propagates_null_in_value() -> None:
     df = pl.DataFrame({"x": [0.5, None]}, schema={"x": pl.Float64})
     result = df.select(r=Uniform(min=0.0, max=1.0).log_cdf(pl.col("x")))["r"]
-    expected = pl.Series("r", [float(np.log(0.5)), None], dtype=pl.Float64)
+    expected = pl.Series("r", [math.log(0.5), None], dtype=pl.Float64)
     assert_series_equal(result, expected)

--- a/tests/distributions/uniform/log_sf_test.py
+++ b/tests/distributions/uniform/log_sf_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import numpy as np
+import math
+
 import polars as pl
 from polars.testing import assert_series_equal
 
@@ -17,5 +18,5 @@ def test_log_sf_is_neg_inf_at_or_above_max() -> None:
 def test_log_sf_propagates_null_in_value() -> None:
     df = pl.DataFrame({"x": [0.5, None]}, schema={"x": pl.Float64})
     result = df.select(r=Uniform(min=0.0, max=1.0).log_sf(pl.col("x")))["r"]
-    expected = pl.Series("r", [float(np.log(0.5)), None], dtype=pl.Float64)
+    expected = pl.Series("r", [math.log(0.5), None], dtype=pl.Float64)
     assert_series_equal(result, expected)

--- a/tests/distributions/uniform/samples_test.py
+++ b/tests/distributions/uniform/samples_test.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
-import numpy as np
 import polars as pl
 import pytest
 from polars.testing import assert_series_equal
@@ -39,20 +38,15 @@ def test_samples_columns_are_not_all_equal(frame: Callable[..., pl.DataFrame], s
 
 def test_samples_within_bounds(frame: Callable[..., pl.DataFrame], seed: int) -> None:
     mn, mx = -3.0, 2.0
-    flat = np.asarray(
-        frame(size=2_000).select(s=Uniform(min=mn, max=mx).samples(size=8, seed=seed))["s"].to_list(),
-        dtype=float,
-    ).ravel()
-    assert flat.min() >= mn
-    assert flat.max() <= mx
+    series = frame(size=2_000).select(s=Uniform(min=mn, max=mx).samples(size=8, seed=seed))["s"].arr.explode()
+
+    assert series.is_between(mn, mx).all()
 
 
 def test_samples_mean_close_to_midpoint(frame: Callable[..., pl.DataFrame], seed: int) -> None:
-    flat = np.asarray(
-        frame(size=4_000).select(s=Uniform(min=2.0, max=5.0).samples(size=16, seed=seed))["s"].to_list(),
-        dtype=float,
-    ).ravel()
-    assert abs(flat.mean() - 3.5) < 0.01 * 3.0
+    series = frame(size=4_000).select(s=Uniform(min=2.0, max=5.0).samples(size=16, seed=seed))["s"].arr.explode()
+    mean = cast("float", series.mean())
+    assert abs(mean - 3.5) < 0.01 * 3.0
 
 
 @pytest.mark.parametrize("bad_size", [0, -1])

--- a/tests/property/_specs.py
+++ b/tests/property/_specs.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
 from hypothesis import strategies as st
 
-from polars_stats import Bernoulli, Normal, Uniform
+from polars_stats import Bernoulli, LogNormal, Normal, Uniform
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -86,6 +87,20 @@ _UNIFORM = DistSpec(
     integration_bounds=lambda p: (p[0], p[1]),
 )
 
-ALL_SPECS = [_BERNOULLI, _NORMAL, _UNIFORM]
+_LOGNORMAL = DistSpec(
+    name="lognormal",
+    continuous=True,
+    # `sigma` is capped at 0.9: the heavy right tail makes a uniform-grid trapezoidal integral lose
+    # accuracy as `sigma` grows, and past ~1.0 the 4096-point mass check drifts above the 1e-3
+    # tolerance. The functional and scipy-parity suites cover larger `sigma` directly.
+    params=st.tuples(_finite(-1.5, 1.5), _finite(0.1, 0.9)),
+    make=lambda p: LogNormal(mu=p[0], sigma=p[1]),
+    density=lambda d, c: d.pdf(c),
+    # Support is (0, inf); the grid stays on the positive side and out to a 4-sigma-in-log upper tail.
+    eval_range=lambda p: (0.0, float(np.exp(p[0] + 4.0 * p[1]))),
+    integration_bounds=lambda p: (0.0, float(np.exp(p[0] + 6.0 * p[1]))),
+)
+
+ALL_SPECS = [_BERNOULLI, _NORMAL, _UNIFORM, _LOGNORMAL]
 CONTINUOUS_SPECS = [s for s in ALL_SPECS if s.continuous]
 DISCRETE_SPECS = [s for s in ALL_SPECS if not s.continuous]

--- a/tests/scipy_parity/lognormal_test.py
+++ b/tests/scipy_parity/lognormal_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+import polars as pl
 import pytest
 from scipy.stats import lognorm as scipy_lognorm
 
@@ -46,8 +47,8 @@ _CASES: list[Case[LogNormal]] = [
 
 def _value_grid(mu: float, sigma: float) -> list[float]:
     """Positive evaluation points, geometric around the median `exp(mu)`."""
-    ks = np.array([-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0])
-    return np.exp(mu + ks * sigma).tolist()
+    ks = pl.Series([-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0])
+    return (mu + ks * sigma).exp().to_list()
 
 
 @pytest.mark.parametrize(("mu", "sigma"), _PARAMS, ids=[f"mu={m},sigma={s}" for m, s in _PARAMS])

--- a/tests/scipy_parity/lognormal_test.py
+++ b/tests/scipy_parity/lognormal_test.py
@@ -46,7 +46,8 @@ _CASES: list[Case[LogNormal]] = [
 
 def _value_grid(mu: float, sigma: float) -> list[float]:
     """Positive evaluation points, geometric around the median `exp(mu)`."""
-    return [float(np.exp(mu + k * sigma)) for k in (-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0)]
+    ks = np.array([-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0])
+    return np.exp(mu + ks * sigma).tolist()
 
 
 @pytest.mark.parametrize(("mu", "sigma"), _PARAMS, ids=[f"mu={m},sigma={s}" for m, s in _PARAMS])

--- a/tests/scipy_parity/lognormal_test.py
+++ b/tests/scipy_parity/lognormal_test.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.stats import lognorm as scipy_lognorm
+
+from polars_stats import LogNormal
+from tests.scipy_parity._harness import Case, assert_case_matches_scipy
+
+# Parameter and evaluation grids for the parity sweep. Owned by this test category and independent
+# of the per-method functional tests under `tests/distributions/lognormal`. `sigma` is kept moderate:
+# the mean / variance grow exponentially in `sigma` and lose absolute precision against scipy past
+# `sigma > 5` (see the issue caveat).
+_PARAMS = [(0.0, 1.0), (0.5, 0.5), (-1.0, 0.25), (1.0, 0.75), (0.0, 0.1)]
+_QUANTILES = [0.01, 0.1, 0.25, 0.5, 0.75, 0.9, 0.99]
+
+# Tolerance split, by upstream implementation rather than by aspiration:
+#   * `statrs` evaluates pdf / ln_pdf to ~1e-15 against scipy, and the moments (exp-based) to
+#     machine precision on this grid, so they hold the default 1e-12 target;
+#   * cdf / sf (and their logs) and the closed-form ppf go through `erfc` / `erfc_inv`, while scipy
+#     uses Cephes; the two agree only to ~1e-10. 1e-9 is the honest, comfortably-padded bound.
+_TOL_ERF = 1e-9
+
+
+def _scipy_frozen(mu: float, sigma: float) -> object:
+    """`scipy.stats.lognorm` frozen at the polars-stats `(mu, sigma)`: `s=sigma`, `scale=exp(mu)`."""
+    return scipy_lognorm(s=sigma, scale=np.exp(mu))
+
+
+_CASES: list[Case[LogNormal]] = [
+    Case("pdf", "value", lambda d, c: d.pdf(c), "pdf"),
+    Case("log_pdf", "value", lambda d, c: d.log_pdf(c), "logpdf"),
+    Case("cdf", "value", lambda d, c: d.cdf(c), "cdf", _TOL_ERF),
+    Case("log_cdf", "value", lambda d, c: d.log_cdf(c), "logcdf", _TOL_ERF),
+    Case("sf", "value", lambda d, c: d.sf(c), "sf", _TOL_ERF),
+    Case("log_sf", "value", lambda d, c: d.log_sf(c), "logsf", _TOL_ERF),
+    Case("ppf", "quantile", lambda d, c: d.ppf(c), "ppf", _TOL_ERF),
+    Case("isf", "quantile", lambda d, c: d.isf(c), "isf", _TOL_ERF),
+    Case("mean", "scalar", lambda d, _: d.mean(), "mean"),
+    Case("variance", "scalar", lambda d, _: d.variance(), "var"),
+    Case("std", "scalar", lambda d, _: d.std(), "std"),
+    Case("median", "scalar", lambda d, _: d.median(), "median"),
+    Case("entropy", "scalar", lambda d, _: d.entropy(), "entropy"),
+]
+
+
+def _value_grid(mu: float, sigma: float) -> list[float]:
+    """Positive evaluation points, geometric around the median `exp(mu)`."""
+    return [float(np.exp(mu + k * sigma)) for k in (-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0)]
+
+
+@pytest.mark.parametrize(("mu", "sigma"), _PARAMS, ids=[f"mu={m},sigma={s}" for m, s in _PARAMS])
+@pytest.mark.parametrize("case", _CASES, ids=lambda c: c.name)
+def test_method_matches_scipy(case: Case[LogNormal], mu: float, sigma: float) -> None:
+    """Every closed-form method matches `scipy.stats.lognorm(s=sigma, scale=exp(mu))` across the grid.
+
+    Table-driven: adding a method is one row in `_CASES`. Method-specific behaviour (null
+    propagation, out-of-range quantiles, the `x <= 0` support edge) is asserted in the per-method files.
+    """
+    assert_case_matches_scipy(
+        case,
+        dist=LogNormal(mu=mu, sigma=sigma),
+        scipy_frozen=_scipy_frozen(mu, sigma),
+        value_grid=_value_grid(mu, sigma),
+        quantiles=_QUANTILES,
+    )


### PR DESCRIPTION
Add `polars_stats.LogNormal` wrapping `statrs::distribution::LogNormal`, parameterised as `(mu, sigma)`, matching scipy's `lognorm(s=sigma, scale=exp(mu))`.
