### PR TITLE
ci: Add benchmark regression guard via pytest-codspeed

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -238,7 +238,7 @@ jobs:
       - name: Run benchmarks under CodSpeed
         uses: CodSpeedHQ/action@9d332c4d90b43981c3e55ae8e38e68709996240f # v4.17.0
         with:
-          mode: simulation
+          mode: walltime
           run: >
             uv run --no-sync pytest tests/benchmark
             -o "addopts=--import-mode=importlib"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -212,6 +212,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write # required for OIDC authentication with CodSpeed
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -235,7 +238,7 @@ jobs:
       - name: Run benchmarks under CodSpeed
         uses: CodSpeedHQ/action@9d332c4d90b43981c3e55ae8e38e68709996240f # v4.17.0
         with:
-          token: ${{ secrets.CODSPEED_TOKEN }}
+          mode: simulation
           run: >
             uv run --no-sync pytest tests/benchmark
             -o "addopts=--import-mode=importlib"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           key: build-wheel
       - name: Build abi3 wheel
-        run: uvx maturin build --out dist
+        run: uvx maturin build --release --out dist
       - name: Upload wheel
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -167,6 +167,8 @@ jobs:
       - name: Show resolved dependencies
         run: uv export --no-annotate --no-hashes --group testing
       - name: Run tests
+        # tests/benchmark/ is still collected (imported), catching API drift, but its tests are deselected
+        # by the default `-m "not benchmark"` in addopts; the timed run is the `bench-guard` job.
         run: uv run --no-sync pytest tests
 
   test-oldest:
@@ -201,7 +203,44 @@ jobs:
       - name: Show resolved dependencies
         run: uv export --no-annotate --no-hashes --group testing
       - name: Run tests
+        # tests/benchmark/ is still collected (imported), catching API drift, but its tests are deselected
+        # by the default `-m "not benchmark"` in addopts; the timed run is the `bench-guard` job.
         run: uv run --no-sync pytest tests
+
+  bench-guard:
+    name: bench-guard
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          enable-cache: true
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: wheel
+          path: dist
+      - name: Sync project dependencies
+        run: uv sync --group testing --group bench-guard --no-install-project
+      - name: Install built wheel
+        run: uv pip install dist/*.whl
+      - name: Show resolved dependencies
+        run: uv export --no-annotate --no-hashes --group testing --group bench-guard
+      # `-o addopts=...` drops the project default `--cov` (untraced timing) and the `-m "not benchmark"`
+      # deselection. `--codspeed` puts pytest-codspeed into measurement mode.
+      - name: Run benchmarks under CodSpeed
+        uses: CodSpeedHQ/action@9d332c4d90b43981c3e55ae8e38e68709996240f # v4.17.0
+        with:
+          token: ${{ secrets.CODSPEED_TOKEN }}
+          run: >
+            uv run --no-sync pytest tests/benchmark
+            -o "addopts=--import-mode=importlib"
+            -o filterwarnings=default
+            --codspeed
 
   docs-strict-build:
     name: docs-strict-build

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,11 @@ venv
 
 # Testing
 .hypothesis/
-.benchmarks/
-benchmark.json
+# A broad `benchmark/` pattern in a user's global gitignore (core.excludesFile) would otherwise hide the
+# CI regression guard in tests/benchmark/. Re-include the directory so it stays tracked. Scoped to source
+# files: a bare `**` would also re-include `__pycache__/` (last match wins over the rule above).
+!tests/benchmark/
+!tests/benchmark/**/*.py
 # Generated comparison reports (machine-specific timings); publish curated tables in the README/docs.
 benchmarks/results/
 .coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,8 @@ repos:
             (?x)^(
                 tests/_polars_compat.py|
                 tests/property/_specs.py|
-                tests/scipy_parity/_harness.py
+                tests/scipy_parity/_harness.py|
+                tests/benchmark/_bench.py
             )$
       - id: end-of-file-fixer
       - id: requirements-txt-fixer

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,17 @@ lint:
 test:
 	POLARS_MAX_THREADS=4 uv run --group testing pytest tests
 
-benchmark:
-	uv run --group benchmarks benchmarks/run.py
+# Routine 1: CI regression guard, our crate only (tests/benchmark/). pytest-codspeed everywhere: without
+# the CodSpeed runner (locally) it measures walltime and prints a timing table; the CI `bench-guard` job
+# wraps the same command in the runner for deterministic instruction counts. `-o addopts=...` drops the
+# project's `--cov` and the default `-m "not benchmark"` deselection; 1M rows give stable local numbers.
+bench-guard:
+	POLARS_STATS_BENCH_ROWS=10_000 uv run --group testing --group bench-guard pytest tests/benchmark \
+		--codspeed -o "addopts=--import-mode=importlib" -o filterwarnings=default
+
+# Routine 2: manual scipy/numpy comparison report (benchmarks/). Wall-clock + peak RSS, not gated in CI.
+bench-compare:
+	uv run --group bench-compare benchmarks/run.py
 
 typing:
 	uv run --group typing pyrefly check . --min-severity info

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -15,12 +15,12 @@ There is one runnable entrypoint, [run.py](run.py). Run it with `uv` and the `be
 group, which provides the extra tooling (`cyclopts`, `rich`, `psutil`, plus `scipy` / `numpy`):
 
 ```bash
-uv run --group benchmarks benchmarks/run.py                                   # all distributions, rich table in the terminal
-uv run --group benchmarks benchmarks/run.py normal binomial                   # a subset
-uv run --group benchmarks benchmarks/run.py normal --rows 1_000_000 10_000_000 --n-samples 5 10 20  # sweep a grid
-uv run --group benchmarks benchmarks/run.py --format markdown                 # write benchmarks/results/<dist>.md
-uv run --group benchmarks benchmarks/run.py --format json                     # write benchmarks/results/<dist>.json
-uv run --group benchmarks benchmarks/run.py --help
+uv run --group bench-compare benchmarks/run.py  # all distributions, rich table in the terminal
+uv run --group bench-compare benchmarks/run.py normal binomial  # a subset
+uv run --group bench-compare benchmarks/run.py normal --rows 1_000_000 10_000_000 --n-samples 5 10 20  # sweep a grid
+uv run --group bench-compare benchmarks/run.py --format markdown  # write benchmarks/results/<dist>.md
+uv run --group bench-compare benchmarks/run.py --format json  # write benchmarks/results/<dist>.json
+uv run --group bench-compare benchmarks/run.py --help
 ```
 
 | argument | default | meaning |
@@ -50,7 +50,7 @@ README or a docs page, not the raw per-run output.
 
 ## Build mode (important for fair numbers)
 
-`uv run --group benchmarks` measures whatever `polars_stats` is installed in the project environment.
+`uv run --group bench-compare` measures whatever `polars_stats` is installed in the project environment.
 
 Build it in **release** mode first (`make install-release`, i.e. `maturin develop --release`). A debug
 `maturin develop` build runs the Rust extension unoptimised and would make `polars_stats` look far

--- a/benchmarks/_harness.py
+++ b/benchmarks/_harness.py
@@ -5,7 +5,7 @@ Scope is deliberately narrow: the two sampling methods, `sample` (one variate pe
 work, so they are the meaningful throughput and memory comparison.
 
 `run.py` owns the `Comparison` registry (one entry per distribution) and the CLI; it calls `run_comparison` over a
-`Sweep` of sizes. This module is *not* runnable; run ``uv run --group benchmarks benchmarks/run.py`` instead.
+`Sweep` of sizes. This module is *not* runnable; run ``uv run --group bench-compare benchmarks/run.py`` instead.
 
 For each method and each side we report:
 

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -3,10 +3,10 @@
 Compare the `sample` / `samples` methods against ``scipy.rvs`` on speed and peak memory, sweeping over
 one or more row counts and sample widths in a single report::
 
-    uv run --group benchmarks benchmarks/run.py                                   # all distributions, rich table
-    uv run --group benchmarks benchmarks/run.py normal binomial                   # a subset
-    uv run --group benchmarks benchmarks/run.py normal --rows 1_000_000 10_000_000 --n-samples 5 10 20
-    uv run --group benchmarks benchmarks/run.py --format markdown                 # write benchmarks/results/<dist>.md
+    uv run --group bench-compare benchmarks/run.py  # all distributions, rich table
+    uv run --group bench-compare benchmarks/run.py normal binomial  # a subset
+    uv run --group bench-compare benchmarks/run.py normal --rows 1_000_000 10_000_000 --n-samples 5 10 20
+    uv run --group bench-compare benchmarks/run.py --format markdown  # write benchmarks/results/<dist>.md
 
 The harness does the work; each distribution is just one `Comparison` in the registry below.
 """

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,10 +18,11 @@ make install-release   # uvx maturin develop --release (use for benchmarking)
 Prefer the `Makefile` targets so flags stay consistent with CI:
 
 ```bash
-make test       # POLARS_MAX_THREADS=4 uv run --group testing pytest tests
-make typing     # pyrefly + pyright + mypy (all three, as in CI)
-make lint       # ruff + rumdl + cargo fmt (nightly) + clippy
-make benchmark  # polars_stats vs scipy comparison report (benchmarks/)
+make test           # POLARS_MAX_THREADS=4 uv run --group testing pytest tests
+make typing         # pyrefly + pyright + mypy (all three, as in CI)
+make lint           # ruff + rumdl + cargo fmt (nightly) + clippy
+make bench-guard    # CI regression guard, our crate only (tests/benchmark/, pytest-codspeed)
+make bench-compare  # polars_stats vs scipy comparison report (benchmarks/)
 ```
 
 `make test` caps `POLARS_MAX_THREADS=4` on purpose: it forces multi-thread, multi-chunk execution so the chunk- and
@@ -57,8 +58,8 @@ Only `polars>=1.15`. No other runtime dependencies.
 
 ### Dev and CI tooling
 
-* Dev dependencies are grouped in `pyproject.toml` (`testing`, `benchmarks`, `typing`, `docs`) and installed with
-    `uv sync --group ...`.
+* Dev dependencies are grouped in `pyproject.toml` (`testing`, `bench-guard`, `bench-compare`, `typing`, `docs`) and
+    installed with `uv sync --group ...`.
 * Tests run under `pytest` with `scipy` + `numpy` as the parity oracle (`tests/scipy_parity/`) and `hypothesis` for
     property tests; the `benchmarks/` comparison report measures wall-clock time and peak memory against `scipy.stats`.
 * Python is checked by `ruff` (lint + format) and three type checkers in CI (`mypy`, `pyright`, `pyrefly`);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,14 @@ testing = [
     "pytest>=8.3.5",
     "pytest-cov>=7.1.0",
 ]
-benchmarks = [
+# Routine 1: the CI regression guard (tests/benchmark/). pytest-codspeed measures instruction count under
+# the CodSpeed runner in CI and falls back to local walltime measurement without it (`make bench-guard`).
+# Always run alongside the `testing` group: the shared DistSpec registry needs hypothesis.
+bench-guard = [
+    "pytest-codspeed>=5.0.0",
+]
+# Routine 2 (manual scipy/numpy comparison report under benchmarks/): see `make bench-compare`.
+bench-compare = [
     "cyclopts>=4.16.1",
     "psutil>=5.9",
     "rich>=15.0.0",
@@ -59,7 +66,8 @@ typing = [
     "pyrefly>=0.62.0",
     "pyright>=1.1.409",
     "scipy-stubs>=1.15.3.0",
-    {include-group = "benchmarks"},
+    {include-group = "bench-compare"},
+    {include-group = "bench-guard"},
     {include-group = "testing"},
 ]
 docs = [
@@ -73,6 +81,15 @@ testpaths = ["tests"]
 addopts = [
   "--import-mode=importlib",
   "--cov",
+  # Deselect the regression-guard benchmarks by default. They are still collected (imported), so API
+  # drift in tests/benchmark/ fails any pytest run; `make bench-guard` overrides addopts to run them.
+  "-m",
+  "not benchmark",
+]
+# Registered here, not only by pytest-codspeed: the default test env does not install the plugin, and an
+# unregistered mark would escalate to an error under `filterwarnings = error`.
+markers = [
+  "benchmark: regression-guard benchmark (tests/benchmark/), run via `make bench-guard`",
 ]
 filterwarnings = [
   "error",
@@ -190,8 +207,8 @@ disable = [
 indent = 4
 start-indented = false
 
-[tool.ryl]
-yaml-files = ["*.yaml", "*.yml"]
+[tool.ryl.files]
+yaml = ["*.yaml", "*.yml"]
 
 [tool.ryl.rules.line-length]
 max = 120

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # Test layout convention
 
-Tests for the distribution surface live in three places, split by what they assert.
+Tests for the distribution surface live in four categories, split by what they assert.
 A new distribution adds tests by following the existing files, not by writing fixtures from scratch.
 
 ## 1. Per-method behavioural tests — `tests/distributions/<name>/`
@@ -47,3 +47,24 @@ These use [`hypothesis`](https://hypothesis.readthedocs.io).
 
 The capped profile in [`conftest.py`](property/conftest.py) (`max_examples`, `deadline=None`) keeps the suite under the
 CI budget and non-flaky; raise `max_examples` locally when investigating a failure.
+
+## 4. Benchmark guard — `tests/benchmark/`
+
+Times **our crate only** (no scipy or other contender: that comparison is the separate manual report under
+[`benchmarks/`](../benchmarks), `make bench-compare`). One module per method group, all parametrised off the same
+[`_specs.py`](property/_specs.py) `DistSpec` registry, so a distribution with a property-test row is benchmarked for
+free:
+
+* [`sample_bench_test.py`](benchmark/sample_bench_test.py): `sample` (scalar fast path + column per-row path) and the
+    `samples` array path, the canonical per-row-RNG regression;
+* [`pointwise_bench_test.py`](benchmark/pointwise_bench_test.py): pmf/pdf, log-density, cdf, log_cdf, sf, log_sf, ppf,
+    isf, in both parameter regimes;
+* [`summary_bench_test.py`](benchmark/summary_bench_test.py): mean, variance, std, median, entropy, column regime only.
+
+Bodies are written against the `pytest-codspeed` `benchmark` fixture and carry the `benchmark` mark:
+`make bench-guard` runs them locally (walltime mode, 1M rows, printed timing table), and the CI `bench-guard` job
+runs the **same command** under the CodSpeed runner (deterministic instruction count). Row count is
+`POLARS_STATS_BENCH_ROWS`. The default `make test` run deselects the mark (`-m "not benchmark"` in `addopts`) but still
+imports the modules, so API drift is caught. The only registry input the property suite does not already supply is
+`bench_params`, a fixed representative parameter tuple per `DistSpec`
+(the suite samples a strategy; the guard needs one deterministic point).

--- a/tests/benchmark/_bench.py
+++ b/tests/benchmark/_bench.py
@@ -1,0 +1,79 @@
+"""Shared inputs for the regression-guard benchmarks (`tests/benchmark/`).
+
+Everything the three benchmark modules need that is not already on the property `DistSpec`: the row count,
+the fixed seed / sample width, the input-frame builders, and the per-spec method enumeration. The guard
+times our crate only, so there is nothing here about scipy or any other contender.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+if TYPE_CHECKING:
+    from polars_stats.distributions._base import _UnivariateDistribution
+    from tests.property._specs import DistSpec
+
+# Rows per benchmark body. The default is tuned for the (deterministic, instruction-count) CodSpeed CI
+# run: a per-row-cost regression such as re-seeding the RNG every row shows at any N, so a small frame
+# keeps the CI budget low without losing the signal. `make bench-guard` sets `POLARS_STATS_BENCH_ROWS=1_000_000`
+# for stable local wall-clock numbers; override the env var for anything in between.
+DEFAULT_BENCH_ROWS = 10_000
+ROWS = int(os.environ.get("POLARS_STATS_BENCH_ROWS", DEFAULT_BENCH_ROWS))
+
+# `samples` draws this many independent variates per row; the per-row sub-seed derivation is the regression
+# this array path guards, so the width is fixed and modest.
+SAMPLES_SIZE = 10
+
+# One fixed seed across the suite: timings must not depend on it, and a constant keeps runs comparable.
+SEED = 0
+
+# Parameter regimes for pointwise methods and samplers: `scalar` exercises the constant-parameter fast path,
+# `column` the general per-row plugin (where per-row scale matters).
+REGIMES = ("scalar", "column")
+
+# Summary statistics, benchmarked in the column regime only: with scalar params they collapse to a length-1
+# scalar, so per-row parameters are the only meaningful input (see issue-tracker/03-infra-benchmarks.md).
+SUMMARY_METHODS = ("mean", "variance", "std", "median", "entropy")
+
+
+def length_frame(n: int) -> pl.DataFrame:
+    """An `n`-row frame whose only job is to set `pl.len()` for the samplers and column-param expansion."""
+    return pl.select(pl.int_range(0, n, dtype=pl.Int64).alias("row"))
+
+
+def pointwise_frame(spec: DistSpec, n: int) -> pl.DataFrame:
+    """`n` rows with a `value` column over the spec's eval window and a `quantile` column in (0, 1).
+
+    `value` feeds the density / cdf / sf family; `quantile` feeds ppf / isf. Built once per spec so a
+    benchmark times only the method call, not the input construction.
+    """
+    lo, hi = spec.eval_range(spec.bench_params)
+    frac = pl.int_range(0, n, dtype=pl.Int64).cast(pl.Float64) / float(max(n - 1, 1))
+    return pl.select(value=lo + frac * (hi - lo), quantile=0.01 + frac * 0.98)
+
+
+def make_dist(spec: DistSpec, regime: str) -> _UnivariateDistribution:
+    """The spec's instance in the requested regime: `scalar` (fast path) or `column` (per-row)."""
+    return spec.make(spec.bench_params) if regime == "scalar" else spec.make_columns(spec.bench_params)
+
+
+def pointwise_methods(spec: DistSpec) -> list[tuple[str, str]]:
+    """`(method_name, input_column)` for every pointwise method the spec exposes.
+
+    `input_column` names the `pointwise_frame` column each method reads: `value` for the density / cdf / sf
+    family, `quantile` for ppf / isf.
+    """
+    density = "pdf" if spec.continuous else "pmf"
+    return [
+        (density, "value"),
+        (f"log_{density}", "value"),
+        ("cdf", "value"),
+        ("log_cdf", "value"),
+        ("sf", "value"),
+        ("log_sf", "value"),
+        ("ppf", "quantile"),
+        ("isf", "quantile"),
+    ]

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.benchmark._bench import ROWS, length_frame, pointwise_frame
+from tests.property._specs import ALL_SPECS
+
+if TYPE_CHECKING:
+    import polars as pl
+
+
+@pytest.fixture(scope="session")
+def bench_frame() -> pl.DataFrame:
+    """A single `ROWS`-row frame for the sampler and summary benchmarks, which need only a length."""
+    return length_frame(ROWS)
+
+
+@pytest.fixture(scope="session")
+def pointwise_frames() -> dict[str, pl.DataFrame]:
+    """Per-distribution `value` / `quantile` input frames for the pointwise benchmarks, built once."""
+    return {spec.name: pointwise_frame(spec, ROWS) for spec in ALL_SPECS}

--- a/tests/benchmark/pointwise_bench_test.py
+++ b/tests/benchmark/pointwise_bench_test.py
@@ -1,0 +1,52 @@
+"""Regression-guard benchmarks for the pointwise methods (pdf/pmf, log-density, cdf, sf, ppf, isf).
+
+Our crate only, scalar + column parameter regimes, every method driven off the property `DistSpec`
+registry so a new distribution is benchmarked the moment it has a spec row. Written against the
+pytest-codspeed ``benchmark`` fixture (CodSpeed instruction count in CI, walltime locally); run with
+``make bench-guard``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+
+from tests.benchmark._bench import REGIMES, make_dist, pointwise_methods
+from tests.property._specs import ALL_SPECS
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from tests.property._specs import DistSpec
+
+pytestmark = pytest.mark.benchmark
+
+# One leaf benchmark per (distribution, regime, method): the registry's method enumeration keeps the
+# discrete (pmf/log_pmf) vs continuous (pdf/log_pdf) split correct without per-distribution code here.
+_Case = tuple["DistSpec", str, str, str]
+_CASES: list[_Case] = [
+    (spec, regime, method, column)
+    for spec in ALL_SPECS
+    for regime in REGIMES
+    for method, column in pointwise_methods(spec)
+]
+
+
+def _case_id(case: _Case) -> str:
+    spec, regime, method, _column = case
+    return f"{spec.name}-{method}-{regime}"
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_case_id)
+def test_pointwise(
+    benchmark: Callable[..., object],
+    pointwise_frames: dict[str, pl.DataFrame],
+    case: _Case,
+) -> None:
+    """Time one pointwise method on a `ROWS`-row input column in the given parameter regime."""
+    spec, regime, method, column = case
+    frame = pointwise_frames[spec.name]
+    expr = getattr(make_dist(spec, regime), method)(pl.col(column))
+    benchmark(lambda: frame.select(r=expr))

--- a/tests/benchmark/sample_bench_test.py
+++ b/tests/benchmark/sample_bench_test.py
@@ -1,0 +1,43 @@
+"""Regression-guard benchmarks for the sampler hot paths (`sample`, `samples`), our crate only.
+
+Written against the pytest-codspeed ``benchmark`` fixture: deterministic instruction count under the
+CodSpeed runner in CI, walltime locally. Both regimes are timed: ``scalar`` parameters take the
+constant-parameter fast path, ``column`` parameters the general per-row plugin. The per-row RNG
+construction cost scales with the row count, so a single wide column surfaces a regression like the
+ChaCha20-per-row one this guard was written for.
+
+Run with ``make bench-guard``; the default run deselects the ``benchmark`` mark.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.benchmark._bench import REGIMES, SAMPLES_SIZE, SEED, make_dist
+from tests.property._specs import ALL_SPECS
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import polars as pl
+
+    from tests.property._specs import DistSpec
+
+pytestmark = pytest.mark.benchmark
+
+
+@pytest.mark.parametrize("regime", REGIMES)
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+def test_sample(benchmark: Callable[..., object], bench_frame: pl.DataFrame, spec: DistSpec, regime: str) -> None:
+    """`sample`: one variate per row, in the scalar (fast-path) and column (per-row) regimes."""
+    expr = make_dist(spec, regime).sample(seed=SEED)
+    benchmark(lambda: bench_frame.select(s=expr))
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+def test_samples_array(benchmark: Callable[..., object], bench_frame: pl.DataFrame, spec: DistSpec) -> None:
+    """`samples`: `SAMPLES_SIZE` independent draws per row, the canonical per-row-RNG regression guard."""
+    expr = make_dist(spec, "scalar").samples(SAMPLES_SIZE, seed=SEED)
+    benchmark(lambda: bench_frame.select(s=expr))

--- a/tests/benchmark/summary_bench_test.py
+++ b/tests/benchmark/summary_bench_test.py
@@ -1,0 +1,41 @@
+"""Regression-guard benchmarks for the summary statistics (mean, variance, std, median, entropy).
+
+Column-param regime only: with scalar params a summary collapses to a length-1 scalar, so per-row
+parameters (a different distribution per row) are the only input that scales. Our crate only, driven off
+the property `DistSpec` registry. Written against the pytest-codspeed ``benchmark`` fixture; run with
+``make bench-guard``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.benchmark._bench import SUMMARY_METHODS, make_dist
+from tests.property._specs import ALL_SPECS
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import polars as pl
+
+    from tests.property._specs import DistSpec
+
+pytestmark = pytest.mark.benchmark
+
+_Case = tuple["DistSpec", str]
+_CASES: list[_Case] = [(spec, method) for spec in ALL_SPECS for method in SUMMARY_METHODS]
+
+
+def _case_id(case: _Case) -> str:
+    spec, method = case
+    return f"{spec.name}-{method}"
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_case_id)
+def test_summary(benchmark: Callable[..., object], bench_frame: pl.DataFrame, case: _Case) -> None:
+    """Time one summary statistic with per-row (column) parameters over a `ROWS`-row frame."""
+    spec, method = case
+    expr = getattr(make_dist(spec, "column"), method)()
+    benchmark(lambda: bench_frame.select(r=expr))

--- a/tests/property/_specs.py
+++ b/tests/property/_specs.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from math import exp
 from typing import TYPE_CHECKING, Any
 
+import polars as pl
 from hypothesis import strategies as st
 
 from polars_stats import Bernoulli, Binomial, LogNormal, Normal, Uniform
@@ -11,10 +12,20 @@ from polars_stats import Bernoulli, Binomial, LogNormal, Normal, Uniform
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    import polars as pl
     from hypothesis.strategies import SearchStrategy
 
+    from polars_stats._typing import PolarsDataType
     from polars_stats.distributions._base import _UnivariateDistribution
+
+
+def _col(value: float, dtype: PolarsDataType | None = None) -> pl.Expr:
+    """A full-length constant column expr (`pl.repeat`), forcing the per-row sampler path.
+
+    A Python scalar would route through the constant-parameter fast path; wrapping it as an `Expr`
+    instead drives the general per-row plugin, so a spec can build both variants from one parameter
+    tuple and a test can assert the two paths agree.
+    """
+    return pl.repeat(value, n=pl.len(), dtype=dtype)
 
 
 def _finite(min_value: float, max_value: float) -> SearchStrategy[float]:
@@ -36,10 +47,16 @@ class DistSpec:
         continuous: `True` for a continuous distribution (has `pdf`, finite-grid integral), `False` for
             a discrete one (has `pmf`, finite-support sum).
         params: Strategy yielding a valid parameter tuple.
-        make: Builds an instance from a parameter tuple.
+        make: Builds an instance from a parameter tuple (scalar parameters: the constant-parameter fast path).
+        make_columns: Builds the same instance with each parameter wrapped as a full-length column expr,
+            forcing the general per-row sampler path. Lets a test assert the fast path matches it draw-for-draw,
+            and lets the benchmark guard time the per-row regime against the scalar one.
         density: `pdf` or `pmf` as `(dist, expr) -> expr`. Typed loosely because the method differs by family;
             the concrete distribution is fixed per spec.
         eval_range: `(lo, hi)` finite window for evaluating cdf / density on a grid.
+        bench_params: A fixed, representative parameter tuple for the benchmark guard. Unlike `params` (a
+            strategy the property suite samples), the guard needs one deterministic parameterisation so timings
+            are comparable run to run; the value barely affects compute cost, so any valid point will do.
         integration_bounds: `(lo, hi)` over which the pdf integrates to ~1 (continuous only);
             the normal is truncated to a wide multiple of `std`. `None` for discrete.
         support: Finite list of mass points summing to ~1 (discrete only). `None` for continuous.
@@ -49,8 +66,10 @@ class DistSpec:
     continuous: bool
     params: SearchStrategy[tuple[float, ...]]
     make: Callable[[tuple[float, ...]], _UnivariateDistribution]
+    make_columns: Callable[[tuple[float, ...]], _UnivariateDistribution]
     density: Callable[[Any, pl.Expr], pl.Expr]
     eval_range: Callable[[tuple[float, ...]], tuple[float, float]]
+    bench_params: tuple[float, ...]
     integration_bounds: Callable[[tuple[float, ...]], tuple[float, float]] | None = None
     support: Callable[[tuple[float, ...]], list[float]] | None = None
 
@@ -60,8 +79,10 @@ _BERNOULLI = DistSpec(
     continuous=False,
     params=st.tuples(_finite(0.0, 1.0)),
     make=lambda p: Bernoulli(p=p[0]),
+    make_columns=lambda p: Bernoulli(p=_col(p[0])),
     density=lambda d, c: d.pmf(c),
     eval_range=lambda _: (-1.0, 2.0),
+    bench_params=(0.3,),
     support=lambda _: [0.0, 1.0],
 )
 
@@ -72,8 +93,10 @@ _BINOMIAL = DistSpec(
     # degenerate endpoints, where the mass collapses onto a single support point).
     params=st.tuples(st.integers(min_value=0, max_value=20), _finite(0.0, 1.0)),
     make=lambda p: Binomial(n=int(p[0]), p=p[1]),
+    make_columns=lambda p: Binomial(n=_col(int(p[0]), pl.Int64()), p=_col(p[1])),
     density=lambda d, c: d.pmf(c),
     eval_range=lambda p: (-1.0, p[0] + 1.0),
+    bench_params=(10.0, 0.3),
     support=lambda p: [float(k) for k in range(int(p[0]) + 1)],
 )
 
@@ -82,8 +105,10 @@ _NORMAL = DistSpec(
     continuous=True,
     params=st.tuples(_finite(-10.0, 10.0), _finite(1e-2, 10.0)),
     make=lambda p: Normal(mean=p[0], std_dev=p[1]),
+    make_columns=lambda p: Normal(mean=_col(p[0]), std_dev=_col(p[1])),
     density=lambda d, c: d.pdf(c),
     eval_range=lambda p: (p[0] - 6.0 * p[1], p[0] + 6.0 * p[1]),
+    bench_params=(0.0, 1.0),
     integration_bounds=lambda p: (p[0] - 12.0 * p[1], p[0] + 12.0 * p[1]),
 )
 
@@ -94,8 +119,10 @@ _UNIFORM = DistSpec(
     # without rejection, so every drawn parameterisation is valid.
     params=st.tuples(_finite(-10.0, 10.0), _finite(1e-2, 20.0)).map(lambda mw: (mw[0], mw[0] + mw[1])),
     make=lambda p: Uniform(min=p[0], max=p[1]),
+    make_columns=lambda p: Uniform(min=_col(p[0]), max=_col(p[1])),
     density=lambda d, c: d.pdf(c),
     eval_range=lambda p: (p[0] - 0.5 * (p[1] - p[0]), p[1] + 0.5 * (p[1] - p[0])),
+    bench_params=(0.0, 1.0),
     integration_bounds=lambda p: (p[0], p[1]),
 )
 
@@ -107,9 +134,11 @@ _LOGNORMAL = DistSpec(
     # tolerance. The functional and scipy-parity suites cover larger `sigma` directly.
     params=st.tuples(_finite(-1.5, 1.5), _finite(0.1, 0.9)),
     make=lambda p: LogNormal(mu=p[0], sigma=p[1]),
+    make_columns=lambda p: LogNormal(mu=_col(p[0]), sigma=_col(p[1])),
     density=lambda d, c: d.pdf(c),
     # Support is (0, inf); the grid stays on the positive side and out to a 4-sigma-in-log upper tail.
     eval_range=lambda p: (0.0, exp(p[0] + 4.0 * p[1])),
+    bench_params=(0.0, 1.0),
     integration_bounds=lambda p: (0.0, exp(p[0] + 6.0 * p[1])),
 )
 

--- a/uv.lock
+++ b/uv.lock
@@ -209,7 +209,7 @@ toml = [
 
 [[package]]
 name = "cyclopts"
-version = "4.16.1"
+version = "4.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -219,9 +219,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/07/bf61d13de86d96a4c46aff00c9ca0eced44bcc8c3e16280605c1253e5720/cyclopts-4.16.1.tar.gz", hash = "sha256:8aa47bf92a5fb33abca5af05e576eecdb0d2f79893ad29238046df78370fc4a8", size = 181196, upload-time = "2026-05-25T15:29:08.518Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/b7/2e64e26e7189c2f0f88cea467d068ec968f2fa24628b0ffb93132a0f2b14/cyclopts-4.17.0.tar.gz", hash = "sha256:6b3231f18b404879e978214ef26fa174e8b505bd0f2117290b4135560666004b", size = 181338, upload-time = "2026-06-09T13:41:26.801Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/8d/7f362c2fb8ef4decd2160bc24d4292c6ca658cc6d9a161b89ca5122bbdbf/cyclopts-4.16.1-py3-none-any.whl", hash = "sha256:617795392c4113a2c2cc7af716f20244900e87f23daa05442d1268d81472a592", size = 219020, upload-time = "2026-05-25T15:29:09.646Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/26/1614f15b8ea89ee201a2484ea5bede7319a2b07c796c321ffdadd705559e/cyclopts-4.17.0-py3-none-any.whl", hash = "sha256:6ee947c9f3bbe9679b9fa9cea1bb327298db80b302df62d7f1d1bd82726508e0", size = 219147, upload-time = "2026-06-09T13:41:24.97Z" },
 ]
 
 [[package]]
@@ -277,15 +277,15 @@ wheels = [
 
 [[package]]
 name = "hypothesis"
-version = "6.155.1"
+version = "6.155.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/ef/4a94c12429986a90076057513e084bf32106a9bdc62c8e29f58673dd85a2/hypothesis-6.155.1.tar.gz", hash = "sha256:07c102031612b98d7c1be15ca3608c43e1234d9d07e3a190a53fa01536700196", size = 477300, upload-time = "2026-05-29T23:12:57.515Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/04/64032a1dccd2233615c8a3f701bbb563558575ed017496a24b6d81762c91/hypothesis-6.155.2.tar.gz", hash = "sha256:ae36880287c9c5defe9f199d3d2b67d9947a4da2a46e6c57373cbdf2345b20e1", size = 477765, upload-time = "2026-06-05T16:32:23.63Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/6e/8c9cf32201238617454303b1605dfa667d90cd1ef51226f92d9c2b3b8f7c/hypothesis-6.155.1-py3-none-any.whl", hash = "sha256:2753f469df3ba3c483b08e0c37dbcbc41d8316ebb921abcc07493ee9c8a7d187", size = 543715, upload-time = "2026-05-29T23:12:54.77Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6e/e735f27ac1a530a4cd0a31cd970ec495a3a11830fdc5d281cc292593b330/hypothesis-6.155.2-py3-none-any.whl", hash = "sha256:c85ce6dcd630a90ce501f1d1dd1bc84b97f5649ca8a27e134c8cbf5aa480b1a5", size = 544213, upload-time = "2026-06-05T16:32:21.15Z" },
 ]
 
 [[package]]
@@ -630,7 +630,7 @@ wheels = [
 
 [[package]]
 name = "mkdocstrings-python"
-version = "2.0.3"
+version = "2.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffelib" },
@@ -638,9 +638,9 @@ dependencies = [
     { name = "mkdocstrings" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/33/c225eaf898634bdda489a6766fc35d1683c640bffe0e0acd10646b13536d/mkdocstrings_python-2.0.3.tar.gz", hash = "sha256:c518632751cc869439b31c9d3177678ad2bfa5c21b79b863956ad68fc92c13b8", size = 199083, upload-time = "2026-02-20T10:38:36.368Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/b4/5fed370d8ebd96e4e399460a7146ae989263f16588b05a6facd6dbd51e60/mkdocstrings_python-2.0.4.tar.gz", hash = "sha256:58c73c5d358e64e9b1673447663f4a2f8a8941e392e225fc0a0c893758cc452f", size = 199219, upload-time = "2026-06-05T08:13:01.819Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/28/79f0f8de97cce916d5ae88a7bee1ad724855e83e6019c0b4d5b3fabc80f3/mkdocstrings_python-2.0.3-py3-none-any.whl", hash = "sha256:0b83513478bdfd803ff05aa43e9b1fca9dd22bcd9471f09ca6257f009bc5ee12", size = 104779, upload-time = "2026-02-20T10:38:34.517Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e3/00ec594aef5f55522e6d373bc2ac53e53a8f5e9ae32f2d6854b0de4270f3/mkdocstrings_python-2.0.4-py3-none-any.whl", hash = "sha256:fd87c173e1e719a85997b6d4f852cdc55f36710e0ed08da3a7bd9abe79c9db00", size = 104790, upload-time = "2026-06-05T08:13:00.393Z" },
 ]
 
 [[package]]
@@ -989,10 +989,13 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
-benchmarks = [
+bench-compare = [
     { name = "cyclopts" },
     { name = "psutil" },
     { name = "rich" },
+]
+bench-guard = [
+    { name = "pytest-codspeed" },
 ]
 dev = [
     { name = "maturin" },
@@ -1023,6 +1026,7 @@ typing = [
     { name = "pyrefly" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "rich" },
     { name = "scipy-stubs", version = "1.15.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1033,11 +1037,12 @@ typing = [
 requires-dist = [{ name = "polars", specifier = ">=1.15.0" }]
 
 [package.metadata.requires-dev]
-benchmarks = [
+bench-compare = [
     { name = "cyclopts", specifier = ">=4.16.1" },
     { name = "psutil", specifier = ">=5.9" },
     { name = "rich", specifier = ">=15.0.0" },
 ]
+bench-guard = [{ name = "pytest-codspeed", specifier = ">=5.0.0" }]
 dev = [
     { name = "maturin", specifier = ">=1.13.1" },
     { name = "numpy", specifier = ">=2.2.6" },
@@ -1065,6 +1070,7 @@ typing = [
     { name = "pyrefly", specifier = ">=0.62.0" },
     { name = "pyright", specifier = ">=1.1.409" },
     { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-codspeed", specifier = ">=5.0.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "rich", specifier = ">=15.0.0" },
     { name = "scipy-stubs", specifier = ">=1.15.3.0" },
@@ -1178,6 +1184,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-codspeed"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/b4/cf932fcd1960a2fd6d9b09eb403253a8709aeee975961afa6299239a830e/pytest_codspeed-5.0.3.tar.gz", hash = "sha256:91afef90e6a96b013495e4702ef5d6358614a449e71008cdc194ef668778b92f", size = 324571, upload-time = "2026-05-22T16:20:49.231Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/f5/a8f70147216e4b84046ca406d03ecc8e83e3ea56ba1bdca0bb79cca79fee/pytest_codspeed-5.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:005348ea52ace3ede2e2f595913912ad2564cca7b124211a88dc78a9cb1fca63", size = 366249, upload-time = "2026-05-22T16:20:39.985Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/bd/7a4dbcf457fcc3ed788c55d402f3af2671e0e342b6098090fd590aa8712e/pytest_codspeed-5.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dbe6a4a00b449b6ba2771f644cbc38bdf55acf5c812e60e5659110e19dd9f510", size = 932229, upload-time = "2026-05-22T16:20:37.283Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e1/414ea4c66559f24ec06aeb6db62bfc7079582dac1452e648affe1eb5cfb4/pytest_codspeed-5.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ac4344f34bbcdd17f6f8c30dbac3da2f80d223dd112e568fd7f7c2cd4cbc693", size = 934647, upload-time = "2026-05-22T16:20:31.997Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ef/32ce60d42a4aa43e728d988e13eb6568fbc7b10a514517b459bafd3f2b94/pytest_codspeed-5.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f56d0339cd98d26f6e561987be25bdd2761a5d53d8f73493b1ebe02d0d451093", size = 366253, upload-time = "2026-05-22T16:21:10.013Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/15/c66ef90a793c5d2c039e63a1726a5e55c678be2618b0f5f1660d0f79e25f/pytest_codspeed-5.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c682f6645d4eb472f3bd95dbda1805e3af4243610572cb7d6bf94a88e8a0b6c", size = 932465, upload-time = "2026-05-22T16:20:34.265Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7b/d231279301967f05b7909160489e85ee3a1b9da76094ea25343faba1abc2/pytest_codspeed-5.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f852bee785a7a124cb1720b1915670c6742af87747dc4d838f3ffdbd365ce9d9", size = 934925, upload-time = "2026-05-22T16:20:47.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/22/456c48160b761d5028c8afa119f085a9fc42855a783a13d73918078969f0/pytest_codspeed-5.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2eeb25fb1ac3f73c4de50e739e78fea396b89782bdb740bf2a7cd2df21f8d4ee", size = 366255, upload-time = "2026-05-22T16:20:56.214Z" },
+    { url = "https://files.pythonhosted.org/packages/74/33/ac7441fa937c9d9f158083a8c46920a5a5c81ed3c5f96240fc8d650db5c2/pytest_codspeed-5.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73c5c9d98a3372a42611989ccfa437cce3842431ac6d6b9ab42c4f0e59c070f7", size = 932325, upload-time = "2026-05-22T16:21:08.814Z" },
+    { url = "https://files.pythonhosted.org/packages/77/bc/8b994adcb9e9016e7d9a808056a3dd9cca21441e432ef456eae2b697d7fe/pytest_codspeed-5.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2e0ab65df73e837666d12357280ca50ff6d6ac03ea5266703be518b68170edf", size = 934885, upload-time = "2026-05-22T16:21:01.444Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8e/e032451e9e0a06b0c4bff53105f62b693d9a54595dd8c024693741ce3380/pytest_codspeed-5.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6524c57fec279a22ffef6112af404036afc71b4704758ae9f0abda429b8478d4", size = 366253, upload-time = "2026-05-22T16:20:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/7b/ae76fd8ac656b9695806a6aafd5f22ec32e6ce20e266a58f9112e01d3cd8/pytest_codspeed-5.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c383c9121deb58a69f174188e9e4488ffc0daced0ed276abf87747182511901", size = 932360, upload-time = "2026-05-22T16:20:30.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/4a/dfd43d943fdb143be4fd62f34c2793ba349dc27aa188e521d19d629aa7ab/pytest_codspeed-5.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4bcdb4b6522738152885ef067e0c8524d5699828d780fb6f464cdb3db44369c", size = 934928, upload-time = "2026-05-22T16:20:38.62Z" },
+    { url = "https://files.pythonhosted.org/packages/04/6a/fdcec19c7f267c195f147c51d3fd2245f6b8d09b80495ed0a90c008e0842/pytest_codspeed-5.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:25464363c7f9b9bd5022e969c0addba616fa40ac9b8f0fc9e030c4538863b32d", size = 366259, upload-time = "2026-05-22T16:21:06.039Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/96/c6b03b81dcd21ae3d6b32cca0b3c10149fa378eb21b338d4b63c9eb8050b/pytest_codspeed-5.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efd43f82ea03ced8488a767ded9473f050791ab7783ea8654107e1e0ac66af40", size = 932395, upload-time = "2026-05-22T16:21:04.804Z" },
+    { url = "https://files.pythonhosted.org/packages/96/08/56ad8f1cc7d6962f8a680141b361e93467a2abc53d976cd9d5e1edd740e3/pytest_codspeed-5.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:782f9985b6f6b45b8bc20152d206d3a52b56dd088ba81cb70a71f0b39841be9e", size = 934994, upload-time = "2026-05-22T16:20:28.809Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/54/9096c4545f09da94b1b00f3be2fe4952949e86c9bcafca9a29b26aed1a75/pytest_codspeed-5.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9aa0815b90196f3c20d736ea8691381e97f12bbe8c7d87af10a351e434b452cb", size = 366311, upload-time = "2026-05-22T16:20:41.791Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/3c/24c53f67a38ad48cb087105ac30a8aa0923223ee274ea9bf2dc705edaa59/pytest_codspeed-5.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:85505c96a3477c346ec2d2b7dced8478f4c651e2b1666ee102d53a832b511853", size = 933169, upload-time = "2026-05-22T16:20:43.178Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/de/2213f868fa7694f743f96cccbc07e757f45c920c523cccc2da97bc8652df/pytest_codspeed-5.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:20eba63765be9d1b6cacbbfad84b87d49eb04b357a7045a0899880da181f81e3", size = 935522, upload-time = "2026-05-22T16:21:03.398Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/5dfea1c031d6cccc11653464828edf205c30f798caf5b2a85375aacd914a/pytest_codspeed-5.0.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:ec9fa6f0af0a9feb0e0bd517fb59ef28f806fbd50c0c6900ac26cbb4d080eba5", size = 366275, upload-time = "2026-05-22T16:20:59.463Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2b/af4d1b612f03b98a6cf3c7d5f62678917a60110a8bf380d49ab408b31137/pytest_codspeed-5.0.3-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8df77b3409f54f4a268f77f3ff74992fe1d995cdbaf2cecf8ad74d32db217ce7", size = 932537, upload-time = "2026-05-22T16:20:54.945Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/a2/c7ec45e36a61b418efb2a3cccaa67a0c2fcf1f21d5880f64c33114f0c249/pytest_codspeed-5.0.3-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5d8695a227ea1c3a41d25db5b3fe720bf1b4808bd38862be811a4efd902c792", size = 934153, upload-time = "2026-05-22T16:21:07.494Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c7/d5bada9618a0af56a5c8065fc61280849cab8e7c1e24025807a51c3157ce/pytest_codspeed-5.0.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bf4cc4178cbace8f4d2bd240408276bc4da3850ac5fcb5fb5f8a74ab417615bb", size = 366339, upload-time = "2026-05-22T16:20:51.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/37/fb27aeb40a81320e7349553b877a21333c897b27c8dfe215630452908f36/pytest_codspeed-5.0.3-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abe793da40f87295d33988673d34f06ea569848b44490b847552cd416816258a", size = 933055, upload-time = "2026-05-22T16:20:44.861Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d9/6f2d69e96deaf0475a695fc9195af59e7a3b5fab50782855e65c63a7bc28/pytest_codspeed-5.0.3-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c3a9ed38dfa776443b86f4b49a982e8443d0953db4974bd2673d63cc904ae1ad", size = 934481, upload-time = "2026-05-22T16:20:58.264Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b2/1d2a993c532146dce9eca5b5942d51898021c3579ce18b2454f932a915f8/pytest_codspeed-5.0.3-py3-none-any.whl", hash = "sha256:fe2ea83c924c2250675b75686c3ee456b8cf0208d83d552e182a195fdf467378", size = 74033, upload-time = "2026-05-22T16:20:26.814Z" },
 ]
 
 [[package]]
@@ -1588,7 +1631,7 @@ wheels = [
 
 [[package]]
 name = "zensical"
-version = "0.0.43"
+version = "0.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1600,18 +1643,18 @@ dependencies = [
     { name = "pyyaml" },
     { name = "tomli" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/85/ec45162e7824a8f879d887ef0774ee65926bf7d1064e2eebccc7eaee3378/zensical-0.0.43.tar.gz", hash = "sha256:dc2d3804ff562795c1024130e0c3ce79736467930729dda314f096d0e35b98c8", size = 3932396, upload-time = "2026-05-19T09:44:07.418Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/d1/ecb1889fd2208b2d577e6ff952d9bee201302eec7966b5b61cc64adfd8f5/zensical-0.0.45.tar.gz", hash = "sha256:315bce4ab0470338dd3588add38fb325f840856c375722e6802bd58a06446266", size = 3935947, upload-time = "2026-06-09T11:23:32.349Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/c2/55e0709607ae41c266987c3b91a1a9702b37fbbef0d07eddfe5e25c2d823/zensical-0.0.43-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:17c335362b6bac3a50178181694a964f6d9f0c516fc532129ba5a0a5c4103fb6", size = 12706531, upload-time = "2026-05-19T09:43:32.729Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/64/ce8627bc5ea30556162b29b041fe97d6a6aef2a87b51f12def628e4fa608/zensical-0.0.43-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8fe97f185194215f6193af45a17d2b30ebd72c8113e3650f2d7d6767b9c2206", size = 12563012, upload-time = "2026-05-19T09:43:35.962Z" },
-    { url = "https://files.pythonhosted.org/packages/66/d1/533bc9454f0e06b3d9d8bd2e7ac405308c3d4dee6572acab98f0ed6d1c07/zensical-0.0.43-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c4c85978c765b3e7f347e8102dfe1373d4bbe4229d7008b6bdbf352f1fbcd7f", size = 12947599, upload-time = "2026-05-19T09:43:38.754Z" },
-    { url = "https://files.pythonhosted.org/packages/75/a0/94f47d6fb592997be7ab9526938c929f0199adf2637c3c2b2b9b2101b28e/zensical-0.0.43-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:90d7c06ffd07b2bdf78bef041d541baba8a3ea51fd2dd84dbdbc5b0229076524", size = 12904911, upload-time = "2026-05-19T09:43:42.434Z" },
-    { url = "https://files.pythonhosted.org/packages/96/fb/1db3ad9a86ff772f74a8bc60ad5b447aa02a158e70f94adacf50bdd5c40f/zensical-0.0.43-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:60022f4a6b95e46ec0023f51052fcd491743b3ebd08c0066b22a5cf1e741fecd", size = 13269386, upload-time = "2026-05-19T09:43:45.387Z" },
-    { url = "https://files.pythonhosted.org/packages/31/ee/b24fd0f94885519d851c35615b086d069a1077b0198021a56755395a4633/zensical-0.0.43-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e278eb948a0b7545d50609d713c7c27e366dade4523ff73a311a5d5f136518a", size = 12999364, upload-time = "2026-05-19T09:43:48.549Z" },
-    { url = "https://files.pythonhosted.org/packages/28/78/401ccd7afd9d2690f81b5319b7f1eed05108154ce20e4207053914518c1c/zensical-0.0.43-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b85e5ab99fbda13823e67c43a4be6e5ebda6600602969c6575e143f20ac203fd", size = 13124392, upload-time = "2026-05-19T09:43:50.965Z" },
-    { url = "https://files.pythonhosted.org/packages/98/b3/9af6eba5826b0ef143fc8308bd1e219e221441e307a958e39f824ba9ab53/zensical-0.0.43-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:751385accc92cccfd4560dabed7c423870686ef6ede244a67e5c96286af25e8f", size = 13177538, upload-time = "2026-05-19T09:43:53.964Z" },
-    { url = "https://files.pythonhosted.org/packages/be/6b/cd090bd6659d32692487206469988ee84d41aa6de4cdf9e380f847da90e2/zensical-0.0.43-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:dd3ff5bfa6e65cf3d2550dc639c3da2a3bfa11087b83d57e06623c4c1607d583", size = 13327086, upload-time = "2026-05-19T09:43:56.8Z" },
-    { url = "https://files.pythonhosted.org/packages/79/5b/ac2555354b5a53cb9c2c942811905c47be0b9f5603d3c1328ee8564333eb/zensical-0.0.43-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:85055a115b12f49c6ab194dcf04f966fc06b690ed6a8ddddd819929fc5f340e6", size = 13284645, upload-time = "2026-05-19T09:43:59.329Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/c6/1688ec6e5be15e3ab367d7804753291bfbdff3109b06e20c19ce30a7129c/zensical-0.0.43-cp310-abi3-win32.whl", hash = "sha256:8a75ddd4bb3cd3c4a8e71d2ebae44c5611fd636c1d355c6124dd96e2f9c52838", size = 12256740, upload-time = "2026-05-19T09:44:02.102Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/a8/d967e70eac810a7e9eb8c5150d6d02848a1f42260f42977c71debed3cb02/zensical-0.0.43-cp310-abi3-win_amd64.whl", hash = "sha256:03a9d1744a6394ad66c355d6f1de04cfd92efa525b0b94bf6dbf6971c5cd2c6b", size = 12496166, upload-time = "2026-05-19T09:44:04.915Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fd/6b84115e3bbe6b76ebb1265e8ff2161c0bc88dcd6499eaf29c61a66421e9/zensical-0.0.45-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c4cb2e11132f02ae824e246e016e073458e12e9de1eaf86fd39f01890d41204c", size = 12698844, upload-time = "2026-06-09T11:22:56.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/dc/4ddf05d77c1455c32cb26da71f2a19d355927a45a3db5b26fb258a07ce8f/zensical-0.0.45-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:799a01de2102b5f731744ad31bdbc464d0c07d484e67ba148f6923679afa6ce6", size = 12571590, upload-time = "2026-06-09T11:23:00.192Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/53/60c6cc7b2ce8b1a83eb87bff3f7289447995552fd9a30ca76ffba22ca9d5/zensical-0.0.45-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6201e79ea8a64bd3ced3f05ef4b1529da0e675d67b1395987c0ba942e4e10dc4", size = 12939590, upload-time = "2026-06-09T11:23:02.721Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/1e/e9217ed75dba323a6f9a4eee28eb40416eff99932cd0ee6c394bf07b9ead/zensical-0.0.45-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:854aaf500e4a3ce64adea1faa7a1820c7cf9a4f66be1043e4e9ba727fe9cf2b5", size = 12911669, upload-time = "2026-06-09T11:23:05.407Z" },
+    { url = "https://files.pythonhosted.org/packages/71/3c/6fc9fe2334bb4460a8a8d732e23a30d2ddc2ecf63c2eb3487d9e7405e70d/zensical-0.0.45-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a80c57fd50fc60415914388286ac10a7d8b6f70b8ca7235597d09fb12c3171b0", size = 13267643, upload-time = "2026-06-09T11:23:07.915Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f9/5696114af4ede5f1bd01e641a4ff24ee8ca49810bfaa28e5be12d930c0ef/zensical-0.0.45-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58c3510f69e08b6ed8bb9596fc9393e4687f90394aa0ef2d6118b1375ad97be5", size = 12972147, upload-time = "2026-06-09T11:23:12.069Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9e/5c6acde480c43f8c993b13260925df8db31d51ab8a9977618e9efdd98d45/zensical-0.0.45-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:01c484bb2ee85e98e21e24b397ff52ffc31101f7485935eee5d3afa6cca6cc08", size = 13117360, upload-time = "2026-06-09T11:23:15.155Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/31/ea21f102049b35a8fe5218c5331857a15eeb60deb1bb21823a4c0701e274/zensical-0.0.45-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:3654b708830303759e866a58a60c483cd2a1c56a44acdaae5bbb341a3f40ebce", size = 13185593, upload-time = "2026-06-09T11:23:18.166Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/97/6ded39fe27fa8a292d17d9af713b018e4919315233b60fa4b4b0aca737a6/zensical-0.0.45-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:c4da1c37eca1474b487def0ef40d7ac2aff31a9d7a029cb7479ef7c354437361", size = 13326882, upload-time = "2026-06-09T11:23:21.027Z" },
+    { url = "https://files.pythonhosted.org/packages/79/80/075975032a9e20f319c0134f8ca659d295ee4908f15ab212702a2728247f/zensical-0.0.45-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f8a1966c186feebd3b795f9d420000bfd582e16eefdd9bc7a286d878faabae52", size = 13253961, upload-time = "2026-06-09T11:23:23.99Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/6a/0eab0eb311af6a07cde15ca58d5d720cbfa02cd509e4c7fb5fa20cda0b46/zensical-0.0.45-cp310-abi3-win32.whl", hash = "sha256:a1dd63a5efb8d0e5f2fadf862f02771a279dc5cbe9a982700194650065758f01", size = 12257083, upload-time = "2026-06-09T11:23:26.769Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/cd/b117e749c60b1d1e16b8450db1355f69f38376f783b8c6c8815202988933/zensical-0.0.45-cp310-abi3-win_amd64.whl", hash = "sha256:1f2c0e69839ce4274bde34d18139d3b0d96bbf02b245ada46243590c9eedebc1", size = 12498335, upload-time = "2026-06-09T11:23:29.702Z" },
 ]


### PR DESCRIPTION
Implements a CI regression guard, via `pytest-codspeed`
