### PR TITLE
refactor: Generate value-keyed and validator plugin shells via shared macros

### DIFF
--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -4,11 +4,10 @@ use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distributions::Distribution as RandDistribution;
 use rand_distr::Binomial as BinomialSampler;
-use serde::Deserialize;
 use statrs::distribution::{Binomial, Discrete, DiscreteCDF};
 use statrs::statistics::Distribution as StatrsDistribution;
 
-use crate::distributions::value_keyed_scalar;
+use crate::distributions::{param_validator, value_keyed_per_row, value_keyed_scalar_plugins};
 use crate::rng::{
     sample_scalar_plugin, samples_per_row, samples_u64_output, ternary_param_rows, SampleKwargs,
     SamplesKwargs,
@@ -63,40 +62,16 @@ fn support_point(value: f64) -> Option<u64> {
     }
 }
 
-/// Apply a value-keyed function `f(dist, value)` element-wise over `(value, n, p)`.
-///
-/// `inputs[0]` is the evaluation point, `inputs[1]` is `n`, `inputs[2]` is `p`. `null` in any input
-/// propagates to `null`; an invalid parameterisation raises via [`build_dist`]. `f` returns an
-/// `Option` so a method can null a row on its own terms (e.g. `ppf` outside `[0, 1]`). Shared by
-/// `pmf`, `ln_pmf`, `cdf`, `sf`, `ppf`.
-fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
-where
-    F: Fn(&Binomial, f64) -> Option<f64>,
-{
-    let value = inputs[0].cast(&DataType::Float64)?;
-    let value_ca = value.f64()?;
-    let n = inputs[1].cast(&DataType::Int64)?;
-    let n_ca = n.i64()?;
-    let p = inputs[2].cast(&DataType::Float64)?;
-    let p_ca = p.f64()?;
-    let name = inputs[0].name().clone();
-
-    let ca: Float64Chunked = try_ternary_elementwise(
-        value_ca,
-        n_ca,
-        p_ca,
-        |value_opt, n_opt, p_opt| -> PolarsResult<Option<f64>> {
-            match (value_opt, n_opt, p_opt) {
-                (Some(v), Some(n), Some(p)) => {
-                    let dist = build_dist(n, p)?;
-                    Ok(f(&dist, v))
-                },
-                _ => Ok(None),
-            }
-        },
-    )?;
-
-    Ok(ca.with_name(name).into_series())
+value_keyed_per_row! {
+    /// Apply a value-keyed function `f(dist, value)` element-wise over `(value, n, p)`.
+    ///
+    /// `inputs[0]` is the evaluation point, `inputs[1]` is `n`, `inputs[2]` is `p`. `null` in any
+    /// input propagates to `null`; an invalid parameterisation raises via [`build_dist`]. `f`
+    /// returns an `Option` so a method can null a row on its own terms (e.g. `ppf` outside
+    /// `[0, 1]`). Shared by `pmf`, `ln_pmf`, `cdf`, `sf`, `ppf`.
+    fn value_keyed(&Binomial);
+    params = (DataType::Int64 => i64, DataType::Float64 => f64);
+    build = build_dist;
 }
 
 /// Apply a parameter-keyed moment `f(dist)` element-wise over `(n, p)`.
@@ -316,81 +291,50 @@ fn binomial_ppf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, ppf_value)
 }
 
-/// Static parameters for the constant-parameter value-keyed fast paths (`<method>_scalar`).
-///
-/// Like [`BinomialScalarKwargs`] minus the sampler `seed`: when both parameters are Python
-/// scalars, the Python layer routes them here as kwargs instead of expanding each into a
-/// full-length column re-validated on every row. The distribution is validated and built once;
-/// only the evaluation-point column travels as an input.
-#[derive(Deserialize)]
-struct BinomialParamsKwargs {
-    n: i64,
-    p: f64,
+value_keyed_scalar_plugins! {
+    /// Static parameters for the constant-parameter value-keyed fast paths (`<method>_scalar`).
+    ///
+    /// Like [`BinomialScalarKwargs`] minus the sampler `seed`: when both parameters are Python
+    /// scalars, the Python layer routes them here as kwargs instead of expanding each into a
+    /// full-length column re-validated on every row. The distribution is validated and built once;
+    /// only the evaluation-point column travels as an input.
+    struct BinomialParamsKwargs { n: i64, p: f64 }
+
+    build = |kw| build_dist(kw.n, kw.p)?;
+
+    methods {
+        /// Constant-parameter pmf; same body as [`binomial_pmf`] via [`pmf_value`], dist built once.
+        fn binomial_pmf_scalar => pmf_value;
+
+        /// Constant-parameter log-pmf; same body as [`binomial_ln_pmf`] via [`ln_pmf_value`], dist built once.
+        fn binomial_ln_pmf_scalar => ln_pmf_value;
+
+        /// Constant-parameter cdf; same body as [`binomial_cdf`] via [`cdf_value`], dist built once.
+        fn binomial_cdf_scalar => cdf_value;
+
+        /// Constant-parameter sf; same body as [`binomial_sf`] via [`sf_value`], dist built once.
+        fn binomial_sf_scalar => sf_value;
+
+        /// Constant-parameter ppf; same body as [`binomial_ppf`] via [`ppf_value`], dist built once.
+        fn binomial_ppf_scalar => ppf_value;
+    }
 }
 
-/// Constant-parameter pmf; same body as [`binomial_pmf`] via [`pmf_value`], dist built once.
-#[polars_expr(output_type=Float64)]
-fn binomial_pmf_scalar(inputs: &[Series], kwargs: BinomialParamsKwargs) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.n, kwargs.p)?;
-    value_keyed_scalar(&inputs[0], |v| pmf_value(&dist, v))
-}
-
-/// Constant-parameter log-pmf; same body as [`binomial_ln_pmf`] via [`ln_pmf_value`], dist built once.
-#[polars_expr(output_type=Float64)]
-fn binomial_ln_pmf_scalar(inputs: &[Series], kwargs: BinomialParamsKwargs) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.n, kwargs.p)?;
-    value_keyed_scalar(&inputs[0], |v| ln_pmf_value(&dist, v))
-}
-
-/// Constant-parameter cdf; same body as [`binomial_cdf`] via [`cdf_value`], dist built once.
-#[polars_expr(output_type=Float64)]
-fn binomial_cdf_scalar(inputs: &[Series], kwargs: BinomialParamsKwargs) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.n, kwargs.p)?;
-    value_keyed_scalar(&inputs[0], |v| cdf_value(&dist, v))
-}
-
-/// Constant-parameter sf; same body as [`binomial_sf`] via [`sf_value`], dist built once.
-#[polars_expr(output_type=Float64)]
-fn binomial_sf_scalar(inputs: &[Series], kwargs: BinomialParamsKwargs) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.n, kwargs.p)?;
-    value_keyed_scalar(&inputs[0], |v| sf_value(&dist, v))
-}
-
-/// Constant-parameter ppf; same body as [`binomial_ppf`] via [`ppf_value`], dist built once.
-#[polars_expr(output_type=Float64)]
-fn binomial_ppf_scalar(inputs: &[Series], kwargs: BinomialParamsKwargs) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.n, kwargs.p)?;
-    value_keyed_scalar(&inputs[0], |q| ppf_value(&dist, q))
-}
-
-/// Validate the `(n, p)` parameterisation and return the validated `p`.
-///
-/// `inputs[0]` is `n`, `inputs[1]` is `p`. Mirrors `normal_std_dev` / `bernoulli_proba`: the
-/// closed-form moments (`mean = n * p`, `variance = n * p * (1 - p)`) are computed from Polars
-/// expressions and gated on this single FFI round-trip, so they report an invalid parameterisation
-/// identically to the value-keyed methods that build the distribution directly, rather than silently
-/// computing a moment from a negative `n` or an out-of-range `p`. `null` in either input propagates;
-/// a negative `n` or a `NaN` / out-of-range `p` raises `InvalidOperation` via [`build_dist`].
-#[polars_expr(output_type=Float64)]
-fn binomial_params(inputs: &[Series]) -> PolarsResult<Series> {
-    let n = inputs[0].cast(&DataType::Int64)?;
-    let n_ca = n.i64()?;
-    let p = inputs[1].cast(&DataType::Float64)?;
-    let p_ca = p.f64()?;
-    let name = inputs[1].name().clone();
-
-    let ca: Float64Chunked =
-        try_binary_elementwise(n_ca, p_ca, |n_opt, p_opt| -> PolarsResult<Option<f64>> {
-            match (n_opt, p_opt) {
-                (Some(n), Some(p)) => {
-                    build_dist(n, p)?;
-                    Ok(Some(p))
-                },
-                _ => Ok(None),
-            }
-        })?;
-
-    Ok(ca.with_name(name).into_series())
+param_validator! {
+    /// Validate the `(n, p)` parameterisation and return the validated `p`.
+    ///
+    /// `inputs[0]` is `n`, `inputs[1]` is `p`. Mirrors `normal_std_dev` / `bernoulli_proba`: the
+    /// closed-form moments (`mean = n * p`, `variance = n * p * (1 - p)`) are computed from Polars
+    /// expressions and gated on this single FFI round-trip, so they report an invalid
+    /// parameterisation identically to the value-keyed methods that build the distribution
+    /// directly, rather than silently computing a moment from a negative `n` or an out-of-range
+    /// `p`. `null` in either input propagates; a negative `n` or a `NaN` / out-of-range `p` raises
+    /// `InvalidOperation` via [`build_dist`].
+    fn binomial_params;
+    params = (n: DataType::Int64 => i64, p: DataType::Float64 => f64);
+    build = build_dist;
+    returns = p;
+    output_name = inputs[1];
 }
 
 /// Element-wise Shannon entropy (in nats) via `statrs` `Distribution::entropy`, the exact support

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -1,12 +1,11 @@
 #![allow(clippy::unused_unit)]
-use polars::prelude::arity::{try_binary_elementwise, try_ternary_elementwise};
+use polars::prelude::arity::try_ternary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distributions::Distribution as RandDistribution;
-use serde::Deserialize;
 use statrs::distribution::{Continuous, ContinuousCDF, LogNormal};
 
-use crate::distributions::value_keyed_scalar;
+use crate::distributions::{param_validator, value_keyed_per_row, value_keyed_scalar_plugins};
 use crate::rng::{
     sample_scalar_plugin, samples_f64_output, samples_per_row, ternary_param_rows, SampleKwargs,
     SamplesKwargs,
@@ -29,72 +28,32 @@ fn build_dist(mu: f64, sigma: f64) -> PolarsResult<LogNormal> {
     })
 }
 
-/// Apply a value-keyed function `f(dist, value)` element-wise over `(value, mu, sigma)`.
-///
-/// `inputs[0]` is the evaluation point, `inputs[1]` is `mu`, `inputs[2]` is `sigma`. `null` in any
-/// input propagates to `null`; an invalid parameterisation raises via [`build_dist`]. `f` returns an
-/// `Option` so a method can null a row on its own terms (e.g. `ppf` outside `[0, 1]`). Shared by
-/// `pdf`, `ln_pdf`, `cdf`, `sf`, `ppf`.
-fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
-where
-    F: Fn(&LogNormal, f64) -> Option<f64>,
-{
-    let value = inputs[0].cast(&DataType::Float64)?;
-    let value_ca = value.f64()?;
-    let mu = inputs[1].cast(&DataType::Float64)?;
-    let mu_ca = mu.f64()?;
-    let sigma = inputs[2].cast(&DataType::Float64)?;
-    let sigma_ca = sigma.f64()?;
-    let name = inputs[0].name().clone();
-
-    let ca: Float64Chunked = try_ternary_elementwise(
-        value_ca,
-        mu_ca,
-        sigma_ca,
-        |value_opt, mu_opt, sigma_opt| -> PolarsResult<Option<f64>> {
-            match (value_opt, mu_opt, sigma_opt) {
-                (Some(v), Some(m), Some(s)) => {
-                    let dist = build_dist(m, s)?;
-                    Ok(f(&dist, v))
-                },
-                _ => Ok(None),
-            }
-        },
-    )?;
-
-    Ok(ca.with_name(name).into_series())
+value_keyed_per_row! {
+    /// Apply a value-keyed function `f(dist, value)` element-wise over `(value, mu, sigma)`.
+    ///
+    /// `inputs[0]` is the evaluation point, `inputs[1]` is `mu`, `inputs[2]` is `sigma`. `null` in
+    /// any input propagates to `null`; an invalid parameterisation raises via [`build_dist`]. `f`
+    /// returns an `Option` so a method can null a row on its own terms (e.g. `ppf` outside
+    /// `[0, 1]`). Shared by `pdf`, `ln_pdf`, `cdf`, `sf`, `ppf`.
+    fn value_keyed(&LogNormal);
+    params = (DataType::Float64 => f64, DataType::Float64 => f64);
+    build = build_dist;
 }
 
-/// Validate the `(mu, sigma)` parameterisation and return the validated `sigma`.
-///
-/// `inputs[0]` is `mu`, `inputs[1]` is `sigma`. Mirrors `normal_std_dev` / `uniform_range`: the
-/// closed-form moments (`mean`, `variance`, `median`, `entropy`) are computed in Python and all
-/// derive from this single FFI round-trip, so they report an invalid parameterisation identically to
-/// the value-keyed methods that build the distribution directly. `null` in either input propagates;
-/// a `NaN` `mu` or a non-positive / `NaN` `sigma` raises `InvalidOperation` via [`build_dist`].
-#[polars_expr(output_type=Float64)]
-fn lognormal_sigma(inputs: &[Series]) -> PolarsResult<Series> {
-    let mu = inputs[0].cast(&DataType::Float64)?;
-    let mu_ca = mu.f64()?;
-    let sigma = inputs[1].cast(&DataType::Float64)?;
-    let sigma_ca = sigma.f64()?;
-    let name = inputs[1].name().clone();
-
-    let ca: Float64Chunked = try_binary_elementwise(
-        mu_ca,
-        sigma_ca,
-        |mu_opt, sigma_opt| -> PolarsResult<Option<f64>> {
-            match (mu_opt, sigma_opt) {
-                (Some(m), Some(s)) => {
-                    build_dist(m, s)?;
-                    Ok(Some(s))
-                },
-                _ => Ok(None),
-            }
-        },
-    )?;
-
-    Ok(ca.with_name(name).into_series())
+param_validator! {
+    /// Validate the `(mu, sigma)` parameterisation and return the validated `sigma`.
+    ///
+    /// `inputs[0]` is `mu`, `inputs[1]` is `sigma`. Mirrors `normal_std_dev` / `uniform_range`: the
+    /// closed-form moments (`mean`, `variance`, `median`, `entropy`) are computed in Python and all
+    /// derive from this single FFI round-trip, so they report an invalid parameterisation
+    /// identically to the value-keyed methods that build the distribution directly. `null` in
+    /// either input propagates; a `NaN` `mu` or a non-positive / `NaN` `sigma` raises
+    /// `InvalidOperation` via [`build_dist`].
+    fn lognormal_sigma;
+    params = (mu: DataType::Float64 => f64, sigma: DataType::Float64 => f64);
+    build = build_dist;
+    returns = sigma;
+    output_name = inputs[1];
 }
 
 /// Element-wise LogNormal sampler.
@@ -249,52 +208,31 @@ fn lognormal_ppf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, ppf_value)
 }
 
-/// Static parameters for the constant-parameter value-keyed fast paths (`<method>_scalar`).
-///
-/// Like [`LogNormalScalarKwargs`] minus the sampler `seed`: when both parameters are Python
-/// scalars, the Python layer routes them here as kwargs instead of expanding each into a
-/// full-length column re-validated on every row. The distribution is validated and built once;
-/// only the evaluation-point column travels as an input.
-#[derive(Deserialize)]
-struct LogNormalParamsKwargs {
-    mu: f64,
-    sigma: f64,
-}
+value_keyed_scalar_plugins! {
+    /// Static parameters for the constant-parameter value-keyed fast paths (`<method>_scalar`).
+    ///
+    /// Like [`LogNormalScalarKwargs`] minus the sampler `seed`: when both parameters are Python
+    /// scalars, the Python layer routes them here as kwargs instead of expanding each into a
+    /// full-length column re-validated on every row. The distribution is validated and built once;
+    /// only the evaluation-point column travels as an input.
+    struct LogNormalParamsKwargs { mu: f64, sigma: f64 }
 
-/// Constant-parameter pdf; same body as [`lognormal_pdf`] via [`pdf_value`], dist built once.
-#[polars_expr(output_type=Float64)]
-fn lognormal_pdf_scalar(inputs: &[Series], kwargs: LogNormalParamsKwargs) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.mu, kwargs.sigma)?;
-    value_keyed_scalar(&inputs[0], |v| pdf_value(&dist, v))
-}
+    build = |kw| build_dist(kw.mu, kw.sigma)?;
 
-/// Constant-parameter log-pdf; same body as [`lognormal_ln_pdf`] via [`ln_pdf_value`], dist built once.
-#[polars_expr(output_type=Float64)]
-fn lognormal_ln_pdf_scalar(
-    inputs: &[Series],
-    kwargs: LogNormalParamsKwargs,
-) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.mu, kwargs.sigma)?;
-    value_keyed_scalar(&inputs[0], |v| ln_pdf_value(&dist, v))
-}
+    methods {
+        /// Constant-parameter pdf; same body as [`lognormal_pdf`] via [`pdf_value`], dist built once.
+        fn lognormal_pdf_scalar => pdf_value;
 
-/// Constant-parameter cdf; same body as [`lognormal_cdf`] via [`cdf_value`], dist built once.
-#[polars_expr(output_type=Float64)]
-fn lognormal_cdf_scalar(inputs: &[Series], kwargs: LogNormalParamsKwargs) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.mu, kwargs.sigma)?;
-    value_keyed_scalar(&inputs[0], |v| cdf_value(&dist, v))
-}
+        /// Constant-parameter log-pdf; same body as [`lognormal_ln_pdf`] via [`ln_pdf_value`], dist built once.
+        fn lognormal_ln_pdf_scalar => ln_pdf_value;
 
-/// Constant-parameter sf; same body as [`lognormal_sf`] via [`sf_value`], dist built once.
-#[polars_expr(output_type=Float64)]
-fn lognormal_sf_scalar(inputs: &[Series], kwargs: LogNormalParamsKwargs) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.mu, kwargs.sigma)?;
-    value_keyed_scalar(&inputs[0], |v| sf_value(&dist, v))
-}
+        /// Constant-parameter cdf; same body as [`lognormal_cdf`] via [`cdf_value`], dist built once.
+        fn lognormal_cdf_scalar => cdf_value;
 
-/// Constant-parameter ppf; same body as [`lognormal_ppf`] via [`ppf_value`], dist built once.
-#[polars_expr(output_type=Float64)]
-fn lognormal_ppf_scalar(inputs: &[Series], kwargs: LogNormalParamsKwargs) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.mu, kwargs.sigma)?;
-    value_keyed_scalar(&inputs[0], |q| ppf_value(&dist, q))
+        /// Constant-parameter sf; same body as [`lognormal_sf`] via [`sf_value`], dist built once.
+        fn lognormal_sf_scalar => sf_value;
+
+        /// Constant-parameter ppf; same body as [`lognormal_ppf`] via [`ppf_value`], dist built once.
+        fn lognormal_ppf_scalar => ppf_value;
+    }
 }

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -32,3 +32,179 @@ where
     let ca: Float64Chunked = unary_elementwise(value_ca, |opt| opt.and_then(&f));
     Ok(ca.with_name(name).into_series())
 }
+
+/// Generates a distribution's constant-parameter value-keyed fast paths: one `<method>_scalar`
+/// plugin per Rust-bound method (`pdf`/`pmf`, `ln_*`, `cdf`, `sf`, `ppf`), all over the shared
+/// [`value_keyed_scalar`] driver.
+///
+/// The constant-parameter counterpart of the per-row `value_keyed` helper, and the value-keyed
+/// twin of [`sample_scalar_plugin!`](crate::rng::sample_scalar_plugin): when every distribution
+/// parameter is a Python scalar, the parameters arrive as kwargs (validated and built into the
+/// distribution **once** per call), and only the evaluation-point column crosses FFI. The three
+/// things that vary between distributions are the macro's inputs:
+///
+/// * the kwargs fields (parameter names and types), one `<Name>ParamsKwargs` struct shared by
+///   every method;
+/// * `build`: validates the parameters and returns the `statrs` distribution, built **once** per
+///   call (`?` is available);
+/// * the `methods` list, each `fn <plugin_name> => <body>`, where `<body>` is the same named
+///   per-method function the per-row `value_keyed` path applies (`pdf_value`, `ppf_value`, ...),
+///   so the scalar and per-row paths share one body and cannot drift.
+///
+/// Every value-keyed method returns `Float64` (a density, probability, or quantile), so the output
+/// dtype is fixed here; that is the structural difference from `sample_scalar_plugin!`, whose dtype
+/// varies. Plugin and struct names stay literal in each invocation (greppable from the Python
+/// layer), so `value_keyed_test.py`'s `test_value_keyed_scalar_fast_path_matches_per_row` keeps
+/// pinning bit-equality with the per-row path. Call sites are the distribution modules, which all
+/// have `polars::prelude::*` in scope.
+macro_rules! value_keyed_scalar_plugins {
+    (
+        $(#[$kwargs_meta:meta])*
+        struct $kwargs:ident { $($param:ident: $param_ty:ty),+ $(,)? }
+
+        build = |$kw:ident| $build:expr;
+
+        methods {
+            $(
+                $(#[$fn_meta:meta])*
+                fn $fn_name:ident => $body:ident;
+            )+
+        }
+    ) => {
+        $(#[$kwargs_meta])*
+        #[derive(serde::Deserialize)]
+        struct $kwargs {
+            $($param: $param_ty,)+
+        }
+
+        $(
+            $(#[$fn_meta])*
+            #[pyo3_polars::derive::polars_expr(output_type=Float64)]
+            fn $fn_name(inputs: &[Series], kwargs: $kwargs) -> PolarsResult<Series> {
+                let $kw = &kwargs;
+                let dist = $build;
+                $crate::distributions::value_keyed_scalar(&inputs[0], |v| $body(&dist, v))
+            }
+        )+
+    };
+}
+pub(crate) use value_keyed_scalar_plugins;
+
+/// Generates a distribution's per-row `value_keyed` helper: the column-parameter counterpart of
+/// [`value_keyed_scalar`], building and validating the distribution **once per row** over
+/// `(value, p1, p2)` and applying the per-method body `f`.
+///
+/// The general (non-fast-path) side of the value-keyed methods. Where the scalar fast path builds
+/// the distribution once per call, this rebuilds it per row because at least one parameter is a
+/// column. The three things that vary between distributions are the macro's inputs:
+///
+/// * the distribution type, used in the `F: Fn(&$dist, f64) -> Option<f64>` bound;
+/// * each parameter's `<cast dtype> => <accessor>` pair (binomial's `n` is `Int64`/`.i64()`, the
+///   continuous scales are `Float64`/`.f64()`); the evaluation point is always cast to `Float64`;
+/// * `build`: the distribution constructor (`build_dist`), validating per row and raising on an
+///   invalid parameterisation (`?` is available inside the closure).
+///
+/// `f` is the same named per-method body the scalar fast path applies, so the two paths share one
+/// body and cannot drift. Only the 2-parameter (ternary) arm exists today, since every current
+/// distribution takes two parameters; a 1-parameter distribution would add a `try_binary_elementwise`
+/// arm here. Call sites are the distribution modules (`polars::prelude::*` in scope).
+macro_rules! value_keyed_per_row {
+    (
+        $(#[$meta:meta])*
+        fn $name:ident(&$dist:ty);
+        params = ($p1_dt:expr => $p1_acc:ident, $p2_dt:expr => $p2_acc:ident);
+        build = $build:path;
+    ) => {
+        $(#[$meta])*
+        fn $name<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
+        where
+            F: Fn(&$dist, f64) -> Option<f64>,
+        {
+            let value = inputs[0].cast(&DataType::Float64)?;
+            let value_ca = value.f64()?;
+            let p1 = inputs[1].cast(&$p1_dt)?;
+            let p1_ca = p1.$p1_acc()?;
+            let p2 = inputs[2].cast(&$p2_dt)?;
+            let p2_ca = p2.$p2_acc()?;
+            let name = inputs[0].name().clone();
+
+            let ca: Float64Chunked = polars::prelude::arity::try_ternary_elementwise(
+                value_ca,
+                p1_ca,
+                p2_ca,
+                |value_opt, p1_opt, p2_opt| -> PolarsResult<Option<f64>> {
+                    match (value_opt, p1_opt, p2_opt) {
+                        (Some(v), Some(a), Some(b)) => {
+                            let dist = $build(a, b)?;
+                            Ok(f(&dist, v))
+                        },
+                        _ => Ok(None),
+                    }
+                },
+            )?;
+
+            Ok(ca.with_name(name).into_series())
+        }
+    };
+}
+pub(crate) use value_keyed_per_row;
+
+/// Generates a two-parameter validation plugin: validate `(p1, p2)` per row by constructing the
+/// distribution, then return a derived `Float64` the closed-form Python methods can build on,
+/// raising identically to the sampler on an invalid parameterisation.
+///
+/// These plugins exist so the closed-form moments and (for Uniform / Bernoulli) value-keyed
+/// methods, which are pure Polars expressions, still report an invalid parameterisation through
+/// the same Rust `build_dist` rather than silently producing a garbage result. The constant-
+/// parameter fast path (issue 20 item 6) calls the very same plugin on length-1 `pl.lit` inputs,
+/// so it is built once instead of per row. The four knobs that vary between distributions are the
+/// macro's inputs:
+///
+/// * each parameter's `<name>: <cast dtype> => <accessor>` (binomial's `n` is `Int64`/`.i64()`,
+///   the continuous parameters are `Float64`/`.f64()`); the matched values bind to `<name>`;
+/// * `build`: the constructor (`build_dist`), validating per row (`?` is available);
+/// * `returns`: the `Float64` to emit, an expression over the parameter names (a parameter itself,
+///   e.g. `std_dev`, or a derived width, e.g. `max - min`);
+/// * `output_name = inputs[i]`: which input column names the output (most return the second
+///   parameter and name after it; Uniform's width names after the first).
+///
+/// Only the binary arm exists: `bernoulli_proba` is the lone unary validator and stays
+/// hand-written until a second one-parameter distribution justifies an arity arm. Call sites are
+/// the distribution modules (`polars::prelude::*` in scope).
+macro_rules! param_validator {
+    (
+        $(#[$meta:meta])*
+        fn $name:ident;
+        params = ($p1:ident: $p1_dt:expr => $p1_acc:ident, $p2:ident: $p2_dt:expr => $p2_acc:ident);
+        build = $build:path;
+        returns = $ret:expr;
+        output_name = inputs[$out_idx:literal];
+    ) => {
+        $(#[$meta])*
+        #[pyo3_polars::derive::polars_expr(output_type=Float64)]
+        fn $name(inputs: &[Series]) -> PolarsResult<Series> {
+            let p1 = inputs[0].cast(&$p1_dt)?;
+            let p1_ca = p1.$p1_acc()?;
+            let p2 = inputs[1].cast(&$p2_dt)?;
+            let p2_ca = p2.$p2_acc()?;
+            let name = inputs[$out_idx].name().clone();
+
+            let ca: Float64Chunked = polars::prelude::arity::try_binary_elementwise(
+                p1_ca,
+                p2_ca,
+                |o1, o2| -> PolarsResult<Option<f64>> {
+                    match (o1, o2) {
+                        (Some($p1), Some($p2)) => {
+                            $build($p1, $p2)?;
+                            Ok(Some($ret))
+                        },
+                        _ => Ok(None),
+                    }
+                },
+            )?;
+
+            Ok(ca.with_name(name).into_series())
+        }
+    };
+}
+pub(crate) use param_validator;

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -1,12 +1,11 @@
 #![allow(clippy::unused_unit)]
-use polars::prelude::arity::{try_binary_elementwise, try_ternary_elementwise};
+use polars::prelude::arity::try_ternary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distributions::Distribution as RandDistribution;
-use serde::Deserialize;
 use statrs::distribution::{Continuous, ContinuousCDF, Normal};
 
-use crate::distributions::value_keyed_scalar;
+use crate::distributions::{param_validator, value_keyed_per_row, value_keyed_scalar_plugins};
 use crate::rng::{
     sample_scalar_plugin, samples_f64_output, samples_per_row, ternary_param_rows, SampleKwargs,
     SamplesKwargs,
@@ -29,72 +28,31 @@ fn build_dist(mean: f64, std_dev: f64) -> PolarsResult<Normal> {
     })
 }
 
-/// Validate the `(mean, std_dev)` parameterisation and return the validated `std_dev`.
-///
-/// `inputs[0]` is `mean`, `inputs[1]` is `std_dev`. Mirrors `uniform_range`: the closed-form moments
-/// (`mean`, `variance`, `median`, `entropy`) all derive from this single FFI round-trip, so they
-/// report an invalid parameterisation identically to the value-keyed methods that build the
-/// distribution directly. `null` in either input propagates; a `NaN` mean or a non-positive / `NaN`
-/// `std_dev` raises `InvalidOperation` via [`build_dist`].
-#[polars_expr(output_type=Float64)]
-fn normal_std_dev(inputs: &[Series]) -> PolarsResult<Series> {
-    let mean = inputs[0].cast(&DataType::Float64)?;
-    let mean_ca = mean.f64()?;
-    let std_dev = inputs[1].cast(&DataType::Float64)?;
-    let std_dev_ca = std_dev.f64()?;
-    let name = inputs[1].name().clone();
-
-    let ca: Float64Chunked = try_binary_elementwise(
-        mean_ca,
-        std_dev_ca,
-        |mean_opt, std_opt| -> PolarsResult<Option<f64>> {
-            match (mean_opt, std_opt) {
-                (Some(m), Some(s)) => {
-                    build_dist(m, s)?;
-                    Ok(Some(s))
-                },
-                _ => Ok(None),
-            }
-        },
-    )?;
-
-    Ok(ca.with_name(name).into_series())
+param_validator! {
+    /// Validate the `(mean, std_dev)` parameterisation and return the validated `std_dev`.
+    ///
+    /// `inputs[0]` is `mean`, `inputs[1]` is `std_dev`. Mirrors `uniform_range`: the closed-form
+    /// moments (`mean`, `variance`, `median`, `entropy`) all derive from this single FFI
+    /// round-trip, so they report an invalid parameterisation identically to the value-keyed
+    /// methods that build the distribution directly. `null` in either input propagates; a `NaN`
+    /// mean or a non-positive / `NaN` `std_dev` raises `InvalidOperation` via [`build_dist`].
+    fn normal_std_dev;
+    params = (mean: DataType::Float64 => f64, std_dev: DataType::Float64 => f64);
+    build = build_dist;
+    returns = std_dev;
+    output_name = inputs[1];
 }
 
-/// Apply a value-keyed function `f(dist, value)` element-wise over `(value, mean, std_dev)`.
-///
-/// `inputs[0]` is the evaluation point, `inputs[1]` is `mean`, `inputs[2]` is `std_dev`. `null` in
-/// any input propagates to `null`; an invalid `std_dev` raises via [`build_dist`]. `f` returns an
-/// `Option` so a method can null a row on its own terms (e.g. `ppf` outside `[0, 1]`). Shared by
-/// `pdf`, `ln_pdf`, `cdf`, `sf`, `ppf`.
-fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
-where
-    F: Fn(&Normal, f64) -> Option<f64>,
-{
-    let value = inputs[0].cast(&DataType::Float64)?;
-    let value_ca = value.f64()?;
-    let mean = inputs[1].cast(&DataType::Float64)?;
-    let mean_ca = mean.f64()?;
-    let std_dev = inputs[2].cast(&DataType::Float64)?;
-    let std_dev_ca = std_dev.f64()?;
-    let name = inputs[0].name().clone();
-
-    let ca: Float64Chunked = try_ternary_elementwise(
-        value_ca,
-        mean_ca,
-        std_dev_ca,
-        |value_opt, mean_opt, std_opt| -> PolarsResult<Option<f64>> {
-            match (value_opt, mean_opt, std_opt) {
-                (Some(v), Some(m), Some(s)) => {
-                    let dist = build_dist(m, s)?;
-                    Ok(f(&dist, v))
-                },
-                _ => Ok(None),
-            }
-        },
-    )?;
-
-    Ok(ca.with_name(name).into_series())
+value_keyed_per_row! {
+    /// Apply a value-keyed function `f(dist, value)` element-wise over `(value, mean, std_dev)`.
+    ///
+    /// `inputs[0]` is the evaluation point, `inputs[1]` is `mean`, `inputs[2]` is `std_dev`. `null`
+    /// in any input propagates to `null`; an invalid `std_dev` raises via [`build_dist`]. `f`
+    /// returns an `Option` so a method can null a row on its own terms (e.g. `ppf` outside
+    /// `[0, 1]`). Shared by `pdf`, `ln_pdf`, `cdf`, `sf`, `ppf`.
+    fn value_keyed(&Normal);
+    params = (DataType::Float64 => f64, DataType::Float64 => f64);
+    build = build_dist;
 }
 
 /// Element-wise Normal sampler.
@@ -250,49 +208,31 @@ fn normal_ppf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, ppf_value)
 }
 
-/// Static parameters for the constant-parameter value-keyed fast paths (`<method>_scalar`).
-///
-/// Like [`NormalScalarKwargs`] minus the sampler `seed`: when both parameters are Python scalars,
-/// the Python layer routes them here as kwargs instead of expanding each into a full-length
-/// column re-validated on every row. The distribution is validated and built once; only the
-/// evaluation-point column travels as an input.
-#[derive(Deserialize)]
-struct NormalParamsKwargs {
-    mean: f64,
-    std_dev: f64,
-}
+value_keyed_scalar_plugins! {
+    /// Static parameters for the constant-parameter value-keyed fast paths (`<method>_scalar`).
+    ///
+    /// Like [`NormalScalarKwargs`] minus the sampler `seed`: when both parameters are Python
+    /// scalars, the Python layer routes them here as kwargs instead of expanding each into a
+    /// full-length column re-validated on every row. The distribution is validated and built once;
+    /// only the evaluation-point column travels as an input.
+    struct NormalParamsKwargs { mean: f64, std_dev: f64 }
 
-/// Constant-parameter pdf; same body as [`normal_pdf`] via [`pdf_value`], dist built once.
-#[polars_expr(output_type=Float64)]
-fn normal_pdf_scalar(inputs: &[Series], kwargs: NormalParamsKwargs) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.mean, kwargs.std_dev)?;
-    value_keyed_scalar(&inputs[0], |v| pdf_value(&dist, v))
-}
+    build = |kw| build_dist(kw.mean, kw.std_dev)?;
 
-/// Constant-parameter log-pdf; same body as [`normal_ln_pdf`] via [`ln_pdf_value`], dist built once.
-#[polars_expr(output_type=Float64)]
-fn normal_ln_pdf_scalar(inputs: &[Series], kwargs: NormalParamsKwargs) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.mean, kwargs.std_dev)?;
-    value_keyed_scalar(&inputs[0], |v| ln_pdf_value(&dist, v))
-}
+    methods {
+        /// Constant-parameter pdf; same body as [`normal_pdf`] via [`pdf_value`], dist built once.
+        fn normal_pdf_scalar => pdf_value;
 
-/// Constant-parameter cdf; same body as [`normal_cdf`] via [`cdf_value`], dist built once.
-#[polars_expr(output_type=Float64)]
-fn normal_cdf_scalar(inputs: &[Series], kwargs: NormalParamsKwargs) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.mean, kwargs.std_dev)?;
-    value_keyed_scalar(&inputs[0], |v| cdf_value(&dist, v))
-}
+        /// Constant-parameter log-pdf; same body as [`normal_ln_pdf`] via [`ln_pdf_value`], dist built once.
+        fn normal_ln_pdf_scalar => ln_pdf_value;
 
-/// Constant-parameter sf; same body as [`normal_sf`] via [`sf_value`], dist built once.
-#[polars_expr(output_type=Float64)]
-fn normal_sf_scalar(inputs: &[Series], kwargs: NormalParamsKwargs) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.mean, kwargs.std_dev)?;
-    value_keyed_scalar(&inputs[0], |v| sf_value(&dist, v))
-}
+        /// Constant-parameter cdf; same body as [`normal_cdf`] via [`cdf_value`], dist built once.
+        fn normal_cdf_scalar => cdf_value;
 
-/// Constant-parameter ppf; same body as [`normal_ppf`] via [`ppf_value`], dist built once.
-#[polars_expr(output_type=Float64)]
-fn normal_ppf_scalar(inputs: &[Series], kwargs: NormalParamsKwargs) -> PolarsResult<Series> {
-    let dist = build_dist(kwargs.mean, kwargs.std_dev)?;
-    value_keyed_scalar(&inputs[0], |q| ppf_value(&dist, q))
+        /// Constant-parameter sf; same body as [`normal_sf`] via [`sf_value`], dist built once.
+        fn normal_sf_scalar => sf_value;
+
+        /// Constant-parameter ppf; same body as [`normal_ppf`] via [`ppf_value`], dist built once.
+        fn normal_ppf_scalar => ppf_value;
+    }
 }

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -1,10 +1,11 @@
 #![allow(clippy::unused_unit)]
-use polars::prelude::arity::{try_binary_elementwise, try_ternary_elementwise};
+use polars::prelude::arity::try_ternary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distributions::{Distribution, Standard};
 use statrs::distribution::Uniform;
 
+use crate::distributions::param_validator;
 use crate::rng::{
     sample_scalar_plugin, samples_f64_output, samples_per_row, ternary_param_rows, SampleKwargs,
     SamplesKwargs,
@@ -157,36 +158,19 @@ fn uniform_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Ser
     )
 }
 
-/// Element-wise support width `max - min`, validating the parameterisation.
-///
-/// `inputs[0]` is the lower bound, `inputs[1]` the upper bound. `null` in either propagates;
-/// `max <= min`, non-finite bounds, or a width overflowing `f64` raise `InvalidOperation`
-/// (surfaces as a `ComputeError`).
-///
-/// Every closed-form Python method derives from this width, so routing it through Rust is what lets
-/// them report an invalid parameterisation consistently with `uniform_sample`, instead of silently
-/// producing a negative or infinite result.
-#[polars_expr(output_type=Float64)]
-fn uniform_range(inputs: &[Series]) -> PolarsResult<Series> {
-    let min = inputs[0].cast(&DataType::Float64)?;
-    let min_ca = min.f64()?;
-    let max = inputs[1].cast(&DataType::Float64)?;
-    let max_ca = max.f64()?;
-    let name = inputs[0].name().clone();
-
-    let ca: Float64Chunked = try_binary_elementwise(
-        min_ca,
-        max_ca,
-        |min_opt, max_opt| -> PolarsResult<Option<f64>> {
-            match (min_opt, max_opt) {
-                (Some(lo), Some(hi)) => {
-                    build_dist(lo, hi)?;
-                    Ok(Some(hi - lo))
-                },
-                _ => Ok(None),
-            }
-        },
-    )?;
-
-    Ok(ca.with_name(name).into_series())
+param_validator! {
+    /// Element-wise support width `max - min`, validating the parameterisation.
+    ///
+    /// `inputs[0]` is the lower bound, `inputs[1]` the upper bound. `null` in either propagates;
+    /// `max <= min`, non-finite bounds, or a width overflowing `f64` raise `InvalidOperation`
+    /// (surfaces as a `ComputeError`).
+    ///
+    /// Every closed-form Python method derives from this width, so routing it through Rust is what
+    /// lets them report an invalid parameterisation consistently with `uniform_sample`, instead of
+    /// silently producing a negative or infinite result.
+    fn uniform_range;
+    params = (min: DataType::Float64 => f64, max: DataType::Float64 => f64);
+    build = build_dist;
+    returns = max - min;
+    output_name = inputs[0];
 }


### PR DESCRIPTION
Adds three `macro_rules!` (`value_keyed_scalar_plugins!`, `value_keyed_per_row!`, `param_validator!`) and converts the copy-per-file value-keyed `<method>_scalar` plugins, the per-row `value_keyed` helpers, and the four two-parameter validators to one-invocation-each. Bernoulli's lone unary validator stays hand-written (a single copy does not earn a macro). 