### PR TITLE
refactor: Consolidate per-distribution routing into `_UnivariateDistribution`

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -76,23 +76,40 @@ is canonical if it conflicts with this section.
 1. **Rust.** Add `src/distributions/<name>.rs`, register it in `src/distributions/mod.rs`, and implement a
    `#[polars_expr]` only for methods that need it:
 
-    * Always `sample` (native `statrs::Distribution::sample`). The sampler takes a per-row index as its last input
-      `Series` and derives its RNG from `src/rng.rs`: `let rngs = kwargs.row_rngs();` once outside the loop, then
-      `rngs.rng(i)` inside. Never reseed from chunk position. Use `try_*_elementwise` so a `null` in any input
-      propagates and an invalid parameter raises.
+    * Always the samplers, deriving the RNG from `src/rng.rs` (`let rngs = kwargs.row_rngs();` once outside the loop,
+      then `rngs.rng(i)` inside; never reseed from chunk position; `try_*_elementwise` so a `null` in any input
+      propagates and an invalid parameter raises). The per-row `<name>_sample` / `<name>_samples` (multi-draw, backing
+      `samples`) take the parameter columns plus a row index as the last input; the constant-parameter fast paths
+      `<name>_sample_scalar` / `<name>_samples_scalar` (parameters validated once in `kwargs`) come from the
+      `sample_scalar_plugin!` macro in `src/rng.rs`, generated from one shared `build` / `draw` so they stay
+      byte-identical to the per-row path.
     * When `statrs` is the cheapest path: `pdf` / `pmf`, `cdf`, `ppf`, `ln_pdf` / `ln_pmf`, native `sf`, native
-      `median`.
+      `median`; each also gets a `<name>_<method>_scalar` constant-parameter twin via the shared `value_keyed_scalar`
+      driver.
     * When the closed form is trivial: leave it in Python instead.
     * Factor the validating constructor into a `build_dist(...) -> PolarsResult<Dist>` helper so an invalid parameter
       maps through a `ComputeError` consistently.
 2. **Python.** Add `polars_stats/distributions/_<name>.py`, subclassing `ContinuousDistribution` or
-   `DiscreteDistribution`. Coerce each parameter with `coerce_param(value, name=...)`. **Do not validate parameter
-   *values* at construction**, coerce types only and let invalid values raise in Rust. Implement the private formula
-   hooks (`_pdf` / `_pmf`, `_cdf`, `_ppf`, and any `_log_*` / `_sf` closed form), plus the
-   `_samples_scalar_plugin` class var and `_samples_columns`. So closed-form methods raise on invalid params too,
-   route them through a small validating plugin that returns a reused quantity (e.g. `uniform_range`).
-   **Never override the public `pdf` / `cdf` / ... methods**: the base owns them. Export the class from
-   `polars_stats/__init__.py`.
+   `DiscreteDistribution`. In `__init__`, coerce each parameter with `coerce_param` / `coerce_n` (types only, **never
+   validate values** at construction, let invalid values raise in Rust) and store the fast-path bundle
+   `self._scalar_kwargs = scalar_kwargs(...)`. The base owns all routing (`sample`, `samples`, `_samples_columns`,
+   `_value_plugin`, `_moment`); a subclass declares only what is distribution-specific:
+
+    * `_plugin_prefix: ClassVar[str]` (e.g. `"normal"`), from which the base derives every sampler plugin name
+      (`<prefix>_sample` / `_sample_scalar` / `_samples` / `_samples_scalar`), routing scalar vs column parameters off
+      `_scalar_kwargs`.
+    * `_param_exprs`, the coerced parameters as a tuple in plugin-input order; the *first* sets the output's root name.
+    * The private formula hooks (`_pdf` / `_pmf`, `_cdf`, `_ppf`, and any `_log_*` / `_sf` closed form). For a
+      statrs-backed method, return `self._value_plugin("<name>_<method>", value)`: the base routes constant parameters
+      to the `_scalar` fast path and column parameters to the per-row plugin.
+    * A validating plugin returning a reused quantity that raises on invalid parameters and nulls on a null one (e.g.
+      `uniform_range` returns `max - min`). For a statrs-backed distribution whose moment formulas may omit a parameter,
+      expose it as `_checked_params` and gate every closed-form moment through `self._moment(<formula>)`; for a
+      closed-form distribution whose validator is already part of every formula (`Uniform`, `Bernoulli`), weave it in
+      directly and do not call `_moment`.
+
+    **Never override the public `pdf` / `cdf` / ... methods**, nor the base-owned `sample` / `samples` /
+    `_samples_columns` / `_value_plugin` / `_moment`. Export the class from `polars_stats/__init__.py`.
 3. **Tests.** Two homes: `tests/distributions/<name>/`, one file per method (including a `validation_test.py` asserting
    an invalid parameter raises `ComputeError` for both scalar and column inputs); and `tests/scipy_parity/<name>_test.py`
    against `scipy.stats.<name>` to within `1e-10` (closed-form) or `1e-6` (binary-search `ppf`), compared with

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -184,29 +184,57 @@ class _UnivariateDistribution(ABC):
     The interface mirrors `scipy.stats.rv_continuous` / `rv_discrete` but returns `pl.Expr` instead of NumPy arrays.
     """
 
-    _samples_scalar_plugin: ClassVar[str]
-    """Name of the `<name>_samples_scalar` multi-draw plugin backing the constant-parameter `samples` fast path.
+    _plugin_prefix: ClassVar[str]
+    """Shared prefix of this distribution's Rust plugin names (typically snake-case distribution name, e.g. `"normal"`).
 
-    Set by each subclass; `_samples` routes through it when `_scalar_kwargs` is non-`None`.
+    Every plugin a distribution registers is expected to follow the pattern: `f"{_plugin_prefix}_{suffix}"`
     """
 
     _scalar_kwargs: dict[str, float | int] | None
-    """Constant parameters for the `<name>_sample_scalar` fast path, `None` when any parameter is column-valued.
+    """Constant parameters for the `<prefix>_*_scalar` fast paths, `None` when any parameter is column-valued.
 
-    Set by each subclass at construction via `scalar_kwargs`. Doubles as the naming switch: with no
-    input column to inherit a name from, the sampler outputs get the deliberate default names
-    `"sample"` / `"samples"`; column-valued parameters keep polars root-name semantics instead.
+    Set by each subclass at construction via `scalar_kwargs`. Doubles as the routing switch shared by
+    `sample`, `_samples`, and `_value_plugin` (all-scalar routes to the validated-once fast path), and
+    as the naming switch: with no input column to inherit a name from, the sampler outputs take the
+    deliberate default names `"sample"` / `"samples"`; column-valued parameters keep polars root-name
+    semantics instead.
     """
 
+    @property
     @abstractmethod
+    def _param_exprs(self) -> tuple[pl.Expr, ...]:
+        """The distribution's parameters as coerced, row-aligned exprs, in plugin-input order.
+
+        The per-row plugins take these as positional inputs, ahead of `ROW_INDEX_EXPR` for the samplers
+        and after `value` for the value-keyed methods.
+        The order is part of the contract: output naming follows the first expression (polars root-name semantics,
+        pinned by `output_name_test.py`), and the Rust side reads them positionally.
+        Constant parameters additionally ride in `_scalar_kwargs` for the fast path.
+        """
+
     def sample(self, seed: int | None = None) -> pl.Expr:
         """Draw one random variate per row.
 
-        Returns a polars Expr evaluating to a column with one variate per input row. With
-        all-constant parameters the column is named `"sample"`; with column-valued parameters the
-        name follows the first parameter expression, as for any polars expression (so multi-column
-        parameters and `.name.*` modifiers keep working).
+        Returns a column with one variate per input row, in the distribution's element dtype
+        (`Float64`, `UInt64` or `Boolean`). Output length follows the surrounding context (frame length
+        under `select` / `with_columns`, partition length under `over` / `group_by`), and each row's draw
+        is derived from a per-row sub-seed mixed from `seed` and the row's position, so the result is
+        independent of Polars chunking and thread scheduling.
+
+        A row with an invalid parameter raises; a row with a null parameter yields null. The output is
+        named `"sample"` when every parameter is constant (the fast path); with any column-valued
+        parameter the name follows the first parameter expression (polars root-name semantics, so
+        `.name.*` modifiers keep working).
         """
+        if self._scalar_kwargs is not None:
+            return register_plugin(
+                f"{self._plugin_prefix}_sample_scalar",
+                (ROW_INDEX_EXPR,),
+                kwargs={"seed": seed, **self._scalar_kwargs},
+            ).alias("sample")
+        return register_plugin(
+            f"{self._plugin_prefix}_sample", (*self._param_exprs, ROW_INDEX_EXPR), kwargs={"seed": seed}
+        )
 
     def samples(self, size: int, seed: int | None = None) -> pl.Expr:
         """Draw `size` random variates per row, returning `Array(inner=<element dtype>, shape=size)`.
@@ -246,20 +274,39 @@ class _UnivariateDistribution(ABC):
         """
         if self._scalar_kwargs is not None:
             return register_plugin(
-                self._samples_scalar_plugin,
+                f"{self._plugin_prefix}_samples_scalar",
                 (ROW_INDEX_EXPR,),
                 kwargs={"seed": seed, "size": size, **self._scalar_kwargs},
             )
         return self._samples_columns(size=size, seed=seed)
 
-    @abstractmethod
     def _samples_columns(self, size: int, seed: int | None) -> pl.Expr:
-        """Register the `<name>_samples` multi-draw plugin call for column-valued parameters.
+        """Register the `<prefix>_samples` multi-draw plugin call for column-valued parameters.
 
         Mirrors `sample`'s per-row plugin shape: the parameter exprs plus `ROW_INDEX_EXPR` as inputs, the root
         `seed` and draw count `size` as kwargs. Called by `_samples`; naming is applied by `samples`, and a
         null-parameter row becomes a null array element inside the plugin.
         """
+        return register_plugin(
+            f"{self._plugin_prefix}_samples",
+            (*self._param_exprs, ROW_INDEX_EXPR),
+            kwargs={"seed": seed, "size": size},
+        )
+
+    def _value_plugin(self, function_name: str, value: pl.Expr) -> pl.Expr:
+        """Register a value-keyed Rust plugin call `f(value, *params)` for a statrs-backed method.
+
+        Parameters are validated inside the plugin, so every value-keyed method reports an invalid
+        parameterisation consistently and propagates input nulls per row. With all-constant parameters the
+        call routes to the `f"{function_name}_scalar"` twin (validated once, passed as kwargs, only `value`
+        crosses FFI), bit-identical to the per-row path. Closed-form distributions (`Uniform`, `Bernoulli`)
+        never call this; their hooks compute the formula directly in Polars.
+        """
+        return (
+            register_plugin(f"{function_name}_scalar", (value,), kwargs=self._scalar_kwargs)
+            if self._scalar_kwargs is not None
+            else register_plugin(function_name, (value, *self._param_exprs))
+        )
 
     def cdf(self, value: float | IntoExprColumn) -> pl.Expr:
         """Cumulative distribution function, `P(X <= value)`. Nulls in `value` are propagated."""
@@ -316,6 +363,33 @@ class _UnivariateDistribution(ABC):
 
     def _isf(self, quantile: pl.Expr) -> pl.Expr:
         return self._ppf(1 - quantile)
+
+    @property
+    def _checked_params(self) -> pl.Expr:
+        """Single validating round-trip backing the closed-form moments (statrs-backed distributions only).
+
+        A Rust plugin expr returning a parameter, or a derived quantity, that raises on an invalid
+        parameterisation and is null when any parameter is null. `_moment` gates on it. A distribution whose
+        moment formulas may omit a parameter (`Normal`, `LogNormal`, `Binomial`) overrides this and routes
+        its moments through `_moment`; one whose validating expr is already part of every moment formula
+        (`Uniform.range`, `Bernoulli._checked_p`) never calls `_moment`, so this default is never reached.
+        """
+        raise NotImplementedError
+
+    def _moment(self, value: pl.Expr) -> pl.Expr:
+        """Gate a closed-form moment on a non-null, valid parameterisation.
+
+        Evaluating `_checked_params` validates the parameters in Rust (raising on an invalid
+        parameterisation) and is null when any parameter is null, so the moment nulls on any null input and
+        raises consistently with the value-keyed methods regardless of which parameters `value` itself
+        references. Validation lives in the gate, so `value` reads the raw parameter exprs without
+        re-validating.
+
+        Gating on `_checked_params` alone suffices: every validator returns non-null only when *all*
+        parameters are non-null (its `(Some, ..)` match arm), so an explicit per-parameter null check would
+        be redundant (pinned by the `*_propagates_null_params` moment tests).
+        """
+        return pl.when(self._checked_params.is_not_null()).then(value)
 
     @abstractmethod
     def mean(self) -> pl.Expr:

--- a/polars_stats/distributions/_bernoulli.py
+++ b/polars_stats/distributions/_bernoulli.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, ClassVar
 import polars as pl
 
 from polars_stats.distributions._base import (
-    ROW_INDEX_EXPR,
     DiscreteDistribution,
     coerce_param,
     register_plugin,
@@ -26,12 +25,16 @@ class Bernoulli(DiscreteDistribution):
     """
 
     _p: pl.Expr
-    _samples_scalar_plugin: ClassVar[str] = "bernoulli_samples_scalar"
+    _plugin_prefix: ClassVar[str] = "bernoulli"
 
     def __init__(self, p: float | IntoExprColumn) -> None:
         self._p = coerce_param(p, name="p")
         # A constant `p` enables the fast sampler path; `None` falls back to the per-row plugin.
         self._scalar_kwargs = scalar_kwargs(p=scalar_float(p))
+
+    @property
+    def _param_exprs(self) -> tuple[pl.Expr, ...]:
+        return (self._p,)
 
     @property
     def _checked_p(self) -> pl.Expr:
@@ -40,28 +43,7 @@ class Bernoulli(DiscreteDistribution):
         Computed in Rust so the closed-form methods report an invalid ``p`` consistently with
         ``sample`` rather than silently computing a negative probability. Null propagates.
         """
-        return register_plugin("bernoulli_proba", self._p)
-
-    def sample(self, seed: int | None = None) -> pl.Expr:
-        """Draw one Bernoulli sample per row, returning a ``Boolean`` column.
-
-        Output length follows the surrounding context (frame length under ``select`` / ``with_columns``,
-        partition length under ``over`` / ``group_by``). Each row's draw is derived from a per-row sub-seed mixed from
-        ``seed`` and the row's position, so the result is independent of Polars chunking and thread scheduling.
-
-        Rows with an invalid parameter raise; rows with a null parameter yield null.
-
-        The output column is named ``"sample"`` when ``p`` is a constant; a column-valued ``p``
-        keeps polars root-name semantics (the name follows the parameter expression).
-        """
-        if self._scalar_kwargs is not None:
-            return register_plugin(
-                "bernoulli_sample_scalar", (ROW_INDEX_EXPR,), kwargs={"seed": seed, **self._scalar_kwargs}
-            ).alias("sample")
-        return register_plugin("bernoulli_sample", (self._p, ROW_INDEX_EXPR), kwargs={"seed": seed})
-
-    def _samples_columns(self, size: int, seed: int | None) -> pl.Expr:
-        return register_plugin("bernoulli_samples", (self._p, ROW_INDEX_EXPR), kwargs={"seed": seed, "size": size})
+        return register_plugin("bernoulli_proba", self._param_exprs)
 
     def _pmf(self, value: pl.Expr) -> pl.Expr:
         """``1 - p`` at 0, ``p`` at 1, ``0`` elsewhere."""

--- a/polars_stats/distributions/_binomial.py
+++ b/polars_stats/distributions/_binomial.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
-import polars as pl
-
 from polars_stats.distributions._base import (
-    ROW_INDEX_EXPR,
     DiscreteDistribution,
     coerce_n,
     coerce_param,
@@ -16,6 +13,8 @@ from polars_stats.distributions._base import (
 )
 
 if TYPE_CHECKING:
+    import polars as pl
+
     from polars_stats._typing import IntoExprColumn
 
 
@@ -38,7 +37,7 @@ class Binomial(DiscreteDistribution):
 
     _n: pl.Expr
     _p: pl.Expr
-    _samples_scalar_plugin: ClassVar[str] = "binomial_samples_scalar"
+    _plugin_prefix: ClassVar[str] = "binomial"
 
     def __init__(self, n: int | IntoExprColumn, p: float | IntoExprColumn) -> None:
         self._n = coerce_n(n, name="n")
@@ -46,64 +45,21 @@ class Binomial(DiscreteDistribution):
         # Constant `(n, p)` enables the fast sampler path; `None` falls back to the per-row plugin.
         self._scalar_kwargs = scalar_kwargs(n=scalar_int(n), p=scalar_float(p))
 
-    def _value_plugin(self, function_name: str, value: pl.Expr) -> pl.Expr:
-        """Register a value-keyed Rust plugin call ``f(value, n, p)``.
-
-        Validation of ``(n, p)`` happens inside the plugin, so every value-keyed method reports an
-        invalid parameterisation consistently; null inputs propagate per row.
-
-        Constant parameters route to the ``<function_name>_scalar`` twin (validated once, passed as
-        kwargs, only ``value`` crosses FFI), the same fast path as ``sample``; its output is
-        bit-identical to the per-row plugin.
-        """
-        if self._scalar_kwargs is not None:
-            return register_plugin(f"{function_name}_scalar", (value,), kwargs=self._scalar_kwargs)
-        return register_plugin(function_name, (value, self._n, self._p))
+    @property
+    def _param_exprs(self) -> tuple[pl.Expr, ...]:
+        return (self._n, self._p)
 
     @property
     def _checked_params(self) -> pl.Expr:
         """``p`` validated in Rust against the full ``(n, p)`` parameterisation (raises otherwise).
 
-        Mirrors ``Normal._checked_std_dev`` / ``Bernoulli._checked_p``: the closed-form moments
+        Mirrors ``Normal._checked_params`` / ``Bernoulli._checked_p``: the closed-form moments
         (``mean``, ``variance``) derive from this single FFI round-trip, so they report an invalid
         parameterisation (``n < 0`` or ``p`` outside ``[0, 1]``) as a ``ComputeError`` consistently
         with the value-keyed methods, rather than silently computing a moment from invalid inputs.
         Null in either parameter propagates to null.
         """
-        return register_plugin("binomial_params", (self._n, self._p))
-
-    def _moment(self, value: pl.Expr) -> pl.Expr:
-        """Gate a closed-form moment on a non-null, valid ``(n, p)`` parameterisation.
-
-        Evaluating ``_checked_params`` validates ``(n, p)`` in Rust (raising on ``n < 0`` or ``p``
-        outside ``[0, 1]``) and is null when either parameter is null. So every moment nulls on a null
-        input and raises identically on an invalid parameterisation, while ``value`` reads the raw
-        ``self._n`` / ``self._p`` without re-validating.
-        """
-        return pl.when(self._checked_params.is_not_null()).then(value)
-
-    def sample(self, seed: int | None = None) -> pl.Expr:
-        """Draw one Binomial sample per row, returning a ``UInt64`` column.
-
-        Output length follows the surrounding context (frame length under ``select`` / ``with_columns``,
-        partition length under ``over`` / ``group_by``). Each row's draw is derived from a per-row sub-seed mixed from
-        ``seed`` and the row's position, so the result is independent of Polars chunking and thread scheduling.
-
-        Rows with an invalid parameter raise; rows with a null parameter yield null.
-
-        The output column is named ``"sample"`` when both parameters are constants; column-valued
-        parameters keep polars root-name semantics (the name follows the first parameter expression).
-        """
-        if self._scalar_kwargs is not None:
-            return register_plugin(
-                "binomial_sample_scalar", (ROW_INDEX_EXPR,), kwargs={"seed": seed, **self._scalar_kwargs}
-            ).alias("sample")
-        return register_plugin("binomial_sample", (self._n, self._p, ROW_INDEX_EXPR), kwargs={"seed": seed})
-
-    def _samples_columns(self, size: int, seed: int | None) -> pl.Expr:
-        return register_plugin(
-            "binomial_samples", (self._n, self._p, ROW_INDEX_EXPR), kwargs={"seed": seed, "size": size}
-        )
+        return register_plugin("binomial_params", self._param_exprs)
 
     def _pmf(self, value: pl.Expr) -> pl.Expr:
         """Mass via native ``Discrete::pmf``; zero off the integer support ``{0, ..., n}``."""

--- a/polars_stats/distributions/_lognormal.py
+++ b/polars_stats/distributions/_lognormal.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING, ClassVar
 
-import polars as pl
-
 from polars_stats.distributions._base import (
-    ROW_INDEX_EXPR,
     ContinuousDistribution,
     coerce_param,
     register_plugin,
@@ -15,6 +12,8 @@ from polars_stats.distributions._base import (
 )
 
 if TYPE_CHECKING:
+    import polars as pl
+
     from polars_stats._typing import IntoExprColumn
 
 
@@ -45,7 +44,7 @@ class LogNormal(ContinuousDistribution):
 
     _mu: pl.Expr
     _sigma: pl.Expr
-    _samples_scalar_plugin: ClassVar[str] = "lognormal_samples_scalar"
+    _plugin_prefix: ClassVar[str] = "lognormal"
 
     def __init__(self, mu: float | IntoExprColumn = 0.0, sigma: float | IntoExprColumn = 1.0) -> None:
         self._mu = coerce_param(mu, name="mu")
@@ -53,51 +52,18 @@ class LogNormal(ContinuousDistribution):
         # Constant parameters enable the fast sampler path; `None` falls back to the per-row plugin.
         self._scalar_kwargs = scalar_kwargs(mu=scalar_float(mu), sigma=scalar_float(sigma))
 
-    def _value_plugin(self, function_name: str, value: pl.Expr) -> pl.Expr:
-        """Register a value-keyed Rust plugin call ``f(value, mu, sigma)``.
-
-        Validation of ``sigma`` happens inside the plugin, so every value-keyed method reports an
-        invalid parameterisation consistently; null inputs propagate per row.
-
-        Constant parameters route to the ``<function_name>_scalar`` twin (validated once, passed as
-        kwargs, only ``value`` crosses FFI), the same fast path as ``sample``; its output is
-        bit-identical to the per-row plugin.
-        """
-        if self._scalar_kwargs is not None:
-            return register_plugin(f"{function_name}_scalar", (value,), kwargs=self._scalar_kwargs)
-        return register_plugin(function_name, (value, self._mu, self._sigma))
+    @property
+    def _param_exprs(self) -> tuple[pl.Expr, ...]:
+        return (self._mu, self._sigma)
 
     @property
-    def _checked_sigma(self) -> pl.Expr:
+    def _checked_params(self) -> pl.Expr:
         """``sigma`` validated in Rust against the full ``(mu, sigma)`` parameterisation."""
-        # Mirrors ``Normal._checked_std_dev`` / ``Uniform.range``: the closed-form moments derive from
+        # Mirrors ``Normal._checked_params`` / ``Uniform.range``: the closed-form moments derive from
         # this single FFI round-trip, so they report an invalid parameterisation (``sigma <= 0``, or a
         # non-finite parameter) as a ``ComputeError`` consistently with the value-keyed methods. Null in
         # either parameter propagates to null, so a moment built on this nulls when either input is null.
-        return register_plugin("lognormal_sigma", (self._mu, self._sigma))
-
-    def sample(self, seed: int | None = None) -> pl.Expr:
-        """Draw one LogNormal sample per row, returning a ``Float64`` column.
-
-        Output length follows the surrounding context (frame length under ``select`` / ``with_columns``, partition
-        length under ``over`` / ``group_by``). Each row's draw is derived from a per-row sub-seed mixed from ``seed``
-        and the row's position, so the result is independent of Polars chunking and thread scheduling.
-
-        Rows with an invalid ``sigma`` raise; rows with a null parameter yield null.
-
-        The output column is named ``"sample"`` when both parameters are constants; column-valued
-        parameters keep polars root-name semantics (the name follows the first parameter expression).
-        """
-        if self._scalar_kwargs is not None:
-            return register_plugin(
-                "lognormal_sample_scalar", (ROW_INDEX_EXPR,), kwargs={"seed": seed, **self._scalar_kwargs}
-            ).alias("sample")
-        return register_plugin("lognormal_sample", (self._mu, self._sigma, ROW_INDEX_EXPR), kwargs={"seed": seed})
-
-    def _samples_columns(self, size: int, seed: int | None) -> pl.Expr:
-        return register_plugin(
-            "lognormal_samples", (self._mu, self._sigma, ROW_INDEX_EXPR), kwargs={"seed": seed, "size": size}
-        )
+        return register_plugin("lognormal_sigma", self._param_exprs)
 
     def _pdf(self, value: pl.Expr) -> pl.Expr:
         """Density via native ``statrs`` ``Continuous::pdf`` (``0`` for ``value <= 0``)."""
@@ -126,17 +92,6 @@ class LogNormal(ContinuousDistribution):
         (``ppf(0) = 0``, ``ppf(1) = +inf``), matching scipy.
         """
         return self._value_plugin("lognormal_ppf", quantile)
-
-    def _moment(self, value: pl.Expr) -> pl.Expr:
-        """Gate a closed-form moment on a non-null, valid ``(mu, sigma)`` parameterisation.
-
-        Evaluating ``_checked_sigma`` validates ``sigma`` in Rust (raising on ``sigma <= 0`` or a non-finite parameter)
-        and is null when ``sigma`` is null; the ``mu`` term propagates a null ``mu``. So every moment nulls on either
-        null input and raises identically on an invalid parameterisation, matching ``Normal._moment``.
-        Validation lives in the gate, so ``value`` can read the raw ``self._mu`` / ``self._sigma`` without
-        re-validating.
-        """
-        return pl.when(self._checked_sigma.is_not_null() & self._mu.is_not_null()).then(value)
 
     def mean(self) -> pl.Expr:
         """Expected value, ``exp(mu + sigma ** 2 / 2)``."""

--- a/polars_stats/distributions/_normal.py
+++ b/polars_stats/distributions/_normal.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING, ClassVar
 
-import polars as pl
-
 from polars_stats.distributions._base import (
-    ROW_INDEX_EXPR,
     ContinuousDistribution,
     coerce_param,
     register_plugin,
@@ -15,6 +12,8 @@ from polars_stats.distributions._base import (
 )
 
 if TYPE_CHECKING:
+    import polars as pl
+
     from polars_stats._typing import IntoExprColumn
 
 
@@ -41,7 +40,7 @@ class Normal(ContinuousDistribution):
 
     _mean: pl.Expr
     _std_dev: pl.Expr
-    _samples_scalar_plugin: ClassVar[str] = "normal_samples_scalar"
+    _plugin_prefix: ClassVar[str] = "normal"
 
     def __init__(
         self,
@@ -53,51 +52,18 @@ class Normal(ContinuousDistribution):
         # Constant parameters enable the fast sampler path; `None` falls back to the per-row plugin.
         self._scalar_kwargs = scalar_kwargs(mean=scalar_float(mean), std_dev=scalar_float(std_dev))
 
-    def _value_plugin(self, function_name: str, value: pl.Expr) -> pl.Expr:
-        """Register a value-keyed Rust plugin call ``f(value, mean, std_dev)``.
-
-        Validation of ``std_dev`` happens inside the plugin, so every value-keyed method reports an
-        invalid scale consistently; null inputs propagate per row.
-
-        Constant parameters route to the ``<function_name>_scalar`` twin (validated once, passed as
-        kwargs, only ``value`` crosses FFI), the same fast path as ``sample``; its output is
-        bit-identical to the per-row plugin.
-        """
-        if self._scalar_kwargs is not None:
-            return register_plugin(f"{function_name}_scalar", (value,), kwargs=self._scalar_kwargs)
-        return register_plugin(function_name, (value, self._mean, self._std_dev))
+    @property
+    def _param_exprs(self) -> tuple[pl.Expr, ...]:
+        return (self._mean, self._std_dev)
 
     @property
-    def _checked_std_dev(self) -> pl.Expr:
+    def _checked_params(self) -> pl.Expr:
         """``std_dev`` validated in Rust against the full ``(mean, std_dev)`` parameterisation."""
         # Mirrors ``Uniform.range`` / ``Bernoulli._checked_p``: the closed-form moments derive from this
         # single FFI round-trip, so they report an invalid parameterisation (``std_dev <= 0``, or a
         # non-finite parameter) as a ``ComputeError`` consistently with the value-keyed methods. Null in
         # either parameter propagates to null, so a moment built on this nulls when either input is null.
-        return register_plugin("normal_std_dev", (self._mean, self._std_dev))
-
-    def sample(self, seed: int | None = None) -> pl.Expr:
-        """Draw one Normal sample per row, returning a ``Float64`` column.
-
-        Output length follows the surrounding context (frame length under ``select`` / ``with_columns``,
-        partition length under ``over`` / ``group_by``). Each row's draw is derived from a per-row sub-seed mixed from
-        ``seed`` and the row's position, so the result is independent of Polars chunking and thread scheduling.
-
-        Rows with an invalid ``std_dev`` raise; rows with a null parameter yield null.
-
-        The output column is named ``"sample"`` when both parameters are constants; column-valued
-        parameters keep polars root-name semantics (the name follows the first parameter expression).
-        """
-        if self._scalar_kwargs is not None:
-            return register_plugin(
-                "normal_sample_scalar", (ROW_INDEX_EXPR,), kwargs={"seed": seed, **self._scalar_kwargs}
-            ).alias("sample")
-        return register_plugin("normal_sample", (self._mean, self._std_dev, ROW_INDEX_EXPR), kwargs={"seed": seed})
-
-    def _samples_columns(self, size: int, seed: int | None) -> pl.Expr:
-        return register_plugin(
-            "normal_samples", (self._mean, self._std_dev, ROW_INDEX_EXPR), kwargs={"seed": seed, "size": size}
-        )
+        return register_plugin("normal_std_dev", self._param_exprs)
 
     def _pdf(self, value: pl.Expr) -> pl.Expr:
         """Density via native ``statrs`` ``Continuous::pdf``."""
@@ -126,17 +92,6 @@ class Normal(ContinuousDistribution):
         (``ppf(0) = -inf``, ``ppf(1) = +inf``), matching scipy.
         """
         return self._value_plugin("normal_ppf", quantile)
-
-    def _moment(self, value: pl.Expr) -> pl.Expr:
-        """Gate a closed-form moment on a non-null, valid ``(mean, std_dev)`` parameterisation.
-
-        Evaluating ``_checked_std_dev`` validates ``std_dev`` in Rust (raising on ``std_dev <= 0`` or a
-        non-finite parameter) and is null when ``std_dev`` is null; the ``mean`` term propagates a null
-        ``mean``. So every moment nulls on either null input and raises identically on an invalid scale,
-        regardless of which parameter ``value`` itself references. Validation lives in the gate, so
-        ``value`` can read the raw ``self._std_dev`` / ``self._mean`` without re-validating.
-        """
-        return pl.when(self._checked_std_dev.is_not_null() & self._mean.is_not_null()).then(value)
 
     def mean(self) -> pl.Expr:
         """Expected value, the ``mean`` location parameter."""

--- a/polars_stats/distributions/_uniform.py
+++ b/polars_stats/distributions/_uniform.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, ClassVar
 import polars as pl
 
 from polars_stats.distributions._base import (
-    ROW_INDEX_EXPR,
     ContinuousDistribution,
     coerce_param,
     register_plugin,
@@ -38,7 +37,7 @@ class Uniform(ContinuousDistribution):
 
     _min: pl.Expr
     _max: pl.Expr
-    _samples_scalar_plugin: ClassVar[str] = "uniform_samples_scalar"
+    _plugin_prefix: ClassVar[str] = "uniform"
 
     def __init__(self, min: float | IntoExprColumn, max: float | IntoExprColumn) -> None:  # noqa: A002
         self._min = coerce_param(min, name="min")
@@ -46,6 +45,10 @@ class Uniform(ContinuousDistribution):
         # Constant bounds enable the constant-bounds sampler fast path; `None` falls back to the
         # per-row plugin.
         self._scalar_kwargs = scalar_kwargs(min=scalar_float(min), max=scalar_float(max))
+
+    @property
+    def _param_exprs(self) -> tuple[pl.Expr, ...]:
+        return (self._min, self._max)
 
     @property
     def range(self) -> pl.Expr:
@@ -56,31 +59,7 @@ class Uniform(ContinuousDistribution):
         infinite width. Every closed-form method derives from this, so they all validate
         consistently. Null bounds propagate.
         """
-        return register_plugin("uniform_range", (self._min, self._max))
-
-    def sample(self, seed: int | None = None) -> pl.Expr:
-        """Draw one uniform sample per row, returning a ``Float64`` column.
-
-        Output length follows the surrounding context (frame length under ``select`` / ``with_columns``,
-        partition length under ``over`` / ``group_by``). Each row's draw is derived from a per-row sub-seed mixed from
-        ``seed`` and the row's position, so the result is independent of Polars chunking and thread scheduling.
-
-        The output column is named ``"sample"`` when both bounds are constants; column-valued
-        bounds keep polars root-name semantics (the name follows the first parameter expression).
-        """
-        if self._scalar_kwargs is not None:
-            # Constant bounds: pass them as kwargs and validate once in Rust, instead of expanding
-            # each into a full-length `pl.repeat` column re-validated per row. Only the row index
-            # crosses FFI, so seeding (and thus output) is identical to the per-row path.
-            return register_plugin(
-                "uniform_sample_scalar", (ROW_INDEX_EXPR,), kwargs={"seed": seed, **self._scalar_kwargs}
-            ).alias("sample")
-        return register_plugin("uniform_sample", (self._min, self._max, ROW_INDEX_EXPR), kwargs={"seed": seed})
-
-    def _samples_columns(self, size: int, seed: int | None) -> pl.Expr:
-        return register_plugin(
-            "uniform_samples", (self._min, self._max, ROW_INDEX_EXPR), kwargs={"seed": seed, "size": size}
-        )
+        return register_plugin("uniform_range", self._param_exprs)
 
     def _pdf(self, value: pl.Expr) -> pl.Expr:
         """``1 / (max - min)`` on ``[min, max]``, ``0`` outside."""


### PR DESCRIPTION
Consolidates the Python routing into `_UnivariateDistribution` to avoid code duplication in the distribution classes