### PR TITLE
chore: Expand benchmark comparison to value-keyed methods

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,13 +1,17 @@
 # Benchmarks: `polars_stats` vs `scipy.stats`
 
-Manual comparison of the **sampling** methods against `scipy.stats`, on speed and peak memory.
+Manual comparison against `scipy.stats`, on speed and peak memory.
 
 This is the routine whose output backs the comparison numbers in the project README/documentation benchmarks.
 
 It is **not** the CI regression guard.
 
-Scope is deliberately narrow: `sample` (one variate per row) and `samples` (`n_samples` per row) against
-`scipy.rvs`.
+Two method families are compared:
+
+* **sampling**: `sample` (one variate per row) and `samples` (`n_samples` per row) against `scipy.rvs`;
+* **value-keyed**: `density` (`pdf` / `pmf` by family), `cdf`, `sf` and `ppf` against the matching
+  frozen-scipy methods, both sides evaluating the same deterministic inputs (the distribution's own
+  seeded draws; uniform quantiles for `ppf`).
 
 ## Running
 
@@ -15,27 +19,29 @@ There is one runnable entrypoint, [run.py](run.py). Run it with `uv` and the `be
 group, which provides the extra tooling (`cyclopts`, `rich`, `psutil`, plus `scipy` / `numpy`):
 
 ```bash
-uv run --group benchmarks benchmarks/run.py                                   # all distributions, rich table in the terminal
-uv run --group benchmarks benchmarks/run.py normal binomial                   # a subset
+uv run --group benchmarks benchmarks/run.py  # all distributions, rich table in the terminal
+uv run --group benchmarks benchmarks/run.py normal binomial  # a subset of distributions
+uv run --group benchmarks benchmarks/run.py --methods sample density ppf  # a subset of methods
 uv run --group benchmarks benchmarks/run.py normal --rows 1_000_000 10_000_000 --n-samples 5 10 20  # sweep a grid
-uv run --group benchmarks benchmarks/run.py --format markdown                 # write benchmarks/results/<dist>.md
-uv run --group benchmarks benchmarks/run.py --format json                     # write benchmarks/results/<dist>.json
+uv run --group benchmarks benchmarks/run.py --format markdown  # write benchmarks/results/<dist>.md
+uv run --group benchmarks benchmarks/run.py --format json  # write benchmarks/results/<dist>.json
 uv run --group benchmarks benchmarks/run.py --help
 ```
 
 | argument | default | meaning |
 | --- | --- | --- |
 | `distributions` (positional) | all | which distributions to compare, e.g. `normal binomial` |
-| `--rows` | `1_000_000` | one or more row counts to sweep; rows for `sample`/`samples`/`scipy.rvs` |
+| `--methods` | all | which methods to compare: `sample`, `samples`, `density` (= `pdf`/`pmf`), `cdf`, `sf`, `ppf` |
+| `--rows` | `1_000_000` | one or more row counts to sweep; rows for every method |
 | `--n-samples` | `10` | one or more draws-per-row widths to sweep for `samples` |
 | `--iterations` | `50` | timed runs per cell; runtime reported as `p50 ± std` |
-| `--seed` | `0` | seed for the samplers (reproducible) |
+| `--seed` | `0` | seed for the samplers and the value-keyed evaluation inputs (reproducible) |
 | `--format` | `rich` | `rich` (coloured terminal table), `markdown`, or `json` |
 | `--output-dir` | `benchmarks/results/` | where `markdown` / `json` files are written |
 
-`--rows` and `--n-samples` accept multiple values and are swept as a grid in one report: `sample` is
-benchmarked once per `rows` value (`n_samples` does not apply, shown as `-`); `samples` over the full
-`rows` x `n_samples` product.
+`--rows` and `--n-samples` accept multiple values and are swept as a grid in one report: every method
+except `samples` is benchmarked once per `rows` value (`n_samples` does not apply, shown as `-`);
+`samples` over the full `rows` x `n_samples` product.
 
 Output formats:
 
@@ -76,8 +82,10 @@ Adding a distribution is one entry in `REGISTRY`.
   Isolation is required: an in-process measurement after the timing loop is meaningless because each library's
   allocator retains freed pages differently (scipy would read ~0 while `polars_stats` re-allocates).
   RSS (not `tracemalloc`) so the native Rust/Arrow and NumPy allocations are counted.
-* **Correctness gate:** values cannot match across independent RNGs, so the gate is a shape check
-  (column length and array width vs scipy's output shape), flagged `MISMATCH` if it diverges. Warn-only.
+* **Correctness gate:** for the samplers, values cannot match across independent RNGs, so the gate is a
+  shape check (column length and array width vs scipy's output shape). The value-keyed methods evaluate
+  the same inputs on both sides, so their gate is `np.allclose` to loose tolerances (the scipy-parity
+  test suite owns the tight per-method bounds). Flagged `MISMATCH` if it diverges. Warn-only.
 
 Caveats on the memory numbers (read before quoting them):
 
@@ -89,5 +97,5 @@ Caveats on the memory numbers (read before quoting them):
 * One measurement per call (not a distribution); allocation sizes are deterministic, but the sampled
   peak can miss a very short transient.
 
-Out of scope (this routine is sampling-only): pointwise methods (`pdf`/`cdf`/`ppf`/...), summary
-statistics, and the column-parameter regime.
+Out of scope: summary statistics (`mean`/`variance`/`entropy`/...; cheap closed forms, nothing to
+compare at scale) and the column-parameter regime (no scipy equivalent to compare against).

--- a/benchmarks/_harness.py
+++ b/benchmarks/_harness.py
@@ -1,8 +1,14 @@
-"""Shared comparison harness for the ``polars_stats`` vs ``scipy.stats`` sampling benchmarks.
+"""Shared comparison harness for the ``polars_stats`` vs ``scipy.stats`` benchmarks.
 
-Scope is deliberately narrow: the two sampling methods, `sample` (one variate per row) and `samples`
-(``n_samples`` variates per row), against ``scipy.rvs``. These are the calls where `polars_stats` does real per-row
-work, so they are the meaningful throughput and memory comparison.
+Two method families are compared:
+
+* **sampling**: `sample` (one variate per row) and `samples` (``n_samples`` variates per row),
+  against ``scipy.rvs``. Independent RNGs mean values cannot match, so correctness is a shape-only
+  gate.
+* **value-keyed**: `density` (`pdf` / `pmf` by family), `cdf`, `sf` and `ppf`, against the matching
+  frozen-scipy method. Both sides evaluate the *same* deterministic inputs (the distribution's own
+  seeded draws; open-interval quantiles for `ppf`), so here the `match` column is a real
+  ``np.allclose`` value check, not just a shape check.
 
 `run.py` owns the `Comparison` registry (one entry per distribution) and the CLI; it calls `run_comparison` over a
 `Sweep` of sizes. This module is *not* runnable; run ``uv run --group benchmarks benchmarks/run.py`` instead.
@@ -34,6 +40,8 @@ import scipy
 from rich.console import Console
 from rich.table import Table
 
+from polars_stats.distributions._base import ContinuousDistribution
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
     from pathlib import Path
@@ -42,19 +50,31 @@ if TYPE_CHECKING:
 
     from polars_stats.distributions._base import _UnivariateDistribution
 
-    # The frozen instance a spec passes (`norm(...)`, `binom(n, p)`, ...). Sampling-only, so we just call `rvs`;
-    # typing against scipy's own frozen types rather than a hand-rolled Protocol keeps it honest against scipy-stubs.
+    # The frozen instance a spec passes (`norm(...)`, `binom(n, p)`, ...). Typing against scipy's own frozen
+    # types rather than a hand-rolled Protocol keeps it honest against scipy-stubs.
     ScipyFrozen = rv_continuous_frozen | rv_discrete_frozen
 
     Distribution = _UnivariateDistribution
     """Any `polars_stats` distribution"""
 
-    Method = Literal["sample", "samples"]
     Side = Literal["polars_stats", "scipy"]
 
 
+Method = Literal["sample", "samples", "density", "cdf", "sf", "ppf"]
+"""A benchmarkable method. `density` resolves to `pdf` (continuous) or `pmf` (discrete) per distribution."""
+
+ALL_METHODS: tuple[Method, ...] = ("sample", "samples", "density", "cdf", "sf", "ppf")
+
+_VALUE_METHODS: frozenset[Method] = frozenset({"density", "cdf", "sf", "ppf"})
+
 OutputFormat = Literal["markdown", "json", "rich"]
 """How a report is emitted: a markdown file, a JSON file, or a rich table printed to the terminal."""
+
+# Value-keyed match tolerances: statrs and scipy implement the same special functions with
+# different algorithms, so agreement is to high relative precision, not bit-equality. The
+# scipy-parity test suite owns the tight per-method bounds; this is a sanity gate.
+_MATCH_RTOL = 1e-5
+_MATCH_ATOL = 1e-12
 
 _MIB = 1024.0 * 1024.0
 # Background memory sampler poll interval. Short enough to catch the transient peak of `samples`
@@ -95,8 +115,9 @@ class RunConfig:
 class Sweep:
     """A grid of sizes to benchmark in one report: each `rows`, crossed with each `n_samples` for `samples`.
 
-    `sample` (one draw per row) ignores `n_samples`, so it is benchmarked once per `rows` value; `samples`
-    is benchmarked over the full `rows` x `n_samples` product.
+    Every method except `samples` works one value per row and ignores `n_samples`, so it is
+    benchmarked once per `rows` value; `samples` is benchmarked over the full `rows` x `n_samples`
+    product.
     """
 
     rows: tuple[int, ...] = (1_000_000,)
@@ -194,40 +215,96 @@ def _length_frame(rows: int) -> pl.LazyFrame:
     return pl.LazyFrame({"_": pl.Boolean()}).clear(rows)
 
 
-def _build_fn(comp: Comparison, method: Method, config: RunConfig, side: Side) -> Callable[[], object]:
-    """The single source of the timed/measured call, so timing, memory, and the shape check never drift.
+def _density_name(dist: Distribution) -> Literal["pdf", "pmf"]:
+    """The family-specific density method `density` resolves to (both as report label and call)."""
+    return "pdf" if isinstance(dist, ContinuousDistribution) else "pmf"
 
-    Returns a zero-arg closure. The polars side builds its length frame up front (outside the closure)
-    so frame construction is not part of what is timed or charged to peak memory.
+
+def _eval_inputs(comp: Comparison, config: RunConfig, method: Method) -> np.ndarray:
+    """Deterministic evaluation inputs for a value-keyed method, shared by both sides.
+
+    Derived only from `(comp, config)` so the two sides (and the isolated memory subprocesses)
+    regenerate the identical array. `ppf` gets uniform quantiles from `[0, 1)`; the other methods
+    get the distribution's own seeded draws, which cover the support with realistic density.
+    """
+    if method == "ppf":
+        return np.random.default_rng(config.seed).uniform(0.0, 1.0, size=config.rows)
+    return np.asarray(comp.scipy_frozen.rvs(size=config.rows, random_state=config.seed), dtype=np.float64)
+
+
+def _value_expr(dist: Distribution, method: Method) -> pl.Expr:
+    """The `polars_stats` expression for a value-keyed method, evaluated on the shared `x` column."""
+    x = pl.col("x")
+    match method:
+        case "density":
+            return dist.pdf(x) if isinstance(dist, ContinuousDistribution) else dist.pmf(x)  # type: ignore[attr-defined]
+        case "cdf":
+            return dist.cdf(x)
+        case "sf":
+            return dist.sf(x)
+        case "ppf":
+            return dist.ppf(x)
+        case _:
+            msg = f"not a value-keyed method: {method}"
+            raise AssertionError(msg)
+
+
+def _build_fn(comp: Comparison, method: Method, config: RunConfig, side: Side) -> Callable[[], object]:
+    """The single source of the timed/measured call, so timing, memory, and the match check never drift.
+
+    Returns a zero-arg closure. Input construction (the length frame for samplers, the shared
+    evaluation column for value-keyed methods) happens up front, outside the closure, so it is not
+    part of what is timed or charged to peak memory.
     """
     rows, n, seed = config.rows, config.n_samples, config.seed
     match side:
         case "scipy":
             frozen = comp.scipy_frozen
+            if method in _VALUE_METHODS:
+                values = _eval_inputs(comp, config, method)
+                scipy_method = _density_name(comp.dist) if method == "density" else method
+                fn = getattr(frozen, scipy_method)
+                return lambda: fn(values)
             size: int | tuple[int, int] = rows if method == "sample" else (rows, n)
             return lambda: frozen.rvs(size=size, random_state=seed)
         case "polars_stats":
-            dist, lf = comp.dist, _length_frame(rows)
-            expr = dist.sample(seed=seed) if method == "sample" else dist.samples(n, seed=seed)
+            dist = comp.dist
+            if method in _VALUE_METHODS:
+                lf = pl.LazyFrame({"x": _eval_inputs(comp, config, method)})
+                expr = _value_expr(dist, method)
+            else:
+                lf = _length_frame(rows)
+                expr = dist.sample(seed=seed) if method == "sample" else dist.samples(n, seed=seed)
             return lambda: lf.select(s=expr).collect(engine="streaming")
         case _:
             msg = "Unreachable path"
             raise AssertionError(msg)
 
 
-def _shape_ok(method: Method, config: RunConfig, polars_out: object, scipy_out: object) -> bool:
-    """Shape-only correctness gate: independent RNGs mean values cannot match, but shapes must."""
+def _matches(method: Method, config: RunConfig, polars_out: object, scipy_out: object) -> bool:
+    """Correctness gate.
+
+    * Samplers: shape-only (independent RNGs cannot match values).
+    * Value-keyed methods evaluate the same inputs on both sides, so values must agree to `np.allclose` within
+        the loose `_MATCH_RTOL`/`_MATCH_ATOL` (the scipy-parity suite owns the tight bounds).
+    """
     assert isinstance(polars_out, pl.DataFrame)  # noqa: S101  # help the type checker
     assert isinstance(scipy_out, np.ndarray)  # noqa: S101  # help the type checker
+    if method == "samples":
+        dtype = polars_out.to_series().dtype
+        return (
+            polars_out.height == config.rows
+            and isinstance(dtype, pl.Array)
+            and getattr(dtype, "size", None) == config.n_samples
+            and scipy_out.shape == (config.rows, config.n_samples)
+        )
+    if polars_out.height != config.rows or scipy_out.shape != (config.rows,):
+        return False
     if method == "sample":
-        return polars_out.height == config.rows and scipy_out.shape == (config.rows,)
-    dtype = polars_out.to_series().dtype
-    return (
-        polars_out.height == config.rows
-        and isinstance(dtype, pl.Array)
-        and getattr(dtype, "size", None) == config.n_samples
-        and scipy_out.shape == (config.rows, config.n_samples)
-    )
+        return True
+    ours = polars_out.to_series().cast(pl.Float64).to_numpy()
+    theirs = np.asarray(scipy_out, dtype=np.float64)
+    return np.allclose(ours, theirs, rtol=_MATCH_RTOL, atol=_MATCH_ATOL, equal_nan=True)
 
 
 def _mem_entry(queue: object, comp: Comparison, method: Method, config: RunConfig, side: Side) -> None:
@@ -267,7 +344,7 @@ def _peak_memory_isolated(comp: Comparison, method: Method, config: RunConfig, s
 def _measure(comp: Comparison, method: Method, config: RunConfig) -> Result:
     sides: tuple[Side, ...] = ("polars_stats", "scipy")
     fns = {side: _build_fn(comp, method, config, side) for side in sides}
-    matches = _shape_ok(method, config, fns["polars_stats"](), fns["scipy"]())
+    matches = _matches(method, config, fns["polars_stats"](), fns["scipy"]())
     measurements = {
         side: Measurement(
             *_time(fns[side], iterations=config.iterations),
@@ -276,7 +353,8 @@ def _measure(comp: Comparison, method: Method, config: RunConfig) -> Result:
         for side in sides
     }
     return Result(
-        method=method,
+        # `density` is the sweep token; the report shows the method actually called.
+        method=_density_name(comp.dist) if method == "density" else method,
         rows=config.rows,
         n_samples=config.n_samples if method == "samples" else None,
         polars_stats=measurements["polars_stats"],
@@ -285,17 +363,20 @@ def _measure(comp: Comparison, method: Method, config: RunConfig) -> Result:
     )
 
 
-def run_comparison(comp: Comparison, sweep: Sweep) -> list[Result]:
-    """Benchmark `sample` (per `rows`) and `samples` (per `rows` x `n_samples`) across the sweep grid."""
-    results = [
-        _measure(comp, "sample", RunConfig(rows=rows, n_samples=1, iterations=sweep.iterations, seed=sweep.seed))
-        for rows in sweep.rows
-    ]
-    results.extend(
-        _measure(comp, "samples", RunConfig(rows=rows, n_samples=n, iterations=sweep.iterations, seed=sweep.seed))
-        for rows in sweep.rows
-        for n in sweep.n_samples
-    )
+def run_comparison(comp: Comparison, sweep: Sweep, methods: Sequence[Method] = ALL_METHODS) -> list[Result]:
+    """Benchmark each requested method across the sweep grid.
+
+    Every method is measured once per `rows` value; `samples` additionally crosses `rows` with each
+    `n_samples` width.
+    """
+    results: list[Result] = []
+    for method in methods:
+        widths = sweep.n_samples if method == "samples" else (1,)
+        results.extend(
+            _measure(comp, method, RunConfig(rows=rows, n_samples=n, iterations=sweep.iterations, seed=sweep.seed))
+            for rows in sweep.rows
+            for n in widths
+        )
     return results
 
 

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -1,10 +1,12 @@
-"""Entrypoint for the ``polars_stats`` vs ``scipy.stats`` sampling benchmarks.
+"""Entrypoint for the ``polars_stats`` vs ``scipy.stats`` benchmarks.
 
-Compare the `sample` / `samples` methods against ``scipy.rvs`` on speed and peak memory, sweeping over
-one or more row counts and sample widths in a single report::
+Compare the sampling methods (`sample` / `samples` vs ``scipy.rvs``) and the value-keyed methods
+(`pdf` / `pmf`, `cdf`, `sf`, `ppf` vs their frozen-scipy counterparts) on speed and peak memory,
+sweeping over one or more row counts and sample widths in a single report::
 
-    uv run --group benchmarks benchmarks/run.py                                   # all distributions, rich table
-    uv run --group benchmarks benchmarks/run.py normal binomial                   # a subset
+    uv run --group benchmarks benchmarks/run.py                                   # all distributions and methods
+    uv run --group benchmarks benchmarks/run.py normal binomial                   # a subset of distributions
+    uv run --group benchmarks benchmarks/run.py --methods sample density ppf      # a subset of methods
     uv run --group benchmarks benchmarks/run.py normal --rows 1_000_000 10_000_000 --n-samples 5 10 20
     uv run --group benchmarks benchmarks/run.py --format markdown                 # write benchmarks/results/<dist>.md
 
@@ -15,17 +17,18 @@ from __future__ import annotations
 
 from math import exp
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, get_args
 
 from cyclopts import App, Parameter
 from scipy.stats import bernoulli, binom, lognorm, norm, uniform
 
-from benchmarks._harness import Comparison, OutputFormat, Sweep, emit, run_comparison
+from benchmarks._harness import ALL_METHODS, Comparison, Method, OutputFormat, Sweep, emit, run_comparison
 from polars_stats import Bernoulli, Binomial, LogNormal, Normal, Uniform
 
 # `--rows 1 2 3` (multiple tokens per flag), not `--rows 1 --rows 2`; without this a list option takes
 # a single token and the rest leak onto the positional `distributions`.
 _MultiInt = Annotated[list[int], Parameter(consume_multiple=True)]
+_MultiMethod = Annotated[list[Method], Parameter(consume_multiple=True)]
 
 # One row per distribution: the polars_stats instance and the matching frozen scipy distribution,
 # reparameterised to scipy's convention. Adding a distribution is one entry here.
@@ -44,6 +47,7 @@ app = App(name="bench", help="Benchmark polars_stats sampling against scipy.stat
 def main(  # noqa: PLR0913
     distributions: list[str] | None = None,
     *,
+    methods: _MultiMethod | None = None,
     rows: _MultiInt | None = None,
     n_samples: _MultiInt | None = None,
     iterations: int = 50,
@@ -51,14 +55,16 @@ def main(  # noqa: PLR0913
     format: OutputFormat = "rich",  # noqa: A002
     output_dir: Path | None = None,
 ) -> None:
-    """Compare each requested distribution's `sample` and `samples` methods against scipy.
+    """Compare each requested distribution's methods against scipy.
 
     Arguments:
         distributions: Distributions to compare (e.g. `normal binomial`). Defaults to all of them.
+        methods: Methods to compare (e.g. `--methods sample density ppf`); `density` resolves to
+            `pdf` / `pmf` per distribution family. Defaults to all of them.
         rows: Row counts to sweep over (e.g. `--rows 1_000_000 10_000_000`). Defaults to `[1_000_000]`.
         n_samples: Sample widths to sweep over for `samples` (e.g. `--n-samples 5 10 20`). Defaults to `[10]`.
         iterations: Timed runs per cell; runtime is reported as p50 +/- std.
-        seed: Seed for the samplers (reproducible).
+        seed: Seed for the samplers and the value-keyed evaluation inputs (reproducible).
         format: `rich` prints a coloured table to the terminal; `markdown` / `json` write a file per
             distribution to the output directory.
         output_dir: Where the `markdown` / `json` files are written. Defaults to `benchmarks/results/`.
@@ -66,6 +72,10 @@ def main(  # noqa: PLR0913
     names = distributions or list(REGISTRY)
     if unknown := [n for n in names if n not in REGISTRY]:
         msg = f"unknown distribution(s): {', '.join(unknown)}. Available: {', '.join(REGISTRY)}"
+        raise ValueError(msg)
+    selected = tuple(methods) if methods else ALL_METHODS
+    if bad := [m for m in selected if m not in get_args(Method)]:
+        msg = f"unknown method(s): {', '.join(bad)}. Available: {', '.join(get_args(Method))}"
         raise ValueError(msg)
 
     sweep = Sweep(
@@ -77,7 +87,7 @@ def main(  # noqa: PLR0913
     results_dir = output_dir or (Path(__file__).parent / "results")
 
     for name in names:
-        results = run_comparison(REGISTRY[name], sweep)
+        results = run_comparison(REGISTRY[name], sweep, methods=selected)
         emit(REGISTRY[name], results, sweep, fmt=format, output_dir=results_dir)
 
 


### PR DESCRIPTION
The benchmark sweep now covers density (pdf/pmf by family), cdf, sf and ppf against the frozen-scipy counterparts, alongside sample/samples; selectable via `--methods`.

Both sides evaluate the same deterministic inputs (the distribution's own seeded draws; uniform quantiles for ppf),
so the report's match column is a real np.allclose value gate for these methods instead of a shape check.

---

Closes #24 
