### PR TITLE
perf: Constant-parameter fast path for closed-form moments

### DIFF
--- a/benchmarks/_harness.py
+++ b/benchmarks/_harness.py
@@ -60,12 +60,32 @@ if TYPE_CHECKING:
     Side = Literal["polars_stats", "scipy"]
 
 
-Method = Literal["sample", "samples", "density", "cdf", "sf", "ppf"]
-"""A benchmarkable method. `density` resolves to `pdf` (continuous) or `pmf` (discrete) per distribution."""
+Method = Literal["sample", "samples", "density", "cdf", "sf", "ppf", "mean", "variance", "std", "entropy"]
+"""A benchmarkable method. `density` resolves to `pdf` (continuous) or `pmf` (discrete) per distribution.
 
-ALL_METHODS: tuple[Method, ...] = ("sample", "samples", "density", "cdf", "sf", "ppf")
+`mean` / `variance` / `std` / `entropy` are the parameter-only moments: they take no value column, so
+polars_stats returns a length-`rows` column of the (constant, for scalar params) moment while scipy
+returns a single scalar. The comparison is therefore inherently O(n) vs O(1); it exists to track the
+polars_stats cost (time and peak memory) across a change, not to "beat" scipy on a scalar reduction.
+"""
+
+ALL_METHODS: tuple[Method, ...] = (
+    "sample",
+    "samples",
+    "density",
+    "cdf",
+    "sf",
+    "ppf",
+    "mean",
+    "variance",
+    "std",
+    "entropy",
+)
 
 _VALUE_METHODS: frozenset[Method] = frozenset({"density", "cdf", "sf", "ppf"})
+
+_MOMENT_METHODS: frozenset[Method] = frozenset({"mean", "variance", "std", "entropy"})
+"""Parameter-only moments: no value column, one expression evaluated over the length frame."""
 
 OutputFormat = Literal["markdown", "json", "rich"]
 """How a report is emitted: a markdown file, a JSON file, or a rich table printed to the terminal."""
@@ -265,6 +285,11 @@ def _build_fn(comp: Comparison, method: Method, config: RunConfig, side: Side) -
                 scipy_method = _density_name(comp.dist) if method == "density" else method
                 fn = getattr(frozen, scipy_method)
                 return lambda: fn(values)
+            if method in _MOMENT_METHODS:
+                # scipy's variance is `var`; `mean` / `std` / `entropy` share the name. Each is one
+                # scalar (O(1)), the baseline the length-n polars_stats moment is measured against.
+                # The bound method is itself the zero-arg callable the timing loop invokes.
+                return getattr(frozen, "var" if method == "variance" else method)  # type: ignore[no-any-return]
             size: int | tuple[int, int] = rows if method == "sample" else (rows, n)
             return lambda: frozen.rvs(size=size, random_state=seed)
         case "polars_stats":
@@ -272,6 +297,9 @@ def _build_fn(comp: Comparison, method: Method, config: RunConfig, side: Side) -
             if method in _VALUE_METHODS:
                 lf = pl.LazyFrame({"x": _eval_inputs(comp, config, method)})
                 expr = _value_expr(dist, method)
+            elif method in _MOMENT_METHODS:
+                lf = _length_frame(rows)
+                expr = getattr(dist, method)()
             else:
                 lf = _length_frame(rows)
                 expr = dist.sample(seed=seed) if method == "sample" else dist.samples(n, seed=seed)
@@ -289,6 +317,14 @@ def _matches(method: Method, config: RunConfig, polars_out: object, scipy_out: o
         the loose `_MATCH_RTOL`/`_MATCH_ATOL` (the scipy-parity suite owns the tight bounds).
     """
     assert isinstance(polars_out, pl.DataFrame)  # noqa: S101  # help the type checker
+    if method in _MOMENT_METHODS:
+        # polars_stats returns a length-`rows` column of the (constant) moment; scipy returns one
+        # scalar. Gate on the column length and on every entry matching the scipy scalar.
+        ours = polars_out.to_series().cast(pl.Float64).to_numpy()
+        theirs = np.asarray(scipy_out, dtype=np.float64)
+        return polars_out.height == config.rows and np.allclose(
+            ours, theirs, rtol=_MATCH_RTOL, atol=_MATCH_ATOL, equal_nan=True
+        )
     assert isinstance(scipy_out, np.ndarray)  # noqa: S101  # help the type checker
     if method == "samples":
         dtype = polars_out.to_series().dtype

--- a/docs/design.md
+++ b/docs/design.md
@@ -61,6 +61,26 @@ thread-invariance guarantees untouched.
 It is the one deliberate exception to "parameters travel in `inputs`, not `kwargs`": admissible precisely because the
 path is selected only when the parameters are known scalars, so nothing column-valued is ever forced into `kwargs`.
 
+### Constant parameters validate once, not per row
+
+The closed-form moments (`mean`, `variance`, `std`, `entropy`) and the closed-form methods of `Uniform` / `Bernoulli`
+do not build a distribution; they compute a Polars expression. But they still route their *validation* through a small
+Rust plugin (`normal_std_dev`, `uniform_range`, `bernoulli_proba`, `binomial_params`, `lognormal_sigma`) so an invalid
+parameterisation raises the same `ComputeError` as the sampler and value-keyed methods rather than silently producing a
+nonsense moment (see "Invalid parameters raise"). On the general path that plugin runs over the full-length `pl.repeat`
+parameter columns, validating the *same constant* on every row.
+
+For all-scalar parameters the same plugin is instead called on length-1 `pl.lit` inputs, so its elementwise closure runs
+once. The validated quantity (or, for `Binomial.entropy`, the support-sum value) is returned behind a `pl.when(...)`
+validity gate; the length-1 condition broadcasts, so the moment stays a length-n column byte-identical to the per-row
+path — and a length-1 collapse is deliberately *not* used, because it would break that path equality (column parameters
+still yield length-n). This needs no new plugin and no kwargs: it reuses the existing validators, called on fewer rows.
+
+It is the same "constant parameters take a fast path" idea as the sampler, applied to validation: nothing leaves Rust,
+and the raise contract is unchanged (pinned by `moment_test.py` and the `*_scalar` validation tests). So it is not a
+carve-out of "validation lives in Rust per row" so much as the observation that, for a constant, "per row" and "once"
+are the same check — and once is enough.
+
 ### `samples` draws each row's array in one native call
 
 `sample_iter` was rejected for the multi-draw loop body: it advances a single stream in row order, which couples rows

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -308,6 +308,45 @@ class _UnivariateDistribution(ABC):
             else register_plugin(function_name, (value, *self._param_exprs))
         )
 
+    def _scalar_lit_args(self) -> list[pl.Expr]:
+        """The constant parameters as length-1 `pl.lit` exprs, in `_param_exprs` order.
+
+        Only meaningful when every parameter is constant (`_scalar_kwargs is not None`); the callers
+        guard on that. Passing these length-1 literals to a validating or computing plugin makes its
+        elementwise closure run **once**, not once per frame row, which is the whole point of the
+        constant-parameter moment fast path (see `_checked`).
+
+        The order follows `_scalar_kwargs` insertion order, and every subclass builds `_scalar_kwargs`
+        in `_param_exprs` order (the same order the per-row plugin reads its inputs positionally), so
+        the once-call and the per-row call validate the identical parameterisation. A drift there
+        surfaces in the moment / value-keyed property tests.
+        """
+        assert self._scalar_kwargs is not None  # noqa: S101  # guarded by every caller
+        return [pl.lit(value) for value in self._scalar_kwargs.values()]
+
+    def _checked(self, plugin_name: str, validated: pl.Expr) -> pl.Expr:
+        """A parameter-validating plugin call: per-row for column params, validated **once** for scalars.
+
+        The validating plugins (`normal_std_dev`, `uniform_range`, `bernoulli_proba`, ...) are
+        elementwise and return the quantity they are named for (the validated `std_dev`, the width
+        `max - min`, the validated `p`, ...). Called on the length-n `pl.repeat` parameter columns
+        they run `build_dist` once per row purely to re-check constants. This factors the two paths,
+        byte-identical for the same parameters:
+
+        * **Column parameters**: the per-row plugin over `_param_exprs` (unchanged behaviour); it
+          validates each row and propagates per-row nulls.
+        * **All-scalar parameters**: the same plugin is called once on length-1 `pl.lit` inputs, so it
+          validates a single time and still raises the same `ComputeError` on an invalid constant.
+          `validated` (a length-n expr recomputing that quantity from the raw parameter columns, e.g.
+          `self._std_dev` or `self._max - self._min`) is returned behind the length-1 validity gate;
+          `pl.when` broadcasts the length-1 condition, so the result stays length-n and equals the
+          per-row output element for element. Only the per-row revalidation is removed.
+        """
+        if self._scalar_kwargs is None:
+            return register_plugin(plugin_name, self._param_exprs)
+        validated_once = register_plugin(plugin_name, self._scalar_lit_args())
+        return pl.when(validated_once.is_not_null()).then(validated)
+
     def cdf(self, value: float | IntoExprColumn) -> pl.Expr:
         """Cumulative distribution function, `P(X <= value)`. Nulls in `value` are propagated."""
         v = as_expr(value)

--- a/polars_stats/distributions/_bernoulli.py
+++ b/polars_stats/distributions/_bernoulli.py
@@ -7,7 +7,6 @@ import polars as pl
 from polars_stats.distributions._base import (
     DiscreteDistribution,
     coerce_param,
-    register_plugin,
     scalar_float,
     scalar_kwargs,
 )
@@ -38,12 +37,15 @@ class Bernoulli(DiscreteDistribution):
 
     @property
     def _checked_p(self) -> pl.Expr:
-        """``p`` validated in Rust to lie in ``[0, 1]`` (raises otherwise).
+        """``p`` validated in Rust to lie in ``[0, 1]`` (raises otherwise), as a length-n column.
 
-        Computed in Rust so the closed-form methods report an invalid ``p`` consistently with
-        ``sample`` rather than silently computing a negative probability. Null propagates.
+        Validated in Rust so the closed-form methods (moments and pmf/cdf/ppf) report an invalid ``p`` consistently
+        with ``sample`` rather than silently computing a negative probability. Null propagates.
+
+        `_checked` validates once for a scalar ``p`` (length-1 input) and per-row for a column,
+        returning the raw ``p`` behind the validity gate either way (length-n on both paths).
         """
-        return register_plugin("bernoulli_proba", self._param_exprs)
+        return self._checked("bernoulli_proba", self._p)
 
     def _pmf(self, value: pl.Expr) -> pl.Expr:
         """``1 - p`` at 0, ``p`` at 1, ``0`` elsewhere."""

--- a/polars_stats/distributions/_binomial.py
+++ b/polars_stats/distributions/_binomial.py
@@ -53,13 +53,15 @@ class Binomial(DiscreteDistribution):
     def _checked_params(self) -> pl.Expr:
         """``p`` validated in Rust against the full ``(n, p)`` parameterisation (raises otherwise).
 
-        Mirrors ``Normal._checked_params`` / ``Bernoulli._checked_p``: the closed-form moments
-        (``mean``, ``variance``) derive from this single FFI round-trip, so they report an invalid
-        parameterisation (``n < 0`` or ``p`` outside ``[0, 1]``) as a ``ComputeError`` consistently
-        with the value-keyed methods, rather than silently computing a moment from invalid inputs.
-        Null in either parameter propagates to null.
+        Mirrors ``Normal._checked_params`` / ``Bernoulli._checked_p``: the closed-form moments (``mean``, ``variance``)
+        derive from this FFI round-trip, so they report an invalid parameterisation (``n < 0`` or
+        ``p`` outside ``[0, 1]``) as a ``ComputeError`` consistently with the value-keyed methods, rather than silently
+        computing a moment from invalid inputs.
+
+        Null in either parameter propagates to null. `_checked` validates once for scalar parameters
+        (length-1 inputs) and per-row for columns.
         """
-        return register_plugin("binomial_params", self._param_exprs)
+        return self._checked("binomial_params", self._p)
 
     def _pmf(self, value: pl.Expr) -> pl.Expr:
         """Mass via native ``Discrete::pmf``; zero off the integer support ``{0, ..., n}``."""
@@ -104,4 +106,10 @@ class Binomial(DiscreteDistribution):
 
         ``0`` at the degenerate endpoints ``p in {0, 1}``.
         """
-        return register_plugin("binomial_entropy", (self._n, self._p))
+        # Unlike ``mean`` / ``variance`` there is no closed form, so the sum is evaluated by ``binomial_entropy``
+        # in Rust. For column parameters that runs once per row; for scalar parameters it is computed **once** on
+        # length-1 inputs and broadcast to length-n behind the ``_moment`` validity gate, so a constant's support sum is
+        # not re-evaluated on every row.
+        if self._scalar_kwargs is None:
+            return register_plugin("binomial_entropy", (self._n, self._p))
+        return self._moment(register_plugin("binomial_entropy", self._scalar_lit_args()))

--- a/polars_stats/distributions/_lognormal.py
+++ b/polars_stats/distributions/_lognormal.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, ClassVar
 from polars_stats.distributions._base import (
     ContinuousDistribution,
     coerce_param,
-    register_plugin,
     scalar_float,
     scalar_kwargs,
 )
@@ -60,10 +59,11 @@ class LogNormal(ContinuousDistribution):
     def _checked_params(self) -> pl.Expr:
         """``sigma`` validated in Rust against the full ``(mu, sigma)`` parameterisation."""
         # Mirrors ``Normal._checked_params`` / ``Uniform.range``: the closed-form moments derive from
-        # this single FFI round-trip, so they report an invalid parameterisation (``sigma <= 0``, or a
+        # this FFI round-trip, so they report an invalid parameterisation (``sigma <= 0``, or a
         # non-finite parameter) as a ``ComputeError`` consistently with the value-keyed methods. Null in
         # either parameter propagates to null, so a moment built on this nulls when either input is null.
-        return register_plugin("lognormal_sigma", self._param_exprs)
+        # `_checked` validates once for scalar parameters (length-1 inputs) and per-row for columns.
+        return self._checked("lognormal_sigma", self._sigma)
 
     def _pdf(self, value: pl.Expr) -> pl.Expr:
         """Density via native ``statrs`` ``Continuous::pdf`` (``0`` for ``value <= 0``)."""

--- a/polars_stats/distributions/_normal.py
+++ b/polars_stats/distributions/_normal.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, ClassVar
 from polars_stats.distributions._base import (
     ContinuousDistribution,
     coerce_param,
-    register_plugin,
     scalar_float,
     scalar_kwargs,
 )
@@ -60,10 +59,11 @@ class Normal(ContinuousDistribution):
     def _checked_params(self) -> pl.Expr:
         """``std_dev`` validated in Rust against the full ``(mean, std_dev)`` parameterisation."""
         # Mirrors ``Uniform.range`` / ``Bernoulli._checked_p``: the closed-form moments derive from this
-        # single FFI round-trip, so they report an invalid parameterisation (``std_dev <= 0``, or a
-        # non-finite parameter) as a ``ComputeError`` consistently with the value-keyed methods. Null in
-        # either parameter propagates to null, so a moment built on this nulls when either input is null.
-        return register_plugin("normal_std_dev", self._param_exprs)
+        # FFI round-trip, so they report an invalid parameterisation (``std_dev <= 0``, or a non-finite parameter) as a
+        # ``ComputeError`` consistently with the value-keyed methods. Null in either parameter propagates to null, so a
+        # moment built on this nulls when either input is null.
+        # `_checked` validates once for scalar parameters (length-1 inputs) and per-row for columns.
+        return self._checked("normal_std_dev", self._std_dev)
 
     def _pdf(self, value: pl.Expr) -> pl.Expr:
         """Density via native ``statrs`` ``Continuous::pdf``."""

--- a/polars_stats/distributions/_uniform.py
+++ b/polars_stats/distributions/_uniform.py
@@ -7,7 +7,6 @@ import polars as pl
 from polars_stats.distributions._base import (
     ContinuousDistribution,
     coerce_param,
-    register_plugin,
     scalar_float,
     scalar_kwargs,
 )
@@ -54,12 +53,14 @@ class Uniform(ContinuousDistribution):
     def range(self) -> pl.Expr:
         """Width of the support, ``max - min``.
 
-        Computed in Rust so an invalid parameterisation (``max <= min``, a non-finite bound, or a
+        Validated in Rust so an invalid parameterisation (``max <= min``, a non-finite bound, or a
         width overflowing ``float64``) raises rather than silently yielding a non-positive or
-        infinite width. Every closed-form method derives from this, so they all validate
-        consistently. Null bounds propagate.
+        infinite width. Every closed-form method (moments and pdf/cdf/ppf) derives from this, so they
+        all validate consistently. Null bounds propagate. `_checked` validates once for scalar bounds
+        (length-1 inputs) and per-row for columns; on the scalar path the width is recomputed in
+        Polars as ``max - min`` (bit-identical to the Rust ``hi - lo``) behind the validity gate.
         """
-        return register_plugin("uniform_range", self._param_exprs)
+        return self._checked("uniform_range", self._max - self._min)
 
     def _pdf(self, value: pl.Expr) -> pl.Expr:
         """``1 / (max - min)`` on ``[min, max]``, ``0`` outside."""

--- a/tests/distributions/moment_fast_path_test.py
+++ b/tests/distributions/moment_fast_path_test.py
@@ -1,0 +1,158 @@
+"""Validation contract of the constant-parameter moment fast path (validate-once, issue 20 item 6).
+
+The closed-form moments (`mean` / `variance` / `std` / `entropy`) and the closed forms of `Uniform`
+/ `Bernoulli` route their *validation* through a small Rust plugin (`normal_std_dev`, `uniform_range`,
+`bernoulli_proba`, `binomial_params`, `lognormal_sigma`, plus `binomial_entropy`'s support sum). For
+all-scalar parameters that plugin is called once on length-1 `pl.lit` inputs instead of per row.
+`tests/property/moment_test.py` pins bit-equality against the per-row path for *valid* parameters;
+this module pins the parts that test does not reach:
+
+* **Both paths agree on validation.** An invalid scalar parameterisation must raise the same
+  `ComputeError` as the equivalent per-row columns; an accepted non-finite one (a positive-infinite
+  scale, which `statrs` allows) must produce identical output on both. The fast path cannot quietly
+  accept or reject something the per-row path does not. Unlike the value-keyed fast-path test, this
+  covers `Uniform` and `Bernoulli` too: their moments *do* route through a validator, so the scalar
+  path can drift there.
+* **The validator runs once but only when there is work.** Because the scalar validator rides as a
+  *gated* length-1 plugin input (not as kwargs), an empty frame skips it entirely: both paths return
+  an empty column and neither raises. This differs from the value-keyed fast path, whose kwargs
+  validation raises even on a zero-row frame (`value_keyed_fast_path_test.py`); it is pinned here so
+  the asymmetry is intentional and cannot regress silently.
+
+A Python `None` parameter cannot reach either path (`coerce_param` rejects it at construction), so
+there is no null-scalar case here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+
+from polars_stats import Bernoulli, Binomial, LogNormal, Normal, Uniform
+from tests._polars_compat import assert_series_equal
+
+if TYPE_CHECKING:
+    from polars_stats.distributions._base import _UnivariateDistribution
+
+_NAN = float("nan")
+_INF = float("inf")
+
+
+def _col(value: float, dtype: pl.DataType | None = None) -> pl.Expr:
+    """A full-length constant column (`pl.repeat`), forcing the general per-row path for a scalar value."""
+    return pl.repeat(value, n=pl.len(), dtype=dtype)
+
+
+# id -> (scalar instance, equivalent per-row instance, should_raise). `variance` is the representative
+# moment: it routes through the parameter validator for every distribution (Normal/LogNormal/Binomial
+# via `_moment`, Uniform via `range`, Bernoulli via `_checked_p`). The accepted-`inf` cases guard that
+# the fast path does not reject a parameterisation the per-row path accepts.
+_CASES: dict[str, tuple[_UnivariateDistribution, _UnivariateDistribution, bool]] = {
+    "normal mean=nan": (Normal(_NAN, 1.0), Normal(_col(_NAN), _col(1.0)), True),
+    "normal std=0": (Normal(0.0, 0.0), Normal(_col(0.0), _col(0.0)), True),
+    "normal std=-1": (Normal(0.0, -1.0), Normal(_col(0.0), _col(-1.0)), True),
+    "normal std=nan": (Normal(0.0, _NAN), Normal(_col(0.0), _col(_NAN)), True),
+    "normal std=inf (accepted)": (Normal(0.0, _INF), Normal(_col(0.0), _col(_INF)), False),
+    "lognormal sigma=-1": (LogNormal(0.0, -1.0), LogNormal(_col(0.0), _col(-1.0)), True),
+    "lognormal sigma=nan": (LogNormal(0.0, _NAN), LogNormal(_col(0.0), _col(_NAN)), True),
+    "lognormal sigma=inf (accepted)": (LogNormal(0.0, _INF), LogNormal(_col(0.0), _col(_INF)), False),
+    "uniform max<min": (Uniform(2.0, 1.0), Uniform(_col(2.0), _col(1.0)), True),
+    "uniform max=min": (Uniform(1.0, 1.0), Uniform(_col(1.0), _col(1.0)), True),
+    "uniform min=nan": (Uniform(_NAN, 1.0), Uniform(_col(_NAN), _col(1.0)), True),
+    "bernoulli p=1.5": (Bernoulli(1.5), Bernoulli(_col(1.5)), True),
+    "bernoulli p=-0.1": (Bernoulli(-0.1), Bernoulli(_col(-0.1)), True),
+    "bernoulli p=nan": (Bernoulli(_NAN), Bernoulli(_col(_NAN)), True),
+    "binomial n=-1": (Binomial(-1, 0.5), Binomial(_col(-1, pl.Int64()), _col(0.5)), True),
+    "binomial p=1.5": (Binomial(5, 1.5), Binomial(_col(5, pl.Int64()), _col(1.5)), True),
+    "binomial p=nan": (Binomial(5, _NAN), Binomial(_col(5, pl.Int64()), _col(_NAN)), True),
+}
+
+
+@pytest.mark.parametrize(("scalar", "per_row", "should_raise"), _CASES.values(), ids=list(_CASES))
+def test_scalar_and_column_paths_agree_on_validation(
+    scalar: _UnivariateDistribution, per_row: _UnivariateDistribution, *, should_raise: bool
+) -> None:
+    """The moment fast path and the per-row path agree on what is a valid parameterisation."""
+    frame = pl.DataFrame({"_": range(4)})
+
+    if should_raise:
+        with pytest.raises(pl.exceptions.ComputeError):
+            frame.select(r=scalar.variance())
+        with pytest.raises(pl.exceptions.ComputeError):
+            frame.select(r=per_row.variance())
+    else:
+        fast = frame.select(r=scalar.variance())["r"]
+        slow = frame.select(r=per_row.variance())["r"]
+        assert_series_equal(fast, slow, check_exact=True)
+
+
+@pytest.mark.parametrize(
+    ("scalar", "per_row"),
+    [
+        (Binomial(-1, 0.5), Binomial(_col(-1, pl.Int64()), _col(0.5))),
+        (Binomial(5, 1.5), Binomial(_col(5, pl.Int64()), _col(1.5))),
+    ],
+    ids=["n=-1", "p=1.5"],
+)
+def test_binomial_entropy_scalar_and_column_paths_agree_on_validation(scalar: Binomial, per_row: Binomial) -> None:
+    """`Binomial.entropy` has its own scalar branch (the Rust support sum on length-1 inputs).
+
+    It is gated by `_moment` like the closed-form moments, so an invalid `(n, p)` must raise on both
+    paths there too, not only through `variance`.
+    """
+    frame = pl.DataFrame({"_": range(4)})
+    with pytest.raises(pl.exceptions.ComputeError):
+        frame.select(r=scalar.entropy())
+    with pytest.raises(pl.exceptions.ComputeError):
+        frame.select(r=per_row.entropy())
+
+
+def test_moment_fast_path_on_empty_frame_matches_per_row() -> None:
+    """On a zero-row frame the moment fast path mirrors the per-row path: empty out, no raise.
+
+    For valid parameters both paths produce an empty column of the moment's dtype. For *invalid*
+    parameters the moment fast path still does not raise on an empty frame: its validator is a gated
+    length-1 plugin input, which polars never evaluates when the gated output is empty. This is the
+    opposite of the value-keyed fast path (kwargs validation raises on empty), and matching the
+    per-row path here is the intended behaviour, so it is asserted rather than worked around.
+    """
+    empty = pl.DataFrame({"_": []}, schema={"_": pl.Int64})
+
+    valid_fast = empty.select(r=Normal(0.0, 2.0).variance())
+    valid_slow = empty.select(r=Normal(_col(0.0), _col(2.0)).variance())
+    assert valid_fast.height == 0
+    assert_series_equal(valid_fast["r"], valid_slow["r"], check_exact=True)
+
+    # Invalid scalar params: no rows, so no validation fires; both paths return empty (no raise).
+    invalid_fast = empty.select(r=Normal(0.0, -1.0).variance())
+    invalid_slow = empty.select(r=Normal(_col(0.0), _col(-1.0)).variance())
+    assert invalid_fast.height == 0
+    assert invalid_slow.height == 0
+
+
+# id -> (scalar instance, equivalent per-row instance, expected constant moment value). Degenerate
+# but *valid* parameterisations where a moment collapses to a closed value: the discrete entropies
+# use the `0 log 0 = 0` convention at the mass-collapsing endpoints, and `n = 0` is a valid (point
+# mass at 0) binomial. The fast path must reach the same value as the per-row path, not raise.
+_DEGENERATE: dict[str, tuple[_UnivariateDistribution, _UnivariateDistribution, float]] = {
+    "bernoulli p=0 entropy": (Bernoulli(0.0), Bernoulli(_col(0.0)), 0.0),
+    "bernoulli p=1 entropy": (Bernoulli(1.0), Bernoulli(_col(1.0)), 0.0),
+    "binomial p=0 entropy": (Binomial(5, 0.0), Binomial(_col(5, pl.Int64()), _col(0.0)), 0.0),
+    "binomial p=1 entropy": (Binomial(5, 1.0), Binomial(_col(5, pl.Int64()), _col(1.0)), 0.0),
+    "binomial n=0 entropy": (Binomial(0, 0.5), Binomial(_col(0, pl.Int64()), _col(0.5)), 0.0),
+}
+
+
+@pytest.mark.parametrize(("scalar", "per_row", "expected"), _DEGENERATE.values(), ids=list(_DEGENERATE))
+def test_degenerate_valid_params_entropy(
+    scalar: _UnivariateDistribution, per_row: _UnivariateDistribution, expected: float
+) -> None:
+    """Mass-collapsing endpoints (`p in {0, 1}`, `n = 0`) give a finite entropy on both paths."""
+    frame = pl.DataFrame({"_": range(4)})
+
+    fast = frame.select(r=scalar.entropy())["r"]
+    slow = frame.select(r=per_row.entropy())["r"]
+    assert_series_equal(fast, slow, check_exact=True)
+    assert fast.to_list() == [expected] * 4

--- a/tests/distributions/moment_fast_path_test.py
+++ b/tests/distributions/moment_fast_path_test.py
@@ -110,13 +110,15 @@ def test_binomial_entropy_scalar_and_column_paths_agree_on_validation(scalar: Bi
 
 
 def test_moment_fast_path_on_empty_frame_matches_per_row() -> None:
-    """On a zero-row frame the moment fast path mirrors the per-row path: empty out, no raise.
+    """On a zero-row frame, valid scalar params give an empty column matching the per-row path.
 
-    For valid parameters both paths produce an empty column of the moment's dtype. For *invalid*
-    parameters the moment fast path still does not raise on an empty frame: its validator is a gated
-    length-1 plugin input, which polars never evaluates when the gated output is empty. This is the
-    opposite of the value-keyed fast path (kwargs validation raises on empty), and matching the
-    per-row path here is the intended behaviour, so it is asserted rather than worked around.
+    The invalid-parameter case on an empty frame is deliberately *not* asserted. Unlike the
+    value-keyed fast path (whose kwargs validation raises unconditionally, pinned by
+    `value_keyed_fast_path_test.py`), the moment fast path validates via a *gated* length-1 plugin
+    input, and whether polars evaluates that input when the gated output is empty is
+    optimizer-dependent: some versions elide it and return empty, others run it and raise. Both are
+    acceptable for an invalid parameterisation over zero rows, so it is left unspecified rather than
+    pinned to one version's behaviour.
     """
     empty = pl.DataFrame({"_": []}, schema={"_": pl.Int64})
 
@@ -124,12 +126,6 @@ def test_moment_fast_path_on_empty_frame_matches_per_row() -> None:
     valid_slow = empty.select(r=Normal(_col(0.0), _col(2.0)).variance())
     assert valid_fast.height == 0
     assert_series_equal(valid_fast["r"], valid_slow["r"], check_exact=True)
-
-    # Invalid scalar params: no rows, so no validation fires; both paths return empty (no raise).
-    invalid_fast = empty.select(r=Normal(0.0, -1.0).variance())
-    invalid_slow = empty.select(r=Normal(_col(0.0), _col(-1.0)).variance())
-    assert invalid_fast.height == 0
-    assert invalid_slow.height == 0
 
 
 # id -> (scalar instance, equivalent per-row instance, expected constant moment value). Degenerate

--- a/tests/property/fast_path_context_test.py
+++ b/tests/property/fast_path_context_test.py
@@ -1,0 +1,133 @@
+"""Constant-parameter fast paths stay byte-identical to the per-row path across polars contexts.
+
+The scalar moment and closed-form value-keyed fast paths (issue 20 item 6) build a length-1
+validity gate, `pl.when(validated_once.is_not_null()).then(<context-length value>)`, where
+`validated_once` is a validating plugin called on length-1 `pl.lit` inputs. The bit-equality tests
+`moment_test.py` and `value_keyed_test.py` pin the fast path against the per-row path under a plain
+`select`, where the gate broadcasts a length-1 condition against a whole-frame value.
+
+This module pins the same equality under the contexts where the broadcast target length is *not* the
+whole frame, the cases a `select`-only test cannot see:
+
+* `over(group)` and `group_by(group).agg(...)` partition the frame, so `pl.len()` (the length the
+  length-1 gate must broadcast to) differs per partition, and the partitions here are deliberately
+  uneven;
+* the streaming engine ingests the source in morsels rather than as one contiguous block.
+
+A gate that silently assumed whole-frame length, or a validating plugin that mishandled its length-1
+input under partitioning, would diverge from the per-row path here while still passing the
+`select`-only suites.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from packaging.version import Version
+
+from polars_stats.distributions._base import ContinuousDistribution, DiscreteDistribution
+from tests._polars_compat import PL_VERSION, assert_series_equal, linear_space
+from tests.property._specs import ALL_SPECS
+
+if TYPE_CHECKING:
+    from polars_stats.distributions._base import _UnivariateDistribution
+    from tests.property._specs import DistSpec
+
+_MOMENTS = ("mean", "variance", "std", "entropy")
+
+# Uneven partitions on purpose: a length-1 validity gate that quietly broadcast against the whole
+# frame instead of the partition would match on equal-sized groups and diverge here.
+_GROUP_SIZES = (3, 1, 4, 2, 5)
+_GROUPS = [g for g, size in enumerate(_GROUP_SIZES) for _ in range(size)]
+_N_ROWS = len(_GROUPS)
+
+# `engine="streaming"` is only selectable on recent polars; below this both code paths still run
+# under the default (in-memory) engine via the eager contexts. Mirrors `sample_test.py`.
+_STREAMING_AVAILABLE = Version("1.36.0") <= PL_VERSION
+
+
+def _log_density(dist: _UnivariateDistribution, value: pl.Expr) -> pl.Expr:
+    """`log_pdf` / `log_pmf` by family; the method lives on the family subclass, hence the narrowing."""
+    if isinstance(dist, ContinuousDistribution):
+        return dist.log_pdf(value)
+    if isinstance(dist, DiscreteDistribution):
+        return dist.log_pmf(value)
+    msg = f"unsupported distribution family: {type(dist)}"  # pragma: no cover
+    raise TypeError(msg)  # pragma: no cover
+
+
+def _assert_matches_across_contexts(frame: pl.DataFrame, fast: pl.Expr, slow: pl.Expr) -> None:
+    """The scalar fast-path expr equals the per-row expr in every context the frame supports.
+
+    `frame` must carry a `"g"` grouping column. Each context is checked independently so a failure
+    names the context that diverged. `check_exact` because the two paths compute the identical value
+    (same Polars formula or same Rust body); only the validation differs, so any difference is a bug.
+    """
+    # `select`: the whole-frame context the other suites already cover, re-checked here as the anchor.
+    assert_series_equal(frame.select(r=fast)["r"], frame.select(r=slow)["r"], check_exact=True)
+
+    # `over`: the gate must broadcast to each (uneven) partition's length, then scatter back.
+    assert_series_equal(frame.select(r=fast.over("g"))["r"], frame.select(r=slow.over("g"))["r"], check_exact=True)
+
+    # `group_by().agg()`: the moment / value-keyed column aggregates to one list per group.
+    grouped_fast = frame.group_by("g", maintain_order=True).agg(r=fast)["r"]
+    grouped_slow = frame.group_by("g", maintain_order=True).agg(r=slow)["r"]
+    assert_series_equal(grouped_fast, grouped_slow, check_exact=True)
+
+    # streaming engine: the source is split across morsels; non-positional exprs must be invariant.
+    if _STREAMING_AVAILABLE:
+        lazy_fast = frame.lazy().select(r=fast).collect(engine="streaming")["r"]
+        lazy_slow = frame.lazy().select(r=slow).collect(engine="streaming")["r"]
+        assert_series_equal(lazy_fast, lazy_slow, check_exact=True)
+
+
+@settings(max_examples=10)
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@pytest.mark.parametrize("moment", _MOMENTS)
+@given(data=st.data())
+def test_moment_fast_path_matches_per_row_across_contexts(spec: DistSpec, moment: str, data: st.DataObject) -> None:
+    """Each closed-form moment's scalar fast path equals the per-row path under every context."""
+    params = data.draw(spec.params)
+    frame = pl.DataFrame({"g": _GROUPS})
+
+    fast = getattr(spec.make(params), moment)()
+    slow = getattr(spec.make_columns(params), moment)()
+    _assert_matches_across_contexts(frame, fast, slow)
+
+
+@settings(max_examples=10)
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@given(data=st.data())
+def test_value_keyed_fast_path_matches_per_row_across_contexts(spec: DistSpec, data: st.DataObject) -> None:
+    """Density / log-density / cdf / sf / ppf scalar fast paths equal the per-row path under every context.
+
+    This is where the Uniform / Bernoulli closed forms (which route their *validation* through the
+    same `_checked` gate as the moments) get their cross-context coverage: their value-keyed methods
+    are pure Polars, so a broadcast bug in the scalar gate is the only way they could diverge.
+    """
+    params = data.draw(spec.params)
+    scalar = spec.make(params)
+    per_row = spec.make_columns(params)
+
+    lo, hi = spec.eval_range(params)
+    frame = pl.DataFrame(
+        {
+            "g": _GROUPS,
+            "x": linear_space(lo, hi, _N_ROWS),
+            "q": linear_space(0.05, 0.95, _N_ROWS),
+        }
+    )
+    x, q = pl.col("x"), pl.col("q")
+    cases = (
+        (spec.density(scalar, x), spec.density(per_row, x)),
+        (_log_density(scalar, x), _log_density(per_row, x)),
+        (scalar.cdf(x), per_row.cdf(x)),
+        (scalar.sf(x), per_row.sf(x)),
+        (scalar.ppf(q), per_row.ppf(q)),
+    )
+    for fast, slow in cases:
+        _assert_matches_across_contexts(frame, fast, slow)

--- a/tests/property/moment_test.py
+++ b/tests/property/moment_test.py
@@ -1,0 +1,50 @@
+"""Bit-equality of the constant-parameter moment fast path against the per-row path.
+
+The parameter-only moments (`mean`, `variance`, `std`, `entropy`) validate their parameters in Rust so an invalid
+parameterisation raises consistently with the value-keyed methods.
+
+With constant scalar parameters that validation runs **once** (the validating plugin is called on length-1 `pl.lit`
+inputs); with column parameters it runs per row. Both return a length-n column and gate the same closed form, so for any
+valid parameterisation the two paths must agree bit for bit, the moment counterpart of
+`test_value_keyed_scalar_fast_path_matches_per_row`.
+
+A divergence (a parameter-order swap in the length-1 lit args, a non-bit-identical width recompute on the scalar path,
+or a length mismatch from a missing broadcast) must fail here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from tests._polars_compat import assert_series_equal
+from tests.property._specs import ALL_SPECS
+
+if TYPE_CHECKING:
+    from tests.property._specs import DistSpec
+
+_N_ROWS = 64
+
+# Every distribution exposes these as closed forms (or, for Binomial entropy, a Rust support sum)
+# derived from the validated parameters; `median` is excluded as it routes through `ppf` for the
+# discrete families (covered by the value-keyed suite) rather than the moment validator.
+_MOMENTS = ("mean", "variance", "std", "entropy")
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@pytest.mark.parametrize("moment", _MOMENTS)
+@given(data=st.data())
+def test_moment_scalar_fast_path_matches_per_row(spec: DistSpec, moment: str, data: st.DataObject) -> None:
+    """Constant scalar parameters and the equivalent per-row columns evaluate each moment identically."""
+    params = data.draw(spec.params)
+    frame = pl.DataFrame({"_": range(_N_ROWS)})
+
+    fast = frame.select(r=getattr(spec.make(params), moment)())["r"]
+    per_row = frame.select(r=getattr(spec.make_columns(params), moment)())["r"]
+
+    assert_series_equal(fast, per_row, check_exact=True)
+    assert fast.len() == _N_ROWS  # the scalar fast path stays length-n (broadcast), not collapsed to 1


### PR DESCRIPTION
Closed-form moments and the Uniform/Bernoulli closed forms re-validated their constant parameters on every row. For all-scalar params the validator now runs once on length-1 inputs, gating the length-n result behind a broadcasting `pl.when` — byte-identical to the per-row path.
