### PR TITLE
perf: run `samples()` as a single native multi-draw plugin call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,6 +1831,7 @@ version = "0.1.0"
 dependencies = [
  "polars",
  "polars-arrow",
+ "polars-core",
  "pyo3",
  "pyo3-polars",
  "rand 0.8.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ pyo3-polars = { version = "0.25.0", features = ["derive", "dtype-struct", "dtype
 serde = { version = "1", features = ["derive"] }
 polars = { version = "0.52.0", default-features = false, features = ["dtype-u8"] }
 polars-arrow = { version = "0.52.0", default-features = false }
+# Already in polars' tree; depended on directly for POOL and its rayon re-export, so the
+# multi-draw samplers parallelise on the same thread pool polars itself uses.
+polars-core = { version = "0.52.0", default-features = false }
 statrs = "0.18.0"
 rand = "0.8"
 # The binomial sampler's seeded output depends on rand_distr's draw algorithm (BINV/BTPE) and its

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -88,10 +88,11 @@ is canonical if it conflicts with this section.
 2. **Python.** Add `polars_stats/distributions/_<name>.py`, subclassing `ContinuousDistribution` or
    `DiscreteDistribution`. Coerce each parameter with `coerce_param(value, name=...)`. **Do not validate parameter
    *values* at construction**, coerce types only and let invalid values raise in Rust. Implement the private formula
-   hooks (`_pdf` / `_pmf`, `_cdf`, `_ppf`, and any `_log_*` / `_sf` closed form), plus `_valid_mask` and the
-   `_sample_dtype` class var. So closed-form methods raise on invalid params too, route them through a small validating
-   plugin that returns a reused quantity (e.g. `uniform_range`). **Never override the public `pdf` / `cdf` / ...
-   methods**: the base owns them. Export the class from `polars_stats/__init__.py`.
+   hooks (`_pdf` / `_pmf`, `_cdf`, `_ppf`, and any `_log_*` / `_sf` closed form), plus the
+   `_samples_scalar_plugin` class var and `_samples_columns`. So closed-form methods raise on invalid params too,
+   route them through a small validating plugin that returns a reused quantity (e.g. `uniform_range`).
+   **Never override the public `pdf` / `cdf` / ... methods**: the base owns them. Export the class from
+   `polars_stats/__init__.py`.
 3. **Tests.** Two homes: `tests/distributions/<name>/`, one file per method (including a `validation_test.py` asserting
    an invalid parameter raises `ComputeError` for both scalar and column inputs); and `tests/scipy_parity/<name>_test.py`
    against `scipy.stats.<name>` to within `1e-10` (closed-form) or `1e-6` (binary-search `ppf`), compared with

--- a/docs/design.md
+++ b/docs/design.md
@@ -63,6 +63,14 @@ path is selected only when the parameters are known scalars, so nothing column-v
 `sample_iter` was rejected for the loop body: it advances a single stream in row order, which couples rows across chunks
 and breaks the invariance guarantee the per-row seeding exists to provide.
 
+`samples` does, however, use one stream *per row*: row `i`'s `size` draws are consecutive values from the
+`(root_seed, i)` stream, the same stream `sample` takes its single draw from. That stays chunk-invariant because the
+stream is keyed by global row position; what remains rejected is any stream shared across rows. The per-row stream is
+what makes `samples(size=1)` equal `sample` bit for bit and `samples` prefix-stable in `size` (both pinned by property
+tests). The measured trade-off at 100k rows, `size=20`: cheap-draw distributions speed up (no per-draw re-seeding)
+while the normal slows ~20% (consecutive draws are sequentially dependent, so the ziggurat loses cross-draw
+instruction overlap); recorded in CHANGELOG.md as a pre-release seeded-output change.
+
 ### Binomial sampling uses `rand_distr`, not `statrs`
 
 `statrs` 0.18 implements `Distribution<u64> for Binomial` as `(0..n).fold(...)`, one uniform draw per trial, so a sampled

--- a/docs/design.md
+++ b/docs/design.md
@@ -71,19 +71,7 @@ is any stream shared across rows. The per-row stream is what makes `samples(size
 `samples` prefix-stable in `size` (both pinned by property tests).
 
 It also runs as a single native plugin call that fills the whole `Array(inner, size)` column in one pass, replacing an
-earlier construction of `size` separate `sample` calls glued by `concat_arr`. The old shape paid the per-call FFI and
-expression-graph cost `size` times and rebuilt the distribution once per draw; the new one pays each once and fills rows
-in parallel above a draw-count threshold. Measured against that baseline (release build, `size=20`), every distribution
-speeds up with no regression anywhere: roughly 3 to 8x at 100k rows and 1.5 to 4.5x at 1M, at roughly 2.5 to 3.5x lower
-peak memory (no per-draw intermediate columns). Uniform and normal gain most; binomial least, since its `rand_distr`
-per-draw cost dominates the fixed overhead either way. Drawing `size` consecutive values from one stream is sequentially
-dependent, so a ziggurat sampler (normal, lognormal) loses some cross-draw instruction overlap versus `size` independent
-streams; that micro effect is real but is dwarfed by the call-count and construction savings, so it does not surface end
-to end.
-
-Moving to the per-row stream changes the seeded output of `samples` (the previous design derived `size` sub-seeds from
-the root seed and drew each from its own stream), a deliberate pre-release change. It is also what lets `samples(size=1)`
-equal `sample`, which the sub-seed design could not offer.
+earlier construction of `size` separate `sample` calls glued by `concat_arr`.
 
 ### Binomial sampling uses `rand_distr`, not `statrs`
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -60,16 +60,30 @@ thread-invariance guarantees untouched.
 
 It is the one deliberate exception to "parameters travel in `inputs`, not `kwargs`": admissible precisely because the
 path is selected only when the parameters are known scalars, so nothing column-valued is ever forced into `kwargs`.
-`sample_iter` was rejected for the loop body: it advances a single stream in row order, which couples rows across chunks
-and breaks the invariance guarantee the per-row seeding exists to provide.
 
-`samples` does, however, use one stream *per row*: row `i`'s `size` draws are consecutive values from the
-`(root_seed, i)` stream, the same stream `sample` takes its single draw from. That stays chunk-invariant because the
-stream is keyed by global row position; what remains rejected is any stream shared across rows. The per-row stream is
-what makes `samples(size=1)` equal `sample` bit for bit and `samples` prefix-stable in `size` (both pinned by property
-tests). The measured trade-off at 100k rows, `size=20`: cheap-draw distributions speed up (no per-draw re-seeding)
-while the normal slows ~20% (consecutive draws are sequentially dependent, so the ziggurat loses cross-draw
-instruction overlap); recorded in CHANGELOG.md as a pre-release seeded-output change.
+### `samples` draws each row's array in one native call
+
+`sample_iter` was rejected for the multi-draw loop body: it advances a single stream in row order, which couples rows
+across chunks and breaks the invariance the per-row seeding exists to provide. `samples` instead uses one stream *per
+row*: row `i`'s `size` draws are consecutive values from the `(root_seed, i)` stream, the same stream `sample` takes its
+single draw from. That stays chunk-invariant because the stream is keyed by global row position; what remains rejected
+is any stream shared across rows. The per-row stream is what makes `samples(size=1)` equal `sample` bit for bit and
+`samples` prefix-stable in `size` (both pinned by property tests).
+
+It also runs as a single native plugin call that fills the whole `Array(inner, size)` column in one pass, replacing an
+earlier construction of `size` separate `sample` calls glued by `concat_arr`. The old shape paid the per-call FFI and
+expression-graph cost `size` times and rebuilt the distribution once per draw; the new one pays each once and fills rows
+in parallel above a draw-count threshold. Measured against that baseline (release build, `size=20`), every distribution
+speeds up with no regression anywhere: roughly 3 to 8x at 100k rows and 1.5 to 4.5x at 1M, at roughly 2.5 to 3.5x lower
+peak memory (no per-draw intermediate columns). Uniform and normal gain most; binomial least, since its `rand_distr`
+per-draw cost dominates the fixed overhead either way. Drawing `size` consecutive values from one stream is sequentially
+dependent, so a ziggurat sampler (normal, lognormal) loses some cross-draw instruction overlap versus `size` independent
+streams; that micro effect is real but is dwarfed by the call-count and construction savings, so it does not surface end
+to end.
+
+Moving to the per-row stream changes the seeded output of `samples` (the previous design derived `size` sub-seeds from
+the root seed and drew each from its own stream), a deliberate pre-release change. It is also what lets `samples(size=1)`
+equal `sample`, which the sub-seed design could not offer.
 
 ### Binomial sampling uses `rand_distr`, not `statrs`
 

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import random
 from abc import ABC, abstractmethod
-from itertools import repeat
 from typing import TYPE_CHECKING, ClassVar
 
 import polars as pl
@@ -137,7 +135,7 @@ def register_plugin(
     function_name: str,
     args: IntoExprColumn | Iterable[IntoExprColumn],
     *,
-    kwargs: Mapping[str, float | int | list[int | None] | None] | None = None,
+    kwargs: Mapping[str, float | int | None] | None = None,
 ) -> pl.Expr:
     """Register a polars-stats Rust plugin call, fixing the defaults every distribution shares.
 
@@ -149,10 +147,10 @@ def register_plugin(
     Arguments:
         function_name: The `#[polars_expr]` function exported by the Rust crate.
         args: One expr or an iterable of exprs forming the plugin's positional inputs.
-        kwargs: Static keyword arguments serialised to Rust (a sampler `seed`, the multi-draw sampler's `seeds`
-            list, and/or the constant parameters of a `*_scalar` fast-path plugin). Accepted as a `Mapping` so the
-            narrower `_scalar_kwargs` dicts pass without an invariance fight; `register_plugin_function` wants a
-            `dict`, hence the copy.
+        kwargs: Static keyword arguments serialised to Rust (a sampler `seed`, the multi-draw sampler's draw
+            count `size`, and/or the constant parameters of a `*_scalar` fast-path plugin). Accepted as a
+            `Mapping` so the narrower `_scalar_kwargs` dicts pass without an invariance fight;
+            `register_plugin_function` wants a `dict`, hence the copy.
     """
     return register_plugin_function(
         plugin_path=LIB,
@@ -223,9 +221,10 @@ class _UnivariateDistribution(ABC):
     def samples(self, size: int, seed: int | None = None) -> pl.Expr:
         """Draw `size` random variates per row, returning `Array(inner=_sample_dtype, shape=size)`.
 
-        When `seed` is set, distinct sub-seeds are derived from it so the `size` underlying `sample`
-        calls produce independent streams. Without this, every plugin call would re-seed the same RNG
-        and yield `size` identical columns.
+        Each row's `size` draws are consecutive values from one per-row random stream keyed by `seed` and the
+        row's position, so the result is reproducible for a fixed `seed` and independent of Polars chunking and
+        thread scheduling. `samples(size=1)` matches `sample` for the same seed, and growing `size` extends each
+        row's array without changing the existing draws.
 
         A row whose parameters are invalid (see `_valid_mask`) yields a null array, not an array of null elements.
 
@@ -247,25 +246,33 @@ class _UnivariateDistribution(ABC):
 
         Returns polars Expr evaluating to a column of `Array(inner=..., shape=size)`.
 
-        When ``seed`` is set, distinct sub-seeds are derived from it so the ``size`` underlying draws produce
-        independent streams. Without this, every draw would re-seed the same RNG and yield ``size`` identical
-        columns. With ``seed=None``, each sub-seed resolves to fresh OS entropy (``size`` independent root seeds).
+        Row ``i``'s ``size`` draws are consecutive values from one per-row stream keyed ``(seed, i)``, the same
+        stream ``sample`` takes its single draw from. So ``samples(size=1)`` matches ``sample`` bit for bit for
+        the same seed, and growing ``size`` extends each row's array without changing the existing draws (both
+        pinned by property tests). With ``seed=None``, a fresh root seed resolves once per call.
 
-        All-constant parameters route to the ``<name>_samples_scalar`` multi-draw plugin: one plugin call returning
-        the ``Array`` column directly, instead of ``size`` `sample` plugin calls glued by ``concat_arr`` (which pay
-        the fixed expression/FFI cost ``size`` times). Draw ``j`` of row ``i`` is seeded ``(seed_j, i)`` on both
-        paths, so their output is bit-identical (pinned by ``test_samples_scalar_fast_path_matches_per_row``).
+        Both parameter shapes run as one native multi-draw plugin call returning the ``Array`` column directly:
+        all-constant parameters route to ``<name>_samples_scalar`` (parameters validated once, in kwargs), column
+        parameters to the per-row ``<name>_samples`` twin via `_samples_columns` (distribution rebuilt once per
+        row, not once per draw). Seeding is positional on both paths, so their output is bit-identical (pinned by
+        ``test_samples_scalar_fast_path_matches_per_row``).
         """
-        rng = random.Random(seed)  # noqa: S311
-        seeds: list[int | None] = (
-            list(repeat(None, size)) if seed is None else [rng.randrange(2**63) for _ in range(size)]
-        )
-
         if self._scalar_kwargs is not None:
             return register_plugin(
-                self._samples_scalar_plugin, (ROW_INDEX_EXPR,), kwargs={"seeds": seeds, **self._scalar_kwargs}
+                self._samples_scalar_plugin,
+                (ROW_INDEX_EXPR,),
+                kwargs={"seed": seed, "size": size, **self._scalar_kwargs},
             )
-        return pl.concat_arr(self.sample(seed=s) for s in seeds)
+        return self._samples_columns(size=size, seed=seed)
+
+    @abstractmethod
+    def _samples_columns(self, size: int, seed: int | None) -> pl.Expr:
+        """Register the `<name>_samples` multi-draw plugin call for column-valued parameters.
+
+        Mirrors `sample`'s per-row plugin shape: the parameter exprs plus `ROW_INDEX_EXPR` as inputs, the root
+        `seed` and draw count `size` as kwargs. Called by `_samples`; null masking and naming are applied by
+        `samples`.
+        """
 
     def cdf(self, value: float | IntoExprColumn) -> pl.Expr:
         """Cumulative distribution function, `P(X <= value)`. Nulls in `value` are propagated."""

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -137,7 +137,7 @@ def register_plugin(
     function_name: str,
     args: IntoExprColumn | Iterable[IntoExprColumn],
     *,
-    kwargs: Mapping[str, float | int | None] | None = None,
+    kwargs: Mapping[str, float | int | list[int | None] | None] | None = None,
 ) -> pl.Expr:
     """Register a polars-stats Rust plugin call, fixing the defaults every distribution shares.
 
@@ -149,9 +149,10 @@ def register_plugin(
     Arguments:
         function_name: The `#[polars_expr]` function exported by the Rust crate.
         args: One expr or an iterable of exprs forming the plugin's positional inputs.
-        kwargs: Static keyword arguments serialised to Rust (a sampler `seed` and/or the constant parameters of a
-            `*_scalar` fast-path plugin). Accepted as a `Mapping` so the narrower `_scalar_kwargs` dicts pass without
-            an invariance fight; `register_plugin_function` wants a `dict`, hence the copy.
+        kwargs: Static keyword arguments serialised to Rust (a sampler `seed`, the multi-draw sampler's `seeds`
+            list, and/or the constant parameters of a `*_scalar` fast-path plugin). Accepted as a `Mapping` so the
+            narrower `_scalar_kwargs` dicts pass without an invariance fight; `register_plugin_function` wants a
+            `dict`, hence the copy.
     """
     return register_plugin_function(
         plugin_path=LIB,
@@ -187,6 +188,12 @@ class _UnivariateDistribution(ABC):
 
     _sample_dtype: ClassVar[PolarsDataType]
     """Element dtype produced `sample` (e.g. `Boolean`, `Float64`, `UInt64`). Set by each subclass."""
+
+    _samples_scalar_plugin: ClassVar[str]
+    """Name of the `<name>_samples_scalar` multi-draw plugin backing the constant-parameter `samples` fast path.
+
+    Set by each subclass; `_samples` routes through it when `_scalar_kwargs` is non-`None`.
+    """
 
     _scalar_kwargs: dict[str, float | int] | None
     """Constant parameters for the `<name>_sample_scalar` fast path, `None` when any parameter is column-valued.
@@ -240,15 +247,24 @@ class _UnivariateDistribution(ABC):
 
         Returns polars Expr evaluating to a column of `Array(inner=..., shape=size)`.
 
-        When ``seed`` is set, distinct sub-seeds are derived from it so the `size` underlying ``sample`` calls
-        produce independent streams. Without this, every plugin call would re-seed the same RNG and yield
-        ``size`` identical columns.
+        When ``seed`` is set, distinct sub-seeds are derived from it so the ``size`` underlying draws produce
+        independent streams. Without this, every draw would re-seed the same RNG and yield ``size`` identical
+        columns. With ``seed=None``, each sub-seed resolves to fresh OS entropy (``size`` independent root seeds).
+
+        All-constant parameters route to the ``<name>_samples_scalar`` multi-draw plugin: one plugin call returning
+        the ``Array`` column directly, instead of ``size`` `sample` plugin calls glued by ``concat_arr`` (which pay
+        the fixed expression/FFI cost ``size`` times). Draw ``j`` of row ``i`` is seeded ``(seed_j, i)`` on both
+        paths, so their output is bit-identical (pinned by ``test_samples_scalar_fast_path_matches_per_row``).
         """
         rng = random.Random(seed)  # noqa: S311
-        seeds: Iterable[int] | Iterable[None] = (
-            repeat(None, size) if seed is None else (rng.randrange(2**63) for _ in range(size))
+        seeds: list[int | None] = (
+            list(repeat(None, size)) if seed is None else [rng.randrange(2**63) for _ in range(size)]
         )
 
+        if self._scalar_kwargs is not None:
+            return register_plugin(
+                self._samples_scalar_plugin, (ROW_INDEX_EXPR,), kwargs={"seeds": seeds, **self._scalar_kwargs}
+            )
         return pl.concat_arr(self.sample(seed=s) for s in seeds)
 
     def cdf(self, value: float | IntoExprColumn) -> pl.Expr:

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -184,9 +184,6 @@ class _UnivariateDistribution(ABC):
     The interface mirrors `scipy.stats.rv_continuous` / `rv_discrete` but returns `pl.Expr` instead of NumPy arrays.
     """
 
-    _sample_dtype: ClassVar[PolarsDataType]
-    """Element dtype produced `sample` (e.g. `Boolean`, `Float64`, `UInt64`). Set by each subclass."""
-
     _samples_scalar_plugin: ClassVar[str]
     """Name of the `<name>_samples_scalar` multi-draw plugin backing the constant-parameter `samples` fast path.
 
@@ -202,13 +199,6 @@ class _UnivariateDistribution(ABC):
     """
 
     @abstractmethod
-    def _valid_mask(self) -> pl.Expr:
-        """Boolean expr, `True` on rows whose parameters yield a well-defined draw.
-
-        Rows that are `False` (null or out-of-domain parameters) get a null array from `samples`.
-        """
-
-    @abstractmethod
     def sample(self, seed: int | None = None) -> pl.Expr:
         """Draw one random variate per row.
 
@@ -219,14 +209,15 @@ class _UnivariateDistribution(ABC):
         """
 
     def samples(self, size: int, seed: int | None = None) -> pl.Expr:
-        """Draw `size` random variates per row, returning `Array(inner=_sample_dtype, shape=size)`.
+        """Draw `size` random variates per row, returning `Array(inner=<element dtype>, shape=size)`.
 
         Each row's `size` draws are consecutive values from one per-row random stream keyed by `seed` and the
         row's position, so the result is reproducible for a fixed `seed` and independent of Polars chunking and
         thread scheduling. `samples(size=1)` matches `sample` for the same seed, and growing `size` extends each
         row's array without changing the existing draws.
 
-        A row whose parameters are invalid (see `_valid_mask`) yields a null array, not an array of null elements.
+        A row with a null parameter yields a null array (not an array of null elements), produced natively by
+        the plugin via the output's outer validity; an invalid parameterisation raises.
 
         Naming follows `sample`: `"samples"` with all-constant parameters, the first parameter
         expression's root name otherwise.
@@ -234,11 +225,7 @@ class _UnivariateDistribution(ABC):
         if size <= 0:
             msg = f"size must be a positive integer, got {size}"
             raise ValueError(msg)
-        out = (
-            pl.when(self._valid_mask())
-            .then(self._samples(size=size, seed=seed))
-            .otherwise(pl.lit(None, dtype=pl.Array(self._sample_dtype, shape=size)))
-        )
+        out = self._samples(size=size, seed=seed)
         return out.alias("samples") if self._scalar_kwargs is not None else out
 
     def _samples(self, size: int, seed: int | None = None) -> pl.Expr:
@@ -270,8 +257,8 @@ class _UnivariateDistribution(ABC):
         """Register the `<name>_samples` multi-draw plugin call for column-valued parameters.
 
         Mirrors `sample`'s per-row plugin shape: the parameter exprs plus `ROW_INDEX_EXPR` as inputs, the root
-        `seed` and draw count `size` as kwargs. Called by `_samples`; null masking and naming are applied by
-        `samples`.
+        `seed` and draw count `size` as kwargs. Called by `_samples`; naming is applied by `samples`, and a
+        null-parameter row becomes a null array element inside the plugin.
         """
 
     def cdf(self, value: float | IntoExprColumn) -> pl.Expr:

--- a/polars_stats/distributions/_bernoulli.py
+++ b/polars_stats/distributions/_bernoulli.py
@@ -65,6 +65,9 @@ class Bernoulli(DiscreteDistribution):
             ).alias("sample")
         return register_plugin("bernoulli_sample", (self._p, ROW_INDEX_EXPR), kwargs={"seed": seed})
 
+    def _samples_columns(self, size: int, seed: int | None) -> pl.Expr:
+        return register_plugin("bernoulli_samples", (self._p, ROW_INDEX_EXPR), kwargs={"seed": seed, "size": size})
+
     def _pmf(self, value: pl.Expr) -> pl.Expr:
         """``1 - p`` at 0, ``p`` at 1, ``0`` elsewhere."""
         p = self._checked_p

--- a/polars_stats/distributions/_bernoulli.py
+++ b/polars_stats/distributions/_bernoulli.py
@@ -27,6 +27,7 @@ class Bernoulli(DiscreteDistribution):
 
     _p: pl.Expr
     _sample_dtype: ClassVar[PolarsDataType] = pl.Boolean()
+    _samples_scalar_plugin: ClassVar[str] = "bernoulli_samples_scalar"
 
     def __init__(self, p: float | IntoExprColumn) -> None:
         self._p = coerce_param(p, name="p")

--- a/polars_stats/distributions/_bernoulli.py
+++ b/polars_stats/distributions/_bernoulli.py
@@ -14,7 +14,7 @@ from polars_stats.distributions._base import (
 )
 
 if TYPE_CHECKING:
-    from polars_stats._typing import IntoExprColumn, PolarsDataType
+    from polars_stats._typing import IntoExprColumn
 
 
 class Bernoulli(DiscreteDistribution):
@@ -26,7 +26,6 @@ class Bernoulli(DiscreteDistribution):
     """
 
     _p: pl.Expr
-    _sample_dtype: ClassVar[PolarsDataType] = pl.Boolean()
     _samples_scalar_plugin: ClassVar[str] = "bernoulli_samples_scalar"
 
     def __init__(self, p: float | IntoExprColumn) -> None:
@@ -42,10 +41,6 @@ class Bernoulli(DiscreteDistribution):
         ``sample`` rather than silently computing a negative probability. Null propagates.
         """
         return register_plugin("bernoulli_proba", self._p)
-
-    def _valid_mask(self) -> pl.Expr:
-        # Only null p is masked to a null array here; an out-of-range p raises via `_checked_p`.
-        return self._p.is_not_null()
 
     def sample(self, seed: int | None = None) -> pl.Expr:
         """Draw one Bernoulli sample per row, returning a ``Boolean`` column.

--- a/polars_stats/distributions/_binomial.py
+++ b/polars_stats/distributions/_binomial.py
@@ -16,7 +16,7 @@ from polars_stats.distributions._base import (
 )
 
 if TYPE_CHECKING:
-    from polars_stats._typing import IntoExprColumn, PolarsDataType
+    from polars_stats._typing import IntoExprColumn
 
 
 class Binomial(DiscreteDistribution):
@@ -38,7 +38,6 @@ class Binomial(DiscreteDistribution):
 
     _n: pl.Expr
     _p: pl.Expr
-    _sample_dtype: ClassVar[PolarsDataType] = pl.UInt64()
     _samples_scalar_plugin: ClassVar[str] = "binomial_samples_scalar"
 
     def __init__(self, n: int | IntoExprColumn, p: float | IntoExprColumn) -> None:
@@ -72,10 +71,6 @@ class Binomial(DiscreteDistribution):
         Null in either parameter propagates to null.
         """
         return register_plugin("binomial_params", (self._n, self._p))
-
-    def _valid_mask(self) -> pl.Expr:
-        # Only null parameters are masked to a null array here; an invalid n/p raises in the plugin.
-        return self._n.is_not_null() & self._p.is_not_null()
 
     def _moment(self, value: pl.Expr) -> pl.Expr:
         """Gate a closed-form moment on a non-null, valid ``(n, p)`` parameterisation.

--- a/polars_stats/distributions/_binomial.py
+++ b/polars_stats/distributions/_binomial.py
@@ -105,6 +105,11 @@ class Binomial(DiscreteDistribution):
             ).alias("sample")
         return register_plugin("binomial_sample", (self._n, self._p, ROW_INDEX_EXPR), kwargs={"seed": seed})
 
+    def _samples_columns(self, size: int, seed: int | None) -> pl.Expr:
+        return register_plugin(
+            "binomial_samples", (self._n, self._p, ROW_INDEX_EXPR), kwargs={"seed": seed, "size": size}
+        )
+
     def _pmf(self, value: pl.Expr) -> pl.Expr:
         """Mass via native ``Discrete::pmf``; zero off the integer support ``{0, ..., n}``."""
         return self._value_plugin("binomial_pmf", value)

--- a/polars_stats/distributions/_binomial.py
+++ b/polars_stats/distributions/_binomial.py
@@ -39,6 +39,7 @@ class Binomial(DiscreteDistribution):
     _n: pl.Expr
     _p: pl.Expr
     _sample_dtype: ClassVar[PolarsDataType] = pl.UInt64()
+    _samples_scalar_plugin: ClassVar[str] = "binomial_samples_scalar"
 
     def __init__(self, n: int | IntoExprColumn, p: float | IntoExprColumn) -> None:
         self._n = coerce_n(n, name="n")

--- a/polars_stats/distributions/_lognormal.py
+++ b/polars_stats/distributions/_lognormal.py
@@ -99,6 +99,11 @@ class LogNormal(ContinuousDistribution):
             ).alias("sample")
         return register_plugin("lognormal_sample", (self._mu, self._sigma, ROW_INDEX_EXPR), kwargs={"seed": seed})
 
+    def _samples_columns(self, size: int, seed: int | None) -> pl.Expr:
+        return register_plugin(
+            "lognormal_samples", (self._mu, self._sigma, ROW_INDEX_EXPR), kwargs={"seed": seed, "size": size}
+        )
+
     def _pdf(self, value: pl.Expr) -> pl.Expr:
         """Density via native ``statrs`` ``Continuous::pdf`` (``0`` for ``value <= 0``)."""
         return self._value_plugin("lognormal_pdf", value)

--- a/polars_stats/distributions/_lognormal.py
+++ b/polars_stats/distributions/_lognormal.py
@@ -15,7 +15,7 @@ from polars_stats.distributions._base import (
 )
 
 if TYPE_CHECKING:
-    from polars_stats._typing import IntoExprColumn, PolarsDataType
+    from polars_stats._typing import IntoExprColumn
 
 
 _TWO_PI_E = math.tau * math.e
@@ -45,7 +45,6 @@ class LogNormal(ContinuousDistribution):
 
     _mu: pl.Expr
     _sigma: pl.Expr
-    _sample_dtype: ClassVar[PolarsDataType] = pl.Float64()
     _samples_scalar_plugin: ClassVar[str] = "lognormal_samples_scalar"
 
     def __init__(self, mu: float | IntoExprColumn = 0.0, sigma: float | IntoExprColumn = 1.0) -> None:
@@ -76,10 +75,6 @@ class LogNormal(ContinuousDistribution):
         # non-finite parameter) as a ``ComputeError`` consistently with the value-keyed methods. Null in
         # either parameter propagates to null, so a moment built on this nulls when either input is null.
         return register_plugin("lognormal_sigma", (self._mu, self._sigma))
-
-    def _valid_mask(self) -> pl.Expr:
-        # Only null parameters are masked to a null array here; an invalid `sigma` raises in the plugin.
-        return self._mu.is_not_null() & self._sigma.is_not_null()
 
     def sample(self, seed: int | None = None) -> pl.Expr:
         """Draw one LogNormal sample per row, returning a ``Float64`` column.

--- a/polars_stats/distributions/_lognormal.py
+++ b/polars_stats/distributions/_lognormal.py
@@ -46,6 +46,7 @@ class LogNormal(ContinuousDistribution):
     _mu: pl.Expr
     _sigma: pl.Expr
     _sample_dtype: ClassVar[PolarsDataType] = pl.Float64()
+    _samples_scalar_plugin: ClassVar[str] = "lognormal_samples_scalar"
 
     def __init__(self, mu: float | IntoExprColumn = 0.0, sigma: float | IntoExprColumn = 1.0) -> None:
         self._mu = coerce_param(mu, name="mu")

--- a/polars_stats/distributions/_normal.py
+++ b/polars_stats/distributions/_normal.py
@@ -42,6 +42,7 @@ class Normal(ContinuousDistribution):
     _mean: pl.Expr
     _std_dev: pl.Expr
     _sample_dtype: ClassVar[PolarsDataType] = pl.Float64()
+    _samples_scalar_plugin: ClassVar[str] = "normal_samples_scalar"
 
     def __init__(
         self,

--- a/polars_stats/distributions/_normal.py
+++ b/polars_stats/distributions/_normal.py
@@ -99,6 +99,11 @@ class Normal(ContinuousDistribution):
             ).alias("sample")
         return register_plugin("normal_sample", (self._mean, self._std_dev, ROW_INDEX_EXPR), kwargs={"seed": seed})
 
+    def _samples_columns(self, size: int, seed: int | None) -> pl.Expr:
+        return register_plugin(
+            "normal_samples", (self._mean, self._std_dev, ROW_INDEX_EXPR), kwargs={"seed": seed, "size": size}
+        )
+
     def _pdf(self, value: pl.Expr) -> pl.Expr:
         """Density via native ``statrs`` ``Continuous::pdf``."""
         return self._value_plugin("normal_pdf", value)

--- a/polars_stats/distributions/_normal.py
+++ b/polars_stats/distributions/_normal.py
@@ -15,7 +15,7 @@ from polars_stats.distributions._base import (
 )
 
 if TYPE_CHECKING:
-    from polars_stats._typing import IntoExprColumn, PolarsDataType
+    from polars_stats._typing import IntoExprColumn
 
 
 _TWO_PI_E = math.tau * math.e
@@ -41,7 +41,6 @@ class Normal(ContinuousDistribution):
 
     _mean: pl.Expr
     _std_dev: pl.Expr
-    _sample_dtype: ClassVar[PolarsDataType] = pl.Float64()
     _samples_scalar_plugin: ClassVar[str] = "normal_samples_scalar"
 
     def __init__(
@@ -76,10 +75,6 @@ class Normal(ContinuousDistribution):
         # non-finite parameter) as a ``ComputeError`` consistently with the value-keyed methods. Null in
         # either parameter propagates to null, so a moment built on this nulls when either input is null.
         return register_plugin("normal_std_dev", (self._mean, self._std_dev))
-
-    def _valid_mask(self) -> pl.Expr:
-        # Only null parameters are masked to a null array here; an invalid `std_dev` raises in the plugin.
-        return self._mean.is_not_null() & self._std_dev.is_not_null()
 
     def sample(self, seed: int | None = None) -> pl.Expr:
         """Draw one Normal sample per row, returning a ``Float64`` column.

--- a/polars_stats/distributions/_uniform.py
+++ b/polars_stats/distributions/_uniform.py
@@ -82,6 +82,11 @@ class Uniform(ContinuousDistribution):
             ).alias("sample")
         return register_plugin("uniform_sample", (self._min, self._max, ROW_INDEX_EXPR), kwargs={"seed": seed})
 
+    def _samples_columns(self, size: int, seed: int | None) -> pl.Expr:
+        return register_plugin(
+            "uniform_samples", (self._min, self._max, ROW_INDEX_EXPR), kwargs={"seed": seed, "size": size}
+        )
+
     def _pdf(self, value: pl.Expr) -> pl.Expr:
         """``1 / (max - min)`` on ``[min, max]``, ``0`` outside."""
         in_range = value.is_between(self._min, self._max, closed="both")

--- a/polars_stats/distributions/_uniform.py
+++ b/polars_stats/distributions/_uniform.py
@@ -39,6 +39,7 @@ class Uniform(ContinuousDistribution):
     _min: pl.Expr
     _max: pl.Expr
     _sample_dtype: ClassVar[PolarsDataType] = pl.Float64()
+    _samples_scalar_plugin: ClassVar[str] = "uniform_samples_scalar"
 
     def __init__(self, min: float | IntoExprColumn, max: float | IntoExprColumn) -> None:  # noqa: A002
         self._min = coerce_param(min, name="min")

--- a/polars_stats/distributions/_uniform.py
+++ b/polars_stats/distributions/_uniform.py
@@ -14,7 +14,7 @@ from polars_stats.distributions._base import (
 )
 
 if TYPE_CHECKING:
-    from polars_stats._typing import IntoExprColumn, PolarsDataType
+    from polars_stats._typing import IntoExprColumn
 
 
 class Uniform(ContinuousDistribution):
@@ -38,7 +38,6 @@ class Uniform(ContinuousDistribution):
 
     _min: pl.Expr
     _max: pl.Expr
-    _sample_dtype: ClassVar[PolarsDataType] = pl.Float64()
     _samples_scalar_plugin: ClassVar[str] = "uniform_samples_scalar"
 
     def __init__(self, min: float | IntoExprColumn, max: float | IntoExprColumn) -> None:  # noqa: A002
@@ -58,10 +57,6 @@ class Uniform(ContinuousDistribution):
         consistently. Null bounds propagate.
         """
         return register_plugin("uniform_range", (self._min, self._max))
-
-    def _valid_mask(self) -> pl.Expr:
-        # Only null bounds are masked to a null array here; `max <= min` raises via `range`.
-        return self._min.is_not_null() & self._max.is_not_null()
 
     def sample(self, seed: int | None = None) -> pl.Expr:
         """Draw one uniform sample per row, returning a ``Float64`` column.

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -3,11 +3,10 @@ use polars::prelude::arity::try_binary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distributions::Distribution;
-use serde::Deserialize;
 use statrs::distribution::Bernoulli;
 
 use crate::rng::{
-    sample_scalar_plugin, samples_bool_output, samples_by_index, samples_per_row, SampleKwargs,
+    binary_param_rows, sample_scalar_plugin, samples_bool_output, samples_per_row, SampleKwargs,
     SamplesKwargs,
 };
 
@@ -90,38 +89,11 @@ sample_scalar_plugin! {
     /// seeding and the draw are unchanged, so output matches `bernoulli_sample` for the same
     /// `(seed, index, p)`.
     fn bernoulli_sample_scalar(output_type = Boolean, physical = BooleanType);
+
+    samples = bernoulli_samples_scalar as BernoulliSamplesScalarKwargs -> samples_bool_output;
+
     build = |kw| build_dist(kw.p)?;
     draw = |dist, rng| <Bernoulli as Distribution<bool>>::sample(&dist, rng);
-}
-
-/// Static parameters for the constant-probability multi-draw fast path.
-///
-/// Like [`BernoulliScalarKwargs`] plus the draw count `size` (the shared [`SamplesKwargs`] shape
-/// with the scalar `p` alongside).
-#[derive(Deserialize)]
-struct BernoulliSamplesScalarKwargs {
-    seed: Option<u64>,
-    size: usize,
-    p: f64,
-}
-
-/// Constant-probability multi-draw Bernoulli sampler: `size` draws per row in one call.
-///
-/// Row `i`'s draws are consecutive values from the one stream seeded `(seed, i)`, the same
-/// stream [`bernoulli_sample_scalar`] takes its single draw from, so `samples(size=1)` matches
-/// `sample` bit for bit and growing `size` extends each row's array. Returns
-/// `Array(Boolean, size)`.
-#[polars_expr(output_type_func_with_kwargs=samples_bool_output)]
-fn bernoulli_samples_scalar(
-    inputs: &[Series],
-    kwargs: BernoulliSamplesScalarKwargs,
-) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.p)?;
-    let name = inputs[0].name().clone();
-
-    samples_by_index::<BooleanType, _, _>(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
-        <Bernoulli as Distribution<bool>>::sample(&dist, rng)
-    })
 }
 
 /// Element-wise multi-draw Bernoulli sampler: `size` draws per row in one call.
@@ -136,18 +108,10 @@ fn bernoulli_samples_scalar(
 #[polars_expr(output_type_func_with_kwargs=samples_bool_output)]
 fn bernoulli_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
     let proba = inputs[0].cast(&DataType::Float64)?;
-    let proba_ca = proba.f64()?;
     let index = inputs[1].cast(&DataType::UInt64)?;
-    let index_ca = index.u64()?;
     let name = inputs[0].name().clone();
 
-    let rows = proba_ca
-        .iter()
-        .zip(index_ca.iter())
-        .map(|(p_opt, i_opt)| match (p_opt, i_opt) {
-            (Some(p), Some(i)) => Ok(Some((i, build_dist(p)?))),
-            _ => Ok(None),
-        });
+    let rows = binary_param_rows(proba.f64()?, index.u64()?, build_dist);
 
     samples_per_row::<BooleanType, _, _, _, _>(
         name,

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -6,7 +6,7 @@ use rand::distributions::Distribution;
 use serde::Deserialize;
 use statrs::distribution::Bernoulli;
 
-use crate::rng::{sample_by_index, SampleKwargs};
+use crate::rng::{sample_by_index, samples_bool_output, samples_by_index, SampleKwargs};
 
 fn build_dist(proba: f64) -> PolarsResult<Bernoulli> {
     Bernoulli::new(proba).map_err(|e| {
@@ -107,6 +107,43 @@ fn bernoulli_sample_scalar(
             index_ca.into_no_null_iter().map(|i| {
                 let mut rng = rngs.rng(i);
                 <Bernoulli as Distribution<bool>>::sample(&dist, &mut rng)
+            }),
+        )
+    })
+}
+
+/// Static parameters for the constant-probability multi-draw fast path.
+///
+/// Like [`BernoulliScalarKwargs`] with the single `seed` replaced by the `samples(size=k)` call's
+/// `k` sub-seeds, derived in Python exactly as before.
+#[derive(Deserialize)]
+struct BernoulliSamplesScalarKwargs {
+    seeds: Vec<Option<u64>>,
+    p: f64,
+}
+
+/// Constant-probability multi-draw Bernoulli sampler: `seeds.len()` draws per row in one call.
+///
+/// Replaces `samples`' former construction of `k` [`bernoulli_sample_scalar`] calls glued by
+/// `concat_arr`: draw `j` of row `i` still seeds from `(seed_j, i)` and uses the same draw, so
+/// output is bit-identical to that path (pinned by
+/// `test_samples_scalar_fast_path_matches_per_row`). Returns `Array(Boolean, seeds.len())`.
+#[polars_expr(output_type_func_with_kwargs=samples_bool_output)]
+fn bernoulli_samples_scalar(
+    inputs: &[Series],
+    kwargs: BernoulliSamplesScalarKwargs,
+) -> PolarsResult<Series> {
+    let dist = build_dist(kwargs.p)?;
+    let name = inputs[0].name().clone();
+
+    samples_by_index::<BooleanType, _>(&inputs[0], &kwargs.seeds, |index_ca, rngs| {
+        BooleanChunked::from_iter_values(
+            name,
+            index_ca.into_no_null_iter().flat_map(|i| {
+                rngs.iter().map(move |row_rngs| {
+                    let mut rng = row_rngs.rng(i);
+                    <Bernoulli as Distribution<bool>>::sample(&dist, &mut rng)
+                })
             }),
         )
     })

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -6,7 +6,10 @@ use rand::distributions::Distribution;
 use serde::Deserialize;
 use statrs::distribution::Bernoulli;
 
-use crate::rng::{sample_scalar_plugin, samples_bool_output, samples_by_index, SampleKwargs};
+use crate::rng::{
+    sample_scalar_plugin, samples_bool_output, samples_by_index, samples_per_row, SampleKwargs,
+    SamplesKwargs,
+};
 
 fn build_dist(proba: f64) -> PolarsResult<Bernoulli> {
     Bernoulli::new(proba).map_err(|e| {
@@ -93,37 +96,75 @@ sample_scalar_plugin! {
 
 /// Static parameters for the constant-probability multi-draw fast path.
 ///
-/// Like [`BernoulliScalarKwargs`] with the single `seed` replaced by the `samples(size=k)` call's
-/// `k` sub-seeds, derived in Python exactly as before.
+/// Like [`BernoulliScalarKwargs`] plus the draw count `size` (the shared [`SamplesKwargs`] shape
+/// with the scalar `p` alongside).
 #[derive(Deserialize)]
 struct BernoulliSamplesScalarKwargs {
-    seeds: Vec<Option<u64>>,
+    seed: Option<u64>,
+    size: usize,
     p: f64,
 }
 
-/// Constant-probability multi-draw Bernoulli sampler: `seeds.len()` draws per row in one call.
+/// Constant-probability multi-draw Bernoulli sampler: `size` draws per row in one call.
 ///
-/// Replaces `samples`' former construction of `k` [`bernoulli_sample_scalar`] calls glued by
-/// `concat_arr`: draw `j` of row `i` still seeds from `(seed_j, i)` and uses the same draw, so
-/// output is bit-identical to that path (pinned by
-/// `test_samples_scalar_fast_path_matches_per_row`). Returns `Array(Boolean, seeds.len())`.
+/// Row `i`'s draws are consecutive values from the one stream seeded `(seed, i)`, the same
+/// stream [`bernoulli_sample_scalar`] takes its single draw from, so `samples(size=1)` matches
+/// `sample` bit for bit and growing `size` extends each row's array. Returns
+/// `Array(Boolean, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_bool_output)]
 fn bernoulli_samples_scalar(
     inputs: &[Series],
     kwargs: BernoulliSamplesScalarKwargs,
 ) -> PolarsResult<Series> {
     let dist = build_dist(kwargs.p)?;
+    let size = kwargs.size;
     let name = inputs[0].name().clone();
 
-    samples_by_index::<BooleanType, _>(&inputs[0], &kwargs.seeds, |index_ca, rngs| {
+    samples_by_index::<BooleanType, _>(&inputs[0], kwargs.seed, size, |index_ca, rngs| {
         BooleanChunked::from_iter_values(
             name,
             index_ca.into_no_null_iter().flat_map(|i| {
-                rngs.iter().map(move |row_rngs| {
-                    let mut rng = row_rngs.rng(i);
+                let mut rng = rngs.rng(i);
+                std::iter::repeat_with(move || {
                     <Bernoulli as Distribution<bool>>::sample(&dist, &mut rng)
                 })
+                .take(size)
             }),
         )
     })
+}
+
+/// Element-wise multi-draw Bernoulli sampler: `size` draws per row in one call.
+///
+/// The column-parameter counterpart of [`bernoulli_samples_scalar`], replacing `samples`' former
+/// construction of `k` [`bernoulli_sample`] calls glued by `concat_arr`: the distribution is
+/// built once per row instead of once per draw. Row `i`'s draws come from the one stream seeded
+/// `(seed, i)`, so output is bit-identical to the scalar path for the same `p` (the seeding is
+/// positional, parameters never enter it, so equal-`p` rows still draw independently).
+/// Null/error contract follows [`bernoulli_sample`] per row; a null row yields an array of null
+/// elements (the Python layer masks it to a null array). Returns `Array(Boolean, size)`.
+#[polars_expr(output_type_func_with_kwargs=samples_bool_output)]
+fn bernoulli_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
+    let proba = inputs[0].cast(&DataType::Float64)?;
+    let proba_ca = proba.f64()?;
+    let index = inputs[1].cast(&DataType::UInt64)?;
+    let index_ca = index.u64()?;
+    let name = inputs[0].name().clone();
+
+    let rows = proba_ca
+        .iter()
+        .zip(index_ca.iter())
+        .map(|(p_opt, i_opt)| match (p_opt, i_opt) {
+            (Some(p), Some(i)) => Ok(Some((i, build_dist(p)?))),
+            _ => Ok(None),
+        });
+
+    samples_per_row::<BooleanType, _, _, _, _>(
+        name,
+        kwargs.seed,
+        kwargs.size,
+        index_ca.len(),
+        rows,
+        <Bernoulli as Distribution<bool>>::sample,
+    )
 }

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -117,20 +117,10 @@ fn bernoulli_samples_scalar(
     kwargs: BernoulliSamplesScalarKwargs,
 ) -> PolarsResult<Series> {
     let dist = build_dist(kwargs.p)?;
-    let size = kwargs.size;
     let name = inputs[0].name().clone();
 
-    samples_by_index::<BooleanType, _>(&inputs[0], kwargs.seed, size, |index_ca, rngs| {
-        BooleanChunked::from_iter_values(
-            name,
-            index_ca.into_no_null_iter().flat_map(|i| {
-                let mut rng = rngs.rng(i);
-                std::iter::repeat_with(move || {
-                    <Bernoulli as Distribution<bool>>::sample(&dist, &mut rng)
-                })
-                .take(size)
-            }),
-        )
+    samples_by_index::<BooleanType, _, _>(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
+        <Bernoulli as Distribution<bool>>::sample(&dist, rng)
     })
 }
 
@@ -141,8 +131,8 @@ fn bernoulli_samples_scalar(
 /// built once per row instead of once per draw. Row `i`'s draws come from the one stream seeded
 /// `(seed, i)`, so output is bit-identical to the scalar path for the same `p` (the seeding is
 /// positional, parameters never enter it, so equal-`p` rows still draw independently).
-/// Null/error contract follows [`bernoulli_sample`] per row; a null row yields an array of null
-/// elements (the Python layer masks it to a null array). Returns `Array(Boolean, size)`.
+/// Null/error contract follows [`bernoulli_sample`] per row; a null row yields a null array
+/// element. Returns `Array(Boolean, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_bool_output)]
 fn bernoulli_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
     let proba = inputs[0].cast(&DataType::Float64)?;
@@ -163,7 +153,6 @@ fn bernoulli_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<S
         name,
         kwargs.seed,
         kwargs.size,
-        index_ca.len(),
         rows,
         <Bernoulli as Distribution<bool>>::sample,
     )

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -9,7 +9,7 @@ use statrs::distribution::{Binomial, Discrete, DiscreteCDF};
 use statrs::statistics::Distribution as StatrsDistribution;
 
 use crate::distributions::value_keyed_scalar;
-use crate::rng::{sample_by_index, SampleKwargs};
+use crate::rng::{sample_by_index, samples_by_index, samples_u64_output, SampleKwargs};
 
 /// Construct a `statrs::Binomial`, mapping both invalid-parameter cases to a `ComputeError`.
 ///
@@ -199,6 +199,44 @@ fn binomial_sample_scalar(inputs: &[Series], kwargs: BinomialScalarKwargs) -> Po
             index_ca.into_no_null_iter().map(|i| {
                 let mut rng = rngs.rng(i);
                 dist.sample(&mut rng)
+            }),
+        )
+    })
+}
+
+/// Static parameters for the constant-parameter multi-draw fast path.
+///
+/// Like [`BinomialScalarKwargs`] with the single `seed` replaced by the `samples(size=k)` call's
+/// `k` sub-seeds, derived in Python exactly as before.
+#[derive(Deserialize)]
+struct BinomialSamplesScalarKwargs {
+    seeds: Vec<Option<u64>>,
+    n: i64,
+    p: f64,
+}
+
+/// Constant-parameter multi-draw Binomial sampler: `seeds.len()` draws per row in one call.
+///
+/// Replaces `samples`' former construction of `k` [`binomial_sample_scalar`] calls glued by
+/// `concat_arr`: draw `j` of row `i` still seeds from `(seed_j, i)` and uses the same
+/// `rand_distr` draw, so output is bit-identical to that path (pinned by
+/// `test_samples_scalar_fast_path_matches_per_row`). Returns `Array(UInt64, seeds.len())`.
+#[polars_expr(output_type_func_with_kwargs=samples_u64_output)]
+fn binomial_samples_scalar(
+    inputs: &[Series],
+    kwargs: BinomialSamplesScalarKwargs,
+) -> PolarsResult<Series> {
+    let dist = build_sampler(kwargs.n, kwargs.p)?;
+    let name = inputs[0].name().clone();
+
+    samples_by_index::<UInt64Type, _>(&inputs[0], &kwargs.seeds, |index_ca, rngs| {
+        UInt64Chunked::from_iter_values(
+            name,
+            index_ca.into_no_null_iter().flat_map(|i| {
+                rngs.iter().map(move |row_rngs| {
+                    let mut rng = row_rngs.rng(i);
+                    dist.sample(&mut rng)
+                })
             }),
         )
     })

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -10,7 +10,7 @@ use statrs::statistics::Distribution as StatrsDistribution;
 
 use crate::distributions::value_keyed_scalar;
 use crate::rng::{
-    sample_scalar_plugin, samples_by_index, samples_per_row, samples_u64_output, SampleKwargs,
+    sample_scalar_plugin, samples_per_row, samples_u64_output, ternary_param_rows, SampleKwargs,
     SamplesKwargs,
 };
 
@@ -182,39 +182,11 @@ sample_scalar_plugin! {
     /// path), and only the per-row index travels as an input; seeding and the draw are unchanged,
     /// so output matches `binomial_sample` for the same `(seed, index, n, p)`.
     fn binomial_sample_scalar(output_type = UInt64, physical = UInt64Type);
+
+    samples = binomial_samples_scalar as BinomialSamplesScalarKwargs -> samples_u64_output;
+
     build = |kw| build_sampler(kw.n, kw.p)?;
     draw = |dist, rng| dist.sample(rng);
-}
-
-/// Static parameters for the constant-parameter multi-draw fast path.
-///
-/// Like [`BinomialScalarKwargs`] plus the draw count `size` (the shared [`SamplesKwargs`] shape
-/// with the scalar parameters alongside).
-#[derive(Deserialize)]
-struct BinomialSamplesScalarKwargs {
-    seed: Option<u64>,
-    size: usize,
-    n: i64,
-    p: f64,
-}
-
-/// Constant-parameter multi-draw Binomial sampler: `size` draws per row in one call.
-///
-/// Row `i`'s draws are consecutive values from the one stream seeded `(seed, i)`, the same
-/// stream [`binomial_sample_scalar`] takes its single draw from, so `samples(size=1)` matches
-/// `sample` bit for bit and growing `size` extends each row's array. Returns
-/// `Array(UInt64, size)`.
-#[polars_expr(output_type_func_with_kwargs=samples_u64_output)]
-fn binomial_samples_scalar(
-    inputs: &[Series],
-    kwargs: BinomialSamplesScalarKwargs,
-) -> PolarsResult<Series> {
-    let dist = build_sampler(kwargs.n, kwargs.p)?;
-    let name = inputs[0].name().clone();
-
-    samples_by_index::<UInt64Type, _, _>(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
-        dist.sample(rng)
-    })
 }
 
 /// Element-wise multi-draw Binomial sampler: `size` draws per row in one call.
@@ -230,21 +202,11 @@ fn binomial_samples_scalar(
 #[polars_expr(output_type_func_with_kwargs=samples_u64_output)]
 fn binomial_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
     let n = inputs[0].cast(&DataType::Int64)?;
-    let n_ca = n.i64()?;
     let p = inputs[1].cast(&DataType::Float64)?;
-    let p_ca = p.f64()?;
     let index = inputs[2].cast(&DataType::UInt64)?;
-    let index_ca = index.u64()?;
     let name = inputs[0].name().clone();
 
-    let rows = n_ca
-        .iter()
-        .zip(p_ca.iter())
-        .zip(index_ca.iter())
-        .map(|((n_opt, p_opt), i_opt)| match (n_opt, p_opt, i_opt) {
-            (Some(n), Some(p), Some(i)) => Ok(Some((i, build_sampler(n, p)?))),
-            _ => Ok(None),
-        });
+    let rows = ternary_param_rows(n.i64()?, p.f64()?, index.u64()?, build_sampler);
 
     samples_per_row::<UInt64Type, _, _, _, _>(name, kwargs.seed, kwargs.size, rows, |dist, rng| {
         dist.sample(rng)

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -210,17 +210,10 @@ fn binomial_samples_scalar(
     kwargs: BinomialSamplesScalarKwargs,
 ) -> PolarsResult<Series> {
     let dist = build_sampler(kwargs.n, kwargs.p)?;
-    let size = kwargs.size;
     let name = inputs[0].name().clone();
 
-    samples_by_index::<UInt64Type, _>(&inputs[0], kwargs.seed, size, |index_ca, rngs| {
-        UInt64Chunked::from_iter_values(
-            name,
-            index_ca.into_no_null_iter().flat_map(|i| {
-                let mut rng = rngs.rng(i);
-                std::iter::repeat_with(move || dist.sample(&mut rng)).take(size)
-            }),
-        )
+    samples_by_index::<UInt64Type, _, _>(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
+        dist.sample(rng)
     })
 }
 
@@ -232,8 +225,8 @@ fn binomial_samples_scalar(
 /// Row `i`'s draws come from the one stream seeded `(seed, i)`, so output is bit-identical to
 /// the scalar path for the same parameters (the seeding is positional, parameters never enter
 /// it, so equal-parameter rows still draw independently). Null/error contract follows
-/// [`binomial_sample`] per row; a null row yields an array of null elements (the Python layer
-/// masks it to a null array). Returns `Array(UInt64, size)`.
+/// [`binomial_sample`] per row; a null row yields a null array element. Returns
+/// `Array(UInt64, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_u64_output)]
 fn binomial_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
     let n = inputs[0].cast(&DataType::Int64)?;
@@ -253,14 +246,9 @@ fn binomial_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Se
             _ => Ok(None),
         });
 
-    samples_per_row::<UInt64Type, _, _, _, _>(
-        name,
-        kwargs.seed,
-        kwargs.size,
-        index_ca.len(),
-        rows,
-        |dist, rng| dist.sample(rng),
-    )
+    samples_per_row::<UInt64Type, _, _, _, _>(name, kwargs.seed, kwargs.size, rows, |dist, rng| {
+        dist.sample(rng)
+    })
 }
 
 // Per-method bodies, named so the per-row plugins and the constant-parameter `*_scalar` twins

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -9,7 +9,10 @@ use statrs::distribution::{Binomial, Discrete, DiscreteCDF};
 use statrs::statistics::Distribution as StatrsDistribution;
 
 use crate::distributions::value_keyed_scalar;
-use crate::rng::{sample_scalar_plugin, samples_by_index, samples_u64_output, SampleKwargs};
+use crate::rng::{
+    sample_scalar_plugin, samples_by_index, samples_per_row, samples_u64_output, SampleKwargs,
+    SamplesKwargs,
+};
 
 /// Construct a `statrs::Binomial`, mapping both invalid-parameter cases to a `ComputeError`.
 ///
@@ -185,40 +188,79 @@ sample_scalar_plugin! {
 
 /// Static parameters for the constant-parameter multi-draw fast path.
 ///
-/// Like [`BinomialScalarKwargs`] with the single `seed` replaced by the `samples(size=k)` call's
-/// `k` sub-seeds, derived in Python exactly as before.
+/// Like [`BinomialScalarKwargs`] plus the draw count `size` (the shared [`SamplesKwargs`] shape
+/// with the scalar parameters alongside).
 #[derive(Deserialize)]
 struct BinomialSamplesScalarKwargs {
-    seeds: Vec<Option<u64>>,
+    seed: Option<u64>,
+    size: usize,
     n: i64,
     p: f64,
 }
 
-/// Constant-parameter multi-draw Binomial sampler: `seeds.len()` draws per row in one call.
+/// Constant-parameter multi-draw Binomial sampler: `size` draws per row in one call.
 ///
-/// Replaces `samples`' former construction of `k` [`binomial_sample_scalar`] calls glued by
-/// `concat_arr`: draw `j` of row `i` still seeds from `(seed_j, i)` and uses the same
-/// `rand_distr` draw, so output is bit-identical to that path (pinned by
-/// `test_samples_scalar_fast_path_matches_per_row`). Returns `Array(UInt64, seeds.len())`.
+/// Row `i`'s draws are consecutive values from the one stream seeded `(seed, i)`, the same
+/// stream [`binomial_sample_scalar`] takes its single draw from, so `samples(size=1)` matches
+/// `sample` bit for bit and growing `size` extends each row's array. Returns
+/// `Array(UInt64, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_u64_output)]
 fn binomial_samples_scalar(
     inputs: &[Series],
     kwargs: BinomialSamplesScalarKwargs,
 ) -> PolarsResult<Series> {
     let dist = build_sampler(kwargs.n, kwargs.p)?;
+    let size = kwargs.size;
     let name = inputs[0].name().clone();
 
-    samples_by_index::<UInt64Type, _>(&inputs[0], &kwargs.seeds, |index_ca, rngs| {
+    samples_by_index::<UInt64Type, _>(&inputs[0], kwargs.seed, size, |index_ca, rngs| {
         UInt64Chunked::from_iter_values(
             name,
             index_ca.into_no_null_iter().flat_map(|i| {
-                rngs.iter().map(move |row_rngs| {
-                    let mut rng = row_rngs.rng(i);
-                    dist.sample(&mut rng)
-                })
+                let mut rng = rngs.rng(i);
+                std::iter::repeat_with(move || dist.sample(&mut rng)).take(size)
             }),
         )
     })
+}
+
+/// Element-wise multi-draw Binomial sampler: `size` draws per row in one call.
+///
+/// The column-parameter counterpart of [`binomial_samples_scalar`], replacing `samples`' former
+/// construction of `k` [`binomial_sample`] calls glued by `concat_arr`: the `rand_distr` sampler
+/// (whose BINV/BTPE setup is the expensive part) is built once per row instead of once per draw.
+/// Row `i`'s draws come from the one stream seeded `(seed, i)`, so output is bit-identical to
+/// the scalar path for the same parameters (the seeding is positional, parameters never enter
+/// it, so equal-parameter rows still draw independently). Null/error contract follows
+/// [`binomial_sample`] per row; a null row yields an array of null elements (the Python layer
+/// masks it to a null array). Returns `Array(UInt64, size)`.
+#[polars_expr(output_type_func_with_kwargs=samples_u64_output)]
+fn binomial_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
+    let n = inputs[0].cast(&DataType::Int64)?;
+    let n_ca = n.i64()?;
+    let p = inputs[1].cast(&DataType::Float64)?;
+    let p_ca = p.f64()?;
+    let index = inputs[2].cast(&DataType::UInt64)?;
+    let index_ca = index.u64()?;
+    let name = inputs[0].name().clone();
+
+    let rows = n_ca
+        .iter()
+        .zip(p_ca.iter())
+        .zip(index_ca.iter())
+        .map(|((n_opt, p_opt), i_opt)| match (n_opt, p_opt, i_opt) {
+            (Some(n), Some(p), Some(i)) => Ok(Some((i, build_sampler(n, p)?))),
+            _ => Ok(None),
+        });
+
+    samples_per_row::<UInt64Type, _, _, _, _>(
+        name,
+        kwargs.seed,
+        kwargs.size,
+        index_ca.len(),
+        rows,
+        |dist, rng| dist.sample(rng),
+    )
 }
 
 // Per-method bodies, named so the per-row plugins and the constant-parameter `*_scalar` twins

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -179,17 +179,10 @@ fn lognormal_samples_scalar(
     kwargs: LogNormalSamplesScalarKwargs,
 ) -> PolarsResult<Series> {
     let dist = build_dist(kwargs.mu, kwargs.sigma)?;
-    let size = kwargs.size;
     let name = inputs[0].name().clone();
 
-    samples_by_index::<Float64Type, _>(&inputs[0], kwargs.seed, size, |index_ca, rngs| {
-        Float64Chunked::from_iter_values(
-            name,
-            index_ca.into_no_null_iter().flat_map(|i| {
-                let mut rng = rngs.rng(i);
-                std::iter::repeat_with(move || RandDistribution::sample(&dist, &mut rng)).take(size)
-            }),
-        )
+    samples_by_index::<Float64Type, _, _>(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
+        RandDistribution::sample(&dist, rng)
     })
 }
 
@@ -201,8 +194,7 @@ fn lognormal_samples_scalar(
 /// `(seed, i)`, so output is bit-identical to the scalar path for the same parameters (the
 /// seeding is positional, parameters never enter it, so equal-parameter rows still draw
 /// independently). Null/error contract follows [`lognormal_sample`] per row; a null row yields
-/// an array of null elements (the Python layer masks it to a null array). Returns
-/// `Array(Float64, size)`.
+/// a null array element. Returns `Array(Float64, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn lognormal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
     let mu = inputs[0].cast(&DataType::Float64)?;
@@ -224,7 +216,6 @@ fn lognormal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<S
         name,
         kwargs.seed,
         kwargs.size,
-        index_ca.len(),
         rows,
         RandDistribution::sample,
     )

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -7,7 +7,10 @@ use serde::Deserialize;
 use statrs::distribution::{Continuous, ContinuousCDF, LogNormal};
 
 use crate::distributions::value_keyed_scalar;
-use crate::rng::{sample_scalar_plugin, samples_by_index, samples_f64_output, SampleKwargs};
+use crate::rng::{
+    sample_scalar_plugin, samples_by_index, samples_f64_output, samples_per_row, SampleKwargs,
+    SamplesKwargs,
+};
 
 /// Construct a `statrs::LogNormal`, mapping the invalid-parameter case to a `ComputeError`.
 ///
@@ -154,40 +157,77 @@ sample_scalar_plugin! {
 
 /// Static parameters for the constant-parameter multi-draw fast path.
 ///
-/// Like [`LogNormalScalarKwargs`] with the single `seed` replaced by the `samples(size=k)` call's
-/// `k` sub-seeds, derived in Python exactly as before.
+/// Like [`LogNormalScalarKwargs`] plus the draw count `size` (the shared [`SamplesKwargs`] shape
+/// with the scalar parameters alongside).
 #[derive(Deserialize)]
 struct LogNormalSamplesScalarKwargs {
-    seeds: Vec<Option<u64>>,
+    seed: Option<u64>,
+    size: usize,
     mu: f64,
     sigma: f64,
 }
 
-/// Constant-parameter multi-draw LogNormal sampler: `seeds.len()` draws per row in one call.
+/// Constant-parameter multi-draw LogNormal sampler: `size` draws per row in one call.
 ///
-/// Replaces `samples`' former construction of `k` [`lognormal_sample_scalar`] calls glued by
-/// `concat_arr`: draw `j` of row `i` still seeds from `(seed_j, i)` and uses the same
-/// `RandDistribution::sample`, so output is bit-identical to that path (pinned by
-/// `test_samples_scalar_fast_path_matches_per_row`). Returns `Array(Float64, seeds.len())`.
+/// Row `i`'s draws are consecutive values from the one stream seeded `(seed, i)`, the same
+/// stream [`lognormal_sample_scalar`] takes its single draw from, so `samples(size=1)` matches
+/// `sample` bit for bit and growing `size` extends each row's array. Returns
+/// `Array(Float64, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn lognormal_samples_scalar(
     inputs: &[Series],
     kwargs: LogNormalSamplesScalarKwargs,
 ) -> PolarsResult<Series> {
     let dist = build_dist(kwargs.mu, kwargs.sigma)?;
+    let size = kwargs.size;
     let name = inputs[0].name().clone();
 
-    samples_by_index::<Float64Type, _>(&inputs[0], &kwargs.seeds, |index_ca, rngs| {
+    samples_by_index::<Float64Type, _>(&inputs[0], kwargs.seed, size, |index_ca, rngs| {
         Float64Chunked::from_iter_values(
             name,
             index_ca.into_no_null_iter().flat_map(|i| {
-                rngs.iter().map(move |row_rngs| {
-                    let mut rng = row_rngs.rng(i);
-                    RandDistribution::sample(&dist, &mut rng)
-                })
+                let mut rng = rngs.rng(i);
+                std::iter::repeat_with(move || RandDistribution::sample(&dist, &mut rng)).take(size)
             }),
         )
     })
+}
+
+/// Element-wise multi-draw LogNormal sampler: `size` draws per row in one call.
+///
+/// The column-parameter counterpart of [`lognormal_samples_scalar`], replacing `samples`' former
+/// construction of `k` [`lognormal_sample`] calls glued by `concat_arr`: the distribution is
+/// built once per row instead of once per draw. Row `i`'s draws come from the one stream seeded
+/// `(seed, i)`, so output is bit-identical to the scalar path for the same parameters (the
+/// seeding is positional, parameters never enter it, so equal-parameter rows still draw
+/// independently). Null/error contract follows [`lognormal_sample`] per row; a null row yields
+/// an array of null elements (the Python layer masks it to a null array). Returns
+/// `Array(Float64, size)`.
+#[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
+fn lognormal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
+    let mu = inputs[0].cast(&DataType::Float64)?;
+    let mu_ca = mu.f64()?;
+    let sigma = inputs[1].cast(&DataType::Float64)?;
+    let sigma_ca = sigma.f64()?;
+    let index = inputs[2].cast(&DataType::UInt64)?;
+    let index_ca = index.u64()?;
+    let name = inputs[0].name().clone();
+
+    let rows = mu_ca.iter().zip(sigma_ca.iter()).zip(index_ca.iter()).map(
+        |((mu_opt, sigma_opt), i_opt)| match (mu_opt, sigma_opt, i_opt) {
+            (Some(m), Some(s), Some(i)) => Ok(Some((i, build_dist(m, s)?))),
+            _ => Ok(None),
+        },
+    );
+
+    samples_per_row::<Float64Type, _, _, _, _>(
+        name,
+        kwargs.seed,
+        kwargs.size,
+        index_ca.len(),
+        rows,
+        RandDistribution::sample,
+    )
 }
 
 // Per-method bodies, named so the per-row plugins and the constant-parameter `*_scalar` twins

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use statrs::distribution::{Continuous, ContinuousCDF, LogNormal};
 
 use crate::distributions::value_keyed_scalar;
-use crate::rng::{sample_by_index, SampleKwargs};
+use crate::rng::{sample_by_index, samples_by_index, samples_f64_output, SampleKwargs};
 
 /// Construct a `statrs::LogNormal`, mapping the invalid-parameter case to a `ComputeError`.
 ///
@@ -171,6 +171,44 @@ fn lognormal_sample_scalar(
             index_ca.into_no_null_iter().map(|i| {
                 let mut rng = rngs.rng(i);
                 RandDistribution::sample(&dist, &mut rng)
+            }),
+        )
+    })
+}
+
+/// Static parameters for the constant-parameter multi-draw fast path.
+///
+/// Like [`LogNormalScalarKwargs`] with the single `seed` replaced by the `samples(size=k)` call's
+/// `k` sub-seeds, derived in Python exactly as before.
+#[derive(Deserialize)]
+struct LogNormalSamplesScalarKwargs {
+    seeds: Vec<Option<u64>>,
+    mu: f64,
+    sigma: f64,
+}
+
+/// Constant-parameter multi-draw LogNormal sampler: `seeds.len()` draws per row in one call.
+///
+/// Replaces `samples`' former construction of `k` [`lognormal_sample_scalar`] calls glued by
+/// `concat_arr`: draw `j` of row `i` still seeds from `(seed_j, i)` and uses the same
+/// `RandDistribution::sample`, so output is bit-identical to that path (pinned by
+/// `test_samples_scalar_fast_path_matches_per_row`). Returns `Array(Float64, seeds.len())`.
+#[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
+fn lognormal_samples_scalar(
+    inputs: &[Series],
+    kwargs: LogNormalSamplesScalarKwargs,
+) -> PolarsResult<Series> {
+    let dist = build_dist(kwargs.mu, kwargs.sigma)?;
+    let name = inputs[0].name().clone();
+
+    samples_by_index::<Float64Type, _>(&inputs[0], &kwargs.seeds, |index_ca, rngs| {
+        Float64Chunked::from_iter_values(
+            name,
+            index_ca.into_no_null_iter().flat_map(|i| {
+                rngs.iter().map(move |row_rngs| {
+                    let mut rng = row_rngs.rng(i);
+                    RandDistribution::sample(&dist, &mut rng)
+                })
             }),
         )
     })

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -8,7 +8,7 @@ use statrs::distribution::{Continuous, ContinuousCDF, LogNormal};
 
 use crate::distributions::value_keyed_scalar;
 use crate::rng::{
-    sample_scalar_plugin, samples_by_index, samples_f64_output, samples_per_row, SampleKwargs,
+    sample_scalar_plugin, samples_f64_output, samples_per_row, ternary_param_rows, SampleKwargs,
     SamplesKwargs,
 };
 
@@ -151,39 +151,11 @@ sample_scalar_plugin! {
     /// seeding and the draw are unchanged, so output matches `lognormal_sample` for the same
     /// `(seed, index, mu, sigma)`.
     fn lognormal_sample_scalar(output_type = Float64, physical = Float64Type);
+
+    samples = lognormal_samples_scalar as LogNormalSamplesScalarKwargs -> samples_f64_output;
+
     build = |kw| build_dist(kw.mu, kw.sigma)?;
     draw = |dist, rng| RandDistribution::sample(&dist, rng);
-}
-
-/// Static parameters for the constant-parameter multi-draw fast path.
-///
-/// Like [`LogNormalScalarKwargs`] plus the draw count `size` (the shared [`SamplesKwargs`] shape
-/// with the scalar parameters alongside).
-#[derive(Deserialize)]
-struct LogNormalSamplesScalarKwargs {
-    seed: Option<u64>,
-    size: usize,
-    mu: f64,
-    sigma: f64,
-}
-
-/// Constant-parameter multi-draw LogNormal sampler: `size` draws per row in one call.
-///
-/// Row `i`'s draws are consecutive values from the one stream seeded `(seed, i)`, the same
-/// stream [`lognormal_sample_scalar`] takes its single draw from, so `samples(size=1)` matches
-/// `sample` bit for bit and growing `size` extends each row's array. Returns
-/// `Array(Float64, size)`.
-#[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
-fn lognormal_samples_scalar(
-    inputs: &[Series],
-    kwargs: LogNormalSamplesScalarKwargs,
-) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.mu, kwargs.sigma)?;
-    let name = inputs[0].name().clone();
-
-    samples_by_index::<Float64Type, _, _>(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
-        RandDistribution::sample(&dist, rng)
-    })
 }
 
 /// Element-wise multi-draw LogNormal sampler: `size` draws per row in one call.
@@ -198,19 +170,11 @@ fn lognormal_samples_scalar(
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn lognormal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
     let mu = inputs[0].cast(&DataType::Float64)?;
-    let mu_ca = mu.f64()?;
     let sigma = inputs[1].cast(&DataType::Float64)?;
-    let sigma_ca = sigma.f64()?;
     let index = inputs[2].cast(&DataType::UInt64)?;
-    let index_ca = index.u64()?;
     let name = inputs[0].name().clone();
 
-    let rows = mu_ca.iter().zip(sigma_ca.iter()).zip(index_ca.iter()).map(
-        |((mu_opt, sigma_opt), i_opt)| match (mu_opt, sigma_opt, i_opt) {
-            (Some(m), Some(s), Some(i)) => Ok(Some((i, build_dist(m, s)?))),
-            _ => Ok(None),
-        },
-    );
+    let rows = ternary_param_rows(mu.f64()?, sigma.f64()?, index.u64()?, build_dist);
 
     samples_per_row::<Float64Type, _, _, _, _>(
         name,

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use statrs::distribution::{Continuous, ContinuousCDF, Normal};
 
 use crate::distributions::value_keyed_scalar;
-use crate::rng::{sample_by_index, SampleKwargs};
+use crate::rng::{sample_by_index, samples_by_index, samples_f64_output, SampleKwargs};
 
 /// Construct a `statrs::Normal`, mapping the invalid-parameter case to a `ComputeError`.
 ///
@@ -169,6 +169,44 @@ fn normal_sample_scalar(inputs: &[Series], kwargs: NormalScalarKwargs) -> Polars
             index_ca.into_no_null_iter().map(|i| {
                 let mut rng = rngs.rng(i);
                 RandDistribution::sample(&dist, &mut rng)
+            }),
+        )
+    })
+}
+
+/// Static parameters for the constant-parameter multi-draw fast path.
+///
+/// Like [`NormalScalarKwargs`] with the single `seed` replaced by the `samples(size=k)` call's `k`
+/// sub-seeds, derived in Python exactly as before.
+#[derive(Deserialize)]
+struct NormalSamplesScalarKwargs {
+    seeds: Vec<Option<u64>>,
+    mean: f64,
+    std_dev: f64,
+}
+
+/// Constant-parameter multi-draw Normal sampler: `seeds.len()` draws per row in one call.
+///
+/// Replaces `samples`' former construction of `k` [`normal_sample_scalar`] calls glued by
+/// `concat_arr`: draw `j` of row `i` still seeds from `(seed_j, i)` and uses the same
+/// `RandDistribution::sample`, so output is bit-identical to that path (pinned by
+/// `test_samples_scalar_fast_path_matches_per_row`). Returns `Array(Float64, seeds.len())`.
+#[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
+fn normal_samples_scalar(
+    inputs: &[Series],
+    kwargs: NormalSamplesScalarKwargs,
+) -> PolarsResult<Series> {
+    let dist = build_dist(kwargs.mean, kwargs.std_dev)?;
+    let name = inputs[0].name().clone();
+
+    samples_by_index::<Float64Type, _>(&inputs[0], &kwargs.seeds, |index_ca, rngs| {
+        Float64Chunked::from_iter_values(
+            name,
+            index_ca.into_no_null_iter().flat_map(|i| {
+                rngs.iter().map(move |row_rngs| {
+                    let mut rng = row_rngs.rng(i);
+                    RandDistribution::sample(&dist, &mut rng)
+                })
             }),
         )
     })

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -179,17 +179,10 @@ fn normal_samples_scalar(
     kwargs: NormalSamplesScalarKwargs,
 ) -> PolarsResult<Series> {
     let dist = build_dist(kwargs.mean, kwargs.std_dev)?;
-    let size = kwargs.size;
     let name = inputs[0].name().clone();
 
-    samples_by_index::<Float64Type, _>(&inputs[0], kwargs.seed, size, |index_ca, rngs| {
-        Float64Chunked::from_iter_values(
-            name,
-            index_ca.into_no_null_iter().flat_map(|i| {
-                let mut rng = rngs.rng(i);
-                std::iter::repeat_with(move || RandDistribution::sample(&dist, &mut rng)).take(size)
-            }),
-        )
+    samples_by_index::<Float64Type, _, _>(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
+        RandDistribution::sample(&dist, rng)
     })
 }
 
@@ -200,9 +193,8 @@ fn normal_samples_scalar(
 /// once per row instead of once per draw. Row `i`'s draws come from the one stream seeded
 /// `(seed, i)`, so output is bit-identical to the scalar path for the same parameters (the
 /// seeding is positional, parameters never enter it, so equal-parameter rows still draw
-/// independently). Null/error contract follows [`normal_sample`] per row; a null row yields an
-/// array of null elements (the Python layer masks it to a null array). Returns
-/// `Array(Float64, size)`.
+/// independently). Null/error contract follows [`normal_sample`] per row; a null row yields a
+/// null array element. Returns `Array(Float64, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn normal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
     let mean = inputs[0].cast(&DataType::Float64)?;
@@ -228,7 +220,6 @@ fn normal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Seri
         name,
         kwargs.seed,
         kwargs.size,
-        index_ca.len(),
         rows,
         RandDistribution::sample,
     )

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -7,7 +7,10 @@ use serde::Deserialize;
 use statrs::distribution::{Continuous, ContinuousCDF, Normal};
 
 use crate::distributions::value_keyed_scalar;
-use crate::rng::{sample_scalar_plugin, samples_by_index, samples_f64_output, SampleKwargs};
+use crate::rng::{
+    sample_scalar_plugin, samples_by_index, samples_f64_output, samples_per_row, SampleKwargs,
+    SamplesKwargs,
+};
 
 /// Construct a `statrs::Normal`, mapping the invalid-parameter case to a `ComputeError`.
 ///
@@ -154,40 +157,81 @@ sample_scalar_plugin! {
 
 /// Static parameters for the constant-parameter multi-draw fast path.
 ///
-/// Like [`NormalScalarKwargs`] with the single `seed` replaced by the `samples(size=k)` call's `k`
-/// sub-seeds, derived in Python exactly as before.
+/// Like [`NormalScalarKwargs`] plus the draw count `size` (the shared [`SamplesKwargs`] shape
+/// with the scalar parameters alongside).
 #[derive(Deserialize)]
 struct NormalSamplesScalarKwargs {
-    seeds: Vec<Option<u64>>,
+    seed: Option<u64>,
+    size: usize,
     mean: f64,
     std_dev: f64,
 }
 
-/// Constant-parameter multi-draw Normal sampler: `seeds.len()` draws per row in one call.
+/// Constant-parameter multi-draw Normal sampler: `size` draws per row in one call.
 ///
-/// Replaces `samples`' former construction of `k` [`normal_sample_scalar`] calls glued by
-/// `concat_arr`: draw `j` of row `i` still seeds from `(seed_j, i)` and uses the same
-/// `RandDistribution::sample`, so output is bit-identical to that path (pinned by
-/// `test_samples_scalar_fast_path_matches_per_row`). Returns `Array(Float64, seeds.len())`.
+/// Row `i`'s draws are consecutive values from the one stream seeded `(seed, i)`, the same
+/// stream [`normal_sample_scalar`] takes its single draw from, so `samples(size=1)` matches
+/// `sample` bit for bit and growing `size` extends each row's array. Returns
+/// `Array(Float64, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn normal_samples_scalar(
     inputs: &[Series],
     kwargs: NormalSamplesScalarKwargs,
 ) -> PolarsResult<Series> {
     let dist = build_dist(kwargs.mean, kwargs.std_dev)?;
+    let size = kwargs.size;
     let name = inputs[0].name().clone();
 
-    samples_by_index::<Float64Type, _>(&inputs[0], &kwargs.seeds, |index_ca, rngs| {
+    samples_by_index::<Float64Type, _>(&inputs[0], kwargs.seed, size, |index_ca, rngs| {
         Float64Chunked::from_iter_values(
             name,
             index_ca.into_no_null_iter().flat_map(|i| {
-                rngs.iter().map(move |row_rngs| {
-                    let mut rng = row_rngs.rng(i);
-                    RandDistribution::sample(&dist, &mut rng)
-                })
+                let mut rng = rngs.rng(i);
+                std::iter::repeat_with(move || RandDistribution::sample(&dist, &mut rng)).take(size)
             }),
         )
     })
+}
+
+/// Element-wise multi-draw Normal sampler: `size` draws per row in one call.
+///
+/// The column-parameter counterpart of [`normal_samples_scalar`], replacing `samples`' former
+/// construction of `k` [`normal_sample`] calls glued by `concat_arr`: the distribution is built
+/// once per row instead of once per draw. Row `i`'s draws come from the one stream seeded
+/// `(seed, i)`, so output is bit-identical to the scalar path for the same parameters (the
+/// seeding is positional, parameters never enter it, so equal-parameter rows still draw
+/// independently). Null/error contract follows [`normal_sample`] per row; a null row yields an
+/// array of null elements (the Python layer masks it to a null array). Returns
+/// `Array(Float64, size)`.
+#[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
+fn normal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
+    let mean = inputs[0].cast(&DataType::Float64)?;
+    let mean_ca = mean.f64()?;
+    let std_dev = inputs[1].cast(&DataType::Float64)?;
+    let std_dev_ca = std_dev.f64()?;
+    let index = inputs[2].cast(&DataType::UInt64)?;
+    let index_ca = index.u64()?;
+    let name = inputs[0].name().clone();
+
+    let rows = mean_ca
+        .iter()
+        .zip(std_dev_ca.iter())
+        .zip(index_ca.iter())
+        .map(
+            |((mean_opt, std_opt), i_opt)| match (mean_opt, std_opt, i_opt) {
+                (Some(m), Some(s), Some(i)) => Ok(Some((i, build_dist(m, s)?))),
+                _ => Ok(None),
+            },
+        );
+
+    samples_per_row::<Float64Type, _, _, _, _>(
+        name,
+        kwargs.seed,
+        kwargs.size,
+        index_ca.len(),
+        rows,
+        RandDistribution::sample,
+    )
 }
 
 // Per-method bodies, named so the per-row plugins and the constant-parameter `*_scalar` twins

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -8,7 +8,7 @@ use statrs::distribution::{Continuous, ContinuousCDF, Normal};
 
 use crate::distributions::value_keyed_scalar;
 use crate::rng::{
-    sample_scalar_plugin, samples_by_index, samples_f64_output, samples_per_row, SampleKwargs,
+    sample_scalar_plugin, samples_f64_output, samples_per_row, ternary_param_rows, SampleKwargs,
     SamplesKwargs,
 };
 
@@ -151,39 +151,11 @@ sample_scalar_plugin! {
     /// seeding and the draw are unchanged, so output matches `normal_sample` for the same
     /// `(seed, index, mean, std_dev)`.
     fn normal_sample_scalar(output_type = Float64, physical = Float64Type);
+
+    samples = normal_samples_scalar as NormalSamplesScalarKwargs -> samples_f64_output;
+
     build = |kw| build_dist(kw.mean, kw.std_dev)?;
     draw = |dist, rng| RandDistribution::sample(&dist, rng);
-}
-
-/// Static parameters for the constant-parameter multi-draw fast path.
-///
-/// Like [`NormalScalarKwargs`] plus the draw count `size` (the shared [`SamplesKwargs`] shape
-/// with the scalar parameters alongside).
-#[derive(Deserialize)]
-struct NormalSamplesScalarKwargs {
-    seed: Option<u64>,
-    size: usize,
-    mean: f64,
-    std_dev: f64,
-}
-
-/// Constant-parameter multi-draw Normal sampler: `size` draws per row in one call.
-///
-/// Row `i`'s draws are consecutive values from the one stream seeded `(seed, i)`, the same
-/// stream [`normal_sample_scalar`] takes its single draw from, so `samples(size=1)` matches
-/// `sample` bit for bit and growing `size` extends each row's array. Returns
-/// `Array(Float64, size)`.
-#[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
-fn normal_samples_scalar(
-    inputs: &[Series],
-    kwargs: NormalSamplesScalarKwargs,
-) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.mean, kwargs.std_dev)?;
-    let name = inputs[0].name().clone();
-
-    samples_by_index::<Float64Type, _, _>(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
-        RandDistribution::sample(&dist, rng)
-    })
 }
 
 /// Element-wise multi-draw Normal sampler: `size` draws per row in one call.
@@ -198,23 +170,11 @@ fn normal_samples_scalar(
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn normal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
     let mean = inputs[0].cast(&DataType::Float64)?;
-    let mean_ca = mean.f64()?;
     let std_dev = inputs[1].cast(&DataType::Float64)?;
-    let std_dev_ca = std_dev.f64()?;
     let index = inputs[2].cast(&DataType::UInt64)?;
-    let index_ca = index.u64()?;
     let name = inputs[0].name().clone();
 
-    let rows = mean_ca
-        .iter()
-        .zip(std_dev_ca.iter())
-        .zip(index_ca.iter())
-        .map(
-            |((mean_opt, std_opt), i_opt)| match (mean_opt, std_opt, i_opt) {
-                (Some(m), Some(s), Some(i)) => Ok(Some((i, build_dist(m, s)?))),
-                _ => Ok(None),
-            },
-        );
+    let rows = ternary_param_rows(mean.f64()?, std_dev.f64()?, index.u64()?, build_dist);
 
     samples_per_row::<Float64Type, _, _, _, _>(
         name,

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -6,7 +6,10 @@ use rand::distributions::{Distribution, Standard};
 use serde::Deserialize;
 use statrs::distribution::Uniform;
 
-use crate::rng::{sample_scalar_plugin, samples_by_index, samples_f64_output, SampleKwargs};
+use crate::rng::{
+    sample_scalar_plugin, samples_by_index, samples_f64_output, samples_per_row, SampleKwargs,
+    SamplesKwargs,
+};
 
 fn build_dist(min: f64, max: f64) -> PolarsResult<Uniform> {
     // `statrs` accepts any finite `min < max`, but a support wider than `f64::MAX` (e.g.
@@ -121,21 +124,22 @@ sample_scalar_plugin! {
 
 /// Static parameters for the constant-bounds multi-draw fast path.
 ///
-/// Like [`UniformScalarKwargs`] with the single `seed` replaced by the `samples(size=k)` call's
-/// `k` sub-seeds, derived in Python exactly as before.
+/// Like [`UniformScalarKwargs`] plus the draw count `size` (the shared [`SamplesKwargs`] shape
+/// with the scalar bounds alongside).
 #[derive(Deserialize)]
 struct UniformSamplesScalarKwargs {
-    seeds: Vec<Option<u64>>,
+    seed: Option<u64>,
+    size: usize,
     min: f64,
     max: f64,
 }
 
-/// Constant-bounds multi-draw Uniform sampler: `seeds.len()` draws per row in one call.
+/// Constant-bounds multi-draw Uniform sampler: `size` draws per row in one call.
 ///
-/// Replaces `samples`' former construction of `k` [`uniform_sample_scalar`] calls glued by
-/// `concat_arr`: draw `j` of row `i` still seeds from `(seed_j, i)` and uses the shared
-/// [`draw_half_open`], so output is bit-identical to that path (pinned by
-/// `test_samples_scalar_fast_path_matches_per_row`). Returns `Array(Float64, seeds.len())`.
+/// Row `i`'s draws are consecutive values from the one stream seeded `(seed, i)`, the same
+/// stream [`uniform_sample_scalar`] takes its single draw from, so `samples(size=1)` matches
+/// `sample` bit for bit and growing `size` extends each row's array. Returns
+/// `Array(Float64, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn uniform_samples_scalar(
     inputs: &[Series],
@@ -143,19 +147,64 @@ fn uniform_samples_scalar(
 ) -> PolarsResult<Series> {
     build_dist(kwargs.min, kwargs.max)?;
     let (lo, hi) = (kwargs.min, kwargs.max);
+    let size = kwargs.size;
     let name = inputs[0].name().clone();
 
-    samples_by_index::<Float64Type, _>(&inputs[0], &kwargs.seeds, |index_ca, rngs| {
+    samples_by_index::<Float64Type, _>(&inputs[0], kwargs.seed, size, |index_ca, rngs| {
         Float64Chunked::from_iter_values(
             name,
             index_ca.into_no_null_iter().flat_map(|i| {
-                rngs.iter().map(move |row_rngs| {
-                    let mut rng = row_rngs.rng(i);
-                    draw_half_open(lo, hi, &mut rng)
-                })
+                let mut rng = rngs.rng(i);
+                std::iter::repeat_with(move || draw_half_open(lo, hi, &mut rng)).take(size)
             }),
         )
     })
+}
+
+/// Element-wise multi-draw Uniform sampler over `[min, max)`: `size` draws per row in one
+/// call.
+///
+/// The column-parameter counterpart of [`uniform_samples_scalar`], replacing `samples`' former
+/// construction of `k` [`uniform_sample`] calls glued by `concat_arr`: the bounds are validated
+/// once per row instead of once per draw. Row `i`'s draws come from the one stream seeded
+/// `(seed, i)` via the shared [`draw_half_open`], so output is bit-identical to the scalar path
+/// for the same bounds (the seeding is positional, parameters never enter it, so equal-bound
+/// rows still draw independently). Null/error contract follows [`uniform_sample`] per row; a
+/// null row yields an array of null elements (the Python layer masks it to a null array).
+/// Returns `Array(Float64, size)`.
+#[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
+fn uniform_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
+    let min = inputs[0].cast(&DataType::Float64)?;
+    let min_ca = min.f64()?;
+    let max = inputs[1].cast(&DataType::Float64)?;
+    let max_ca = max.f64()?;
+    let index = inputs[2].cast(&DataType::UInt64)?;
+    let index_ca = index.u64()?;
+    let name = inputs[0].name().clone();
+
+    let rows =
+        min_ca
+            .iter()
+            .zip(max_ca.iter())
+            .zip(index_ca.iter())
+            .map(
+                |((min_opt, max_opt), i_opt)| match (min_opt, max_opt, i_opt) {
+                    (Some(lo), Some(hi), Some(i)) => {
+                        build_dist(lo, hi)?;
+                        Ok(Some((i, (lo, hi))))
+                    },
+                    _ => Ok(None),
+                },
+            );
+
+    samples_per_row::<Float64Type, _, _, _, _>(
+        name,
+        kwargs.seed,
+        kwargs.size,
+        index_ca.len(),
+        rows,
+        |&(lo, hi), rng| draw_half_open(lo, hi, rng),
+    )
 }
 
 /// Element-wise support width `max - min`, validating the parameterisation.

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -6,7 +6,7 @@ use rand::distributions::{Distribution, Standard};
 use serde::Deserialize;
 use statrs::distribution::Uniform;
 
-use crate::rng::{sample_by_index, SampleKwargs};
+use crate::rng::{sample_by_index, samples_by_index, samples_f64_output, SampleKwargs};
 
 fn build_dist(min: f64, max: f64) -> PolarsResult<Uniform> {
     // `statrs` accepts any finite `min < max`, but a support wider than `f64::MAX` (e.g.
@@ -135,6 +135,45 @@ fn uniform_sample_scalar(inputs: &[Series], kwargs: UniformScalarKwargs) -> Pola
             index_ca.into_no_null_iter().map(|i| {
                 let mut rng = rngs.rng(i);
                 draw_half_open(lo, hi, &mut rng)
+            }),
+        )
+    })
+}
+
+/// Static parameters for the constant-bounds multi-draw fast path.
+///
+/// Like [`UniformScalarKwargs`] with the single `seed` replaced by the `samples(size=k)` call's
+/// `k` sub-seeds, derived in Python exactly as before.
+#[derive(Deserialize)]
+struct UniformSamplesScalarKwargs {
+    seeds: Vec<Option<u64>>,
+    min: f64,
+    max: f64,
+}
+
+/// Constant-bounds multi-draw Uniform sampler: `seeds.len()` draws per row in one call.
+///
+/// Replaces `samples`' former construction of `k` [`uniform_sample_scalar`] calls glued by
+/// `concat_arr`: draw `j` of row `i` still seeds from `(seed_j, i)` and uses the shared
+/// [`draw_half_open`], so output is bit-identical to that path (pinned by
+/// `test_samples_scalar_fast_path_matches_per_row`). Returns `Array(Float64, seeds.len())`.
+#[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
+fn uniform_samples_scalar(
+    inputs: &[Series],
+    kwargs: UniformSamplesScalarKwargs,
+) -> PolarsResult<Series> {
+    build_dist(kwargs.min, kwargs.max)?;
+    let (lo, hi) = (kwargs.min, kwargs.max);
+    let name = inputs[0].name().clone();
+
+    samples_by_index::<Float64Type, _>(&inputs[0], &kwargs.seeds, |index_ca, rngs| {
+        Float64Chunked::from_iter_values(
+            name,
+            index_ca.into_no_null_iter().flat_map(|i| {
+                rngs.iter().map(move |row_rngs| {
+                    let mut rng = row_rngs.rng(i);
+                    draw_half_open(lo, hi, &mut rng)
+                })
             }),
         )
     })

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -147,17 +147,10 @@ fn uniform_samples_scalar(
 ) -> PolarsResult<Series> {
     build_dist(kwargs.min, kwargs.max)?;
     let (lo, hi) = (kwargs.min, kwargs.max);
-    let size = kwargs.size;
     let name = inputs[0].name().clone();
 
-    samples_by_index::<Float64Type, _>(&inputs[0], kwargs.seed, size, |index_ca, rngs| {
-        Float64Chunked::from_iter_values(
-            name,
-            index_ca.into_no_null_iter().flat_map(|i| {
-                let mut rng = rngs.rng(i);
-                std::iter::repeat_with(move || draw_half_open(lo, hi, &mut rng)).take(size)
-            }),
-        )
+    samples_by_index::<Float64Type, _, _>(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
+        draw_half_open(lo, hi, rng)
     })
 }
 
@@ -170,8 +163,7 @@ fn uniform_samples_scalar(
 /// `(seed, i)` via the shared [`draw_half_open`], so output is bit-identical to the scalar path
 /// for the same bounds (the seeding is positional, parameters never enter it, so equal-bound
 /// rows still draw independently). Null/error contract follows [`uniform_sample`] per row; a
-/// null row yields an array of null elements (the Python layer masks it to a null array).
-/// Returns `Array(Float64, size)`.
+/// null row yields a null array element. Returns `Array(Float64, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn uniform_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
     let min = inputs[0].cast(&DataType::Float64)?;
@@ -201,7 +193,6 @@ fn uniform_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Ser
         name,
         kwargs.seed,
         kwargs.size,
-        index_ca.len(),
         rows,
         |&(lo, hi), rng| draw_half_open(lo, hi, rng),
     )

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -3,11 +3,10 @@ use polars::prelude::arity::{try_binary_elementwise, try_ternary_elementwise};
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distributions::{Distribution, Standard};
-use serde::Deserialize;
 use statrs::distribution::Uniform;
 
 use crate::rng::{
-    sample_scalar_plugin, samples_by_index, samples_f64_output, samples_per_row, SampleKwargs,
+    sample_scalar_plugin, samples_f64_output, samples_per_row, ternary_param_rows, SampleKwargs,
     SamplesKwargs,
 };
 
@@ -118,40 +117,11 @@ sample_scalar_plugin! {
     /// travels as an input; seeding and the draw are unchanged, so output matches
     /// `uniform_sample` for the same `(seed, index, min, max)`.
     fn uniform_sample_scalar(output_type = Float64, physical = Float64Type);
+
+    samples = uniform_samples_scalar as UniformSamplesScalarKwargs -> samples_f64_output;
+
     build = |kw| { build_dist(kw.min, kw.max)?; (kw.min, kw.max) };
     draw = |(lo, hi), rng| draw_half_open(lo, hi, rng);
-}
-
-/// Static parameters for the constant-bounds multi-draw fast path.
-///
-/// Like [`UniformScalarKwargs`] plus the draw count `size` (the shared [`SamplesKwargs`] shape
-/// with the scalar bounds alongside).
-#[derive(Deserialize)]
-struct UniformSamplesScalarKwargs {
-    seed: Option<u64>,
-    size: usize,
-    min: f64,
-    max: f64,
-}
-
-/// Constant-bounds multi-draw Uniform sampler: `size` draws per row in one call.
-///
-/// Row `i`'s draws are consecutive values from the one stream seeded `(seed, i)`, the same
-/// stream [`uniform_sample_scalar`] takes its single draw from, so `samples(size=1)` matches
-/// `sample` bit for bit and growing `size` extends each row's array. Returns
-/// `Array(Float64, size)`.
-#[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
-fn uniform_samples_scalar(
-    inputs: &[Series],
-    kwargs: UniformSamplesScalarKwargs,
-) -> PolarsResult<Series> {
-    build_dist(kwargs.min, kwargs.max)?;
-    let (lo, hi) = (kwargs.min, kwargs.max);
-    let name = inputs[0].name().clone();
-
-    samples_by_index::<Float64Type, _, _>(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
-        draw_half_open(lo, hi, rng)
-    })
 }
 
 /// Element-wise multi-draw Uniform sampler over `[min, max)`: `size` draws per row in one
@@ -167,27 +137,16 @@ fn uniform_samples_scalar(
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn uniform_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
     let min = inputs[0].cast(&DataType::Float64)?;
-    let min_ca = min.f64()?;
     let max = inputs[1].cast(&DataType::Float64)?;
-    let max_ca = max.f64()?;
     let index = inputs[2].cast(&DataType::UInt64)?;
-    let index_ca = index.u64()?;
     let name = inputs[0].name().clone();
 
-    let rows =
-        min_ca
-            .iter()
-            .zip(max_ca.iter())
-            .zip(index_ca.iter())
-            .map(
-                |((min_opt, max_opt), i_opt)| match (min_opt, max_opt, i_opt) {
-                    (Some(lo), Some(hi), Some(i)) => {
-                        build_dist(lo, hi)?;
-                        Ok(Some((i, (lo, hi))))
-                    },
-                    _ => Ok(None),
-                },
-            );
+    // The built distribution is validated then dropped; the row state keeps the raw bounds, as
+    // [`draw_half_open`] needs (mirrors the `uniform_sample_scalar` `build`).
+    let rows = ternary_param_rows(min.f64()?, max.f64()?, index.u64()?, |lo, hi| {
+        build_dist(lo, hi)?;
+        Ok((lo, hi))
+    });
 
     samples_per_row::<Float64Type, _, _, _, _>(
         name,

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -126,49 +126,101 @@ where
 
 /// Shared driver for the constant-parameter multi-draw (`samples`) fast paths.
 ///
-/// The multi-draw counterpart of [`sample_by_index`]: `samples(size=k)` used to be `k` independent
-/// `<name>_sample_scalar` plugin calls glued by `concat_arr`, paying the fixed per-call expression
-/// and FFI cost `k` times. Here the Python layer passes all `k` sub-seeds in one call and the plugin
-/// returns the `Array(width=k)` column directly.
+/// The multi-draw counterpart of [`sample_by_index`]: one plugin call returns the
+/// `Array(width=size)` column directly, instead of `size` `sample` plugin calls glued by
+/// `concat_arr` paying the fixed per-call expression and FFI cost `size` times.
 ///
-/// Each sub-seed resolves **once** (drawing OS entropy per `None`, preserving `seed=None`'s
-/// "`k` independent fresh root seeds" semantics), and draw `j` of row `i` seeds from
-/// `(seed_j, i)`, exactly as the `j`-th `sample(seed=seed_j)` call did. `build` produces the flat
-/// row-major buffer (row `i`'s `k` draws adjacent, sub-seed order), so the reshaped output is
-/// bit-identical to the former `concat_arr` construction.
+/// Row `i`'s `size` draws are **consecutive values from one per-row stream** seeded
+/// `(root_seed, i)`, the same stream `sample` takes its single draw from. So `samples(size=1)`
+/// is bit-identical to `sample` for the same seed, and growing `size` extends each row's array
+/// without changing the existing draws. The root seed resolves once per call (fresh OS entropy
+/// when `None`); a row's stream depends only on `(root_seed, i)`, never on other rows, so
+/// chunk/thread invariance is untouched. `build` produces the flat row-major buffer (row `i`'s
+/// `size` draws adjacent, stream order).
 #[inline]
 pub(crate) fn samples_by_index<T, F>(
     index: &Series,
-    seeds: &[Option<u64>],
+    seed: Option<u64>,
+    size: usize,
     build: F,
 ) -> PolarsResult<Series>
 where
     T: PolarsDataType,
     ChunkedArray<T>: IntoSeries,
-    F: FnOnce(&UInt64Chunked, &[RowRngs]) -> ChunkedArray<T>,
+    F: FnOnce(&UInt64Chunked, &RowRngs) -> ChunkedArray<T>,
 {
     // The Python layer rejects `size <= 0` before registering the plugin; this guards the
     // zero-width `Array` reshape against any other caller.
-    if seeds.is_empty() {
+    if size == 0 {
         return Err(PolarsError::InvalidOperation(
-            "samples requires at least one sub-seed".into(),
+            "samples requires a positive size".into(),
         ));
     }
     let index = index.cast(&DataType::UInt64)?;
     let index_ca = index.u64()?;
-    let rngs: Vec<RowRngs> = seeds.iter().map(|seed| row_rngs(*seed)).collect();
+    let rngs = row_rngs(seed);
     let flat = build(index_ca, &rngs).into_series();
-    flat.reshape_array(&[
-        ReshapeDimension::Infer,
-        ReshapeDimension::new(seeds.len() as i64),
-    ])
+    flat.reshape_array(&[ReshapeDimension::Infer, ReshapeDimension::new(size as i64)])
 }
 
-/// The kwargs slice the `<name>_samples_scalar` output-dtype functions read: only the sub-seed
-/// list matters (its length is the `Array` width); serde skips the distribution parameters.
+/// Shared driver for the column-parameter multi-draw (`samples`) per-row paths.
+///
+/// The column-parameter counterpart of [`samples_by_index`]. The caller iterates its parameter
+/// columns and yields, per row, the index and a ready-to-draw state (typically the built
+/// distribution, so it is constructed once per row rather than once per draw). A `None` row (any
+/// null input) becomes an array of `size` null elements (the Python layer masks it to a null
+/// array); an invalid parameterisation `?`-raises out of the row iterator.
+///
+/// Seeding is identical to [`samples_by_index`]: row `i`'s draws are consecutive values from one
+/// stream keyed `(root_seed, i)`, a function of position only, never of the parameters. So the
+/// scalar and column paths stay bit-identical for the same parameters and equal-parameter rows
+/// still draw independently. Note the per-draw *consumption* of that stream does depend on the
+/// row's parameters (rejection samplers draw a variable number of words), which is fine: the
+/// stream is private to the row.
+#[inline]
+pub(crate) fn samples_per_row<T, V, S, I, F>(
+    name: PlSmallStr,
+    seed: Option<u64>,
+    size: usize,
+    len: usize,
+    rows: I,
+    draw: F,
+) -> PolarsResult<Series>
+where
+    T: PolarsDataType,
+    ChunkedArray<T>: NewChunkedArray<T, V> + IntoSeries,
+    I: Iterator<Item = PolarsResult<Option<(u64, S)>>>,
+    F: Fn(&S, &mut Pcg64Mcg) -> V,
+{
+    if size == 0 {
+        return Err(PolarsError::InvalidOperation(
+            "samples requires a positive size".into(),
+        ));
+    }
+    let rngs = row_rngs(seed);
+    let mut flat: Vec<Option<V>> = Vec::with_capacity(len * size);
+    for row in rows {
+        match row? {
+            Some((index, state)) => {
+                let mut rng = rngs.rng(index);
+                flat.extend((0..size).map(|_| Some(draw(&state, &mut rng))));
+            },
+            None => flat.extend(std::iter::repeat_with(|| None).take(size)),
+        }
+    }
+    let ca = ChunkedArray::<T>::from_iter_options(name, flat.into_iter());
+    ca.into_series()
+        .reshape_array(&[ReshapeDimension::Infer, ReshapeDimension::new(size as i64)])
+}
+
+/// Kwargs shared by every column-parameter multi-draw plugin, and the slice the shared
+/// output-dtype functions read from the scalar variants' kwargs (serde skips their extra
+/// parameter fields): the optional root seed and the draw count, which is the output `Array`
+/// width.
 #[derive(Deserialize)]
-pub(crate) struct SamplesOutputKwargs {
-    seeds: Vec<Option<u64>>,
+pub(crate) struct SamplesKwargs {
+    pub(crate) seed: Option<u64>,
+    pub(crate) size: usize,
 }
 
 fn samples_output(fields: &[Field], width: usize, inner: DataType) -> PolarsResult<Field> {
@@ -178,28 +230,19 @@ fn samples_output(fields: &[Field], width: usize, inner: DataType) -> PolarsResu
     ))
 }
 
-/// Output dtype of a float-valued multi-draw plugin: `Array(Float64, seeds.len())`.
-pub(crate) fn samples_f64_output(
-    fields: &[Field],
-    kwargs: SamplesOutputKwargs,
-) -> PolarsResult<Field> {
-    samples_output(fields, kwargs.seeds.len(), DataType::Float64)
+/// Output dtype of a float-valued multi-draw plugin: `Array(Float64, size)`.
+pub(crate) fn samples_f64_output(fields: &[Field], kwargs: SamplesKwargs) -> PolarsResult<Field> {
+    samples_output(fields, kwargs.size, DataType::Float64)
 }
 
-/// Output dtype of an integer-valued multi-draw plugin: `Array(UInt64, seeds.len())`.
-pub(crate) fn samples_u64_output(
-    fields: &[Field],
-    kwargs: SamplesOutputKwargs,
-) -> PolarsResult<Field> {
-    samples_output(fields, kwargs.seeds.len(), DataType::UInt64)
+/// Output dtype of an integer-valued multi-draw plugin: `Array(UInt64, size)`.
+pub(crate) fn samples_u64_output(fields: &[Field], kwargs: SamplesKwargs) -> PolarsResult<Field> {
+    samples_output(fields, kwargs.size, DataType::UInt64)
 }
 
-/// Output dtype of a boolean-valued multi-draw plugin: `Array(Boolean, seeds.len())`.
-pub(crate) fn samples_bool_output(
-    fields: &[Field],
-    kwargs: SamplesOutputKwargs,
-) -> PolarsResult<Field> {
-    samples_output(fields, kwargs.seeds.len(), DataType::Boolean)
+/// Output dtype of a boolean-valued multi-draw plugin: `Array(Boolean, size)`.
+pub(crate) fn samples_bool_output(fields: &[Field], kwargs: SamplesKwargs) -> PolarsResult<Field> {
+    samples_output(fields, kwargs.size, DataType::Boolean)
 }
 
 /// Generates a distribution's constant-parameter sampler fast path: the kwargs struct

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -16,7 +16,10 @@
 //! deliberately not the foundation here.
 
 use polars::prelude::*;
+use polars_arrow::bitmap::Bitmap;
 use polars_arrow::datatypes::reshape::ReshapeDimension;
+use polars_core::utils::rayon::prelude::*;
+use polars_core::POOL;
 use rand::rngs::OsRng;
 use rand::RngCore;
 use rand_pcg::Pcg64Mcg;
@@ -124,6 +127,35 @@ where
     Ok(build(index_ca, &rngs).into_series())
 }
 
+/// Total draw count below which the multi-draw row fill runs serially: a fork-join dispatch
+/// costs more than drawing this few values, and elementwise plugins run once per
+/// `group_by` / `over` partition, so tiny calls are common.
+const PARALLEL_FILL_MIN_DRAWS: usize = 4096;
+
+/// Fill the row-major multi-draw buffer: `fill_row(i, slot)` writes row `i`'s `size` draws into
+/// its own disjoint `size`-wide slice.
+///
+/// Rows fill in parallel on the polars thread pool when the total work justifies it. That is
+/// deterministic because a row's draws depend only on `(root_seed, row_index)`, never on other
+/// rows or on visit order, so the parallel fill is bit-identical to the serial one.
+fn fill_rows<V, F>(flat: &mut [V], size: usize, fill_row: F)
+where
+    V: Send,
+    F: Fn(usize, &mut [V]) + Sync,
+{
+    if flat.len() >= PARALLEL_FILL_MIN_DRAWS {
+        POOL.install(|| {
+            flat.par_chunks_mut(size)
+                .enumerate()
+                .for_each(|(row, slot)| fill_row(row, slot));
+        });
+    } else {
+        for (row, slot) in flat.chunks_mut(size).enumerate() {
+            fill_row(row, slot);
+        }
+    }
+}
+
 /// Shared driver for the constant-parameter multi-draw (`samples`) fast paths.
 ///
 /// The multi-draw counterpart of [`sample_by_index`]: one plugin call returns the
@@ -135,19 +167,22 @@ where
 /// is bit-identical to `sample` for the same seed, and growing `size` extends each row's array
 /// without changing the existing draws. The root seed resolves once per call (fresh OS entropy
 /// when `None`); a row's stream depends only on `(root_seed, i)`, never on other rows, so
-/// chunk/thread invariance is untouched. `build` produces the flat row-major buffer (row `i`'s
-/// `size` draws adjacent, stream order).
+/// chunk/thread invariance is untouched and rows can fill in parallel (see [`fill_rows`]).
+/// `draw` is one draw from a `&mut` per-row RNG already seeded `(root_seed, i)`, the same draw
+/// the distribution's `sample` plugin performs.
 #[inline]
-pub(crate) fn samples_by_index<T, F>(
+pub(crate) fn samples_by_index<T, V, F>(
+    name: PlSmallStr,
     index: &Series,
     seed: Option<u64>,
     size: usize,
-    build: F,
+    draw: F,
 ) -> PolarsResult<Series>
 where
     T: PolarsDataType,
-    ChunkedArray<T>: IntoSeries,
-    F: FnOnce(&UInt64Chunked, &RowRngs) -> ChunkedArray<T>,
+    ChunkedArray<T>: NewChunkedArray<T, V> + IntoSeries,
+    V: Default + Clone + Send,
+    F: Fn(&mut Pcg64Mcg) -> V + Sync,
 {
     // The Python layer rejects `size <= 0` before registering the plugin; this guards the
     // zero-width `Array` reshape against any other caller.
@@ -157,10 +192,20 @@ where
         ));
     }
     let index = index.cast(&DataType::UInt64)?;
-    let index_ca = index.u64()?;
+    let indices: Vec<u64> = index.u64()?.into_no_null_iter().collect();
     let rngs = row_rngs(seed);
-    let flat = build(index_ca, &rngs).into_series();
-    flat.reshape_array(&[ReshapeDimension::Infer, ReshapeDimension::new(size as i64)])
+
+    let mut flat = vec![V::default(); indices.len() * size];
+    fill_rows(&mut flat, size, |row, slot| {
+        let mut rng = rngs.rng(indices[row]);
+        for value in slot {
+            *value = draw(&mut rng);
+        }
+    });
+
+    ChunkedArray::<T>::from_iter_values(name, flat.into_iter())
+        .into_series()
+        .reshape_array(&[ReshapeDimension::Infer, ReshapeDimension::new(size as i64)])
 }
 
 /// Shared driver for the column-parameter multi-draw (`samples`) per-row paths.
@@ -168,49 +213,71 @@ where
 /// The column-parameter counterpart of [`samples_by_index`]. The caller iterates its parameter
 /// columns and yields, per row, the index and a ready-to-draw state (typically the built
 /// distribution, so it is constructed once per row rather than once per draw). A `None` row (any
-/// null input) becomes an array of `size` null elements (the Python layer masks it to a null
-/// array); an invalid parameterisation `?`-raises out of the row iterator.
+/// null input) becomes a null `Array` element directly, with its inner slots also null (the same
+/// two-layer shape as `pl.lit(None, dtype=Array(...))`); an invalid parameterisation `?`-raises
+/// out of the row iterator.
 ///
 /// Seeding is identical to [`samples_by_index`]: row `i`'s draws are consecutive values from one
 /// stream keyed `(root_seed, i)`, a function of position only, never of the parameters. So the
-/// scalar and column paths stay bit-identical for the same parameters and equal-parameter rows
-/// still draw independently. Note the per-draw *consumption* of that stream does depend on the
-/// row's parameters (rejection samplers draw a variable number of words), which is fine: the
-/// stream is private to the row.
+/// scalar and column paths stay bit-identical for the same parameters, equal-parameter rows
+/// still draw independently, and rows can fill in parallel (see [`fill_rows`]). Note the
+/// per-draw *consumption* of that stream does depend on the row's parameters (rejection
+/// samplers draw a variable number of words), which is fine: the stream is private to the row.
 #[inline]
 pub(crate) fn samples_per_row<T, V, S, I, F>(
     name: PlSmallStr,
     seed: Option<u64>,
     size: usize,
-    len: usize,
     rows: I,
     draw: F,
 ) -> PolarsResult<Series>
 where
     T: PolarsDataType,
     ChunkedArray<T>: NewChunkedArray<T, V> + IntoSeries,
+    V: Default + Clone + Send,
+    S: Sync,
     I: Iterator<Item = PolarsResult<Option<(u64, S)>>>,
-    F: Fn(&S, &mut Pcg64Mcg) -> V,
+    F: Fn(&S, &mut Pcg64Mcg) -> V + Sync,
 {
     if size == 0 {
         return Err(PolarsError::InvalidOperation(
             "samples requires a positive size".into(),
         ));
     }
+    // Materialising the states up front separates the sequential part (parameter validation,
+    // which can raise) from the draw loop, whose rows then fill independently. A null row keeps
+    // its `V::default()` slice; it is masked by the validity bitmaps below, never read.
+    let states: Vec<Option<(u64, S)>> = rows.collect::<PolarsResult<_>>()?;
     let rngs = row_rngs(seed);
-    let mut flat: Vec<Option<V>> = Vec::with_capacity(len * size);
-    for row in rows {
-        match row? {
-            Some((index, state)) => {
-                let mut rng = rngs.rng(index);
-                flat.extend((0..size).map(|_| Some(draw(&state, &mut rng))));
-            },
-            None => flat.extend(std::iter::repeat_with(|| None).take(size)),
+
+    let mut flat = vec![V::default(); states.len() * size];
+    fill_rows(&mut flat, size, |row, slot| {
+        if let Some((index, state)) = &states[row] {
+            let mut rng = rngs.rng(*index);
+            for value in slot {
+                *value = draw(state, &mut rng);
+            }
         }
+    });
+
+    let flat = ChunkedArray::<T>::from_iter_values(name.clone(), flat.into_iter()).into_series();
+    let shape = [ReshapeDimension::Infer, ReshapeDimension::new(size as i64)];
+
+    let outer_validity: Bitmap = states.iter().map(Option::is_some).collect();
+    if outer_validity.unset_bits() == 0 {
+        return flat.reshape_array(&shape);
     }
-    let ca = ChunkedArray::<T>::from_iter_options(name, flat.into_iter());
-    ca.into_series()
-        .reshape_array(&[ReshapeDimension::Infer, ReshapeDimension::new(size as i64)])
+    // A null row nulls both layers, matching `pl.lit(None, dtype=Array(...))`: the outer bit makes
+    // the element null, and the inner bits keep value-level reads (`arr.first`, `explode`, ...)
+    // from leaking the placeholder defaults behind it.
+    let inner_validity: Bitmap = states
+        .iter()
+        .flat_map(|state| std::iter::repeat_n(state.is_some(), size))
+        .collect();
+    let inner = flat.rechunk().chunks()[0].with_validity(Some(inner_validity));
+    let out = Series::from_arrow(name.clone(), inner)?.reshape_array(&shape)?;
+    let masked = out.rechunk().chunks()[0].with_validity(Some(outer_validity));
+    Series::from_arrow(name, masked)
 }
 
 /// Kwargs shared by every column-parameter multi-draw plugin, and the slice the shared

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -16,6 +16,7 @@
 //! deliberately not the foundation here.
 
 use polars::prelude::*;
+use polars_arrow::datatypes::reshape::ReshapeDimension;
 use rand::rngs::OsRng;
 use rand::RngCore;
 use rand_pcg::Pcg64Mcg;
@@ -121,6 +122,84 @@ where
     let index_ca = index.u64()?;
     let rngs = row_rngs(seed);
     Ok(build(index_ca, &rngs).into_series())
+}
+
+/// Shared driver for the constant-parameter multi-draw (`samples`) fast paths.
+///
+/// The multi-draw counterpart of [`sample_by_index`]: `samples(size=k)` used to be `k` independent
+/// `<name>_sample_scalar` plugin calls glued by `concat_arr`, paying the fixed per-call expression
+/// and FFI cost `k` times. Here the Python layer passes all `k` sub-seeds in one call and the plugin
+/// returns the `Array(width=k)` column directly.
+///
+/// Each sub-seed resolves **once** (drawing OS entropy per `None`, preserving `seed=None`'s
+/// "`k` independent fresh root seeds" semantics), and draw `j` of row `i` seeds from
+/// `(seed_j, i)`, exactly as the `j`-th `sample(seed=seed_j)` call did. `build` produces the flat
+/// row-major buffer (row `i`'s `k` draws adjacent, sub-seed order), so the reshaped output is
+/// bit-identical to the former `concat_arr` construction.
+#[inline]
+pub(crate) fn samples_by_index<T, F>(
+    index: &Series,
+    seeds: &[Option<u64>],
+    build: F,
+) -> PolarsResult<Series>
+where
+    T: PolarsDataType,
+    ChunkedArray<T>: IntoSeries,
+    F: FnOnce(&UInt64Chunked, &[RowRngs]) -> ChunkedArray<T>,
+{
+    // The Python layer rejects `size <= 0` before registering the plugin; this guards the
+    // zero-width `Array` reshape against any other caller.
+    if seeds.is_empty() {
+        return Err(PolarsError::InvalidOperation(
+            "samples requires at least one sub-seed".into(),
+        ));
+    }
+    let index = index.cast(&DataType::UInt64)?;
+    let index_ca = index.u64()?;
+    let rngs: Vec<RowRngs> = seeds.iter().map(|seed| row_rngs(*seed)).collect();
+    let flat = build(index_ca, &rngs).into_series();
+    flat.reshape_array(&[
+        ReshapeDimension::Infer,
+        ReshapeDimension::new(seeds.len() as i64),
+    ])
+}
+
+/// The kwargs slice the `<name>_samples_scalar` output-dtype functions read: only the sub-seed
+/// list matters (its length is the `Array` width); serde skips the distribution parameters.
+#[derive(Deserialize)]
+pub(crate) struct SamplesOutputKwargs {
+    seeds: Vec<Option<u64>>,
+}
+
+fn samples_output(fields: &[Field], width: usize, inner: DataType) -> PolarsResult<Field> {
+    Ok(Field::new(
+        fields[0].name().clone(),
+        DataType::Array(Box::new(inner), width),
+    ))
+}
+
+/// Output dtype of a float-valued multi-draw plugin: `Array(Float64, seeds.len())`.
+pub(crate) fn samples_f64_output(
+    fields: &[Field],
+    kwargs: SamplesOutputKwargs,
+) -> PolarsResult<Field> {
+    samples_output(fields, kwargs.seeds.len(), DataType::Float64)
+}
+
+/// Output dtype of an integer-valued multi-draw plugin: `Array(UInt64, seeds.len())`.
+pub(crate) fn samples_u64_output(
+    fields: &[Field],
+    kwargs: SamplesOutputKwargs,
+) -> PolarsResult<Field> {
+    samples_output(fields, kwargs.seeds.len(), DataType::UInt64)
+}
+
+/// Output dtype of a boolean-valued multi-draw plugin: `Array(Boolean, seeds.len())`.
+pub(crate) fn samples_bool_output(
+    fields: &[Field],
+    kwargs: SamplesOutputKwargs,
+) -> PolarsResult<Field> {
+    samples_output(fields, kwargs.seeds.len(), DataType::Boolean)
 }
 
 /// Per-call source of per-row RNGs, all derived from one already-resolved root seed.

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -280,6 +280,56 @@ where
     Series::from_arrow(name, masked)
 }
 
+/// Build the per-row state iterator a single-parameter column `samples` plugin feeds to
+/// [`samples_per_row`]: zip the parameter column with the row index and, on a fully-non-null row,
+/// run `build` once to make the row's draw state.
+///
+/// Centralises the null contract every per-row multi-draw plugin shares (any null input nulls the
+/// whole row, matching the single-draw `try_*_elementwise` paths), so each distribution spells only
+/// its cast and its `build`.
+pub(crate) fn binary_param_rows<'a, A, S, F>(
+    param: &'a ChunkedArray<A>,
+    index: &'a UInt64Chunked,
+    build: F,
+) -> impl Iterator<Item = PolarsResult<Option<(u64, S)>>> + 'a
+where
+    A: PolarsNumericType,
+    F: Fn(A::Native) -> PolarsResult<S> + 'a,
+    S: 'a,
+{
+    param
+        .iter()
+        .zip(index.iter())
+        .map(move |(p_opt, i_opt)| match (p_opt, i_opt) {
+            (Some(p), Some(i)) => Ok(Some((i, build(p)?))),
+            _ => Ok(None),
+        })
+}
+
+/// Two-parameter counterpart of [`binary_param_rows`] (e.g. `(mean, std_dev)`, `(n, p)`): zip both
+/// parameter columns with the row index and, on a fully-non-null row, run `build` once. The two
+/// parameter dtypes are independent, so a mixed `(i64, f64)` parameterisation (Binomial) fits.
+pub(crate) fn ternary_param_rows<'a, A, B, S, F>(
+    a: &'a ChunkedArray<A>,
+    b: &'a ChunkedArray<B>,
+    index: &'a UInt64Chunked,
+    build: F,
+) -> impl Iterator<Item = PolarsResult<Option<(u64, S)>>> + 'a
+where
+    A: PolarsNumericType,
+    B: PolarsNumericType,
+    F: Fn(A::Native, B::Native) -> PolarsResult<S> + 'a,
+    S: 'a,
+{
+    a.iter()
+        .zip(b.iter())
+        .zip(index.iter())
+        .map(move |((a_opt, b_opt), i_opt)| match (a_opt, b_opt, i_opt) {
+            (Some(a), Some(b), Some(i)) => Ok(Some((i, build(a, b)?))),
+            _ => Ok(None),
+        })
+}
+
 /// Kwargs shared by every column-parameter multi-draw plugin, and the slice the shared
 /// output-dtype functions read from the scalar variants' kwargs (serde skips their extra
 /// parameter fields): the optional root seed and the draw count, which is the output `Array`
@@ -312,26 +362,33 @@ pub(crate) fn samples_bool_output(fields: &[Field], kwargs: SamplesKwargs) -> Po
     samples_output(fields, kwargs.size, DataType::Boolean)
 }
 
-/// Generates a distribution's constant-parameter sampler fast path: the kwargs struct
-/// (the scalar parameters next to the optional root `seed`) and the `#[polars_expr]`
-/// plugin that drives [`sample_by_index`].
+/// Generates a distribution's constant-parameter fast paths: both the single-draw `sample`
+/// plugin (driving [`sample_by_index`]) and the multi-draw `samples` plugin (driving
+/// [`samples_by_index`]), from one shared `build` / `draw`.
 ///
-/// The four things that vary between distributions are the macro's inputs:
+/// Emitting the two from one definition is what keeps them from drifting: the multi-draw fast
+/// path is just the single-draw one repeated `size` times on the same per-row stream, so they
+/// must share the exact `build` and `draw`. The five things that vary between distributions are
+/// the macro's inputs:
 ///
-/// * the kwargs fields (parameter names and types);
-/// * the output dtype, as the `(logical, physical)` pair `output_type = Float64,
-///   physical = Float64Type` (the two must agree; the logical name feeds
-///   `#[polars_expr]`, the physical one the output `ChunkedArray`);
-/// * `build`: validates the parameters and returns the per-call sampler state, built
-///   **once** (`?` is available). Usually the built distribution; Uniform validates and
-///   keeps the raw bounds instead;
+/// * the kwargs fields (parameter names and types), reused by both kwargs structs;
+/// * the single-draw output dtype, as the `(logical, physical)` pair `output_type = Float64,
+///   physical = Float64Type` (the two must agree; the logical name feeds `#[polars_expr]`, the
+///   physical one the output `ChunkedArray`);
+/// * the multi-draw twin, named by the `samples = <fn> as <kwargs> -> <output_fn>` clause: the
+///   plugin fn, its kwargs struct (the same parameters plus `size`), and the `Array`-typed
+///   output function (`samples_f64_output` / `_u64_` / `_bool_`);
+/// * `build`: validates the parameters and returns the per-call sampler state, built **once**
+///   (`?` is available). Usually the built distribution; Uniform validates and keeps the raw
+///   bounds instead;
 /// * `draw`: one draw from that state, given a `&mut` per-row RNG already seeded from
 ///   `(root_seed, index)`.
 ///
-/// `draw` must be the *same* draw the general per-row plugin performs, so the two paths
-/// stay byte-identical for the same `(seed, index, params)`; that contract is pinned by
-/// `test_sample_scalar_fast_path_matches_per_row`. Call sites are the distribution
-/// modules, which all have `polars::prelude::*` in scope (the expansion relies on it).
+/// `draw` must be the *same* draw the general per-row plugins perform, so the fast paths stay
+/// byte-identical to them for the same `(seed, index, params)`; pinned by
+/// `test_sample_scalar_fast_path_matches_per_row` and `test_samples_scalar_fast_path_matches_per_row`.
+/// Call sites are the distribution modules, which all have `polars::prelude::*` in scope and
+/// import the `samples_*_output` function they name (the expansion relies on both).
 macro_rules! sample_scalar_plugin {
     (
         $(#[$kwargs_meta:meta])*
@@ -339,6 +396,9 @@ macro_rules! sample_scalar_plugin {
 
         $(#[$fn_meta:meta])*
         fn $fn_name:ident(output_type = $logical:ident, physical = $physical:ty);
+
+        samples = $samples_fn:ident as $samples_kwargs:ident -> $samples_output:ident;
+
         build = |$kw:ident| $build:expr;
         draw = |$state:pat_param, $rng:ident| $draw:expr;
     ) => {
@@ -366,6 +426,37 @@ macro_rules! sample_scalar_plugin {
                     }),
                 )
             })
+        }
+
+        /// Constant-parameter kwargs for the multi-draw fast path: the single-draw parameters
+        /// plus the draw count `size` (the output `Array` width).
+        #[derive(serde::Deserialize)]
+        struct $samples_kwargs {
+            seed: Option<u64>,
+            size: usize,
+            $($param: $param_ty,)+
+        }
+
+        #[doc = concat!(
+            "Constant-parameter multi-draw fast path: the `samples` twin of [`", stringify!($fn_name),
+            "`]. `size` draws per row in one call, taken as consecutive values from the same \
+             `(seed, row_index)` per-row stream, so `samples(size=1)` matches `sample` bit for bit \
+             and the state is built once per call rather than once per draw. Returns \
+             `Array(inner, size)`."
+        )]
+        #[pyo3_polars::derive::polars_expr(output_type_func_with_kwargs=$samples_output)]
+        fn $samples_fn(inputs: &[Series], kwargs: $samples_kwargs) -> PolarsResult<Series> {
+            let $kw = &kwargs;
+            let $state = $build;
+            let name = inputs[0].name().clone();
+
+            $crate::rng::samples_by_index::<$physical, _, _>(
+                name,
+                &inputs[0],
+                kwargs.seed,
+                kwargs.size,
+                |$rng| $draw,
+            )
         }
     };
 }

--- a/tests/property/_specs.py
+++ b/tests/property/_specs.py
@@ -50,6 +50,9 @@ class DistSpec:
         make: Builds an instance from a parameter tuple (scalar parameters: the constant-parameter fast path).
         make_columns: Builds the same instance with each parameter wrapped as a full-length column expr,
             forcing the general per-row sampler path. Lets a test assert the fast path matches it draw-for-draw.
+        make_masked: Like `make_columns`, but the first parameter is null on rows where the given boolean
+            mask expr is true (null in any one parameter is enough to null a sampler row). Lets a test
+            assert the per-row path's null contract without knowing the distribution's parameter names.
         density: `pdf` or `pmf` as `(dist, expr) -> expr`. Typed loosely because the method differs by family;
             the concrete distribution is fixed per spec.
         eval_range: `(lo, hi)` finite window for evaluating cdf / density on a grid.
@@ -63,6 +66,7 @@ class DistSpec:
     params: SearchStrategy[tuple[float, ...]]
     make: Callable[[tuple[float, ...]], _UnivariateDistribution]
     make_columns: Callable[[tuple[float, ...]], _UnivariateDistribution]
+    make_masked: Callable[[tuple[float, ...], pl.Expr], _UnivariateDistribution]
     density: Callable[[Any, pl.Expr], pl.Expr]
     eval_range: Callable[[tuple[float, ...]], tuple[float, float]]
     integration_bounds: Callable[[tuple[float, ...]], tuple[float, float]] | None = None
@@ -75,6 +79,7 @@ _BERNOULLI = DistSpec(
     params=st.tuples(_finite(0.0, 1.0)),
     make=lambda p: Bernoulli(p=p[0]),
     make_columns=lambda p: Bernoulli(p=_col(p[0])),
+    make_masked=lambda p, m: Bernoulli(p=pl.when(~m).then(_col(p[0]))),
     density=lambda d, c: d.pmf(c),
     eval_range=lambda _: (-1.0, 2.0),
     support=lambda _: [0.0, 1.0],
@@ -88,6 +93,7 @@ _BINOMIAL = DistSpec(
     params=st.tuples(st.integers(min_value=0, max_value=20), _finite(0.0, 1.0)),
     make=lambda p: Binomial(n=int(p[0]), p=p[1]),
     make_columns=lambda p: Binomial(n=_col(int(p[0]), pl.Int64()), p=_col(p[1])),
+    make_masked=lambda p, m: Binomial(n=pl.when(~m).then(_col(int(p[0]), pl.Int64())), p=_col(p[1])),
     density=lambda d, c: d.pmf(c),
     eval_range=lambda p: (-1.0, p[0] + 1.0),
     support=lambda p: [float(k) for k in range(int(p[0]) + 1)],
@@ -99,6 +105,7 @@ _NORMAL = DistSpec(
     params=st.tuples(_finite(-10.0, 10.0), _finite(1e-2, 10.0)),
     make=lambda p: Normal(mean=p[0], std_dev=p[1]),
     make_columns=lambda p: Normal(mean=_col(p[0]), std_dev=_col(p[1])),
+    make_masked=lambda p, m: Normal(mean=pl.when(~m).then(_col(p[0])), std_dev=_col(p[1])),
     density=lambda d, c: d.pdf(c),
     eval_range=lambda p: (p[0] - 6.0 * p[1], p[0] + 6.0 * p[1]),
     integration_bounds=lambda p: (p[0] - 12.0 * p[1], p[0] + 12.0 * p[1]),
@@ -112,6 +119,7 @@ _UNIFORM = DistSpec(
     params=st.tuples(_finite(-10.0, 10.0), _finite(1e-2, 20.0)).map(lambda mw: (mw[0], mw[0] + mw[1])),
     make=lambda p: Uniform(min=p[0], max=p[1]),
     make_columns=lambda p: Uniform(min=_col(p[0]), max=_col(p[1])),
+    make_masked=lambda p, m: Uniform(min=pl.when(~m).then(_col(p[0])), max=_col(p[1])),
     density=lambda d, c: d.pdf(c),
     eval_range=lambda p: (p[0] - 0.5 * (p[1] - p[0]), p[1] + 0.5 * (p[1] - p[0])),
     integration_bounds=lambda p: (p[0], p[1]),
@@ -126,6 +134,7 @@ _LOGNORMAL = DistSpec(
     params=st.tuples(_finite(-1.5, 1.5), _finite(0.1, 0.9)),
     make=lambda p: LogNormal(mu=p[0], sigma=p[1]),
     make_columns=lambda p: LogNormal(mu=_col(p[0]), sigma=_col(p[1])),
+    make_masked=lambda p, m: LogNormal(mu=pl.when(~m).then(_col(p[0])), sigma=_col(p[1])),
     density=lambda d, c: d.pdf(c),
     # Support is (0, inf); the grid stays on the positive side and out to a 4-sigma-in-log upper tail.
     eval_range=lambda p: (0.0, exp(p[0] + 4.0 * p[1])),

--- a/tests/property/sample_test.py
+++ b/tests/property/sample_test.py
@@ -123,6 +123,94 @@ def test_samples_prefix_is_stable_in_size(spec: DistSpec, data: st.DataObject) -
         assert_series_equal(small.arr.get(j), large.arr.get(j))
 
 
+# Enough rows that `rows * _SAMPLES_SIZE` clears the Rust-side `PARALLEL_FILL_MIN_DRAWS`
+# threshold (4096 total draws), pushing the multi-draw fill onto its parallel branch, while
+# `_N_ROWS * _SAMPLES_SIZE` stays on the serial one. Keep in sync with `src/rng.rs`.
+_PARALLEL_ROWS = 2048
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@pytest.mark.parametrize("builder", ["make", "make_columns"])
+@given(data=st.data())
+def test_samples_prefix_is_stable_in_length(spec: DistSpec, builder: str, data: st.DataObject) -> None:
+    """Row `i`'s array depends only on `(seed, i)`: growing the frame leaves existing rows unchanged.
+
+    Doubles as the serial/parallel equivalence pin for both plugin paths: the small frame's total
+    draw count keeps the Rust fill on its serial branch, the large frame's puts it on the parallel
+    branch, so the two implementations of the fill must agree bit for bit or this fails. A fill
+    that depended on chunk-local position, buffer offset, or visit order would also fail here.
+    """
+    params = data.draw(spec.params)
+    dist = getattr(spec, builder)(params)
+    expr = dist.samples(size=_SAMPLES_SIZE, seed=_SEED)
+
+    small = pl.DataFrame({"_": range(_N_ROWS)}).select(s=expr)["s"]
+    large = pl.DataFrame({"_": range(_PARALLEL_ROWS)}).select(s=expr)["s"]
+
+    assert_series_equal(small, large.head(_N_ROWS))
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@pytest.mark.parametrize("size", [1, _SAMPLES_SIZE])
+@given(data=st.data())
+def test_samples_null_rows_null_both_layers_and_do_not_perturb_valid_rows(
+    spec: DistSpec, size: int, data: st.DataObject
+) -> None:
+    """A null-parameter row yields a null array, null at the value level too, without shifting other rows.
+
+    Three contracts in one sweep, with nulls placed on the first row, the last row, and a
+    scattering in between. The two sizes land on different fill branches (`size=1` stays under
+    `PARALLEL_FILL_MIN_DRAWS`, `_SAMPLES_SIZE` clears it), so nulls are exercised on both:
+
+    * the null mask of the output equals the null mask of the parameters (outer validity);
+    * `arr.get` reads behind a null array are null, never the buffer's placeholder values
+      (inner validity, the regression a value-leak would hit);
+    * every valid row draws exactly what it draws without any nulls present: a row's stream is
+      keyed `(seed, row_index)`, so null neighbours cannot shift or consume its draws.
+    """
+    params = data.draw(spec.params)
+    frame = pl.DataFrame({"i": range(_PARALLEL_ROWS)})
+    mask = (pl.col("i") % 5 == 0) | (pl.col("i") == _PARALLEL_ROWS - 1)
+
+    out = frame.select(s=spec.make_masked(params, mask).samples(size=size, seed=_SEED), m=mask)
+    unmasked = frame.select(s=spec.make_columns(params).samples(size=size, seed=_SEED))["s"]
+
+    assert_series_equal(out["s"].is_null(), out["m"], check_names=False)
+    for j in range(size):
+        assert_series_equal(out["s"].arr.get(j).is_null(), out["m"], check_names=False)
+    assert_series_equal(out.filter(~pl.col("m"))["s"], unmasked.filter(~out["m"]))
+
+
+@settings(max_examples=10)
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@given(data=st.data())
+def test_samples_all_null_and_empty_frames(spec: DistSpec, data: st.DataObject) -> None:
+    """The degenerate inputs hold the shape contract: every-row-null and zero-row frames.
+
+    All-null parameters must yield a column of null arrays (not raise, and not a null column of a
+    different dtype); an empty frame must yield an empty `Array` column of the right width for
+    both plugin paths (the multi-draw reshape divides by `size`, so zero rows is its edge).
+    """
+    params = data.draw(spec.params)
+
+    all_null = pl.DataFrame({"i": range(8)}).select(
+        s=spec.make_masked(params, pl.lit(value=True)).samples(size=_SAMPLES_SIZE, seed=_SEED)
+    )["s"]
+    assert isinstance(all_null.dtype, pl.Array)
+    assert all_null.dtype.size == _SAMPLES_SIZE
+    assert all_null.is_null().all()
+    assert all_null.arr.first().is_null().all()
+
+    empty = pl.DataFrame({"_": []}, schema={"_": pl.Int64})
+    for builder in ("make", "make_columns"):
+        dist = getattr(spec, builder)(params)
+        out = empty.select(s=dist.samples(size=_SAMPLES_SIZE, seed=_SEED))
+        assert out.height == 0
+        dtype = out.schema["s"]
+        assert isinstance(dtype, pl.Array)
+        assert dtype.size == _SAMPLES_SIZE
+
+
 @settings(max_examples=10)
 @pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
 @given(data=st.data())

--- a/tests/property/sample_test.py
+++ b/tests/property/sample_test.py
@@ -66,13 +66,12 @@ _SAMPLES_SIZE = 4
 def test_samples_scalar_fast_path_matches_per_row(spec: DistSpec, data: st.DataObject) -> None:
     """Constant scalar parameters and the equivalent per-row columns multi-draw identically.
 
-    Constant parameters route `samples` through one `<name>_samples_scalar` plugin call that takes all
-    `size` sub-seeds as a kwarg and returns the `Array` column directly; column parameters take the
-    general construction of `size` per-row `sample` calls glued by `concat_arr`. Draw `j` of row `i` is
-    seeded `(seed_j, i)` on both paths, so for one seed they must agree bit for bit, the `samples`
-    counterpart of `test_sample_scalar_fast_path_matches_per_row`. A divergence (wrong sub-seed
-    derivation, a transposed row/draw layout in the flat buffer, or a parameter mix-up in the kwargs)
-    must fail here.
+    Constant parameters route `samples` through the `<name>_samples_scalar` plugin (parameters
+    validated once, in kwargs); column parameters through the per-row `<name>_samples` twin. Row `i`'s
+    draws are consecutive values from the one stream keyed `(seed, i)` on both paths, a function of
+    position only, so for one seed they must agree bit for bit, the `samples` counterpart of
+    `test_sample_scalar_fast_path_matches_per_row`. A divergence (a transposed row/draw layout in the
+    flat buffer, or a parameter mix-up in the kwargs) must fail here.
     """
     params = data.draw(spec.params)
     frame = pl.DataFrame({"_": range(_N_ROWS)})
@@ -81,6 +80,47 @@ def test_samples_scalar_fast_path_matches_per_row(spec: DistSpec, data: st.DataO
     per_row = frame.select(s=spec.make_columns(params).samples(size=_SAMPLES_SIZE, seed=_SEED))["s"]
 
     assert_series_equal(fast, per_row)
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@given(data=st.data())
+def test_samples_size_one_matches_sample(spec: DistSpec, data: st.DataObject) -> None:
+    """`samples(size=1)` equals `sample` element for element for the same seed.
+
+    Each row's draws are consecutive values from the one stream keyed `(seed, row_index)` that
+    `sample` takes its single draw from, so the width-1 array must contain exactly `sample`'s draw.
+    This pins the multi-draw plugins to the single-draw ones: a divergence in seeding or in the draw
+    call must fail here.
+    """
+    params = data.draw(spec.params)
+    dist = spec.make(params)
+    frame = pl.DataFrame({"_": range(_N_ROWS)})
+
+    first = frame.select(s=dist.samples(size=1, seed=_SEED))["s"].arr.first()
+    single = frame.select(s=dist.sample(seed=_SEED))["s"]
+
+    assert_series_equal(first, single)
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@given(data=st.data())
+def test_samples_prefix_is_stable_in_size(spec: DistSpec, data: st.DataObject) -> None:
+    """Growing `size` extends each row's array without changing the existing draws.
+
+    Draw `j` of row `i` is the `j`-th value of the row's `(seed, i)` stream regardless of `size`, so
+    `samples(size=k)` is a prefix of `samples(size=k')` for `k < k'` and the same seed. This is the
+    user-facing consequence of the per-row stream design; a sampler that re-keyed draws on `size`
+    would fail here.
+    """
+    params = data.draw(spec.params)
+    dist = spec.make(params)
+    frame = pl.DataFrame({"_": range(_N_ROWS)})
+
+    small = frame.select(s=dist.samples(size=2, seed=_SEED))["s"]
+    large = frame.select(s=dist.samples(size=_SAMPLES_SIZE, seed=_SEED))["s"]
+
+    for j in range(2):
+        assert_series_equal(small.arr.get(j), large.arr.get(j))
 
 
 @settings(max_examples=10)
@@ -109,6 +149,36 @@ def test_sample_seeded_matches_across_engines(spec: DistSpec, data: st.DataObjec
     assert frame.n_chunks() > 1  # the multi-chunk layout is the whole point; guard against a silent rechunk
 
     expr = dist.sample(seed=_SEED)
+    in_memory = frame.lazy().select(s=expr).collect(engine="in-memory")["s"]
+    streaming = frame.lazy().select(s=expr).collect(engine="streaming")["s"]
+
+    assert_series_equal(in_memory, streaming)
+
+
+@settings(max_examples=10)
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@pytest.mark.parametrize("builder", ["make", "make_columns"])
+@given(data=st.data())
+@pytest.mark.skipif(Version("1.36.0") > PL_VERSION, reason="Arbitrary cut for when both engine's are available")
+def test_samples_seeded_matches_across_engines(spec: DistSpec, builder: str, data: st.DataObject) -> None:
+    """`samples(size=k, seed=N)` is invariant to the execution engine (in-memory vs streaming).
+
+    The multi-draw counterpart of `test_sample_seeded_matches_across_engines`, run for both plugin
+    paths (`make`: the scalar fast path, whose sole input is the injected row index; `make_columns`:
+    the per-row path, where the parameter columns must stay aligned with that index across morsels).
+    Each row's stream is keyed on the global `(seed, row_index)`, so a per-chunk row index would
+    collide sub-streams across chunks and the engines would diverge.
+    """
+    params = data.draw(spec.params)
+    dist = getattr(spec, builder)(params)
+
+    frame = pl.concat(
+        [pl.DataFrame({"_": range(_STREAMING_CHUNK_ROWS)}) for _ in range(_STREAMING_CHUNKS)],
+        rechunk=False,
+    )
+    assert frame.n_chunks() > 1  # the multi-chunk layout is the whole point; guard against a silent rechunk
+
+    expr = dist.samples(size=_SAMPLES_SIZE, seed=_SEED)
     in_memory = frame.lazy().select(s=expr).collect(engine="in-memory")["s"]
     streaming = frame.lazy().select(s=expr).collect(engine="streaming")["s"]
 

--- a/tests/property/sample_test.py
+++ b/tests/property/sample_test.py
@@ -58,6 +58,31 @@ def test_sample_scalar_fast_path_matches_per_row(spec: DistSpec, data: st.DataOb
     assert_series_equal(fast, per_row)
 
 
+_SAMPLES_SIZE = 4
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@given(data=st.data())
+def test_samples_scalar_fast_path_matches_per_row(spec: DistSpec, data: st.DataObject) -> None:
+    """Constant scalar parameters and the equivalent per-row columns multi-draw identically.
+
+    Constant parameters route `samples` through one `<name>_samples_scalar` plugin call that takes all
+    `size` sub-seeds as a kwarg and returns the `Array` column directly; column parameters take the
+    general construction of `size` per-row `sample` calls glued by `concat_arr`. Draw `j` of row `i` is
+    seeded `(seed_j, i)` on both paths, so for one seed they must agree bit for bit, the `samples`
+    counterpart of `test_sample_scalar_fast_path_matches_per_row`. A divergence (wrong sub-seed
+    derivation, a transposed row/draw layout in the flat buffer, or a parameter mix-up in the kwargs)
+    must fail here.
+    """
+    params = data.draw(spec.params)
+    frame = pl.DataFrame({"_": range(_N_ROWS)})
+
+    fast = frame.select(s=spec.make(params).samples(size=_SAMPLES_SIZE, seed=_SEED))["s"]
+    per_row = frame.select(s=spec.make_columns(params).samples(size=_SAMPLES_SIZE, seed=_SEED))["s"]
+
+    assert_series_equal(fast, per_row)
+
+
 @settings(max_examples=10)
 @pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
 @given(data=st.data())


### PR DESCRIPTION
Reimplements `samples(size=k)` as one native plugin call that fills the whole `Array(inner, k)` column in a single pass, replacing the previous `concat_arr` of `k` separate `sample` calls. Each row's draws are now consecutive values from one per-row `(seed, row_index)` stream, so `samples(size=1)` equals `sample`.

Measured across all five distributions this is ~1.5x to 8x faster (100k to 1M rows, size=20) at ~2.5x to 3.5x lower peak memory.
