### PR TITLE
refactor: Generate the `<name>_sample_scalar` plugins via a shared `sample_scalar_plugin!` macro

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,10 +91,13 @@ reproducible across OS and architecture.
 takes a dedicated plugin, `<name>_sample_scalar`. The parameters travel in `kwargs` and are validated once; only the row
 index crosses FFI, instead of one full-length `pl.repeat` column per parameter that the general plugin would marshal and
 re-validate on every row. The shared `sample_by_index` helper in `rng.rs` resolves the seed once and maps the dense,
-non-null index straight into the typed output. It reuses the same `(root_seed, row_index)` seeding and the same draw as
-the per-row path, so output is byte-identical for the same seed (a property test pins that equality); column-valued
-parameters still take the general per-row plugin. This is what moves the sampler from slower than scipy at small frames
-to faster from roughly 100k rows up, where the per-element draw dominates the fixed `int_range` row-index cost.
+non-null index straight into the typed output. Each distribution declares its fast path through the
+`sample_scalar_plugin!` macro in `rng.rs` (kwargs struct, output dtype, one-time `build`, per-row `draw`), which
+generates the kwargs struct and the plugin function, so a new distribution cannot drift from the pattern. It reuses
+the same `(root_seed, row_index)` seeding and the same draw as the per-row path, so output is byte-identical for the
+same seed (a property test pins that equality); column-valued parameters still take the general per-row plugin. This
+is what moves the sampler from slower than scipy at small frames to faster from roughly 100k rows up, where the
+per-element draw dominates the fixed `int_range` row-index cost.
 
 !!! info "Earlier `ChaCha20` design (removed)"
 
@@ -119,7 +122,7 @@ polars-stats/
 ├── rust-toolchain.toml
 ├── src/
 │   ├── lib.rs                # pymodule entry + global allocator
-│   ├── rng.rs                # shared per-row RNG (SampleKwargs, RowRngs, sample_by_index fast path)
+│   ├── rng.rs                # shared per-row RNG (SampleKwargs, RowRngs, sample_scalar_plugin! fast path)
 │   └── distributions/        # one Rust file per distribution
 ├── polars_stats/
 │   ├── __init__.py           # public exports

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -3,10 +3,9 @@ use polars::prelude::arity::try_binary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distributions::Distribution;
-use serde::Deserialize;
 use statrs::distribution::Bernoulli;
 
-use crate::rng::{sample_by_index, SampleKwargs};
+use crate::rng::{sample_scalar_plugin, SampleKwargs};
 
 fn build_dist(proba: f64) -> PolarsResult<Bernoulli> {
     Bernoulli::new(proba).map_err(|e| {
@@ -76,38 +75,17 @@ fn bernoulli_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Ser
     Ok(ca.with_name(name).into_series())
 }
 
-/// Static parameters for the constant-parameter sampler fast path.
-///
-/// When `p` is a Python scalar, the Python layer routes it here as a kwarg instead of expanding it
-/// into a full-length column (`pl.repeat`) that crosses FFI and is re-validated on every row. The
-/// distribution is validated and built once, and only the per-row index travels as an input.
-#[derive(Deserialize)]
-struct BernoulliScalarKwargs {
-    seed: Option<u64>,
-    p: f64,
-}
+sample_scalar_plugin! {
+    /// Static parameters for the constant-parameter sampler fast path: when `p` is a Python
+    /// scalar, it travels here as a kwarg instead of as a full-length `pl.repeat` column
+    /// re-validated on every row.
+    struct BernoulliScalarKwargs { p: f64 }
 
-/// Constant-probability Bernoulli sampler.
-///
-/// Semantically identical to [`bernoulli_sample`] for the common case of a scalar `p`, but built for
-/// it: `inputs[0]` is the per-row index (never null, sole FFI input), and `p` arrives in `kwargs`.
-/// The distribution is validated and constructed once up front, then reused for every row. Seeding
-/// and the draw are unchanged, so output matches `bernoulli_sample` for the same `(seed, index, p)`.
-#[polars_expr(output_type=Boolean)]
-fn bernoulli_sample_scalar(
-    inputs: &[Series],
-    kwargs: BernoulliScalarKwargs,
-) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.p)?;
-    let name = inputs[0].name().clone();
-
-    sample_by_index::<BooleanType, _>(&inputs[0], kwargs.seed, |index_ca, rngs| {
-        BooleanChunked::from_iter_values(
-            name,
-            index_ca.into_no_null_iter().map(|i| {
-                let mut rng = rngs.rng(i);
-                <Bernoulli as Distribution<bool>>::sample(&dist, &mut rng)
-            }),
-        )
-    })
+    /// Constant-probability Bernoulli sampler: [`bernoulli_sample`] for the scalar-`p` case. The
+    /// distribution is validated and built once, and only the per-row index travels as an input;
+    /// seeding and the draw are unchanged, so output matches `bernoulli_sample` for the same
+    /// `(seed, index, p)`.
+    fn bernoulli_sample_scalar(output_type = Boolean, physical = BooleanType);
+    build = |kw| build_dist(kw.p)?;
+    draw = |dist, rng| <Bernoulli as Distribution<bool>>::sample(&dist, rng);
 }

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -9,7 +9,7 @@ use statrs::distribution::{Binomial, Discrete, DiscreteCDF};
 use statrs::statistics::Distribution as StatrsDistribution;
 
 use crate::distributions::value_keyed_scalar;
-use crate::rng::{sample_by_index, SampleKwargs};
+use crate::rng::{sample_scalar_plugin, SampleKwargs};
 
 /// Construct a `statrs::Binomial`, mapping both invalid-parameter cases to a `ComputeError`.
 ///
@@ -168,40 +168,19 @@ fn binomial_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Seri
     Ok(ca.with_name(name).into_series())
 }
 
-/// Static parameters for the constant-parameter sampler fast path.
-///
-/// When both `n` and `p` are Python scalars, the Python layer routes them here as kwargs instead of
-/// expanding each into a full-length column (`pl.repeat`) that crosses FFI and is re-validated on
-/// every row. The distribution is validated and built once, and only the per-row index travels as an
-/// input.
-#[derive(Deserialize)]
-struct BinomialScalarKwargs {
-    seed: Option<u64>,
-    n: i64,
-    p: f64,
-}
+sample_scalar_plugin! {
+    /// Static parameters for the constant-parameter sampler fast path: when both `n` and `p` are
+    /// Python scalars, they travel here as kwargs instead of as two full-length `pl.repeat`
+    /// columns re-validated on every row.
+    struct BinomialScalarKwargs { n: i64, p: f64 }
 
-/// Constant-parameter Binomial sampler.
-///
-/// Semantically identical to [`binomial_sample`] for the common case of scalar parameters, but built
-/// for it: `inputs[0]` is the per-row index (never null, sole FFI input), and the parameters arrive
-/// in `kwargs`. The distribution is validated and constructed once up front, then reused for every
-/// row. Seeding and the draw are unchanged, so output matches `binomial_sample` for the same
-/// `(seed, index, n, p)`.
-#[polars_expr(output_type=UInt64)]
-fn binomial_sample_scalar(inputs: &[Series], kwargs: BinomialScalarKwargs) -> PolarsResult<Series> {
-    let dist = build_sampler(kwargs.n, kwargs.p)?;
-    let name = inputs[0].name().clone();
-
-    sample_by_index::<UInt64Type, _>(&inputs[0], kwargs.seed, |index_ca, rngs| {
-        UInt64Chunked::from_iter_values(
-            name,
-            index_ca.into_no_null_iter().map(|i| {
-                let mut rng = rngs.rng(i);
-                dist.sample(&mut rng)
-            }),
-        )
-    })
+    /// Constant-parameter Binomial sampler: [`binomial_sample`] for the all-scalar case. The
+    /// `rand_distr` sampler is validated and built once (via [`build_sampler`], like the per-row
+    /// path), and only the per-row index travels as an input; seeding and the draw are unchanged,
+    /// so output matches `binomial_sample` for the same `(seed, index, n, p)`.
+    fn binomial_sample_scalar(output_type = UInt64, physical = UInt64Type);
+    build = |kw| build_sampler(kw.n, kw.p)?;
+    draw = |dist, rng| dist.sample(rng);
 }
 
 // Per-method bodies, named so the per-row plugins and the constant-parameter `*_scalar` twins

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use statrs::distribution::{Continuous, ContinuousCDF, LogNormal};
 
 use crate::distributions::value_keyed_scalar;
-use crate::rng::{sample_by_index, SampleKwargs};
+use crate::rng::{sample_scalar_plugin, SampleKwargs};
 
 /// Construct a `statrs::LogNormal`, mapping the invalid-parameter case to a `ComputeError`.
 ///
@@ -137,43 +137,19 @@ fn lognormal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Ser
     Ok(ca.with_name(name).into_series())
 }
 
-/// Static parameters for the constant-parameter sampler fast path.
-///
-/// When both `mu` and `sigma` are Python scalars, the Python layer routes them here as kwargs
-/// instead of expanding each into a full-length column (`pl.repeat`) that crosses FFI and is
-/// re-validated on every row. The distribution is validated and built once, and only the per-row
-/// index travels as an input.
-#[derive(Deserialize)]
-struct LogNormalScalarKwargs {
-    seed: Option<u64>,
-    mu: f64,
-    sigma: f64,
-}
+sample_scalar_plugin! {
+    /// Static parameters for the constant-parameter sampler fast path: when both `mu` and `sigma`
+    /// are Python scalars, they travel here as kwargs instead of as two full-length `pl.repeat`
+    /// columns re-validated on every row.
+    struct LogNormalScalarKwargs { mu: f64, sigma: f64 }
 
-/// Constant-parameter LogNormal sampler.
-///
-/// Semantically identical to [`lognormal_sample`] for the common case of scalar parameters, but
-/// built for it: `inputs[0]` is the per-row index (never null, sole FFI input), and the parameters
-/// arrive in `kwargs`. The distribution is validated and constructed once up front, then reused for
-/// every row. Seeding and the draw are unchanged, so output matches `lognormal_sample` for the same
-/// `(seed, index, mu, sigma)`.
-#[polars_expr(output_type=Float64)]
-fn lognormal_sample_scalar(
-    inputs: &[Series],
-    kwargs: LogNormalScalarKwargs,
-) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.mu, kwargs.sigma)?;
-    let name = inputs[0].name().clone();
-
-    sample_by_index::<Float64Type, _>(&inputs[0], kwargs.seed, |index_ca, rngs| {
-        Float64Chunked::from_iter_values(
-            name,
-            index_ca.into_no_null_iter().map(|i| {
-                let mut rng = rngs.rng(i);
-                RandDistribution::sample(&dist, &mut rng)
-            }),
-        )
-    })
+    /// Constant-parameter LogNormal sampler: [`lognormal_sample`] for the all-scalar case. The
+    /// distribution is validated and built once, and only the per-row index travels as an input;
+    /// seeding and the draw are unchanged, so output matches `lognormal_sample` for the same
+    /// `(seed, index, mu, sigma)`.
+    fn lognormal_sample_scalar(output_type = Float64, physical = Float64Type);
+    build = |kw| build_dist(kw.mu, kw.sigma)?;
+    draw = |dist, rng| RandDistribution::sample(&dist, rng);
 }
 
 // Per-method bodies, named so the per-row plugins and the constant-parameter `*_scalar` twins

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use statrs::distribution::{Continuous, ContinuousCDF, Normal};
 
 use crate::distributions::value_keyed_scalar;
-use crate::rng::{sample_by_index, SampleKwargs};
+use crate::rng::{sample_scalar_plugin, SampleKwargs};
 
 /// Construct a `statrs::Normal`, mapping the invalid-parameter case to a `ComputeError`.
 ///
@@ -137,41 +137,19 @@ fn normal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series
     Ok(ca.with_name(name).into_series())
 }
 
-/// Static parameters for the constant-parameter sampler fast path.
-///
-/// When both `mean` and `std_dev` are Python scalars, the Python layer routes them here as kwargs
-/// instead of expanding each into a full-length column (`pl.repeat`) that crosses FFI and is
-/// re-validated on every row. The distribution is validated and built once, and only the per-row
-/// index travels as an input.
-#[derive(Deserialize)]
-struct NormalScalarKwargs {
-    seed: Option<u64>,
-    mean: f64,
-    std_dev: f64,
-}
+sample_scalar_plugin! {
+    /// Static parameters for the constant-parameter sampler fast path: when both `mean` and
+    /// `std_dev` are Python scalars, they travel here as kwargs instead of as two full-length
+    /// `pl.repeat` columns re-validated on every row.
+    struct NormalScalarKwargs { mean: f64, std_dev: f64 }
 
-/// Constant-parameter Normal sampler.
-///
-/// Semantically identical to [`normal_sample`] for the common case of scalar parameters, but built
-/// for it: `inputs[0]` is the per-row index (never null, sole FFI input), and the parameters arrive
-/// in `kwargs`. The distribution is validated and constructed once up front, then reused for every
-/// row. Seeding is the same `(root_seed, index)` derivation and the draw is the same
-/// `RandDistribution::sample`, so output matches `normal_sample` for the same `(seed, index, mean,
-/// std_dev)`.
-#[polars_expr(output_type=Float64)]
-fn normal_sample_scalar(inputs: &[Series], kwargs: NormalScalarKwargs) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.mean, kwargs.std_dev)?;
-    let name = inputs[0].name().clone();
-
-    sample_by_index::<Float64Type, _>(&inputs[0], kwargs.seed, |index_ca, rngs| {
-        Float64Chunked::from_iter_values(
-            name,
-            index_ca.into_no_null_iter().map(|i| {
-                let mut rng = rngs.rng(i);
-                RandDistribution::sample(&dist, &mut rng)
-            }),
-        )
-    })
+    /// Constant-parameter Normal sampler: [`normal_sample`] for the all-scalar case. The
+    /// distribution is validated and built once, and only the per-row index travels as an input;
+    /// seeding and the draw are unchanged, so output matches `normal_sample` for the same
+    /// `(seed, index, mean, std_dev)`.
+    fn normal_sample_scalar(output_type = Float64, physical = Float64Type);
+    build = |kw| build_dist(kw.mean, kw.std_dev)?;
+    draw = |dist, rng| RandDistribution::sample(&dist, rng);
 }
 
 // Per-method bodies, named so the per-row plugins and the constant-parameter `*_scalar` twins

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -3,10 +3,9 @@ use polars::prelude::arity::{try_binary_elementwise, try_ternary_elementwise};
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distributions::{Distribution, Standard};
-use serde::Deserialize;
 use statrs::distribution::Uniform;
 
-use crate::rng::{sample_by_index, SampleKwargs};
+use crate::rng::{sample_scalar_plugin, SampleKwargs};
 
 fn build_dist(min: f64, max: f64) -> PolarsResult<Uniform> {
     // `statrs` accepts any finite `min < max`, but a support wider than `f64::MAX` (e.g.
@@ -103,41 +102,20 @@ fn uniform_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Serie
     Ok(ca.with_name(name).into_series())
 }
 
-/// Static parameters for the constant-bounds sampler fast path.
-///
-/// When both bounds are Python scalars, the Python layer routes them here as kwargs instead of
-/// expanding each into a full-length column (`pl.repeat`) that crosses FFI and is re-validated on
-/// every row. The bounds are validated once, and only the per-row index travels as an input.
-#[derive(Deserialize)]
-struct UniformScalarKwargs {
-    seed: Option<u64>,
-    min: f64,
-    max: f64,
-}
+sample_scalar_plugin! {
+    /// Static parameters for the constant-bounds sampler fast path: when both bounds are Python
+    /// scalars, they travel here as kwargs instead of as two full-length `pl.repeat` columns
+    /// re-validated on every row.
+    struct UniformScalarKwargs { min: f64, max: f64 }
 
-/// Constant-bounds Uniform sampler over `[min, max)`.
-///
-/// Semantically identical to [`uniform_sample`] for the common case of scalar bounds, but built
-/// for it: `inputs[0]` is the per-row index (never null, sole FFI input), and the bounds arrive in
-/// `kwargs`. Validation happens once up front rather than per row, and the draw is the shared
-/// [`draw_half_open`]. Seeding is the same `(root_seed, index)` derivation, so output matches
-/// `uniform_sample` for the same `(seed, index, min, max)`.
-#[polars_expr(output_type=Float64)]
-fn uniform_sample_scalar(inputs: &[Series], kwargs: UniformScalarKwargs) -> PolarsResult<Series> {
-    // Validate the parameterisation once; same error contract as `uniform_range` / `uniform_sample`.
-    build_dist(kwargs.min, kwargs.max)?;
-    let (lo, hi) = (kwargs.min, kwargs.max);
-    let name = inputs[0].name().clone();
-
-    sample_by_index::<Float64Type, _>(&inputs[0], kwargs.seed, |index_ca, rngs| {
-        Float64Chunked::from_iter_values(
-            name,
-            index_ca.into_no_null_iter().map(|i| {
-                let mut rng = rngs.rng(i);
-                draw_half_open(lo, hi, &mut rng)
-            }),
-        )
-    })
+    /// Constant-bounds Uniform sampler over `[min, max)`: [`uniform_sample`] for the all-scalar
+    /// case. The bounds are validated once (same error contract as `uniform_range`; the built
+    /// distribution is intentionally unused, see [`draw_half_open`]) and only the per-row index
+    /// travels as an input; seeding and the draw are unchanged, so output matches
+    /// `uniform_sample` for the same `(seed, index, min, max)`.
+    fn uniform_sample_scalar(output_type = Float64, physical = Float64Type);
+    build = |kw| { build_dist(kw.min, kw.max)?; (kw.min, kw.max) };
+    draw = |(lo, hi), rng| draw_half_open(lo, hi, rng);
 }
 
 /// Element-wise support width `max - min`, validating the parameterisation.

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -123,6 +123,65 @@ where
     Ok(build(index_ca, &rngs).into_series())
 }
 
+/// Generates a distribution's constant-parameter sampler fast path: the kwargs struct
+/// (the scalar parameters next to the optional root `seed`) and the `#[polars_expr]`
+/// plugin that drives [`sample_by_index`].
+///
+/// The four things that vary between distributions are the macro's inputs:
+///
+/// * the kwargs fields (parameter names and types);
+/// * the output dtype, as the `(logical, physical)` pair `output_type = Float64,
+///   physical = Float64Type` (the two must agree; the logical name feeds
+///   `#[polars_expr]`, the physical one the output `ChunkedArray`);
+/// * `build`: validates the parameters and returns the per-call sampler state, built
+///   **once** (`?` is available). Usually the built distribution; Uniform validates and
+///   keeps the raw bounds instead;
+/// * `draw`: one draw from that state, given a `&mut` per-row RNG already seeded from
+///   `(root_seed, index)`.
+///
+/// `draw` must be the *same* draw the general per-row plugin performs, so the two paths
+/// stay byte-identical for the same `(seed, index, params)`; that contract is pinned by
+/// `test_sample_scalar_fast_path_matches_per_row`. Call sites are the distribution
+/// modules, which all have `polars::prelude::*` in scope (the expansion relies on it).
+macro_rules! sample_scalar_plugin {
+    (
+        $(#[$kwargs_meta:meta])*
+        struct $kwargs:ident { $($param:ident: $param_ty:ty),+ $(,)? }
+
+        $(#[$fn_meta:meta])*
+        fn $fn_name:ident(output_type = $logical:ident, physical = $physical:ty);
+        build = |$kw:ident| $build:expr;
+        draw = |$state:pat_param, $rng:ident| $draw:expr;
+    ) => {
+        $(#[$kwargs_meta])*
+        #[derive(serde::Deserialize)]
+        struct $kwargs {
+            seed: Option<u64>,
+            $($param: $param_ty,)+
+        }
+
+        $(#[$fn_meta])*
+        #[pyo3_polars::derive::polars_expr(output_type=$logical)]
+        fn $fn_name(inputs: &[Series], kwargs: $kwargs) -> PolarsResult<Series> {
+            let $kw = &kwargs;
+            let $state = $build;
+            let name = inputs[0].name().clone();
+
+            $crate::rng::sample_by_index::<$physical, _>(&inputs[0], kwargs.seed, |index_ca, rngs| {
+                ChunkedArray::<$physical>::from_iter_values(
+                    name,
+                    index_ca.into_no_null_iter().map(|i| {
+                        let mut rng = rngs.rng(i);
+                        let $rng = &mut rng;
+                        $draw
+                    }),
+                )
+            })
+        }
+    };
+}
+pub(crate) use sample_scalar_plugin;
+
 /// Per-call source of per-row RNGs, all derived from one already-resolved root seed.
 ///
 /// The resolve-once step happens when this is constructed (via [`SampleKwargs::row_rngs`]),


### PR DESCRIPTION
The hand-written constant-parameter sampler fast paths (kwargs struct + plugin) are now invocations of a `sample_scalar_plugin!` macro in `rng.rs`, declaring only what varies (parameters, output dtype, one-time `build`, per-row `draw`).