### PR TITLE
feat: Add `Binomial` distribution

### DIFF
--- a/polars_stats/__init__.py
+++ b/polars_stats/__init__.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from polars_stats._internal import __version__ as __version__
 from polars_stats.distributions._base import ContinuousDistribution, DiscreteDistribution
 from polars_stats.distributions._bernoulli import Bernoulli
+from polars_stats.distributions._binomial import Binomial
 from polars_stats.distributions._lognormal import LogNormal
 from polars_stats.distributions._normal import Normal
 from polars_stats.distributions._uniform import Uniform
 
 __all__ = (
     "Bernoulli",
+    "Binomial",
     "ContinuousDistribution",
     "DiscreteDistribution",
     "LogNormal",

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -76,15 +76,24 @@ def as_expr(value: float | IntoExprColumn) -> pl.Expr:
     """Coerce a value-keyed method input (`value` / `quantile`) into a `pl.Expr`.
 
     A column name `str` becomes `pl.col(name)` (matching `coerce_param` and the wider Polars
-    convention of accepting bare column names); a `pl.Expr` passes through; a `float` or `pl.Series`
-    becomes a literal. These arguments broadcast against the row-aligned parameter expressions and so
-    do not need the `pl.repeat` expansion `coerce_param` applies.
+    convention of accepting bare column names); a `pl.Expr` or `pl.Series` passes through as-is; a
+    Python scalar is expanded with `pl.repeat(value, n=pl.len())` so the plugin always receives a
+    row-aligned input, exactly like `coerce_param`.
+
+    The expansion is not cosmetic: the Rust plugins zip their inputs element-wise via
+    `try_*_elementwise`, which truncates to the shortest input rather than broadcasting a length-1
+    literal. With column-valued parameters, a scalar `pl.lit(value)` would therefore collapse the
+    result to length 1 and skip every row past the first (silently dropping out-of-range parameter
+    validation on those rows). Some Polars versions broadcast the literal upstream and hide this; not
+    all do, so the plugin contract must own row-alignment rather than rely on it.
     """
     if isinstance(value, pl.Expr):
         return value
     if isinstance(value, str):
         return pl.col(value)
-    return pl.lit(value)
+    if isinstance(value, pl.Series):
+        return pl.lit(value)
+    return pl.repeat(value, n=pl.len())
 
 
 def propagate_null(value: pl.Expr, result: pl.Expr) -> pl.Expr:

--- a/polars_stats/distributions/_binomial.py
+++ b/polars_stats/distributions/_binomial.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
+import polars as pl
+
+from polars_stats.distributions._base import DiscreteDistribution, coerce_param, register_plugin, row_index_expr
+
+if TYPE_CHECKING:
+    from polars_stats._typing import IntoExprColumn, PolarsDataType
+
+
+def _coerce_n(value: int | IntoExprColumn) -> pl.Expr:
+    """Coerce the trial-count parameter ``n`` into a row-aligned integer ``pl.Expr``.
+
+    Mirrors ``coerce_param`` but for an integer parameter: a Python ``int`` expands to a length-N
+    ``Int64`` expression (keeping the plugin call elementwise under ``over`` / ``group_by``), while an
+    ``IntoExprColumn`` passes through for per-row ``n``. ``bool`` is rejected (an ``int`` subclass, but
+    not a sensible trial count); ``float`` and other types raise ``TypeError``. The *value* of ``n``
+    (``>= 0``) is validated per row in Rust, not here.
+    """
+    msg = f"n should be an int or IntoExprColumn (pl.Expr, str, pl.Series), found {type(value)}"
+    if isinstance(value, bool):
+        raise TypeError(msg)
+    if isinstance(value, int):
+        return pl.repeat(value, n=pl.len(), dtype=pl.Int64())
+    if isinstance(value, pl.Expr):
+        return value
+    if isinstance(value, pl.Series):
+        return pl.lit(value)
+    # The `str` check is provably redundant to the type checker, but still guards runtime junk
+    # (list, dict, ...) that the declared type forbids; `construct_test` exercises that path.
+    if isinstance(value, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+        return pl.col(value)
+    raise TypeError(msg)
+
+
+class Binomial(DiscreteDistribution):
+    """Binomial distribution: number of successes in ``n`` trials, each with success probability ``p``.
+
+    Equivalent to ``scipy.stats.binom(n, p)``. The argument order differs from ``statrs``
+    (``Binomial(p, n)``); this class follows scipy's ``(n, p)``.
+
+    Arguments:
+        n: Number of trials, an integer ``>= 0``. Either a Python ``int`` or an ``IntoExprColumn``
+            (``pl.Expr``, ``pl.Series`` or column name ``str``) carrying one count per row.
+        p: Success probability in ``[0, 1]``. Either a Python ``float`` or an ``IntoExprColumn``.
+
+    Neither parameter is validated at construction: a negative ``n`` or a ``p`` outside ``[0, 1]``
+    raises ``InvalidOperation`` (a ``ComputeError``) when a method is evaluated, identically to an
+    invalid column row. Construction rejects only wrong *types* (``TypeError``). Null parameters
+    propagate to null.
+    """
+
+    _n: pl.Expr
+    _p: pl.Expr
+    _sample_dtype: ClassVar[PolarsDataType] = pl.UInt64()
+
+    def __init__(self, n: int | IntoExprColumn, p: float | IntoExprColumn) -> None:
+        self._n = _coerce_n(n)
+        self._p = coerce_param(p, name="p")
+
+    def _value_plugin(self, function_name: str, value: pl.Expr) -> pl.Expr:
+        """Register a value-keyed Rust plugin call ``f(value, n, p)``.
+
+        Validation of ``(n, p)`` happens inside the plugin, so every value-keyed method reports an
+        invalid parameterisation consistently; null inputs propagate per row.
+        """
+        return register_plugin(function_name, (value, self._n, self._p))
+
+    @property
+    def _checked_params(self) -> pl.Expr:
+        """``p`` validated in Rust against the full ``(n, p)`` parameterisation (raises otherwise).
+
+        Mirrors ``Normal._checked_std_dev`` / ``Bernoulli._checked_p``: the closed-form moments
+        (``mean``, ``variance``) derive from this single FFI round-trip, so they report an invalid
+        parameterisation (``n < 0`` or ``p`` outside ``[0, 1]``) as a ``ComputeError`` consistently
+        with the value-keyed methods, rather than silently computing a moment from invalid inputs.
+        Null in either parameter propagates to null.
+        """
+        return register_plugin("binomial_params", (self._n, self._p))
+
+    def _valid_mask(self) -> pl.Expr:
+        # Only null parameters are masked to a null array here; an invalid n/p raises in the plugin.
+        return self._n.is_not_null() & self._p.is_not_null()
+
+    def _moment(self, value: pl.Expr) -> pl.Expr:
+        """Gate a closed-form moment on a non-null, valid ``(n, p)`` parameterisation.
+
+        Evaluating ``_checked_params`` validates ``(n, p)`` in Rust (raising on ``n < 0`` or ``p``
+        outside ``[0, 1]``) and is null when either parameter is null. So every moment nulls on a null
+        input and raises identically on an invalid parameterisation, while ``value`` reads the raw
+        ``self._n`` / ``self._p`` without re-validating.
+        """
+        return pl.when(self._checked_params.is_not_null()).then(value)
+
+    def sample(self, seed: int | None = None) -> pl.Expr:
+        """Draw one Binomial sample per row, returning a ``UInt64`` column.
+
+        Output length follows the surrounding context (frame length under ``select`` /
+        ``with_columns``, partition length under ``over`` / ``group_by``). Each row's draw is derived
+        from a per-row sub-seed mixed from ``seed`` and the row's position, so the result is
+        independent of Polars chunking and thread scheduling. Rows with an invalid parameter raise;
+        rows with a null parameter yield null.
+        """
+        return register_plugin("binomial_sample", (self._n, self._p, row_index_expr()), kwargs={"seed": seed})
+
+    def _pmf(self, value: pl.Expr) -> pl.Expr:
+        """Mass via native ``Discrete::pmf``; zero off the integer support ``{0, ..., n}``."""
+        return self._value_plugin("binomial_pmf", value)
+
+    def _log_pmf(self, value: pl.Expr) -> pl.Expr:
+        """Log-mass via native ``Discrete::ln_pmf`` (more accurate than ``pmf().log()``)."""
+        return self._value_plugin("binomial_ln_pmf", value)
+
+    def _cdf(self, value: pl.Expr) -> pl.Expr:
+        """Cumulative mass ``P(X <= floor(value))`` via native ``DiscreteCDF::cdf``."""
+        return self._value_plugin("binomial_cdf", value)
+
+    def _sf(self, value: pl.Expr) -> pl.Expr:
+        """Survival ``P(X > floor(value))`` via native ``DiscreteCDF::sf`` (accurate upper tail).
+
+        ``log_sf`` and ``isf`` inherit the base-class defaults, which compose this native ``sf`` and
+        ``ppf`` rather than the generic ``1 - cdf`` fallback.
+        """
+        return self._value_plugin("binomial_sf", value)
+
+    def _ppf(self, quantile: pl.Expr) -> pl.Expr:
+        """Inverse cdf via the binary-search ``DiscreteCDF::inverse_cdf``, as an integer-valued ``Float64``.
+
+        A quantile outside ``[0, 1]`` yields null. At the endpoints this returns the support bounds
+        (``ppf(0) = 0``, ``ppf(1) = n``); scipy's below-support sentinel ``ppf(0) = -1`` is not
+        reproduced. ``median`` is ``ppf(0.5)`` (the base-class default), which matches scipy exactly;
+        statrs' native ``floor(n * p)`` median is a different convention and is deliberately not used.
+        """
+        return self._value_plugin("binomial_ppf", quantile)
+
+    def mean(self) -> pl.Expr:
+        """Expected value, ``n * p``."""
+        return self._moment(self._n * self._p)
+
+    def variance(self) -> pl.Expr:
+        """Variance, ``n * p * (1 - p)``."""
+        return self._moment(self._n * self._p * (1 - self._p))
+
+    def entropy(self) -> pl.Expr:
+        """Shannon entropy in nats, the exact support sum ``-sum_k pmf(k) log pmf(k)``.
+
+        ``0`` at the degenerate endpoints ``p in {0, 1}``.
+        """
+        return register_plugin("binomial_entropy", (self._n, self._p))

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -1,0 +1,280 @@
+#![allow(clippy::unused_unit)]
+use polars::prelude::arity::{try_binary_elementwise, try_ternary_elementwise};
+use polars::prelude::*;
+use pyo3_polars::derive::polars_expr;
+use rand::distributions::Distribution as RandDistribution;
+use statrs::distribution::{Binomial, Discrete, DiscreteCDF};
+use statrs::statistics::Distribution as StatrsDistribution;
+
+use crate::rng::SampleKwargs;
+
+/// Construct a `statrs::Binomial`, mapping both invalid-parameter cases to a `ComputeError`.
+///
+/// `statrs::Binomial::new(p, n)` takes the arguments in the opposite order to this crate's `(n, p)`
+/// and only rejects a `NaN` `p` or `p` outside `[0, 1]`; its `n` is a `u64`, so a negative trial
+/// count cannot reach it. We validate `n >= 0` here and surface both failures as `InvalidOperation`
+/// so an invalid parameterisation fails the whole evaluation rather than silently nulling the row,
+/// consistent with every other distribution. Validation lives here so each method that builds a
+/// distribution reports it identically.
+fn build_dist(n: i64, p: f64) -> PolarsResult<Binomial> {
+    let trials = u64::try_from(n).map_err(|_| {
+        PolarsError::InvalidOperation(format!("n must be a non-negative integer, got {n}").into())
+    })?;
+    Binomial::new(p, trials).map_err(|e| {
+        PolarsError::InvalidOperation(format!("p must be in [0, 1], got {p}: {e}").into())
+    })
+}
+
+/// `value` as a binomial support point: `Some(k)` when `value` is a non-negative integer, else
+/// `None` (off the support, where the mass is zero). `value > n` still maps to `Some`; `statrs`
+/// returns zero mass there, so the check need only reject negatives and non-integers. The `as`
+/// cast saturates to `u64::MAX` for values beyond the integer range, which `statrs` then treats as
+/// `> n`.
+#[inline]
+fn support_point(value: f64) -> Option<u64> {
+    if value < 0.0 || value.fract() != 0.0 {
+        None
+    } else {
+        Some(value as u64)
+    }
+}
+
+/// Apply a value-keyed function `f(dist, value)` element-wise over `(value, n, p)`.
+///
+/// `inputs[0]` is the evaluation point, `inputs[1]` is `n`, `inputs[2]` is `p`. `null` in any input
+/// propagates to `null`; an invalid parameterisation raises via [`build_dist`]. `f` returns an
+/// `Option` so a method can null a row on its own terms (e.g. `ppf` outside `[0, 1]`). Shared by
+/// `pmf`, `ln_pmf`, `cdf`, `sf`, `ppf`.
+fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
+where
+    F: Fn(&Binomial, f64) -> Option<f64>,
+{
+    let value = inputs[0].cast(&DataType::Float64)?;
+    let value_ca = value.f64()?;
+    let n = inputs[1].cast(&DataType::Int64)?;
+    let n_ca = n.i64()?;
+    let p = inputs[2].cast(&DataType::Float64)?;
+    let p_ca = p.f64()?;
+    let name = inputs[0].name().clone();
+
+    let ca: Float64Chunked = try_ternary_elementwise(
+        value_ca,
+        n_ca,
+        p_ca,
+        |value_opt, n_opt, p_opt| -> PolarsResult<Option<f64>> {
+            match (value_opt, n_opt, p_opt) {
+                (Some(v), Some(n), Some(p)) => {
+                    let dist = build_dist(n, p)?;
+                    Ok(f(&dist, v))
+                },
+                _ => Ok(None),
+            }
+        },
+    )?;
+
+    Ok(ca.with_name(name).into_series())
+}
+
+/// Apply a parameter-keyed moment `f(dist)` element-wise over `(n, p)`.
+///
+/// `inputs[0]` is `n`, `inputs[1]` is `p`. `null` in either propagates; an invalid parameterisation
+/// raises via [`build_dist`]. Only `entropy` routes through here (the one moment without an
+/// elementary closed form); `mean` and `variance` are closed forms computed in Polars and gated on
+/// [`binomial_params`].
+fn params_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
+where
+    F: Fn(&Binomial) -> f64,
+{
+    let n = inputs[0].cast(&DataType::Int64)?;
+    let n_ca = n.i64()?;
+    let p = inputs[1].cast(&DataType::Float64)?;
+    let p_ca = p.f64()?;
+    let name = inputs[1].name().clone();
+
+    let ca: Float64Chunked =
+        try_binary_elementwise(n_ca, p_ca, |n_opt, p_opt| -> PolarsResult<Option<f64>> {
+            match (n_opt, p_opt) {
+                (Some(n), Some(p)) => {
+                    let dist = build_dist(n, p)?;
+                    Ok(Some(f(&dist)))
+                },
+                _ => Ok(None),
+            }
+        })?;
+
+    Ok(ca.with_name(name).into_series())
+}
+
+/// Element-wise Binomial sampler.
+///
+/// `inputs[0]` carries `n`, `inputs[1]` `p`, and `inputs[2]` a per-row index used to derive a
+/// per-row sub-seed, so the function is genuinely element-wise: chunking and threading cannot change
+/// the output. With `seed=None`, a fresh root seed is drawn once per call.
+///
+/// Per-row validation:
+///   * `null` (in any input) propagates;
+///   * a negative `n`, or a `NaN` / out-of-range `p`, raises `InvalidOperation`.
+///
+/// Returns a `UInt64` series.
+#[polars_expr(output_type=UInt64)]
+fn binomial_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
+    let n = inputs[0].cast(&DataType::Int64)?;
+    let n_ca = n.i64()?;
+    let p = inputs[1].cast(&DataType::Float64)?;
+    let p_ca = p.f64()?;
+    let index = inputs[2].cast(&DataType::UInt64)?;
+    let index_ca = index.u64()?;
+    let name = inputs[0].name().clone();
+
+    let rngs = kwargs.row_rngs();
+
+    let ca: UInt64Chunked = try_ternary_elementwise(
+        n_ca,
+        p_ca,
+        index_ca,
+        |n_opt, p_opt, i_opt| -> PolarsResult<Option<u64>> {
+            match (n_opt, p_opt, i_opt) {
+                (Some(n), Some(p), Some(i)) => {
+                    let dist = build_dist(n, p)?;
+                    let mut rng = rngs.rng(i);
+                    Ok(Some(<Binomial as RandDistribution<u64>>::sample(
+                        &dist, &mut rng,
+                    )))
+                },
+                _ => Ok(None),
+            }
+        },
+    )?;
+
+    Ok(ca.with_name(name).into_series())
+}
+
+/// Element-wise pmf via `statrs` `Discrete::pmf`; zero off the integer support (`value < 0`,
+/// non-integer, or `value > n`). See [`value_keyed`] for the null/error contract.
+#[polars_expr(output_type=Float64)]
+fn binomial_pmf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, |dist, v| {
+        Some(support_point(v).map_or(0.0, |k| dist.pmf(k)))
+    })
+}
+
+/// Element-wise log-pmf via native `Discrete::ln_pmf` (more accurate than `pmf().ln()`);
+/// `-inf` off the integer support.
+#[polars_expr(output_type=Float64)]
+fn binomial_ln_pmf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, |dist, v| {
+        Some(support_point(v).map_or(f64::NEG_INFINITY, |k| dist.ln_pmf(k)))
+    })
+}
+
+/// Element-wise cdf `P(X <= floor(value))` via `statrs` `DiscreteCDF::cdf`; `0` for `value < 0`,
+/// `1` for `value >= n`.
+#[polars_expr(output_type=Float64)]
+fn binomial_cdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, |dist, v| {
+        if v < 0.0 {
+            Some(0.0)
+        } else {
+            Some(dist.cdf(v.floor() as u64))
+        }
+    })
+}
+
+/// Element-wise survival function `P(X > floor(value))` via native `DiscreteCDF::sf` (accurate in
+/// the upper tail); `1` for `value < 0`, `0` for `value >= n`.
+#[polars_expr(output_type=Float64)]
+fn binomial_sf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, |dist, v| {
+        if v < 0.0 {
+            Some(1.0)
+        } else {
+            Some(dist.sf(v.floor() as u64))
+        }
+    })
+}
+
+/// Slack absorbing the rounding error in `statrs`' regularized-incomplete-beta cdf when comparing
+/// against a quantile that sits exactly on a cdf step. The cdf is accurate to a few ULP (~1e-15),
+/// so 1e-12 reliably treats `cdf(k) == q` as satisfied (matching scipy's integer-valued ppf) while
+/// staying far below the gap between distinct adjacent cdf values at any quantile a caller would
+/// pass.
+const PPF_CDF_TOL: f64 = 1e-12;
+
+/// Smallest support point `k in {0, ..., n}` with `cdf(k) >= q`, by binary search over the bounded
+/// discrete CDF.
+///
+/// This is the inverse-cdf statrs documents for `Binomial` (a search over the CDF), reimplemented
+/// here because `statrs`' generic `DiscreteCDF::inverse_cdf` panics for small `n` (it `unwrap`s a
+/// bisection that returns `None`). The comparison carries [`PPF_CDF_TOL`] so a quantile exactly on a
+/// cdf step is not pushed to the next support point by the cdf's last-ULP error. `q == 0` returns the
+/// support minimum `0`; `q == 1` returns `n`.
+fn inverse_cdf(dist: &Binomial, q: f64) -> u64 {
+    let mut lo = 0u64;
+    let mut hi = dist.n();
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        if dist.cdf(mid) + PPF_CDF_TOL >= q {
+            hi = mid;
+        } else {
+            lo = mid + 1;
+        }
+    }
+    lo
+}
+
+/// Element-wise ppf (inverse cdf), returning the integer support point as `f64`.
+///
+/// A quantile outside `[0, 1]` yields `null`. At the endpoints this returns the support bounds
+/// (`ppf(0) = 0`, `ppf(1) = n`); scipy's below-support sentinel `ppf(0) = -1` is not reproduced, so
+/// parity comparisons restrict to interior quantiles.
+#[polars_expr(output_type=Float64)]
+fn binomial_ppf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, |dist, q| {
+        if !(0.0..=1.0).contains(&q) {
+            None
+        } else {
+            Some(inverse_cdf(dist, q) as f64)
+        }
+    })
+}
+
+/// Validate the `(n, p)` parameterisation and return the validated `p`.
+///
+/// `inputs[0]` is `n`, `inputs[1]` is `p`. Mirrors `normal_std_dev` / `bernoulli_proba`: the
+/// closed-form moments (`mean = n * p`, `variance = n * p * (1 - p)`) are computed from Polars
+/// expressions and gated on this single FFI round-trip, so they report an invalid parameterisation
+/// identically to the value-keyed methods that build the distribution directly, rather than silently
+/// computing a moment from a negative `n` or an out-of-range `p`. `null` in either input propagates;
+/// a negative `n` or a `NaN` / out-of-range `p` raises `InvalidOperation` via [`build_dist`].
+#[polars_expr(output_type=Float64)]
+fn binomial_params(inputs: &[Series]) -> PolarsResult<Series> {
+    let n = inputs[0].cast(&DataType::Int64)?;
+    let n_ca = n.i64()?;
+    let p = inputs[1].cast(&DataType::Float64)?;
+    let p_ca = p.f64()?;
+    let name = inputs[1].name().clone();
+
+    let ca: Float64Chunked =
+        try_binary_elementwise(n_ca, p_ca, |n_opt, p_opt| -> PolarsResult<Option<f64>> {
+            match (n_opt, p_opt) {
+                (Some(n), Some(p)) => {
+                    build_dist(n, p)?;
+                    Ok(Some(p))
+                },
+                _ => Ok(None),
+            }
+        })?;
+
+    Ok(ca.with_name(name).into_series())
+}
+
+/// Element-wise Shannon entropy (in nats) via `statrs` `Distribution::entropy`, the exact support
+/// sum `-sum_k pmf(k) ln pmf(k)`; `0` at the degenerate endpoints `p in {0, 1}`.
+///
+/// Kept in Rust, unlike `mean` / `variance`: the binomial entropy has no elementary closed form (it
+/// is a sum over the whole `{0, ..., n}` support, which scipy also evaluates exactly), so there is no
+/// numerically equivalent Polars expression to move it to.
+#[polars_expr(output_type=Float64)]
+fn binomial_entropy(inputs: &[Series]) -> PolarsResult<Series> {
+    params_keyed(inputs, |dist| dist.entropy().unwrap())
+}

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -1,4 +1,5 @@
 pub mod bernoulli;
+pub mod binomial;
 pub mod lognormal;
 pub mod normal;
 pub mod uniform;

--- a/tests/distributions/bernoulli/cdf_test.py
+++ b/tests/distributions/bernoulli/cdf_test.py
@@ -29,8 +29,8 @@ def test_cdf_scalar_p(
     expected_fn: Callable[[float], float],
     unit_frame: pl.DataFrame,
 ) -> None:
-    out = unit_frame.select(v=Bernoulli(p=p).cdf(value)).item(0, "v")
-    assert out == pytest.approx(expected_fn(p))
+    result = unit_frame.select(v=Bernoulli(p=p).cdf(value)).item(0, "v")
+    assert result == pytest.approx(expected_fn(p))
 
 
 def test_cdf_column_p() -> None:

--- a/tests/distributions/bernoulli/entropy_test.py
+++ b/tests/distributions/bernoulli/entropy_test.py
@@ -11,16 +11,16 @@ from polars_stats import Bernoulli
 
 @pytest.mark.parametrize("p", [0.1, 0.3, 0.5, 0.7, 0.9])
 def test_entropy_interior(p: float, unit_frame: pl.DataFrame) -> None:
-    out = unit_frame.select(v=Bernoulli(p=p).entropy()).item(0, "v")
+    result = unit_frame.select(v=Bernoulli(p=p).entropy()).item(0, "v")
     expected = -p * math.log(p) - (1 - p) * math.log(1 - p)
-    assert out == pytest.approx(expected)
+    assert result == pytest.approx(expected)
 
 
 @pytest.mark.parametrize("p", [0.0, 1.0])
 def test_entropy_degenerate_endpoints_are_zero(p: float, unit_frame: pl.DataFrame) -> None:
     # 0 * log 0 = 0 convention: degenerate Bernoulli has zero entropy.
-    out = unit_frame.select(v=Bernoulli(p=p).entropy()).item(0, "v")
-    assert out == 0.0
+    result = unit_frame.select(v=Bernoulli(p=p).entropy()).item(0, "v")
+    assert result == 0.0
 
 
 def test_entropy_at_half_equals_log_two(unit_frame: pl.DataFrame) -> None:

--- a/tests/distributions/bernoulli/log_cdf_test.py
+++ b/tests/distributions/bernoulli/log_cdf_test.py
@@ -35,8 +35,8 @@ def test_log_cdf_scalar_p(
     expected_fn: Callable[[float], float],
     unit_frame: pl.DataFrame,
 ) -> None:
-    out = unit_frame.select(v=Bernoulli(p=p).log_cdf(value)).item(0, "v")
-    assert out == pytest.approx(expected_fn(p))
+    result = unit_frame.select(v=Bernoulli(p=p).log_cdf(value)).item(0, "v")
+    assert result == pytest.approx(expected_fn(p))
 
 
 def test_log_cdf_propagates_null_in_value() -> None:

--- a/tests/distributions/bernoulli/log_pmf_test.py
+++ b/tests/distributions/bernoulli/log_pmf_test.py
@@ -35,8 +35,8 @@ def test_log_pmf_scalar_p(
     expected_fn: Callable[[float], float],
     unit_frame: pl.DataFrame,
 ) -> None:
-    out = unit_frame.select(v=Bernoulli(p=p).log_pmf(value)).item(0, "v")
-    assert out == pytest.approx(expected_fn(p))
+    result = unit_frame.select(v=Bernoulli(p=p).log_pmf(value)).item(0, "v")
+    assert result == pytest.approx(expected_fn(p))
 
 
 def test_log_pmf_propagates_null_in_value() -> None:

--- a/tests/distributions/bernoulli/log_sf_test.py
+++ b/tests/distributions/bernoulli/log_sf_test.py
@@ -35,8 +35,8 @@ def test_log_sf_scalar_p(
     expected_fn: Callable[[float], float],
     unit_frame: pl.DataFrame,
 ) -> None:
-    out = unit_frame.select(v=Bernoulli(p=p).log_sf(value)).item(0, "v")
-    assert out == pytest.approx(expected_fn(p))
+    result = unit_frame.select(v=Bernoulli(p=p).log_sf(value)).item(0, "v")
+    assert result == pytest.approx(expected_fn(p))
 
 
 def test_log_sf_propagates_null_in_value() -> None:

--- a/tests/distributions/bernoulli/mean_test.py
+++ b/tests/distributions/bernoulli/mean_test.py
@@ -9,8 +9,8 @@ from polars_stats import Bernoulli
 
 @pytest.mark.parametrize("p", [0.0, 0.25, 0.5, 0.75, 1.0])
 def test_mean_scalar(p: float, unit_frame: pl.DataFrame) -> None:
-    out = unit_frame.select(v=Bernoulli(p=p).mean()).item(0, "v")
-    assert out == pytest.approx(p)
+    result = unit_frame.select(v=Bernoulli(p=p).mean()).item(0, "v")
+    assert result == pytest.approx(p)
 
 
 def test_mean_column_p() -> None:

--- a/tests/distributions/bernoulli/median_test.py
+++ b/tests/distributions/bernoulli/median_test.py
@@ -10,8 +10,8 @@ from polars_stats import Bernoulli
 @pytest.mark.parametrize(("p", "expected"), [(0.3, False), (0.5, False), (0.7, True)])
 def test_median(p: float, *, expected: bool, unit_frame: pl.DataFrame) -> None:
     # median = ppf(0.5) = (0.5 > 1 - p)
-    out = unit_frame.select(v=Bernoulli(p=p).median()).item(0, "v")
-    assert out is expected
+    result = unit_frame.select(v=Bernoulli(p=p).median()).item(0, "v")
+    assert result is expected
 
 
 def test_median_propagates_null_in_p(p_with_null: pl.DataFrame) -> None:

--- a/tests/distributions/bernoulli/pmf_test.py
+++ b/tests/distributions/bernoulli/pmf_test.py
@@ -29,8 +29,8 @@ def test_pmf_scalar_p(
     expected_fn: Callable[[float], float],
     unit_frame: pl.DataFrame,
 ) -> None:
-    out = unit_frame.select(v=Bernoulli(p=p).pmf(value)).item(0, "v")
-    assert out == pytest.approx(expected_fn(p))
+    result = unit_frame.select(v=Bernoulli(p=p).pmf(value)).item(0, "v")
+    assert result == pytest.approx(expected_fn(p))
 
 
 def test_pmf_column_p() -> None:

--- a/tests/distributions/bernoulli/ppf_test.py
+++ b/tests/distributions/bernoulli/ppf_test.py
@@ -21,8 +21,8 @@ from polars_stats import Bernoulli
     ],
 )
 def test_ppf_scalar(p: float, quantile: float, *, expected: bool, unit_frame: pl.DataFrame) -> None:
-    out = unit_frame.select(v=Bernoulli(p=p).ppf(quantile)).item(0, "v")
-    assert out is expected
+    result = unit_frame.select(v=Bernoulli(p=p).ppf(quantile)).item(0, "v")
+    assert result is expected
 
 
 def test_ppf_propagates_null_in_quantile() -> None:

--- a/tests/distributions/bernoulli/std_test.py
+++ b/tests/distributions/bernoulli/std_test.py
@@ -11,8 +11,8 @@ from polars_stats import Bernoulli
 
 @pytest.mark.parametrize("p", [0.0, 0.25, 0.5, 0.75, 1.0])
 def test_std_scalar(p: float, unit_frame: pl.DataFrame) -> None:
-    out = unit_frame.select(v=Bernoulli(p=p).std()).item(0, "v")
-    assert out == pytest.approx(math.sqrt(p * (1 - p)))
+    result = unit_frame.select(v=Bernoulli(p=p).std()).item(0, "v")
+    assert result == pytest.approx(math.sqrt(p * (1 - p)))
 
 
 def test_std_propagates_null_in_p(p_with_null: pl.DataFrame) -> None:

--- a/tests/distributions/bernoulli/variance_test.py
+++ b/tests/distributions/bernoulli/variance_test.py
@@ -9,8 +9,8 @@ from polars_stats import Bernoulli
 
 @pytest.mark.parametrize("p", [0.0, 0.25, 0.5, 0.75, 1.0])
 def test_variance_scalar(p: float, unit_frame: pl.DataFrame) -> None:
-    out = unit_frame.select(v=Bernoulli(p=p).variance()).item(0, "v")
-    assert out == pytest.approx(p * (1 - p))
+    result = unit_frame.select(v=Bernoulli(p=p).variance()).item(0, "v")
+    assert result == pytest.approx(p * (1 - p))
 
 
 def test_variance_column_p() -> None:

--- a/tests/distributions/binomial/bernoulli_equivalence_test.py
+++ b/tests/distributions/binomial/bernoulli_equivalence_test.py
@@ -1,0 +1,39 @@
+"""`Binomial(n=1, p)` is the Bernoulli(`p`) distribution; the shared methods must agree."""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Bernoulli, Binomial
+
+_PROBS = [0.0, 0.2, 0.5, 0.8, 1.0]
+_VALUE_GRID = [-1.0, 0.0, 0.5, 1.0, 2.0]
+_QUANTILES = [0.1, 0.25, 0.5, 0.75, 0.9]
+
+
+@pytest.mark.parametrize("p", _PROBS)
+@pytest.mark.parametrize("method", ["pmf", "log_pmf", "cdf", "log_cdf", "sf", "log_sf"])
+def test_value_keyed_methods_match_bernoulli(p: float, method: str) -> None:
+    df = pl.DataFrame({"x": _VALUE_GRID})
+    binom = df.select(r=getattr(Binomial(1, p), method)(pl.col("x")))["r"]
+    bern = df.select(r=getattr(Bernoulli(p), method)(pl.col("x")))["r"]
+    assert_series_equal(binom, bern, check_names=False)
+
+
+@pytest.mark.parametrize("p", _PROBS)
+@pytest.mark.parametrize("method", ["mean", "variance", "std", "entropy"])
+def test_scalar_methods_match_bernoulli(p: float, method: str, unit_frame: pl.DataFrame) -> None:
+    binom = unit_frame.select(r=getattr(Binomial(1, p), method)()).item(0, "r")
+    bern = unit_frame.select(r=getattr(Bernoulli(p), method)()).item(0, "r")
+    assert binom == pytest.approx(bern)
+
+
+@pytest.mark.parametrize("p", [0.2, 0.5, 0.8])
+@pytest.mark.parametrize("q", _QUANTILES)
+def test_ppf_matches_bernoulli(p: float, q: float, unit_frame: pl.DataFrame) -> None:
+    # Bernoulli ppf is Boolean {False, True}; Binomial ppf is the integer support {0.0, 1.0}.
+    binom = unit_frame.select(r=Binomial(1, p).ppf(q)).item(0, "r")
+    bern = unit_frame.select(r=Bernoulli(p).ppf(q)).item(0, "r")
+    assert binom == float(bern)

--- a/tests/distributions/binomial/cdf_test.py
+++ b/tests/distributions/binomial/cdf_test.py
@@ -6,8 +6,7 @@ from polars.testing import assert_series_equal
 from scipy.stats import binom as scipy_binom
 
 from polars_stats import Binomial
-
-from .conftest import N_TRIALS
+from tests.distributions.binomial.conftest import N_TRIALS
 
 
 @pytest.mark.parametrize("p", [0.0, 0.25, 0.5, 0.75, 1.0])

--- a/tests/distributions/binomial/cdf_test.py
+++ b/tests/distributions/binomial/cdf_test.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+from scipy.stats import binom as scipy_binom
+
+from polars_stats import Binomial
+
+from .conftest import N_TRIALS
+
+
+@pytest.mark.parametrize("p", [0.0, 0.25, 0.5, 0.75, 1.0])
+@pytest.mark.parametrize("value", [-1.0, 0.0, 2.5, 3.0, 9.0, 10.0, 11.0])
+def test_cdf_matches_scipy(p: float, value: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Binomial(N_TRIALS, p).cdf(value)).item(0, "v")
+    assert result == pytest.approx(float(scipy_binom.cdf(value, N_TRIALS, p)))
+
+
+def test_cdf_floors_value() -> None:
+    # cdf is a step function: it agrees with the value floored to the integer support.
+    n, p = N_TRIALS, 0.4
+    df = pl.DataFrame({"v": [2.0, 2.3, 2.99]})
+    result = df.select(r=Binomial(n, p).cdf(pl.col("v")))["r"]
+    expected = pl.Series("r", [scipy_binom.cdf(2, n, p)] * 3, dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_cdf_below_support_is_zero_above_is_one(unit_frame: pl.DataFrame) -> None:
+    assert unit_frame.select(v=Binomial(N_TRIALS, 0.3).cdf(-0.5)).item(0, "v") == 0.0
+    assert unit_frame.select(v=Binomial(N_TRIALS, 0.3).cdf(N_TRIALS)).item(0, "v") == pytest.approx(1.0)
+
+
+def test_cdf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"v": [0.0, None, 10.0]}, schema={"v": pl.Float64})
+    result = df.select(r=Binomial(N_TRIALS, 0.3).cdf(pl.col("v")))["r"]
+    expected = pl.Series("r", [scipy_binom.cdf(0, N_TRIALS, 0.3), None, 1.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_cdf_propagates_null_in_params(params_with_null: pl.DataFrame) -> None:
+    result = params_with_null.select(r=Binomial(pl.col("n"), pl.col("p")).cdf(3))["r"]
+    expected = pl.Series("r", [scipy_binom.cdf(3, 10, 0.3), None, scipy_binom.cdf(3, 8, 0.8)], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/binomial/conftest.py
+++ b/tests/distributions/binomial/conftest.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import polars as pl
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+SEED = 42
+DEFAULT_SIZE = 1000
+# Fixed trial count used by the per-method functional tests; the scipy-parity suite sweeps several.
+N_TRIALS = 10
+
+
+@pytest.fixture(scope="session")
+def seed() -> int:
+    return SEED
+
+
+@pytest.fixture(scope="session")
+def rng() -> np.random.Generator:
+    return np.random.default_rng(seed=SEED)
+
+
+@pytest.fixture
+def frame(rng: np.random.Generator) -> Callable[..., pl.DataFrame]:
+    def _make(size: int = DEFAULT_SIZE) -> pl.DataFrame:
+        return pl.DataFrame(
+            {
+                "x": list(range(size)),
+                "n1": rng.integers(1, 50, size=size),
+                "n2": rng.integers(1, 50, size=size),
+                "p1": rng.uniform(0.01, 0.99, size=size),
+                "p2": rng.uniform(0.01, 0.99, size=size),
+            },
+        )
+
+    return _make
+
+
+@pytest.fixture
+def unit_frame() -> pl.DataFrame:
+    """Single-row frame for evaluating scalar-output expressions."""
+    return pl.DataFrame({"_": [0]})
+
+
+@pytest.fixture
+def params_with_null() -> pl.DataFrame:
+    """`n` and `p` columns sharing a null on the middle row: (n=10, null, 8) / (p=0.3, null, 0.8)."""
+    return pl.DataFrame(
+        {"n": [10, None, 8], "p": [0.3, None, 0.8]},
+        schema={"n": pl.Int64, "p": pl.Float64},
+    )

--- a/tests/distributions/binomial/construct_test.py
+++ b/tests/distributions/binomial/construct_test.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from polars_stats import Binomial
+
+
+@pytest.mark.parametrize("bad_n", [None, True, False, 1.5, 2.0, [5], (5,), {"n": 5}])
+def test_construct_invalid_n_type_raises(bad_n: object) -> None:
+    with pytest.raises(TypeError, match="n should be an int or IntoExprColumn"):
+        Binomial(n=bad_n, p=0.5)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("bad_p", [None, True, False, 1, 0, [0.5], (0.5,), {"p": 0.5}])
+def test_construct_invalid_p_type_raises(bad_p: object) -> None:
+    with pytest.raises(TypeError, match="p should be a float or IntoExprColumn"):
+        Binomial(n=5, p=bad_p)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("n", [0, 1, 10, "n", pl.col("n"), pl.Series("n", [5])])
+def test_construct_accepts_valid_n_types(n: object) -> None:
+    # int and IntoExprColumn are accepted; value validation is deferred to evaluation.
+    Binomial(n=n, p=0.5)  # type: ignore[arg-type]

--- a/tests/distributions/binomial/entropy_test.py
+++ b/tests/distributions/binomial/entropy_test.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+from scipy.stats import binom as scipy_binom
+
+from polars_stats import Binomial
+
+from .conftest import N_TRIALS
+
+
+@pytest.mark.parametrize("p", [0.1, 0.3, 0.5, 0.7, 0.9])
+def test_entropy_matches_scipy(p: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Binomial(N_TRIALS, p).entropy()).item(0, "v")
+    assert result == pytest.approx(float(scipy_binom.entropy(N_TRIALS, p)))
+
+
+@pytest.mark.parametrize("p", [0.0, 1.0])
+def test_entropy_degenerate_endpoints_are_zero(p: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Binomial(N_TRIALS, p).entropy()).item(0, "v")
+    assert result == 0.0
+
+
+def test_entropy_propagates_null_in_params(params_with_null: pl.DataFrame) -> None:
+    result = params_with_null.select(v=Binomial(pl.col("n"), pl.col("p")).entropy())["v"]
+    expected = pl.Series("v", [scipy_binom.entropy(10, 0.3), None, scipy_binom.entropy(8, 0.8)], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/binomial/entropy_test.py
+++ b/tests/distributions/binomial/entropy_test.py
@@ -6,8 +6,7 @@ from polars.testing import assert_series_equal
 from scipy.stats import binom as scipy_binom
 
 from polars_stats import Binomial
-
-from .conftest import N_TRIALS
+from tests.distributions.binomial.conftest import N_TRIALS
 
 
 @pytest.mark.parametrize("p", [0.1, 0.3, 0.5, 0.7, 0.9])

--- a/tests/distributions/binomial/isf_test.py
+++ b/tests/distributions/binomial/isf_test.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+from scipy.stats import binom as scipy_binom
+
+from polars_stats import Binomial
+
+from .conftest import N_TRIALS
+
+
+@pytest.mark.parametrize("q", [0.1, 0.25, 0.5, 0.75, 0.9])
+def test_isf_is_ppf_of_complement(unit_frame: pl.DataFrame, q: float) -> None:
+    p = 0.3
+    isf = unit_frame.select(v=Binomial(N_TRIALS, p).isf(q)).item(0, "v")
+    ppf_comp = unit_frame.select(v=Binomial(N_TRIALS, p).ppf(1 - q)).item(0, "v")
+    assert isf == ppf_comp
+
+
+@pytest.mark.parametrize("p", [0.3, 0.5, 0.7])
+@pytest.mark.parametrize("q", [0.1, 0.25, 0.5, 0.75, 0.9])
+def test_isf_matches_scipy_interior(p: float, q: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Binomial(N_TRIALS, p).isf(q)).item(0, "v")
+    assert result == pytest.approx(float(scipy_binom.isf(q, N_TRIALS, p)))
+
+
+def test_isf_propagates_null_in_quantile() -> None:
+    df = pl.DataFrame({"q": [0.1, None, 0.9]}, schema={"q": pl.Float64})
+    result = df.select(v=Binomial(N_TRIALS, 0.3).isf(pl.col("q")))["v"]
+    expected = pl.Series(
+        "v", [scipy_binom.isf(0.1, N_TRIALS, 0.3), None, scipy_binom.isf(0.9, N_TRIALS, 0.3)], dtype=pl.Float64
+    )
+    assert_series_equal(result, expected)

--- a/tests/distributions/binomial/isf_test.py
+++ b/tests/distributions/binomial/isf_test.py
@@ -6,8 +6,7 @@ from polars.testing import assert_series_equal
 from scipy.stats import binom as scipy_binom
 
 from polars_stats import Binomial
-
-from .conftest import N_TRIALS
+from tests.distributions.binomial.conftest import N_TRIALS
 
 
 @pytest.mark.parametrize("q", [0.1, 0.25, 0.5, 0.75, 0.9])

--- a/tests/distributions/binomial/log_cdf_test.py
+++ b/tests/distributions/binomial/log_cdf_test.py
@@ -8,8 +8,7 @@ from polars.testing import assert_series_equal
 from scipy.stats import binom as scipy_binom
 
 from polars_stats import Binomial
-
-from .conftest import N_TRIALS
+from tests.distributions.binomial.conftest import N_TRIALS
 
 
 @pytest.mark.parametrize("p", [0.25, 0.5, 0.75])

--- a/tests/distributions/binomial/log_cdf_test.py
+++ b/tests/distributions/binomial/log_cdf_test.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+from scipy.stats import binom as scipy_binom
+
+from polars_stats import Binomial
+
+from .conftest import N_TRIALS
+
+
+@pytest.mark.parametrize("p", [0.25, 0.5, 0.75])
+@pytest.mark.parametrize("value", [0.0, 3.0, 9.0])
+def test_log_cdf_matches_scipy(p: float, value: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Binomial(N_TRIALS, p).log_cdf(value)).item(0, "v")
+    assert result == pytest.approx(float(scipy_binom.logcdf(value, N_TRIALS, p)))
+
+
+def test_log_cdf_below_support_is_neg_inf(unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Binomial(N_TRIALS, 0.3).log_cdf(-0.5)).item(0, "v")
+    assert result == -math.inf
+
+
+def test_log_cdf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"v": [0.0, None, 10.0]}, schema={"v": pl.Float64})
+    result = df.select(r=Binomial(N_TRIALS, 0.3).log_cdf(pl.col("v")))["r"]
+    expected = pl.Series("r", [scipy_binom.logcdf(0, N_TRIALS, 0.3), None, 0.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/binomial/log_pmf_test.py
+++ b/tests/distributions/binomial/log_pmf_test.py
@@ -8,8 +8,7 @@ from polars.testing import assert_series_equal
 from scipy.stats import binom as scipy_binom
 
 from polars_stats import Binomial
-
-from .conftest import N_TRIALS
+from tests.distributions.binomial.conftest import N_TRIALS
 
 
 @pytest.mark.parametrize("p", [0.25, 0.5, 0.75])

--- a/tests/distributions/binomial/log_pmf_test.py
+++ b/tests/distributions/binomial/log_pmf_test.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+from scipy.stats import binom as scipy_binom
+
+from polars_stats import Binomial
+
+from .conftest import N_TRIALS
+
+
+@pytest.mark.parametrize("p", [0.25, 0.5, 0.75])
+def test_log_pmf_integer_support_matches_scipy(p: float, unit_frame: pl.DataFrame) -> None:
+    for k in range(N_TRIALS + 1):
+        result = unit_frame.select(v=Binomial(N_TRIALS, p).log_pmf(k)).item(0, "v")
+        assert result == pytest.approx(float(scipy_binom.logpmf(k, N_TRIALS, p)))
+
+
+@pytest.mark.parametrize("value", [-1.0, 2.5, 11.0])
+def test_log_pmf_off_support_is_neg_inf(value: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Binomial(N_TRIALS, 0.3).log_pmf(value)).item(0, "v")
+    assert result == -math.inf
+
+
+def test_log_pmf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"v": [0, None, 3]}, schema={"v": pl.Int64})
+    result = df.select(r=Binomial(N_TRIALS, 0.3).log_pmf(pl.col("v")))["r"]
+    expected = pl.Series(
+        "r", [scipy_binom.logpmf(0, N_TRIALS, 0.3), None, scipy_binom.logpmf(3, N_TRIALS, 0.3)], dtype=pl.Float64
+    )
+    assert_series_equal(result, expected)
+
+
+def test_log_pmf_propagates_null_in_params(params_with_null: pl.DataFrame) -> None:
+    result = params_with_null.select(r=Binomial(pl.col("n"), pl.col("p")).log_pmf(3))["r"]
+    expected = pl.Series("r", [scipy_binom.logpmf(3, 10, 0.3), None, scipy_binom.logpmf(3, 8, 0.8)], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/binomial/log_sf_test.py
+++ b/tests/distributions/binomial/log_sf_test.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+from scipy.stats import binom as scipy_binom
+
+from polars_stats import Binomial
+
+from .conftest import N_TRIALS
+
+
+@pytest.mark.parametrize("p", [0.25, 0.5, 0.75])
+@pytest.mark.parametrize("value", [0.0, 3.0, 8.0])
+def test_log_sf_matches_scipy(p: float, value: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Binomial(N_TRIALS, p).log_sf(value)).item(0, "v")
+    assert result == pytest.approx(float(scipy_binom.logsf(value, N_TRIALS, p)))
+
+
+def test_log_sf_above_support_is_neg_inf(unit_frame: pl.DataFrame) -> None:
+    # sf(n) = 0 → log_sf = -inf.
+    result = unit_frame.select(v=Binomial(N_TRIALS, 0.3).log_sf(N_TRIALS)).item(0, "v")
+    assert result == -math.inf
+
+
+def test_log_sf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"v": [0.0, None, 3.0]}, schema={"v": pl.Float64})
+    result = df.select(r=Binomial(N_TRIALS, 0.3).log_sf(pl.col("v")))["r"]
+    expected = pl.Series(
+        "r", [scipy_binom.logsf(0, N_TRIALS, 0.3), None, scipy_binom.logsf(3, N_TRIALS, 0.3)], dtype=pl.Float64
+    )
+    assert_series_equal(result, expected)

--- a/tests/distributions/binomial/log_sf_test.py
+++ b/tests/distributions/binomial/log_sf_test.py
@@ -8,8 +8,7 @@ from polars.testing import assert_series_equal
 from scipy.stats import binom as scipy_binom
 
 from polars_stats import Binomial
-
-from .conftest import N_TRIALS
+from tests.distributions.binomial.conftest import N_TRIALS
 
 
 @pytest.mark.parametrize("p", [0.25, 0.5, 0.75])

--- a/tests/distributions/binomial/mean_test.py
+++ b/tests/distributions/binomial/mean_test.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Binomial
+
+from .conftest import N_TRIALS
+
+
+@pytest.mark.parametrize("p", [0.0, 0.25, 0.5, 0.75, 1.0])
+def test_mean_scalar(p: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Binomial(N_TRIALS, p).mean()).item(0, "v")
+    assert result == pytest.approx(N_TRIALS * p)
+
+
+def test_mean_column_params() -> None:
+    df = pl.DataFrame({"n": [5, 10, 20], "p": [0.1, 0.4, 0.6]})
+    result = df.select(v=Binomial(pl.col("n"), pl.col("p")).mean())["v"]
+    expected = pl.Series("v", [5 * 0.1, 10 * 0.4, 20 * 0.6], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_mean_propagates_null_in_params(params_with_null: pl.DataFrame) -> None:
+    result = params_with_null.select(v=Binomial(pl.col("n"), pl.col("p")).mean())["v"]
+    expected = pl.Series("v", [10 * 0.3, None, 8 * 0.8], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/binomial/mean_test.py
+++ b/tests/distributions/binomial/mean_test.py
@@ -5,8 +5,7 @@ import pytest
 from polars.testing import assert_series_equal
 
 from polars_stats import Binomial
-
-from .conftest import N_TRIALS
+from tests.distributions.binomial.conftest import N_TRIALS
 
 
 @pytest.mark.parametrize("p", [0.0, 0.25, 0.5, 0.75, 1.0])

--- a/tests/distributions/binomial/median_test.py
+++ b/tests/distributions/binomial/median_test.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+from scipy.stats import binom as scipy_binom
+
+from polars_stats import Binomial
+
+from .conftest import N_TRIALS
+
+
+@pytest.mark.parametrize("p", [0.1, 0.3, 0.5, 0.75, 0.9])
+def test_median_matches_scipy(p: float, unit_frame: pl.DataFrame) -> None:
+    # median == ppf(0.5), which matches scipy. statrs' native floor(n*p) is a different convention
+    # and is deliberately not used (it disagrees with scipy at several (n, p), e.g. n=10, p=0.75).
+    result = unit_frame.select(v=Binomial(N_TRIALS, p).median()).item(0, "v")
+    assert result == pytest.approx(float(scipy_binom.median(N_TRIALS, p)))
+
+
+def test_median_disagrees_with_floor_np_where_scipy_does(unit_frame: pl.DataFrame) -> None:
+    # Guard the convention choice: floor(10 * 0.75) = 7, but the scipy/ppf(0.5) median is 8.
+    result = unit_frame.select(v=Binomial(10, 0.75).median()).item(0, "v")
+    assert result == float(scipy_binom.median(10, 0.75)) == 8.0  # noqa: PLR2004
+
+
+def test_median_propagates_null_in_params(params_with_null: pl.DataFrame) -> None:
+    result = params_with_null.select(v=Binomial(pl.col("n"), pl.col("p")).median())["v"]
+    expected = pl.Series("v", [scipy_binom.median(10, 0.3), None, scipy_binom.median(8, 0.8)], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/binomial/median_test.py
+++ b/tests/distributions/binomial/median_test.py
@@ -6,8 +6,7 @@ from polars.testing import assert_series_equal
 from scipy.stats import binom as scipy_binom
 
 from polars_stats import Binomial
-
-from .conftest import N_TRIALS
+from tests.distributions.binomial.conftest import N_TRIALS
 
 
 @pytest.mark.parametrize("p", [0.1, 0.3, 0.5, 0.75, 0.9])

--- a/tests/distributions/binomial/pmf_test.py
+++ b/tests/distributions/binomial/pmf_test.py
@@ -6,8 +6,7 @@ from polars.testing import assert_series_equal
 from scipy.stats import binom as scipy_binom
 
 from polars_stats import Binomial
-
-from .conftest import N_TRIALS
+from tests.distributions.binomial.conftest import N_TRIALS
 
 
 @pytest.mark.parametrize("p", [0.0, 0.25, 0.5, 0.75, 1.0])

--- a/tests/distributions/binomial/pmf_test.py
+++ b/tests/distributions/binomial/pmf_test.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+from scipy.stats import binom as scipy_binom
+
+from polars_stats import Binomial
+
+from .conftest import N_TRIALS
+
+
+@pytest.mark.parametrize("p", [0.0, 0.25, 0.5, 0.75, 1.0])
+def test_pmf_integer_support_matches_scipy(p: float, unit_frame: pl.DataFrame) -> None:
+    for k in range(N_TRIALS + 1):
+        result = unit_frame.select(v=Binomial(N_TRIALS, p).pmf(k)).item(0, "v")
+        assert result == pytest.approx(float(scipy_binom.pmf(k, N_TRIALS, p)))
+
+
+@pytest.mark.parametrize("value", [-1.0, 2.5, 11.0, 100.0])
+def test_pmf_off_support_is_zero(value: float, unit_frame: pl.DataFrame) -> None:
+    # Below zero, non-integer, and above n all carry zero mass.
+    result = unit_frame.select(v=Binomial(N_TRIALS, 0.3).pmf(value)).item(0, "v")
+    assert result == 0.0
+
+
+def test_pmf_column_value() -> None:
+    n, p = N_TRIALS, 0.3
+    df = pl.DataFrame({"v": [-1.0, 0.0, 2.5, 3.0, 11.0]})
+    result = df.select(r=Binomial(n, p).pmf(pl.col("v")))["r"]
+    expected = pl.Series("r", [0.0, scipy_binom.pmf(0, n, p), 0.0, scipy_binom.pmf(3, n, p), 0.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_pmf_column_n_and_p() -> None:
+    df = pl.DataFrame({"n": [5, 10, 20], "p": [0.2, 0.5, 0.8]})
+    result = df.select(r=Binomial(pl.col("n"), pl.col("p")).pmf(3))["r"]
+    expected = pl.Series(
+        "r", [scipy_binom.pmf(3, nn, pp) for nn, pp in [(5, 0.2), (10, 0.5), (20, 0.8)]], dtype=pl.Float64
+    )
+    assert_series_equal(result, expected)
+
+
+def test_pmf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"v": [0, None, 3]}, schema={"v": pl.Int64})
+    result = df.select(r=Binomial(N_TRIALS, 0.3).pmf(pl.col("v")))["r"]
+    expected = pl.Series(
+        "r", [scipy_binom.pmf(0, N_TRIALS, 0.3), None, scipy_binom.pmf(3, N_TRIALS, 0.3)], dtype=pl.Float64
+    )
+    assert_series_equal(result, expected)
+
+
+def test_pmf_propagates_null_in_params(params_with_null: pl.DataFrame) -> None:
+    result = params_with_null.select(r=Binomial(pl.col("n"), pl.col("p")).pmf(3))["r"]
+    expected = pl.Series("r", [scipy_binom.pmf(3, 10, 0.3), None, scipy_binom.pmf(3, 8, 0.8)], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/binomial/ppf_test.py
+++ b/tests/distributions/binomial/ppf_test.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+from scipy.stats import binom as scipy_binom
+
+from polars_stats import Binomial
+
+from .conftest import N_TRIALS
+
+
+@pytest.mark.parametrize("p", [0.1, 0.3, 0.5, 0.7, 0.9])
+@pytest.mark.parametrize("q", [0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95])
+def test_ppf_matches_scipy_interior(p: float, q: float, unit_frame: pl.DataFrame) -> None:
+    # Interior quantiles only: scipy's discrete ppf returns the below-support sentinel -1 at q == 0,
+    # which this implementation (clamped to the support) does not reproduce.
+    result = unit_frame.select(v=Binomial(N_TRIALS, p).ppf(q)).item(0, "v")
+    assert result == pytest.approx(float(scipy_binom.ppf(q, N_TRIALS, p)))
+
+
+def test_ppf_is_integer_valued() -> None:
+    qs = [0.05, 0.2, 0.4, 0.6, 0.8, 0.95]
+    result = pl.DataFrame({"q": qs}).select(r=Binomial(N_TRIALS, 0.37).ppf(pl.col("q")))["r"]
+    assert (result == result.floor()).all()
+
+
+def test_ppf_endpoints(unit_frame: pl.DataFrame) -> None:
+    # At q == 1 this matches scipy (n); at q == 0 it returns the support lower bound 0, not scipy's -1.
+    assert unit_frame.select(v=Binomial(N_TRIALS, 0.4).ppf(1.0)).item(0, "v") == float(N_TRIALS)
+    assert unit_frame.select(v=Binomial(N_TRIALS, 0.4).ppf(0.0)).item(0, "v") == 0.0
+
+
+@pytest.mark.parametrize("q", [-0.1, 1.5])
+def test_ppf_out_of_range_quantile_is_null(q: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Binomial(N_TRIALS, 0.4).ppf(q)).item(0, "v")
+    assert result is None
+
+
+def test_ppf_propagates_null_in_quantile() -> None:
+    df = pl.DataFrame({"q": [0.1, None, 0.9]}, schema={"q": pl.Float64})
+    result = df.select(v=Binomial(N_TRIALS, 0.3).ppf(pl.col("q")))["v"]
+    expected = pl.Series(
+        "v", [scipy_binom.ppf(0.1, N_TRIALS, 0.3), None, scipy_binom.ppf(0.9, N_TRIALS, 0.3)], dtype=pl.Float64
+    )
+    assert_series_equal(result, expected)
+
+
+def test_ppf_propagates_null_in_params(params_with_null: pl.DataFrame) -> None:
+    result = params_with_null.select(v=Binomial(pl.col("n"), pl.col("p")).ppf(0.5))["v"]
+    expected = pl.Series("v", [scipy_binom.ppf(0.5, 10, 0.3), None, scipy_binom.ppf(0.5, 8, 0.8)], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/binomial/ppf_test.py
+++ b/tests/distributions/binomial/ppf_test.py
@@ -6,8 +6,7 @@ from polars.testing import assert_series_equal
 from scipy.stats import binom as scipy_binom
 
 from polars_stats import Binomial
-
-from .conftest import N_TRIALS
+from tests.distributions.binomial.conftest import N_TRIALS
 
 
 @pytest.mark.parametrize("p", [0.1, 0.3, 0.5, 0.7, 0.9])

--- a/tests/distributions/binomial/sample_test.py
+++ b/tests/distributions/binomial/sample_test.py
@@ -8,8 +8,7 @@ import pytest
 from polars.testing import assert_series_equal, assert_series_not_equal
 
 from polars_stats import Binomial
-
-from .conftest import N_TRIALS
+from tests.distributions.binomial.conftest import N_TRIALS
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/tests/distributions/binomial/sample_test.py
+++ b/tests/distributions/binomial/sample_test.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal, assert_series_not_equal
+
+from polars_stats import Binomial
+
+from .conftest import N_TRIALS
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@pytest.mark.parametrize("size", [0, 100, 1_000])
+def test_sample_basic_properties(size: int, frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    result = frame(size=size).lazy().with_columns(b=Binomial(N_TRIALS, 0.5).sample(seed=seed))
+    assert result.collect_schema()["b"] == pl.UInt64
+    collected = result.collect()
+    assert collected.height == size
+    assert collected["b"].is_between(0, N_TRIALS).all()
+
+
+@pytest.mark.parametrize("p", [0.0, 0.3, 0.5, 0.8, 1.0, pl.col("p1")])
+def test_sample_seed_reproducible(p: float | pl.Expr, frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    dframe = frame()
+    s1 = dframe.with_columns(b=Binomial(pl.col("n1"), p).sample(seed=seed))["b"]
+    s2 = dframe.with_columns(b=Binomial(pl.col("n1"), p).sample(seed=seed))["b"]
+    assert_series_equal(s1, s2)
+
+
+def test_sample_different_seeds_differ(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    dframe = frame()
+    s1 = dframe.with_columns(b=Binomial(N_TRIALS, 0.5).sample(seed=123))["b"]
+    s2 = dframe.with_columns(b=Binomial(N_TRIALS, 0.5).sample(seed=seed))["b"]
+    assert_series_not_equal(s1, s2)
+
+
+@pytest.mark.parametrize(("p", "expected"), [(0.0, 0), (1.0, N_TRIALS)])
+def test_sample_extreme_p_is_deterministic(p: float, expected: int, frame: Callable[..., pl.DataFrame]) -> None:
+    # p=0 → 0 successes; p=1 → all n successes, regardless of the draw.
+    result = frame().with_columns(b=Binomial(N_TRIALS, p).sample(seed=7))
+    assert result["b"].eq(expected).all()
+
+
+@pytest.mark.parametrize("p", [0.2, 0.5, 0.8])
+def test_sample_mean_close_to_np_for_large_n(p: float, frame: Callable[..., pl.DataFrame]) -> None:
+    n_rows, tolerance = 100_000, 0.05
+    result = frame(n_rows).with_columns(b=Binomial(N_TRIALS, p).sample(seed=123))
+    observed = result["b"].mean()
+    assert isinstance(observed, float)
+    assert abs(observed - N_TRIALS * p) < tolerance
+
+
+@pytest.mark.parametrize("p", [-0.1, 1.5, float("nan")])
+def test_sample_invalid_p_raises(p: float, frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    dframe = frame(size=8)
+    with pytest.raises(pl.exceptions.ComputeError, match="p must be in"):
+        dframe.with_columns(b=Binomial(N_TRIALS, p).sample(seed=seed))
+
+
+def test_sample_negative_n_raises(seed: int) -> None:
+    dframe = pl.DataFrame({"n": [5, -1, 3]}, schema={"n": pl.Int64})
+    with pytest.raises(pl.exceptions.ComputeError, match="n must be a non-negative integer"):
+        dframe.with_columns(b=Binomial(pl.col("n"), 0.5).sample(seed=seed))
+
+
+def test_sample_with_null_param_row_is_null(seed: int) -> None:
+    dframe = pl.DataFrame({"p": [0.5, None, 0.5]}, schema={"p": pl.Float64})
+    result = dframe.with_columns(b=Binomial(N_TRIALS, pl.col("p")).sample(seed=seed))
+    assert_series_equal(result["b"].is_null(), pl.Series("b", [False, True, False]))
+
+
+def test_sample_with_str_params_matches_col(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    dframe = frame()
+    s_str = dframe.with_columns(b=Binomial("n1", "p1").sample(seed=seed))["b"]
+    s_col = dframe.with_columns(b=Binomial(pl.col("n1"), pl.col("p1")).sample(seed=seed))["b"]
+    assert_series_equal(s_str, s_col)
+
+
+def test_sample_in_group_by_draws_per_group(seed: int) -> None:
+    local_rng = np.random.default_rng(seed=seed)
+    n_per_group, n_groups = 200, 40
+    dframe = pl.DataFrame(
+        {
+            "group": np.repeat(np.arange(n_groups), n_per_group),
+            "probas": local_rng.uniform(0.01, 0.99, size=n_groups * n_per_group),
+        },
+    )
+    agg = (
+        dframe.group_by("group", maintain_order=True)
+        .agg(
+            sum_const=Binomial(N_TRIALS, 0.5).sample(seed=seed).sum(),
+            sum_varying=Binomial(N_TRIALS, pl.col("probas")).sample(seed=seed).sum(),
+            size=pl.len(),
+        )
+        .sort("group")
+    )
+    assert agg.get_column("size").eq(n_per_group).all()
+    # Constant p + constant seed + identical per-group indices => identical sums across groups.
+    assert len(set(agg.get_column("sum_const").to_list())) == 1
+    # Per-row p varies across groups, so per-group sums must vary too.
+    assert len(set(agg.get_column("sum_varying").to_list())) > 1
+
+
+def test_sample_unseeded_produces_variability(frame: Callable[..., pl.DataFrame]) -> None:
+    dframe = frame(size=512)
+    s1 = dframe.with_columns(b=Binomial(N_TRIALS, 0.5).sample(seed=None))["b"]
+    s2 = dframe.with_columns(b=Binomial(N_TRIALS, 0.5).sample(seed=None))["b"]
+    assert_series_not_equal(s1, s2)

--- a/tests/distributions/binomial/samples_test.py
+++ b/tests/distributions/binomial/samples_test.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Binomial
+
+from .conftest import N_TRIALS
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@pytest.mark.parametrize("size", [1, 4, 16])
+def test_samples_shape_and_dtype(size: int, frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    n_rows = 32
+    result = frame(size=n_rows).select(s=Binomial(N_TRIALS, 0.5).samples(size=size, seed=seed))
+    assert result.height == n_rows
+    assert result.schema["s"] == pl.Array(pl.UInt64, size)
+
+
+def test_samples_seed_reproducible(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    dframe = frame(size=128)
+    s1 = dframe.select(s=Binomial(N_TRIALS, 0.4).samples(size=8, seed=seed))["s"]
+    s2 = dframe.select(s=Binomial(N_TRIALS, 0.4).samples(size=8, seed=seed))["s"]
+    assert_series_equal(s1, s2)
+
+
+def test_samples_columns_are_not_all_equal(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    size = 8
+    dframe = frame(size=512)
+    result = dframe.select(s=Binomial(N_TRIALS, 0.5).samples(size=size, seed=seed))["s"]
+    columns = [result.arr.get(i) for i in range(size)]
+    distinct = {tuple(c.to_list()) for c in columns}
+    assert len(distinct) == size
+
+
+def test_samples_mean_close_to_np_for_large_total(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    n_rows, size, p = 4_000, 16, 0.3
+    tolerance = 0.05
+    result = frame(n_rows).select(s=Binomial(N_TRIALS, p).samples(size=size, seed=seed))["s"].arr.explode()
+    mean = cast("float", result.mean())
+    assert abs(mean - N_TRIALS * p) < tolerance
+
+
+@pytest.mark.parametrize("bad_size", [0, -1])
+def test_samples_rejects_non_positive_size(bad_size: int) -> None:
+    with pytest.raises(ValueError, match="size must be a positive integer"):
+        Binomial(N_TRIALS, 0.5).samples(size=bad_size, seed=0)
+
+
+def test_samples_null_param_row_is_null_array(seed: int) -> None:
+    size = 4
+    dframe = pl.DataFrame({"p": [0.5, None, 0.5]}, schema={"p": pl.Float64})
+    result = dframe.select(s=Binomial(N_TRIALS, pl.col("p")).samples(size=size, seed=seed))["s"]
+    assert result.dtype == pl.Array(pl.UInt64, size)
+    assert_series_equal(result.is_null(), pl.Series("s", [False, True, False]))

--- a/tests/distributions/binomial/samples_test.py
+++ b/tests/distributions/binomial/samples_test.py
@@ -7,8 +7,7 @@ import pytest
 from polars.testing import assert_series_equal
 
 from polars_stats import Binomial
-
-from .conftest import N_TRIALS
+from tests.distributions.binomial.conftest import N_TRIALS
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/tests/distributions/binomial/sf_test.py
+++ b/tests/distributions/binomial/sf_test.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+from scipy.stats import binom as scipy_binom
+
+from polars_stats import Binomial
+
+from .conftest import N_TRIALS
+
+
+@pytest.mark.parametrize("p", [0.0, 0.25, 0.5, 0.75, 1.0])
+@pytest.mark.parametrize("value", [-1.0, 0.0, 2.5, 3.0, 9.0, 10.0, 11.0])
+def test_sf_matches_scipy(p: float, value: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Binomial(N_TRIALS, p).sf(value)).item(0, "v")
+    assert result == pytest.approx(float(scipy_binom.sf(value, N_TRIALS, p)))
+
+
+def test_sf_is_one_minus_cdf(unit_frame: pl.DataFrame) -> None:
+    n, p, value = N_TRIALS, 0.3, 3
+    cdf = unit_frame.select(v=Binomial(n, p).cdf(value)).item(0, "v")
+    sf = unit_frame.select(v=Binomial(n, p).sf(value)).item(0, "v")
+    assert sf == pytest.approx(1 - cdf)
+
+
+def test_sf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"v": [0.0, None, 10.0]}, schema={"v": pl.Float64})
+    result = df.select(r=Binomial(N_TRIALS, 0.3).sf(pl.col("v")))["r"]
+    expected = pl.Series(
+        "r", [scipy_binom.sf(0, N_TRIALS, 0.3), None, scipy_binom.sf(10, N_TRIALS, 0.3)], dtype=pl.Float64
+    )
+    assert_series_equal(result, expected)
+
+
+def test_sf_propagates_null_in_params(params_with_null: pl.DataFrame) -> None:
+    result = params_with_null.select(r=Binomial(pl.col("n"), pl.col("p")).sf(3))["r"]
+    expected = pl.Series("r", [scipy_binom.sf(3, 10, 0.3), None, scipy_binom.sf(3, 8, 0.8)], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/binomial/sf_test.py
+++ b/tests/distributions/binomial/sf_test.py
@@ -6,8 +6,7 @@ from polars.testing import assert_series_equal
 from scipy.stats import binom as scipy_binom
 
 from polars_stats import Binomial
-
-from .conftest import N_TRIALS
+from tests.distributions.binomial.conftest import N_TRIALS
 
 
 @pytest.mark.parametrize("p", [0.0, 0.25, 0.5, 0.75, 1.0])

--- a/tests/distributions/binomial/std_test.py
+++ b/tests/distributions/binomial/std_test.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Binomial
+
+from .conftest import N_TRIALS
+
+
+@pytest.mark.parametrize("p", [0.0, 0.25, 0.5, 0.75, 1.0])
+def test_std_scalar(p: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Binomial(N_TRIALS, p).std()).item(0, "v")
+    assert result == pytest.approx(math.sqrt(N_TRIALS * p * (1 - p)))
+
+
+def test_std_propagates_null_in_params(params_with_null: pl.DataFrame) -> None:
+    result = params_with_null.select(v=Binomial(pl.col("n"), pl.col("p")).std())["v"]
+    expected = pl.Series("v", [math.sqrt(10 * 0.3 * 0.7), None, math.sqrt(8 * 0.8 * 0.2)], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/binomial/std_test.py
+++ b/tests/distributions/binomial/std_test.py
@@ -7,8 +7,7 @@ import pytest
 from polars.testing import assert_series_equal
 
 from polars_stats import Binomial
-
-from .conftest import N_TRIALS
+from tests.distributions.binomial.conftest import N_TRIALS
 
 
 @pytest.mark.parametrize("p", [0.0, 0.25, 0.5, 0.75, 1.0])

--- a/tests/distributions/binomial/validation_test.py
+++ b/tests/distributions/binomial/validation_test.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+
+from polars_stats import Binomial
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Every public method must report an invalid parameter as a ComputeError, not silently null the row.
+# All deterministic methods build the statrs distribution in their plugin; the sampler validates in
+# its own plugin.
+_METHODS: dict[str, Callable[[Binomial], pl.Expr]] = {
+    "pmf": lambda b: b.pmf(pl.col("x")),
+    "log_pmf": lambda b: b.log_pmf(pl.col("x")),
+    "cdf": lambda b: b.cdf(pl.col("x")),
+    "log_cdf": lambda b: b.log_cdf(pl.col("x")),
+    "sf": lambda b: b.sf(pl.col("x")),
+    "log_sf": lambda b: b.log_sf(pl.col("x")),
+    "ppf": lambda b: b.ppf(pl.col("q")),
+    "isf": lambda b: b.isf(pl.col("q")),
+    "mean": lambda b: b.mean(),
+    "variance": lambda b: b.variance(),
+    "std": lambda b: b.std(),
+    "median": lambda b: b.median(),
+    "entropy": lambda b: b.entropy(),
+    "sample": lambda b: b.sample(seed=0),
+    "samples": lambda b: b.samples(size=4, seed=0),
+}
+
+
+@pytest.mark.parametrize("expr_fn", _METHODS.values(), ids=list(_METHODS))
+def test_method_raises_on_out_of_range_p_column(expr_fn: Callable[[Binomial], pl.Expr]) -> None:
+    df = pl.DataFrame({"n": [10, 10], "p": [0.5, 1.5], "x": [0, 0], "q": [0.5, 0.5]})  # row 1: p out of [0, 1]
+    b = Binomial(pl.col("n"), pl.col("p"))
+    with pytest.raises(pl.exceptions.ComputeError, match="p must be in"):
+        df.select(r=expr_fn(b))
+
+
+@pytest.mark.parametrize("expr_fn", _METHODS.values(), ids=list(_METHODS))
+def test_method_raises_on_out_of_range_p_scalar(expr_fn: Callable[[Binomial], pl.Expr]) -> None:
+    df = pl.DataFrame({"x": [0], "q": [0.5]})
+    b = Binomial(10, 1.5)
+    with pytest.raises(pl.exceptions.ComputeError, match="p must be in"):
+        df.select(r=expr_fn(b))
+
+
+@pytest.mark.parametrize("expr_fn", _METHODS.values(), ids=list(_METHODS))
+def test_method_raises_on_negative_n_column(expr_fn: Callable[[Binomial], pl.Expr]) -> None:
+    df = pl.DataFrame({"n": [10, -1], "p": [0.5, 0.5], "x": [0, 0], "q": [0.5, 0.5]})  # row 1: n < 0
+    b = Binomial(pl.col("n"), pl.col("p"))
+    with pytest.raises(pl.exceptions.ComputeError, match="n must be a non-negative integer"):
+        df.select(r=expr_fn(b))

--- a/tests/distributions/binomial/variance_test.py
+++ b/tests/distributions/binomial/variance_test.py
@@ -5,8 +5,7 @@ import pytest
 from polars.testing import assert_series_equal
 
 from polars_stats import Binomial
-
-from .conftest import N_TRIALS
+from tests.distributions.binomial.conftest import N_TRIALS
 
 
 @pytest.mark.parametrize("p", [0.0, 0.25, 0.5, 0.75, 1.0])

--- a/tests/distributions/binomial/variance_test.py
+++ b/tests/distributions/binomial/variance_test.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Binomial
+
+from .conftest import N_TRIALS
+
+
+@pytest.mark.parametrize("p", [0.0, 0.25, 0.5, 0.75, 1.0])
+def test_variance_scalar(p: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Binomial(N_TRIALS, p).variance()).item(0, "v")
+    assert result == pytest.approx(N_TRIALS * p * (1 - p))
+
+
+def test_variance_column_params() -> None:
+    df = pl.DataFrame({"n": [5, 10, 20], "p": [0.1, 0.4, 0.6]})
+    result = df.select(v=Binomial(pl.col("n"), pl.col("p")).variance())["v"]
+    expected = pl.Series("v", [nn * pp * (1 - pp) for nn, pp in [(5, 0.1), (10, 0.4), (20, 0.6)]], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_variance_propagates_null_in_params(params_with_null: pl.DataFrame) -> None:
+    result = params_with_null.select(v=Binomial(pl.col("n"), pl.col("p")).variance())["v"]
+    expected = pl.Series("v", [10 * 0.3 * 0.7, None, 8 * 0.8 * 0.2], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/uniform/std_test.py
+++ b/tests/distributions/uniform/std_test.py
@@ -13,5 +13,5 @@ if TYPE_CHECKING:
 def test_std_is_sqrt_variance(bounds: tuple[float, float], unit_frame: pl.DataFrame) -> None:
     mn, mx = bounds
     u = Uniform(min=mn, max=mx)
-    out = unit_frame.select(r=u.std() ** 2 - u.variance()).item(0, "r")
-    assert out == pytest.approx(0.0, abs=1e-12)
+    result = unit_frame.select(r=u.std() ** 2 - u.variance()).item(0, "r")
+    assert result == pytest.approx(0.0, abs=1e-12)

--- a/tests/distributions/value_arg_str_test.py
+++ b/tests/distributions/value_arg_str_test.py
@@ -14,7 +14,7 @@ import polars as pl
 import pytest
 from polars.testing import assert_series_equal
 
-from polars_stats import Bernoulli, LogNormal, Normal, Uniform
+from polars_stats import Bernoulli, Binomial, LogNormal, Normal, Uniform
 from polars_stats.distributions._base import ContinuousDistribution
 
 if TYPE_CHECKING:
@@ -26,6 +26,7 @@ DISTRIBUTIONS: list[tuple[_UnivariateDistribution, str]] = [
     (LogNormal(mu="mu", sigma="sigma"), "LogNormal"),
     (Uniform(min="lo", max="hi"), "Uniform"),
     (Bernoulli(p="p"), "Bernoulli"),
+    (Binomial(n="n", p="p"), "Binomial"),
 ]
 
 FRAME = pl.DataFrame(
@@ -34,6 +35,7 @@ FRAME = pl.DataFrame(
         "sigma": [1.0, 2.0, 0.5],
         "lo": [0.0, -1.0, 2.0],
         "hi": [1.0, 3.0, 5.0],
+        "n": [5, 10, 20],
         "p": [0.2, 0.5, 0.9],
         "x": [0.5, 1.5, 3.0],  # support points for pdf / pmf / cdf / sf
         "q": [0.1, 0.5, 0.9],  # quantiles in [0, 1] for ppf / isf

--- a/tests/property/_specs.py
+++ b/tests/property/_specs.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from hypothesis import strategies as st
 
-from polars_stats import Bernoulli, LogNormal, Normal, Uniform
+from polars_stats import Bernoulli, Binomial, LogNormal, Normal, Uniform
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -65,6 +65,18 @@ _BERNOULLI = DistSpec(
     support=lambda _: [0.0, 1.0],
 )
 
+_BINOMIAL = DistSpec(
+    name="binomial",
+    continuous=False,
+    # `n` is drawn as an integer trial count; `p` spans the closed unit interval (incl. the
+    # degenerate endpoints, where the mass collapses onto a single support point).
+    params=st.tuples(st.integers(min_value=0, max_value=20), _finite(0.0, 1.0)),
+    make=lambda p: Binomial(n=int(p[0]), p=p[1]),
+    density=lambda d, c: d.pmf(c),
+    eval_range=lambda p: (-1.0, p[0] + 1.0),
+    support=lambda p: [float(k) for k in range(int(p[0]) + 1)],
+)
+
 _NORMAL = DistSpec(
     name="normal",
     continuous=True,
@@ -101,6 +113,6 @@ _LOGNORMAL = DistSpec(
     integration_bounds=lambda p: (0.0, exp(p[0] + 6.0 * p[1])),
 )
 
-ALL_SPECS = [_BERNOULLI, _NORMAL, _UNIFORM, _LOGNORMAL]
+ALL_SPECS = [_BERNOULLI, _BINOMIAL, _NORMAL, _UNIFORM, _LOGNORMAL]
 CONTINUOUS_SPECS = [s for s in ALL_SPECS if s.continuous]
 DISCRETE_SPECS = [s for s in ALL_SPECS if not s.continuous]

--- a/tests/scipy_parity/binomial_test.py
+++ b/tests/scipy_parity/binomial_test.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+from scipy.stats import binom as scipy_binom
+
+from polars_stats import Binomial
+from tests.scipy_parity._harness import Case, assert_case_matches_scipy
+
+# Parameter and evaluation grids for the parity sweep. Owned by this test category and independent
+# of the per-method functional tests under `tests/distributions/binomial`.
+_NS = [1, 5, 10]
+_PROBS = [0.0, 0.25, 0.5, 0.75, 1.0]
+# Interior quantiles only: scipy's discrete ppf/isf return the below-support sentinel -1 at the
+# exact endpoints q in {0, 1}, which this support-clamped ppf does not reproduce.
+_QUANTILES = [0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95]
+# Spans below the support, several integer points, a non-integer, the upper bound, and above it.
+_VALUE_GRID = [-1.0, 0.0, 1.0, 2.5, 3.0, 5.0, 10.0, 11.0]
+
+
+_CASES: list[Case[Binomial]] = [
+    Case("pmf", "value", lambda b, c: b.pmf(c), "pmf"),
+    Case("log_pmf", "value", lambda b, c: b.log_pmf(c), "logpmf"),
+    Case("cdf", "value", lambda b, c: b.cdf(c), "cdf"),
+    Case("log_cdf", "value", lambda b, c: b.log_cdf(c), "logcdf"),
+    Case("sf", "value", lambda b, c: b.sf(c), "sf"),
+    Case("log_sf", "value", lambda b, c: b.log_sf(c), "logsf"),
+    Case("ppf", "quantile", lambda b, c: b.ppf(c), "ppf"),
+    Case("isf", "quantile", lambda b, c: b.isf(c), "isf"),
+    Case("mean", "scalar", lambda b, _: b.mean(), "mean"),
+    Case("variance", "scalar", lambda b, _: b.variance(), "var"),
+    Case("std", "scalar", lambda b, _: b.std(), "std"),
+    Case("median", "scalar", lambda b, _: b.median(), "median"),
+    Case("entropy", "scalar", lambda b, _: b.entropy(), "entropy"),
+]
+
+
+@pytest.mark.parametrize("p", _PROBS, ids=[f"p={p}" for p in _PROBS])
+@pytest.mark.parametrize("n", _NS, ids=[f"n={n}" for n in _NS])
+@pytest.mark.parametrize("case", _CASES, ids=lambda c: c.name)
+def test_method_matches_scipy(case: Case[Binomial], n: int, p: float) -> None:
+    """Every closed-form method matches `scipy.stats.binom(n, p)` across `_NS` x `_PROBS`.
+
+    Table-driven: adding a method is one row in `_CASES`. `ppf`/`isf` use interior quantiles only,
+    since scipy's discrete inverse returns the below-support sentinel -1 at `q` in `{0, 1}`, which the
+    support-clamped `ppf` here does not reproduce. Method-specific behaviour (support handling, null
+    propagation) is asserted in the per-method test files.
+    """
+    assert_case_matches_scipy(
+        case,
+        dist=Binomial(n, p),
+        scipy_frozen=scipy_binom(n, p),
+        value_grid=_VALUE_GRID,
+        quantiles=_QUANTILES,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -191,7 +191,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
Adds `polars_stats.Binomial(n, p)` (scipy `binom(n, p)` order) over `statrs`, with scipy parity to 1e-12. mean/variance are closed-form Polars exprs gated on a `binomial_params` validation round-trip; only sample, pmf/ln_pmf, cdf/sf, ppf, and entropy stay in Rust.

ppf is a custom bounded CDF search (statrs' generic `inverse_cdf` panics for small n); median uses `ppf(0.5)` since statrs' native `floor(n*p)` disagrees with scipy. Invalid n/p raise `ComputeError`; nulls propagate.
