### PR TITLE
feat: Add `Beta` distribution

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -20,10 +20,10 @@ from pathlib import Path
 from typing import Annotated, get_args
 
 from cyclopts import App, Parameter
-from scipy.stats import bernoulli, binom, expon, lognorm, norm, uniform
+from scipy.stats import bernoulli, beta, binom, expon, lognorm, norm, uniform
 
 from benchmarks._harness import ALL_METHODS, Comparison, Method, OutputFormat, Sweep, emit, run_comparison
-from polars_stats import Bernoulli, Binomial, Exponential, LogNormal, Normal, Uniform
+from polars_stats import Bernoulli, Beta, Binomial, Exponential, LogNormal, Normal, Uniform
 
 # `--rows 1 2 3` (multiple tokens per flag), not `--rows 1 --rows 2`; without this a list option takes
 # a single token and the rest leak onto the positional `distributions`.
@@ -37,6 +37,7 @@ REGISTRY: dict[str, Comparison] = {
     "lognormal": Comparison("lognormal", LogNormal(mu=0.0, sigma=1.0), lognorm(s=1.0, scale=exp(0.0))),
     "uniform": Comparison("uniform", Uniform(min=0.0, max=1.0), uniform(loc=0.0, scale=1.0)),
     "exponential": Comparison("exponential", Exponential(rate=1.0), expon(scale=1.0)),
+    "beta": Comparison("beta", Beta(a=2.0, b=3.0), beta(a=2.0, b=3.0)),
     "bernoulli": Comparison("bernoulli", Bernoulli(p=0.3), bernoulli(0.3)),
     "binomial": Comparison("binomial", Binomial(n=10, p=0.3), binom(10, 0.3)),
 }

--- a/polars_stats/__init__.py
+++ b/polars_stats/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from polars_stats._internal import __version__ as __version__
 from polars_stats.distributions._base import ContinuousDistribution, DiscreteDistribution
 from polars_stats.distributions._bernoulli import Bernoulli
+from polars_stats.distributions._beta import Beta
 from polars_stats.distributions._binomial import Binomial
 from polars_stats.distributions._exponential import Exponential
 from polars_stats.distributions._lognormal import LogNormal
@@ -11,6 +12,7 @@ from polars_stats.distributions._uniform import Uniform
 
 __all__ = (
     "Bernoulli",
+    "Beta",
     "Binomial",
     "ContinuousDistribution",
     "DiscreteDistribution",

--- a/polars_stats/distributions/_bernoulli.py
+++ b/polars_stats/distributions/_bernoulli.py
@@ -28,7 +28,6 @@ class Bernoulli(DiscreteDistribution):
 
     def __init__(self, p: float | IntoExprColumn) -> None:
         self._p = coerce_param(p, name="p")
-        # A constant `p` enables the fast sampler path; `None` falls back to the per-row plugin.
         self._scalar_kwargs = scalar_kwargs(p=scalar_float(p))
 
     @property

--- a/polars_stats/distributions/_beta.py
+++ b/polars_stats/distributions/_beta.py
@@ -23,14 +23,13 @@ class Beta(ContinuousDistribution):
     them ``shape_a`` / ``shape_b``.
 
     Arguments:
-        a: First shape parameter (alpha), with ``a > 0``. Either a Python ``float`` or an
-            ``IntoExprColumn`` (``pl.Expr``, ``pl.Series`` or column name ``str``) carrying one
-            shape per row.
+        a: First shape parameter (alpha), with ``a > 0``. Either a Python ``float`` or an ``IntoExprColumn``
+            (``pl.Expr``, ``pl.Series`` or column name ``str``) carrying one shape per row.
         b: Second shape parameter (beta), with ``b > 0``. Same accepted types as ``a``.
 
-    An invalid shape (``a <= 0``, ``b <= 0``, or a non-finite parameter) is not checked at
-    construction; matching every other distribution, it raises ``InvalidOperation`` (a
-    ``ComputeError``) when any method is evaluated. Null parameters propagate to null.
+    An invalid shape (``a <= 0``, ``b <= 0``, or a non-finite parameter) is not checked at construction; matching every
+    other distribution, it raises ``InvalidOperation`` (a ``ComputeError``) when any method is evaluated.
+    Null parameters propagate to null.
 
     The support is ``[0, 1]``: ``pdf`` is ``0`` outside it, and when a shape is ``< 1`` the density
     diverges (``inf`` or large finite values) at the corresponding boundary.
@@ -43,7 +42,6 @@ class Beta(ContinuousDistribution):
     def __init__(self, a: float | IntoExprColumn, b: float | IntoExprColumn) -> None:
         self._a = coerce_param(a, name="a")
         self._b = coerce_param(b, name="b")
-        # Constant shapes enable the fast sampler path; `None` falls back to the per-row plugin.
         self._scalar_kwargs = scalar_kwargs(a=scalar_float(a), b=scalar_float(b))
 
     @property
@@ -55,10 +53,9 @@ class Beta(ContinuousDistribution):
         """``b`` validated in Rust against the full ``(a, b)`` parameterisation (raises otherwise).
 
         Mirrors ``Normal._checked_params`` / ``Binomial._checked_params``: the closed-form moments
-        (``mean``, ``variance``) derive from this FFI round-trip, so they report an invalid shape as
-        a ``ComputeError`` consistently with the value-keyed methods. Null in either parameter
-        propagates to null. `_checked` validates once for scalar parameters (length-1 inputs) and
-        per-row for columns.
+        (``mean``, ``variance``) derive from this FFI round-trip, so they report an invalid shape as a ``ComputeError``
+        consistently with the value-keyed methods. Null in either parameter propagates to null. `_checked` validates
+        once for scalar parameters (length-1 inputs) and per-row for columns.
         """
         return self._checked("beta_params", self._b)
 
@@ -86,8 +83,8 @@ class Beta(ContinuousDistribution):
         """Inverse cdf via the closed-form ``ContinuousCDF::inverse_cdf`` (inverse regularized incomplete beta).
 
         A quantile outside ``[0, 1]`` yields null; the endpoints map to the support bounds
-        (``ppf(0) = 0``, ``ppf(1) = 1``), matching scipy. ``median`` is ``ppf(0.5)`` (the base-class
-        default); the beta median has no closed form.
+        (``ppf(0) = 0``, ``ppf(1) = 1``), matching scipy. ``median`` is ``ppf(0.5)`` (the base-class default);
+        the beta median has no closed form.
         """
         return self._value_plugin("beta_ppf", quantile)
 

--- a/polars_stats/distributions/_beta.py
+++ b/polars_stats/distributions/_beta.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
+from polars_stats.distributions._base import (
+    ContinuousDistribution,
+    coerce_param,
+    register_plugin,
+    scalar_float,
+    scalar_kwargs,
+)
+
+if TYPE_CHECKING:
+    import polars as pl
+
+    from polars_stats._typing import IntoExprColumn
+
+
+class Beta(ContinuousDistribution):
+    """Beta distribution on ``[0, 1]`` with shape parameters ``a`` (alpha) and ``b`` (beta).
+
+    Equivalent to ``scipy.stats.beta(a, b)``. The parameter names follow scipy; ``statrs`` calls
+    them ``shape_a`` / ``shape_b``.
+
+    Arguments:
+        a: First shape parameter (alpha), with ``a > 0``. Either a Python ``float`` or an
+            ``IntoExprColumn`` (``pl.Expr``, ``pl.Series`` or column name ``str``) carrying one
+            shape per row.
+        b: Second shape parameter (beta), with ``b > 0``. Same accepted types as ``a``.
+
+    An invalid shape (``a <= 0``, ``b <= 0``, or a non-finite parameter) is not checked at
+    construction; matching every other distribution, it raises ``InvalidOperation`` (a
+    ``ComputeError``) when any method is evaluated. Null parameters propagate to null.
+
+    The support is ``[0, 1]``: ``pdf`` is ``0`` outside it, and when a shape is ``< 1`` the density
+    diverges (``inf`` or large finite values) at the corresponding boundary.
+    """
+
+    _a: pl.Expr
+    _b: pl.Expr
+    _plugin_prefix: ClassVar[str] = "beta"
+
+    def __init__(self, a: float | IntoExprColumn, b: float | IntoExprColumn) -> None:
+        self._a = coerce_param(a, name="a")
+        self._b = coerce_param(b, name="b")
+        # Constant shapes enable the fast sampler path; `None` falls back to the per-row plugin.
+        self._scalar_kwargs = scalar_kwargs(a=scalar_float(a), b=scalar_float(b))
+
+    @property
+    def _param_exprs(self) -> tuple[pl.Expr, ...]:
+        return (self._a, self._b)
+
+    @property
+    def _checked_params(self) -> pl.Expr:
+        """``b`` validated in Rust against the full ``(a, b)`` parameterisation (raises otherwise).
+
+        Mirrors ``Normal._checked_params`` / ``Binomial._checked_params``: the closed-form moments
+        (``mean``, ``variance``) derive from this FFI round-trip, so they report an invalid shape as
+        a ``ComputeError`` consistently with the value-keyed methods. Null in either parameter
+        propagates to null. `_checked` validates once for scalar parameters (length-1 inputs) and
+        per-row for columns.
+        """
+        return self._checked("beta_params", self._b)
+
+    def _pdf(self, value: pl.Expr) -> pl.Expr:
+        """Density via native ``statrs`` ``Continuous::pdf`` (Beta function); ``0`` outside ``[0, 1]``."""
+        return self._value_plugin("beta_pdf", value)
+
+    def _log_pdf(self, value: pl.Expr) -> pl.Expr:
+        """Log-density via native ``Continuous::ln_pdf`` (more accurate than ``pdf().log()``)."""
+        return self._value_plugin("beta_ln_pdf", value)
+
+    def _cdf(self, value: pl.Expr) -> pl.Expr:
+        """Cumulative distribution via native ``ContinuousCDF::cdf`` (regularized incomplete beta)."""
+        return self._value_plugin("beta_cdf", value)
+
+    def _sf(self, value: pl.Expr) -> pl.Expr:
+        """Survival function via native ``ContinuousCDF::sf`` (accurate in the upper tail).
+
+        ``log_sf`` and ``isf`` inherit the base-class defaults, which compose this native ``sf`` and
+        ``ppf`` rather than the generic ``1 - cdf`` fallback.
+        """
+        return self._value_plugin("beta_sf", value)
+
+    def _ppf(self, quantile: pl.Expr) -> pl.Expr:
+        """Inverse cdf via the closed-form ``ContinuousCDF::inverse_cdf`` (inverse regularized incomplete beta).
+
+        A quantile outside ``[0, 1]`` yields null; the endpoints map to the support bounds
+        (``ppf(0) = 0``, ``ppf(1) = 1``), matching scipy. ``median`` is ``ppf(0.5)`` (the base-class
+        default); the beta median has no closed form.
+        """
+        return self._value_plugin("beta_ppf", quantile)
+
+    def mean(self) -> pl.Expr:
+        """Expected value, ``a / (a + b)``."""
+        return self._moment(self._a / (self._a + self._b))
+
+    def variance(self) -> pl.Expr:
+        """Variance, ``a * b / ((a + b)^2 * (a + b + 1))``."""
+        return self._moment(self._a * self._b / ((self._a + self._b) ** 2 * (self._a + self._b + 1)))
+
+    def entropy(self) -> pl.Expr:
+        """Differential entropy in nats, ``ln B(a, b) - (a - 1) psi(a) - (b - 1) psi(b) + (a + b - 2) psi(a + b)``."""
+        # Unlike ``mean`` / ``variance`` there is no elementary closed form (log-Beta and digamma), so the
+        # formula is evaluated by ``beta_entropy`` in Rust. For column parameters that runs once per row; for
+        # scalar parameters it is computed **once** on length-1 inputs and broadcast to length-n behind the
+        # ``_moment`` validity gate, so a constant's entropy is not re-evaluated on every row.
+        if self._scalar_kwargs is None:
+            return register_plugin("beta_entropy", (self._a, self._b))
+        return self._moment(register_plugin("beta_entropy", self._scalar_lit_args()))

--- a/polars_stats/distributions/_binomial.py
+++ b/polars_stats/distributions/_binomial.py
@@ -42,7 +42,6 @@ class Binomial(DiscreteDistribution):
     def __init__(self, n: int | IntoExprColumn, p: float | IntoExprColumn) -> None:
         self._n = coerce_n(n, name="n")
         self._p = coerce_param(p, name="p")
-        # Constant `(n, p)` enables the fast sampler path; `None` falls back to the per-row plugin.
         self._scalar_kwargs = scalar_kwargs(n=scalar_int(n), p=scalar_float(p))
 
     @property

--- a/polars_stats/distributions/_exponential.py
+++ b/polars_stats/distributions/_exponential.py
@@ -38,8 +38,6 @@ class Exponential(ContinuousDistribution):
 
     def __init__(self, rate: float | IntoExprColumn) -> None:
         self._rate = coerce_param(rate, name="rate")
-        # A constant `rate` enables the constant-parameter sampler fast path; `None` falls back to the
-        # per-row plugin.
         self._scalar_kwargs = scalar_kwargs(rate=scalar_float(rate))
 
     @property

--- a/polars_stats/distributions/_lognormal.py
+++ b/polars_stats/distributions/_lognormal.py
@@ -48,7 +48,6 @@ class LogNormal(ContinuousDistribution):
     def __init__(self, mu: float | IntoExprColumn = 0.0, sigma: float | IntoExprColumn = 1.0) -> None:
         self._mu = coerce_param(mu, name="mu")
         self._sigma = coerce_param(sigma, name="sigma")
-        # Constant parameters enable the fast sampler path; `None` falls back to the per-row plugin.
         self._scalar_kwargs = scalar_kwargs(mu=scalar_float(mu), sigma=scalar_float(sigma))
 
     @property

--- a/polars_stats/distributions/_normal.py
+++ b/polars_stats/distributions/_normal.py
@@ -48,7 +48,6 @@ class Normal(ContinuousDistribution):
     ) -> None:
         self._mean = coerce_param(mean, name="mean")
         self._std_dev = coerce_param(std_dev, name="std_dev")
-        # Constant parameters enable the fast sampler path; `None` falls back to the per-row plugin.
         self._scalar_kwargs = scalar_kwargs(mean=scalar_float(mean), std_dev=scalar_float(std_dev))
 
     @property

--- a/polars_stats/distributions/_uniform.py
+++ b/polars_stats/distributions/_uniform.py
@@ -41,8 +41,6 @@ class Uniform(ContinuousDistribution):
     def __init__(self, min: float | IntoExprColumn, max: float | IntoExprColumn) -> None:  # noqa: A002
         self._min = coerce_param(min, name="min")
         self._max = coerce_param(max, name="max")
-        # Constant bounds enable the constant-bounds sampler fast path; `None` falls back to the
-        # per-row plugin.
         self._scalar_kwargs = scalar_kwargs(min=scalar_float(min), max=scalar_float(max))
 
     @property

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -14,10 +14,10 @@ use crate::rng::{
 
 /// Construct a `statrs::Beta`, mapping the invalid-parameter case to a `ComputeError`.
 ///
-/// `statrs::Beta::new(shape_a, shape_b)` rejects a `NaN`, infinite, or non-positive shape (unlike
-/// the Normal scale, an infinite shape is rejected too). We surface that as `InvalidOperation` so
-/// an invalid shape fails the whole evaluation rather than silently nulling the row. Validation
-/// lives here so every method that builds a distribution reports an invalid shape identically.
+/// `statrs::Beta::new(shape_a, shape_b)` rejects a `NaN`, infinite, or non-positive shape.
+/// We surface that as `InvalidOperation` so an invalid shape fails the whole evaluation
+/// rather than silently nulling the row.
+/// Validation lives here so every method that builds a distribution reports an invalid shape identically.
 fn build_dist(a: f64, b: f64) -> PolarsResult<Beta> {
     Beta::new(a, b).map_err(|e| {
         PolarsError::InvalidOperation(

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -1,0 +1,280 @@
+#![allow(clippy::unused_unit)]
+use polars::prelude::arity::{try_binary_elementwise, try_ternary_elementwise};
+use polars::prelude::*;
+use pyo3_polars::derive::polars_expr;
+use rand::distributions::Distribution as RandDistribution;
+use statrs::distribution::{Beta, Continuous, ContinuousCDF};
+use statrs::statistics::Distribution as StatrsDistribution;
+
+use crate::distributions::{param_validator, value_keyed_per_row, value_keyed_scalar_plugins};
+use crate::rng::{
+    sample_scalar_plugin, samples_f64_output, samples_per_row, ternary_param_rows, SampleKwargs,
+    SamplesKwargs,
+};
+
+/// Construct a `statrs::Beta`, mapping the invalid-parameter case to a `ComputeError`.
+///
+/// `statrs::Beta::new(shape_a, shape_b)` rejects a `NaN`, infinite, or non-positive shape (unlike
+/// the Normal scale, an infinite shape is rejected too). We surface that as `InvalidOperation` so
+/// an invalid shape fails the whole evaluation rather than silently nulling the row. Validation
+/// lives here so every method that builds a distribution reports an invalid shape identically.
+fn build_dist(a: f64, b: f64) -> PolarsResult<Beta> {
+    Beta::new(a, b).map_err(|e| {
+        PolarsError::InvalidOperation(
+            format!("a and b must be finite and strictly positive, got a={a}, b={b}: {e}").into(),
+        )
+    })
+}
+
+param_validator! {
+    /// Validate the `(a, b)` parameterisation and return the validated `b`.
+    ///
+    /// `inputs[0]` is `a`, `inputs[1]` is `b`. Mirrors `normal_std_dev` / `binomial_params`: the
+    /// closed-form moments (`mean = a / (a + b)`, `variance = a * b / ((a + b)^2 * (a + b + 1))`)
+    /// are computed from Polars expressions and gated on this single FFI round-trip, so they report
+    /// an invalid parameterisation identically to the value-keyed methods that build the
+    /// distribution directly. `null` in either input propagates; a `NaN`, infinite, or non-positive
+    /// shape raises `InvalidOperation` via [`build_dist`].
+    fn beta_params;
+    params = (a: DataType::Float64 => f64, b: DataType::Float64 => f64);
+    build = build_dist;
+    returns = b;
+    output_name = inputs[1];
+}
+
+value_keyed_per_row! {
+    /// Apply a value-keyed function `f(dist, value)` element-wise over `(value, a, b)`.
+    ///
+    /// `inputs[0]` is the evaluation point, `inputs[1]` is `a`, `inputs[2]` is `b`. `null` in any
+    /// input propagates to `null`; an invalid shape raises via [`build_dist`]. `f` returns an
+    /// `Option` so a method can null a row on its own terms (e.g. `ppf` outside `[0, 1]`). Shared
+    /// by `pdf`, `ln_pdf`, `cdf`, `sf`, `ppf`.
+    fn value_keyed(&Beta);
+    params = (DataType::Float64 => f64, DataType::Float64 => f64);
+    build = build_dist;
+}
+
+/// Apply a parameter-keyed moment `f(dist)` element-wise over `(a, b)`.
+///
+/// `inputs[0]` is `a`, `inputs[1]` is `b`. `null` in either propagates; an invalid shape raises
+/// via [`build_dist`]. Only `entropy` routes through here (the one moment without an elementary
+/// closed form); `mean` and `variance` are closed forms computed in Polars and gated on
+/// [`beta_params`].
+fn params_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
+where
+    F: Fn(&Beta) -> f64,
+{
+    let a = inputs[0].cast(&DataType::Float64)?;
+    let a_ca = a.f64()?;
+    let b = inputs[1].cast(&DataType::Float64)?;
+    let b_ca = b.f64()?;
+    let name = inputs[1].name().clone();
+
+    let ca: Float64Chunked =
+        try_binary_elementwise(a_ca, b_ca, |a_opt, b_opt| -> PolarsResult<Option<f64>> {
+            match (a_opt, b_opt) {
+                (Some(a), Some(b)) => {
+                    let dist = build_dist(a, b)?;
+                    Ok(Some(f(&dist)))
+                },
+                _ => Ok(None),
+            }
+        })?;
+
+    Ok(ca.with_name(name).into_series())
+}
+
+/// Element-wise Beta sampler.
+///
+/// `inputs[0]` carries `a`, `inputs[1]` `b`, and `inputs[2]` a per-row index used to derive a
+/// per-row sub-seed, so the function is genuinely element-wise: chunking and threading cannot
+/// change the output. With `seed=None`, a fresh root seed is drawn once per call.
+///
+/// Per-row validation:
+///   * `null` (in any input) propagates;
+///   * a `NaN`, infinite, or non-positive shape raises `InvalidOperation`.
+///
+/// The draw keeps `statrs` (two `O(1)`-amortised Gamma draws, normalised); routing it through
+/// `rand_distr` would buy nothing, since that is already the algorithm class it uses (unlike the
+/// binomial draw, see DESIGN.md). Returns a `Float64` series.
+#[polars_expr(output_type=Float64)]
+fn beta_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
+    let a = inputs[0].cast(&DataType::Float64)?;
+    let a_ca = a.f64()?;
+    let b = inputs[1].cast(&DataType::Float64)?;
+    let b_ca = b.f64()?;
+    let index = inputs[2].cast(&DataType::UInt64)?;
+    let index_ca = index.u64()?;
+    let name = inputs[0].name().clone();
+
+    let rngs = kwargs.row_rngs();
+
+    let ca: Float64Chunked = try_ternary_elementwise(
+        a_ca,
+        b_ca,
+        index_ca,
+        |a_opt, b_opt, i_opt| -> PolarsResult<Option<f64>> {
+            match (a_opt, b_opt, i_opt) {
+                (Some(a), Some(b), Some(i)) => {
+                    let dist = build_dist(a, b)?;
+                    let mut rng = rngs.rng(i);
+                    let draw: f64 = RandDistribution::sample(&dist, &mut rng);
+                    Ok(Some(draw))
+                },
+                _ => Ok(None),
+            }
+        },
+    )?;
+
+    Ok(ca.with_name(name).into_series())
+}
+
+sample_scalar_plugin! {
+    /// Static parameters for the constant-parameter sampler fast path: when both `a` and `b` are
+    /// Python scalars, they travel here as kwargs instead of as two full-length `pl.repeat`
+    /// columns re-validated on every row.
+    struct BetaScalarKwargs { a: f64, b: f64 }
+
+    /// Constant-parameter Beta sampler: [`beta_sample`] for the all-scalar case. The distribution
+    /// is validated and built once, and only the per-row index travels as an input; seeding and
+    /// the draw are unchanged, so output matches `beta_sample` for the same `(seed, index, a, b)`.
+    fn beta_sample_scalar(output_type = Float64, physical = Float64Type);
+
+    samples = beta_samples_scalar as BetaSamplesScalarKwargs -> samples_f64_output;
+
+    build = |kw| build_dist(kw.a, kw.b)?;
+    draw = |dist, rng| RandDistribution::sample(&dist, rng);
+}
+
+/// Element-wise multi-draw Beta sampler: `size` draws per row in one call.
+///
+/// The column-parameter counterpart of [`beta_samples_scalar`]: the distribution is built once per
+/// row instead of once per draw. Row `i`'s draws come from the one stream seeded `(seed, i)`, so
+/// output is bit-identical to the scalar path for the same parameters (the seeding is positional,
+/// parameters never enter it, so equal-parameter rows still draw independently). Null/error
+/// contract follows [`beta_sample`] per row; a null row yields a null array element. Returns
+/// `Array(Float64, size)`.
+#[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
+fn beta_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
+    let a = inputs[0].cast(&DataType::Float64)?;
+    let b = inputs[1].cast(&DataType::Float64)?;
+    let index = inputs[2].cast(&DataType::UInt64)?;
+    let name = inputs[0].name().clone();
+
+    let rows = ternary_param_rows(a.f64()?, b.f64()?, index.u64()?, build_dist);
+
+    samples_per_row::<Float64Type, _, _, _, _>(
+        name,
+        kwargs.seed,
+        kwargs.size,
+        rows,
+        RandDistribution::sample,
+    )
+}
+
+// Per-method bodies, named so the per-row plugins and the constant-parameter `*_scalar` twins
+// share one definition each and cannot drift (the property test pinning their bit-equality only
+// samples parameterisations; sharing the body makes it structural).
+
+fn pdf_value(dist: &Beta, v: f64) -> Option<f64> {
+    Some(dist.pdf(v))
+}
+
+fn ln_pdf_value(dist: &Beta, v: f64) -> Option<f64> {
+    Some(dist.ln_pdf(v))
+}
+
+fn cdf_value(dist: &Beta, v: f64) -> Option<f64> {
+    Some(dist.cdf(v))
+}
+
+fn sf_value(dist: &Beta, v: f64) -> Option<f64> {
+    Some(dist.sf(v))
+}
+
+/// A quantile outside `[0, 1]` yields `null` (statrs' `inverse_cdf` panics there, so the guard is
+/// load-bearing); the endpoints map to the support bounds (`ppf(0) = 0`, `ppf(1) = 1`), matching
+/// `scipy.stats.beta.ppf`.
+fn ppf_value(dist: &Beta, q: f64) -> Option<f64> {
+    if !(0.0..=1.0).contains(&q) {
+        None
+    } else {
+        Some(dist.inverse_cdf(q))
+    }
+}
+
+/// Element-wise pdf via `statrs` `Continuous::pdf` (Beta function); `0` outside `[0, 1]`, and
+/// divergent (`inf`) at a boundary whose shape is `< 1`. See [`value_keyed`] for the null/error
+/// contract.
+#[polars_expr(output_type=Float64)]
+fn beta_pdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, pdf_value)
+}
+
+/// Element-wise log-pdf via native `Continuous::ln_pdf` (more accurate than `pdf().ln()`);
+/// `-inf` outside `[0, 1]`.
+#[polars_expr(output_type=Float64)]
+fn beta_ln_pdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, ln_pdf_value)
+}
+
+/// Element-wise cdf via `statrs` `ContinuousCDF::cdf` (regularized incomplete beta); `0` below the
+/// support, `1` at/above `1`.
+#[polars_expr(output_type=Float64)]
+fn beta_cdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, cdf_value)
+}
+
+/// Element-wise survival function via native `ContinuousCDF::sf` (accurate in the upper tail);
+/// `1` below the support, `0` at/above `1`.
+#[polars_expr(output_type=Float64)]
+fn beta_sf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, sf_value)
+}
+
+/// Element-wise ppf via the closed-form `ContinuousCDF::inverse_cdf` (inverse regularized
+/// incomplete beta). See [`ppf_value`] for the endpoint and out-of-range contract.
+#[polars_expr(output_type=Float64)]
+fn beta_ppf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, ppf_value)
+}
+
+value_keyed_scalar_plugins! {
+    /// Static parameters for the constant-parameter value-keyed fast paths (`<method>_scalar`).
+    ///
+    /// Like [`BetaScalarKwargs`] minus the sampler `seed`: when both parameters are Python
+    /// scalars, the Python layer routes them here as kwargs instead of expanding each into a
+    /// full-length column re-validated on every row. The distribution is validated and built once;
+    /// only the evaluation-point column travels as an input.
+    struct BetaParamsKwargs { a: f64, b: f64 }
+
+    build = |kw| build_dist(kw.a, kw.b)?;
+
+    methods {
+        /// Constant-parameter pdf; same body as [`beta_pdf`] via [`pdf_value`], dist built once.
+        fn beta_pdf_scalar => pdf_value;
+
+        /// Constant-parameter log-pdf; same body as [`beta_ln_pdf`] via [`ln_pdf_value`], dist built once.
+        fn beta_ln_pdf_scalar => ln_pdf_value;
+
+        /// Constant-parameter cdf; same body as [`beta_cdf`] via [`cdf_value`], dist built once.
+        fn beta_cdf_scalar => cdf_value;
+
+        /// Constant-parameter sf; same body as [`beta_sf`] via [`sf_value`], dist built once.
+        fn beta_sf_scalar => sf_value;
+
+        /// Constant-parameter ppf; same body as [`beta_ppf`] via [`ppf_value`], dist built once.
+        fn beta_ppf_scalar => ppf_value;
+    }
+}
+
+/// Element-wise differential entropy (in nats) via `statrs` `Distribution::entropy`:
+/// `ln B(a, b) - (a - 1) psi(a) - (b - 1) psi(b) + (a + b - 2) psi(a + b)`.
+///
+/// Kept in Rust, unlike `mean` / `variance`: the beta entropy needs log-Beta and digamma, which
+/// have no elementary closed form, so there is no numerically equivalent Polars expression to move
+/// it to (the same reasoning as `binomial_entropy`).
+#[polars_expr(output_type=Float64)]
+fn beta_entropy(inputs: &[Series]) -> PolarsResult<Series> {
+    params_keyed(inputs, |dist| dist.entropy().unwrap())
+}

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -1,4 +1,5 @@
 pub mod bernoulli;
+pub mod beta;
 pub mod binomial;
 pub mod exponential;
 pub mod lognormal;

--- a/tests/distributions/beta/cdf_test.py
+++ b/tests/distributions/beta/cdf_test.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Beta
+
+
+@pytest.mark.parametrize("shape", [0.5, 1.0, 2.0, 5.0])
+def test_cdf_is_half_at_centre_for_symmetric_shapes(shape: float) -> None:
+    result = pl.DataFrame({"x": [0.5]}).select(r=Beta(a=shape, b=shape).cdf(pl.col("x")))["r"].item()
+    assert result == pytest.approx(0.5, abs=1e-12)
+
+
+def test_cdf_is_monotone_non_decreasing(params: tuple[float, float], value_grid: list[float]) -> None:
+    a, b = params
+    result = pl.DataFrame({"x": value_grid}).select(r=Beta(a=a, b=b).cdf(pl.col("x")))["r"]
+    assert result.is_sorted()
+    assert result.is_between(0.0, 1.0).all()
+
+
+def test_cdf_clamps_outside_support() -> None:
+    df = pl.DataFrame({"x": [-0.5, 0.0, 1.0, 1.5]})
+    result = df.select(r=Beta(a=2.0, b=3.0).cdf(pl.col("x")))["r"]
+    expected = pl.Series("r", [0.0, 0.0, 1.0, 1.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_cdf_column_params() -> None:
+    # Beta(1, 1) cdf is the identity on the support; Beta(2, 2) cdf is 3x^2 - 2x^3.
+    df = pl.DataFrame({"a": [1.0, 2.0], "b": [1.0, 2.0], "x": [0.25, 0.5]})
+    result = df.select(r=Beta(a=pl.col("a"), b=pl.col("b")).cdf(pl.col("x")))["r"]
+    expected = pl.Series("r", [0.25, 0.5], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_cdf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"x": [0.5, None]}, schema={"x": pl.Float64})
+    result = df.select(r=Beta(a=2.0, b=2.0).cdf(pl.col("x")))["r"]
+    expected = pl.Series("r", [0.5, None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/beta/conftest.py
+++ b/tests/distributions/beta/conftest.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import polars as pl
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+SEED = 42
+DEFAULT_SIZE = 1000
+
+# `(a, b)` shape grid exposed through the `params` fixture so no test file redeclares it. Covers the
+# qualitatively distinct regimes: unimodal, U-shaped (both shapes < 1), uniform (1, 1), J-shaped, and skewed.
+PARAMS = [(2.0, 3.0), (0.5, 0.5), (1.0, 1.0), (5.0, 1.0), (2.0, 8.0)]
+
+
+@pytest.fixture(scope="session")
+def seed() -> int:
+    return SEED
+
+
+@pytest.fixture(params=PARAMS, ids=[f"a={a},b={b}" for a, b in PARAMS])
+def params(request: pytest.FixtureRequest) -> tuple[float, float]:
+    """An `(a, b)` shape pair. Requesting this fixture parametrises the test over `PARAMS`."""
+    return request.param  # type: ignore[no-any-return]
+
+
+@pytest.fixture
+def frame() -> Callable[..., pl.DataFrame]:
+    """Factory for a frame with an `x` column and per-row positive `a` / `b` shape columns.
+
+    Seeds a fresh generator on every call, so the data is reproducible regardless of test execution
+    order, selection (`-k`) or sharding, rather than depending on a shared session-scoped stream.
+    """
+
+    def _make(size: int = DEFAULT_SIZE) -> pl.DataFrame:
+        local_rng = np.random.default_rng(seed=SEED)
+        a = local_rng.uniform(0.5, 5.0, size=size)
+        b = local_rng.uniform(0.5, 5.0, size=size)
+        return pl.DataFrame({"x": list(range(size)), "a": a, "b": b})
+
+    return _make
+
+
+@pytest.fixture
+def value_grid() -> list[float]:
+    """Interior evaluation points of the fixed `[0, 1]` support, spanning both tails through the centre."""
+    return [0.01, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99]

--- a/tests/distributions/beta/construct_test.py
+++ b/tests/distributions/beta/construct_test.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from polars_stats import Beta
+
+
+@pytest.mark.parametrize("bad", [None, True, False, 1, 0, [2.0, 3.0], (2.0,), {"a": 2.0}])
+def test_construct_invalid_a_type_raises(bad: object) -> None:
+    with pytest.raises(TypeError, match="a should be a float or IntoExprColumn"):
+        Beta(a=bad, b=1.0)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("bad", [None, True, False, 1, 0, [1.0], (1.0,), {"b": 1.0}])
+def test_construct_invalid_b_type_raises(bad: object) -> None:
+    with pytest.raises(TypeError, match="b should be a float or IntoExprColumn"):
+        Beta(a=2.0, b=bad)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("a", "b"), [(0.0, 1.0), (-1.0, 1.0), (1.0, 0.0), (1.0, -1e-9), (float("inf"), 1.0), (1.0, float("inf"))]
+)
+def test_construct_scalar_invalid_shape_defers_to_eval(a: float, b: float) -> None:
+    # No early Python validation (matching Normal / Uniform): construction succeeds; the invalid
+    # shape surfaces as a ComputeError when a method is evaluated, not a ValueError here.
+    Beta(a=a, b=b)
+    with pytest.raises(pl.exceptions.ComputeError, match="a and b must be finite and strictly positive"):
+        pl.DataFrame({"x": [0.5]}).select(r=Beta(a=a, b=b).pdf(pl.col("x")))
+
+
+def test_construct_column_params_defers_validation() -> None:
+    # A non-positive shape on a column is not knowable at construction; it must not raise here.
+    Beta(a=pl.col("a"), b=pl.col("b"))
+    Beta(a="a", b="b")

--- a/tests/distributions/beta/entropy_test.py
+++ b/tests/distributions/beta/entropy_test.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from scipy.stats import beta as scipy_beta
+
+from polars_stats import Beta
+from tests._polars_compat import assert_series_equal
+
+
+def test_entropy_matches_scipy_column_params() -> None:
+    shapes = [(2.0, 3.0), (0.5, 0.5), (5.0, 1.0)]
+    df = pl.DataFrame({"a": [s[0] for s in shapes], "b": [s[1] for s in shapes]})
+    result = df.select(r=Beta(a=pl.col("a"), b=pl.col("b")).entropy())["r"]
+    expected = pl.Series("r", [float(scipy_beta.entropy(a, b)) for a, b in shapes], dtype=pl.Float64)
+    assert_series_equal(result, expected, rel_tol=0.0, abs_tol=1e-12)
+
+
+def test_entropy_uniform_shapes_is_zero() -> None:
+    # Beta(1, 1) is Uniform(0, 1), whose differential entropy is log(1) = 0.
+    result = pl.DataFrame({"_": [0]}).select(r=Beta(a=1.0, b=1.0).entropy()).item(0, "r")
+    assert result == pytest.approx(0.0, abs=1e-12)
+
+
+def test_entropy_propagates_null_params() -> None:
+    # A null in either parameter nulls the row (null a, then null b).
+    df = pl.DataFrame({"a": [2.0, None, 1.0], "b": [3.0, 2.0, None]}, schema={"a": pl.Float64, "b": pl.Float64})
+    result = df.select(r=Beta(a=pl.col("a"), b=pl.col("b")).entropy())["r"]
+    expected = pl.Series("r", [float(scipy_beta.entropy(2.0, 3.0)), None, None], dtype=pl.Float64)
+    assert_series_equal(result, expected, rel_tol=0.0, abs_tol=1e-12)

--- a/tests/distributions/beta/isf_test.py
+++ b/tests/distributions/beta/isf_test.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import polars as pl
+
+from polars_stats import Beta
+from tests._polars_compat import assert_series_equal
+
+
+def test_isf_equals_ppf_of_complement(params: tuple[float, float]) -> None:
+    a, b = params
+    qs = [0.05, 0.25, 0.5, 0.75, 0.95]
+    dist = Beta(a=a, b=b)
+    isf = pl.DataFrame({"q": qs}).select(r=dist.isf(pl.col("q")))["r"]
+    ppf_comp = pl.DataFrame({"q": [1 - q for q in qs]}).select(r=dist.ppf(pl.col("q")))["r"]
+    assert_series_equal(isf, ppf_comp, rel_tol=0.0, abs_tol=1e-12)
+
+
+def test_isf_endpoints_are_support_bounds() -> None:
+    df = pl.DataFrame({"q": [0.0, 1.0]})
+    result = df.select(r=Beta(a=2.0, b=3.0).isf(pl.col("q")))["r"]
+    expected = pl.Series("r", [1.0, 0.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_isf_out_of_range_is_null() -> None:
+    df = pl.DataFrame({"q": [-0.1, 0.0, 1.0, 1.1]})
+    result = df.select(r=Beta(a=2.0, b=3.0).isf(pl.col("q")))["r"]
+    expected = pl.Series("r", [None, 1.0, 0.0, None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/beta/log_cdf_test.py
+++ b/tests/distributions/beta/log_cdf_test.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+
+from polars_stats import Beta
+from tests._polars_compat import assert_series_equal
+
+
+def test_log_cdf_equals_log_of_cdf(value_grid: list[float]) -> None:
+    b = Beta(a=2.0, b=3.0)
+    result = pl.DataFrame({"x": value_grid}).select(diff=b.log_cdf(pl.col("x")) - b.cdf(pl.col("x")).log())["diff"]
+    expected = pl.Series("diff", [0.0] * result.len(), dtype=pl.Float64)
+    assert_series_equal(result, expected, rel_tol=0.0, abs_tol=1e-12)
+
+
+def test_log_cdf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"x": [0.5, None]}, schema={"x": pl.Float64})
+    result = df.select(r=Beta(a=2.0, b=2.0).log_cdf(pl.col("x")))["r"]
+    expected = pl.Series("r", [math.log(0.5), None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/beta/log_pdf_test.py
+++ b/tests/distributions/beta/log_pdf_test.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+
+from polars_stats import Beta
+from tests._polars_compat import assert_series_equal
+
+
+def test_log_pdf_equals_log_of_pdf(value_grid: list[float]) -> None:
+    b = Beta(a=2.0, b=3.0)
+    result = pl.DataFrame({"x": value_grid}).select(diff=b.log_pdf(pl.col("x")) - b.pdf(pl.col("x")).log())["diff"]
+    expected = pl.Series("diff", [0.0] * result.len(), dtype=pl.Float64)
+    assert_series_equal(result, expected, rel_tol=0.0, abs_tol=1e-12)
+
+
+def test_log_pdf_outside_support_is_neg_inf() -> None:
+    df = pl.DataFrame({"x": [-0.5, 1.5]})
+    result = df.select(r=Beta(a=2.0, b=3.0).log_pdf(pl.col("x")))["r"]
+    expected = pl.Series("r", [float("-inf"), float("-inf")], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_log_pdf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"x": [0.5, None]}, schema={"x": pl.Float64})
+    result = df.select(r=Beta(a=2.0, b=2.0).log_pdf(pl.col("x")))["r"]
+    expected = pl.Series("r", [math.log(1.5), None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/beta/log_sf_test.py
+++ b/tests/distributions/beta/log_sf_test.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+
+from polars_stats import Beta
+from tests._polars_compat import assert_series_equal
+
+
+def test_log_sf_equals_log_of_sf(value_grid: list[float]) -> None:
+    b = Beta(a=2.0, b=3.0)
+    result = pl.DataFrame({"x": value_grid}).select(diff=b.log_sf(pl.col("x")) - b.sf(pl.col("x")).log())["diff"]
+    expected = pl.Series("diff", [0.0] * result.len(), dtype=pl.Float64)
+    assert_series_equal(result, expected, rel_tol=0.0, abs_tol=1e-12)
+
+
+def test_log_sf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"x": [0.5, None]}, schema={"x": pl.Float64})
+    result = df.select(r=Beta(a=2.0, b=2.0).log_sf(pl.col("x")))["r"]
+    expected = pl.Series("r", [math.log(0.5), None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/beta/mean_test.py
+++ b/tests/distributions/beta/mean_test.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import polars as pl
+from polars.testing import assert_series_equal
+
+from polars_stats import Beta
+
+
+def test_mean_is_shape_ratio_column_params() -> None:
+    df = pl.DataFrame({"a": [2.0, 1.0, 5.0], "b": [3.0, 1.0, 1.0]})
+    result = df.select(r=Beta(a=pl.col("a"), b=pl.col("b")).mean())["r"]
+    expected = pl.Series("r", [0.4, 0.5, 5.0 / 6.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_mean_propagates_null_params() -> None:
+    # A null in either parameter nulls the row (null a, then null b).
+    df = pl.DataFrame({"a": [2.0, None, 1.0], "b": [3.0, 2.0, None]}, schema={"a": pl.Float64, "b": pl.Float64})
+    result = df.select(r=Beta(a=pl.col("a"), b=pl.col("b")).mean())["r"]
+    expected = pl.Series("r", [0.4, None, None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/beta/median_test.py
+++ b/tests/distributions/beta/median_test.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Beta
+
+
+@pytest.mark.parametrize("shape", [0.5, 1.0, 2.0, 5.0])
+def test_median_is_half_for_symmetric_shapes(shape: float) -> None:
+    result = pl.DataFrame({"_": [0]}).select(r=Beta(a=shape, b=shape).median()).item(0, "r")
+    assert result == pytest.approx(0.5, abs=1e-9)
+
+
+def test_median_equals_ppf_half_column_params() -> None:
+    # No closed form: `median` is the base-class `ppf(0.5)` fallback, so the two must agree exactly.
+    df = pl.DataFrame({"a": [2.0, 0.5, 5.0], "b": [3.0, 0.5, 1.0]})
+    dist = Beta(a=pl.col("a"), b=pl.col("b"))
+    median = df.select(r=dist.median())["r"]
+    ppf_half = df.select(r=dist.ppf(0.5))["r"]
+    assert_series_equal(median, ppf_half)
+
+
+def test_median_propagates_null_params() -> None:
+    # A null in either parameter nulls the row (null a, then null b).
+    df = pl.DataFrame({"a": [1.0, None, 1.0], "b": [1.0, 2.0, None]}, schema={"a": pl.Float64, "b": pl.Float64})
+    result = df.select(r=Beta(a=pl.col("a"), b=pl.col("b")).median())["r"]
+    expected = pl.Series("r", [0.5, None, None], dtype=pl.Float64)
+    assert_series_equal(result, expected, check_exact=False)

--- a/tests/distributions/beta/pdf_test.py
+++ b/tests/distributions/beta/pdf_test.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Beta
+
+
+def test_pdf_beta_2_2_peak() -> None:
+    # Beta(2, 2) density is 6x(1 - x), peaking at 1.5 in the middle of the support.
+    result = pl.DataFrame({"x": [0.5]}).select(r=Beta(a=2.0, b=2.0).pdf(pl.col("x")))["r"].item()
+    assert result == pytest.approx(1.5, abs=1e-12)
+
+
+def test_pdf_outside_support_is_zero() -> None:
+    df = pl.DataFrame({"x": [-1.0, -1e-9, 1.0 + 1e-9, 2.0]})
+    result = df.select(r=Beta(a=2.0, b=3.0).pdf(pl.col("x")))["r"]
+    expected = pl.Series("r", [0.0, 0.0, 0.0, 0.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_pdf_diverges_at_boundaries_for_shapes_below_one() -> None:
+    # A shape < 1 makes the density divergent at the matching boundary (the issue caveat).
+    df = pl.DataFrame({"x": [0.0, 1.0]})
+    result = df.select(r=Beta(a=0.5, b=0.5).pdf(pl.col("x")))["r"]
+    expected = pl.Series("r", [float("inf"), float("inf")], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_pdf_column_params() -> None:
+    # Beta(2, 3) density is 12x(1 - x)^2; Beta(1, 1) is the uniform density.
+    df = pl.DataFrame({"a": [2.0, 1.0], "b": [3.0, 1.0], "x": [0.5, 0.25]})
+    result = df.select(r=Beta(a=pl.col("a"), b=pl.col("b")).pdf(pl.col("x")))["r"]
+    expected = pl.Series("r", [1.5, 1.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_pdf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"x": [0.5, None, 0.25]}, schema={"x": pl.Float64})
+    result = df.select(r=Beta(a=2.0, b=2.0).pdf(pl.col("x")))["r"]
+    expected = pl.Series("r", [1.5, None, 1.125], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/beta/ppf_test.py
+++ b/tests/distributions/beta/ppf_test.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from polars_stats import Beta
+from tests._polars_compat import assert_series_equal
+
+
+@pytest.mark.parametrize("shape", [0.5, 1.0, 2.0, 5.0])
+def test_ppf_at_half_is_centre_for_symmetric_shapes(shape: float) -> None:
+    result = pl.DataFrame({"q": [0.5]}).select(r=Beta(a=shape, b=shape).ppf(pl.col("q")))["r"].item()
+    assert result == pytest.approx(0.5, abs=1e-9)
+
+
+def test_ppf_is_cdf_inverse(params: tuple[float, float]) -> None:
+    a, b = params
+    interior = [0.05, 0.25, 0.5, 0.75, 0.95]
+    dist = Beta(a=a, b=b)
+    result = pl.DataFrame({"q": interior}).select(r=dist.cdf(dist.ppf(pl.col("q"))))["r"]
+    expected = pl.Series("r", interior, dtype=pl.Float64)
+    assert_series_equal(result, expected, rel_tol=0.0, abs_tol=1e-9)
+
+
+def test_ppf_endpoints_are_support_bounds() -> None:
+    df = pl.DataFrame({"q": [0.0, 1.0]})
+    result = df.select(r=Beta(a=2.0, b=3.0).ppf(pl.col("q")))["r"]
+    expected = pl.Series("r", [0.0, 1.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_ppf_out_of_range_is_null() -> None:
+    df = pl.DataFrame({"q": [-0.1, 0.0, 0.5, 1.0, 1.1]})
+    result = df.select(r=Beta(a=2.0, b=2.0).ppf(pl.col("q")))["r"]
+    expected = pl.Series("r", [None, 0.0, 0.5, 1.0, None], dtype=pl.Float64)
+    assert_series_equal(result, expected, rel_tol=0.0, abs_tol=1e-9)
+
+
+def test_ppf_propagates_null_in_quantile() -> None:
+    df = pl.DataFrame({"q": [0.5, None]}, schema={"q": pl.Float64})
+    result = df.select(r=Beta(a=2.0, b=2.0).ppf(pl.col("q")))["r"]
+    expected = pl.Series("r", [0.5, None], dtype=pl.Float64)
+    assert_series_equal(result, expected, rel_tol=0.0, abs_tol=1e-9)

--- a/tests/distributions/beta/sample_test.py
+++ b/tests/distributions/beta/sample_test.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal, assert_series_not_equal
+
+from polars_stats import Beta
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@pytest.mark.parametrize("size", [0, 100, 1_000])
+def test_sample_basic_properties(size: int, frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    result = frame(size=size).lazy().with_columns(z=Beta(a=2.0, b=3.0).sample(seed=seed))
+    assert result.collect_schema()["z"] == pl.Float64
+    assert result.collect().height == size
+
+
+def test_sample_within_support(params: tuple[float, float], frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    a, b = params
+    s = frame(size=2_000).with_columns(z=Beta(a=a, b=b).sample(seed=seed))["z"]
+    assert s.is_between(0.0, 1.0).all()
+
+
+def test_sample_seed_reproducible(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    dframe = frame()
+    s1 = dframe.with_columns(z=Beta(a=2.0, b=3.0).sample(seed=seed))["z"]
+    s2 = dframe.with_columns(z=Beta(a=2.0, b=3.0).sample(seed=seed))["z"]
+    assert_series_equal(s1, s2)
+
+
+def test_sample_different_seeds_differ(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    dframe = frame()
+    s1 = dframe.with_columns(z=Beta(a=2.0, b=3.0).sample(seed=123))["z"]
+    s2 = dframe.with_columns(z=Beta(a=2.0, b=3.0).sample(seed=seed))["z"]
+    assert_series_not_equal(s1, s2)
+
+
+@pytest.mark.parametrize(("a", "b"), [(2.0, 3.0), (0.5, 0.5), (5.0, 1.0)])
+def test_sample_moments_close_for_large_n(a: float, b: float, frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    s = frame(size=200_000).with_columns(z=Beta(a=a, b=b).sample(seed=seed))["z"]
+    mean = a / (a + b)
+    std = math.sqrt(a * b / ((a + b) ** 2 * (a + b + 1)))
+    observed_mean = s.mean()
+    observed_std = s.std()
+    assert isinstance(observed_mean, float)
+    assert isinstance(observed_std, float)
+    assert abs(observed_mean - mean) < 0.02 * std
+    assert abs(observed_std - std) < 0.02 * std
+
+
+def test_sample_column_params_moments_per_row(seed: int) -> None:
+    # Constant params per row, but a wide frame: the empirical moments must track the parameters.
+    size = 200_000
+    a, b = 2.0, 3.0
+    mean = a / (a + b)
+    std = math.sqrt(a * b / ((a + b) ** 2 * (a + b + 1)))
+    dframe = pl.DataFrame({"a": [a] * size, "b": [b] * size})
+    s = dframe.with_columns(z=Beta(a=pl.col("a"), b=pl.col("b")).sample(seed=seed))["z"]
+    assert abs(s.mean() - mean) < 0.02 * std  # type: ignore[operator]
+    assert abs(s.std() - std) < 0.02 * std  # type: ignore[operator]
+
+
+def test_sample_str_params_match_col(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    dframe = frame()
+    s_str = dframe.with_columns(z=Beta(a="a", b="b").sample(seed=seed))["z"]
+    s_col = dframe.with_columns(z=Beta(a=pl.col("a"), b=pl.col("b")).sample(seed=seed))["z"]
+    assert_series_equal(s_str, s_col)
+
+
+def test_sample_null_param_row_is_null(seed: int) -> None:
+    dframe = pl.DataFrame(
+        {"a": [2.0, None, 1.0], "b": [3.0, 2.0, None]},
+        schema={"a": pl.Float64, "b": pl.Float64},
+    )
+    result = dframe.with_columns(z=Beta(a=pl.col("a"), b=pl.col("b")).sample(seed=seed))["z"]
+    assert_series_equal(result.is_null(), pl.Series("z", [False, True, True]))
+
+
+def test_sample_non_positive_shape_row_raises(seed: int) -> None:
+    # An invalid shape on a row raises (no early Python validation), the same way Normal reports a
+    # non-positive scale. Plugin errors surface as `ComputeError`.
+    dframe = pl.DataFrame({"a": [2.0, 1.0, 3.0], "b": [3.0, -2.0, 1.0]})  # row 1: b = -2.0
+    with pytest.raises(pl.exceptions.ComputeError, match="a and b must be finite and strictly positive"):
+        dframe.with_columns(z=Beta(a=pl.col("a"), b=pl.col("b")).sample(seed=seed))
+
+
+def test_sample_in_group_by_draws_per_group(seed: int) -> None:
+    n_per_group, n_groups = 200, 20
+    dframe = pl.DataFrame({"group": np.repeat(np.arange(n_groups), n_per_group)})
+    agg = (
+        dframe.group_by("group", maintain_order=True)
+        .agg(mean_z=Beta(a=2.0, b=3.0).sample(seed=seed).mean(), size=pl.len())
+        .sort("group")
+    )
+    assert agg["size"].eq(n_per_group).all()
+    # Constant params + constant seed + same per-group indices => identical per-group means.
+    assert len(set(agg["mean_z"].to_list())) == 1
+
+
+def test_sample_over_partitions_full_length(seed: int) -> None:
+    n_per_group, n_groups = 200, 10
+    dframe = pl.DataFrame({"group": np.repeat(np.arange(n_groups), n_per_group)})
+    s1 = dframe.with_columns(z=Beta(a=2.0, b=3.0).sample(seed=seed).over("group"))["z"]
+    s2 = dframe.with_columns(z=Beta(a=2.0, b=3.0).sample(seed=seed).over("group"))["z"]
+    assert s1.len() == n_groups * n_per_group
+    assert_series_equal(s1, s2)
+
+
+def test_sample_unseeded_produces_variability(frame: Callable[..., pl.DataFrame]) -> None:
+    dframe = frame(size=512)
+    s1 = dframe.with_columns(z=Beta(a=2.0, b=3.0).sample(seed=None))["z"]
+    s2 = dframe.with_columns(z=Beta(a=2.0, b=3.0).sample(seed=None))["z"]
+    assert_series_not_equal(s1, s2)
+
+
+def test_sample_rows_are_independent_no_aliasing(seed: int) -> None:
+    # Each row derives its stream from `(seed, row_index)`, so even with constant params and a fixed
+    # seed every row must draw an independent value. Full uniqueness among Float64 draws is the
+    # observable form of the per-row non-aliasing guarantee.
+    size = 50_000
+    s = pl.DataFrame({"x": range(size)}).with_columns(z=Beta(a=2.0, b=3.0).sample(seed=seed))["z"]
+    assert s.n_unique() == size

--- a/tests/distributions/beta/samples_test.py
+++ b/tests/distributions/beta/samples_test.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, cast
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Beta
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@pytest.mark.parametrize("size", [1, 4, 16])
+def test_samples_shape_and_dtype(size: int, frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    n = 32
+    result = frame(size=n).select(s=Beta(a=2.0, b=3.0).samples(size=size, seed=seed))
+    assert result.height == n
+    assert result.schema["s"] == pl.Array(pl.Float64, size)
+
+
+def test_samples_seed_reproducible(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    dframe = frame(size=128)
+    s1 = dframe.select(s=Beta(a=2.0, b=3.0).samples(size=8, seed=seed))["s"]
+    s2 = dframe.select(s=Beta(a=2.0, b=3.0).samples(size=8, seed=seed))["s"]
+    assert_series_equal(s1, s2)
+
+
+def test_samples_within_support(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    result = frame(size=512).select(s=Beta(a=0.5, b=0.5).samples(size=8, seed=seed))["s"].arr.explode()
+    assert result.is_between(0.0, 1.0).all()
+
+
+def test_samples_columns_are_not_all_equal(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    size = 8
+    dframe = frame(size=512)
+    result = dframe.select(s=Beta(a=2.0, b=3.0).samples(size=size, seed=seed))["s"]
+    columns = [result.arr.get(i) for i in range(size)]
+    distinct = {tuple(c.to_list()) for c in columns}
+    assert len(distinct) == size
+
+
+def test_samples_moments_close(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    a, b = 2.0, 3.0
+    mean = a / (a + b)
+    std = math.sqrt(a * b / ((a + b) ** 2 * (a + b + 1)))
+    result = frame(size=4_000).select(s=Beta(a=a, b=b).samples(size=16, seed=seed))["s"].arr.explode()
+    _mean, _std = cast("float", result.mean()), cast("float", result.std())
+    assert abs(_mean - mean) < 0.05 * std
+    assert abs(_std - std) < 0.05 * std
+
+
+@pytest.mark.parametrize("bad_size", [0, -1])
+def test_samples_rejects_non_positive_size(bad_size: int) -> None:
+    with pytest.raises(ValueError, match="size must be a positive integer"):
+        Beta(a=2.0, b=3.0).samples(size=bad_size, seed=0)
+
+
+def test_samples_null_param_row_is_null_array(seed: int) -> None:
+    size = 4
+    dframe = pl.DataFrame(
+        {"a": [2.0, None, 1.0], "b": [3.0, 2.0, 1.0]},
+        schema={"a": pl.Float64, "b": pl.Float64},
+    )
+    result = dframe.select(s=Beta(a=pl.col("a"), b=pl.col("b")).samples(size=size, seed=seed))["s"]
+    assert result.dtype == pl.Array(pl.Float64, size)
+    # A null param row yields a null array, not an array of inner-null elements.
+    assert_series_equal(result.is_null(), pl.Series("s", [False, True, False]))
+
+
+def test_samples_non_positive_shape_raises(seed: int) -> None:
+    dframe = pl.DataFrame({"a": [2.0, 1.0], "b": [3.0, -2.0]})  # row 1: b = -2.0
+    with pytest.raises(pl.exceptions.ComputeError, match="a and b must be finite and strictly positive"):
+        dframe.select(s=Beta(a=pl.col("a"), b=pl.col("b")).samples(size=4, seed=seed))

--- a/tests/distributions/beta/sf_test.py
+++ b/tests/distributions/beta/sf_test.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from polars_stats import Beta
+from tests._polars_compat import assert_series_equal
+
+
+@pytest.mark.parametrize("shape", [0.5, 1.0, 2.0, 5.0])
+def test_sf_is_half_at_centre_for_symmetric_shapes(shape: float) -> None:
+    result = pl.DataFrame({"x": [0.5]}).select(r=Beta(a=shape, b=shape).sf(pl.col("x")))["r"].item()
+    assert result == pytest.approx(0.5, abs=1e-12)
+
+
+def test_sf_complements_cdf(params: tuple[float, float], value_grid: list[float]) -> None:
+    a, b = params
+    dist = Beta(a=a, b=b)
+    result = pl.DataFrame({"x": value_grid}).select(total=dist.cdf(pl.col("x")) + dist.sf(pl.col("x")))["total"]
+    expected = pl.Series("total", [1.0] * result.len(), dtype=pl.Float64)
+    assert_series_equal(result, expected, rel_tol=0.0, abs_tol=1e-12)
+
+
+def test_sf_clamps_outside_support() -> None:
+    df = pl.DataFrame({"x": [-0.5, 0.0, 1.0, 1.5]})
+    result = df.select(r=Beta(a=2.0, b=3.0).sf(pl.col("x")))["r"]
+    expected = pl.Series("r", [1.0, 1.0, 0.0, 0.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_sf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"x": [0.5, None]}, schema={"x": pl.Float64})
+    result = df.select(r=Beta(a=2.0, b=2.0).sf(pl.col("x")))["r"]
+    expected = pl.Series("r", [0.5, None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/beta/std_test.py
+++ b/tests/distributions/beta/std_test.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+from polars.testing import assert_series_equal
+
+from polars_stats import Beta
+
+
+def test_std_is_sqrt_of_variance_column_params() -> None:
+    df = pl.DataFrame({"a": [2.0, 1.0], "b": [3.0, 1.0]})
+    result = df.select(r=Beta(a=pl.col("a"), b=pl.col("b")).std())["r"]
+    expected = pl.Series("r", [0.2, math.sqrt(1.0 / 12.0)], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_std_propagates_null_params() -> None:
+    # A null in either parameter nulls the row (null a, then null b).
+    df = pl.DataFrame({"a": [2.0, None, 1.0], "b": [3.0, 2.0, None]}, schema={"a": pl.Float64, "b": pl.Float64})
+    result = df.select(r=Beta(a=pl.col("a"), b=pl.col("b")).std())["r"]
+    expected = pl.Series("r", [0.2, None, None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/beta/symmetry_test.py
+++ b/tests/distributions/beta/symmetry_test.py
@@ -1,0 +1,16 @@
+"""`X ~ Beta(a, b)` implies `1 - X ~ Beta(b, a)`, so the cdf must satisfy `F_{a,b}(x) = 1 - F_{b,a}(1 - x)`."""
+
+from __future__ import annotations
+
+import polars as pl
+
+from polars_stats import Beta
+from tests._polars_compat import assert_series_equal
+
+
+def test_cdf_reflection_symmetry(params: tuple[float, float], value_grid: list[float]) -> None:
+    a, b = params
+    df = pl.DataFrame({"x": value_grid})
+    lhs = df.select(r=Beta(a=a, b=b).cdf(pl.col("x")))["r"]
+    rhs = df.select(r=1 - Beta(a=b, b=a).cdf(1 - pl.col("x")))["r"]
+    assert_series_equal(lhs, rhs, rel_tol=0.0, abs_tol=1e-12)

--- a/tests/distributions/beta/uniform_equivalence_test.py
+++ b/tests/distributions/beta/uniform_equivalence_test.py
@@ -1,0 +1,40 @@
+"""`Beta(1, 1)` is `Uniform(0, 1)`; every closed-form method must agree across the two."""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from polars_stats import Beta, Uniform
+from tests._polars_compat import assert_series_equal
+
+_XS = [-0.5, 0.0, 0.25, 0.5, 0.75, 1.0, 1.5]  # interior, both boundaries, and both sides outside
+_QS = [0.0, 0.1, 0.5, 0.9, 1.0]
+
+_BETA = Beta(a=1.0, b=1.0)
+_UNIFORM = Uniform(min=0.0, max=1.0)
+
+
+@pytest.mark.parametrize("method", ["pdf", "log_pdf", "cdf", "log_cdf", "sf", "log_sf"])
+def test_value_keyed_methods_match_uniform(method: str) -> None:
+    df = pl.DataFrame({"x": _XS})
+    via_beta = df.select(r=getattr(_BETA, method)(pl.col("x")))["r"]
+    via_uniform = df.select(r=getattr(_UNIFORM, method)(pl.col("x")))["r"]
+    assert_series_equal(via_beta, via_uniform, rel_tol=0.0, abs_tol=1e-12)
+
+
+@pytest.mark.parametrize("method", ["ppf", "isf"])
+def test_quantile_methods_match_uniform(method: str) -> None:
+    # The inverse regularized incomplete beta is Newton-refined, so agreement is close but not exact.
+    df = pl.DataFrame({"q": _QS})
+    via_beta = df.select(r=getattr(_BETA, method)(pl.col("q")))["r"]
+    via_uniform = df.select(r=getattr(_UNIFORM, method)(pl.col("q")))["r"]
+    assert_series_equal(via_beta, via_uniform, rel_tol=0.0, abs_tol=1e-9)
+
+
+@pytest.mark.parametrize("method", ["mean", "variance", "std", "median", "entropy"])
+def test_scalar_methods_match_uniform(method: str) -> None:
+    frame = pl.DataFrame({"_": [0]})
+    via_beta = frame.select(r=getattr(_BETA, method)()).item(0, "r")
+    via_uniform = frame.select(r=getattr(_UNIFORM, method)()).item(0, "r")
+    assert via_beta == pytest.approx(via_uniform, abs=1e-9)

--- a/tests/distributions/beta/validation_test.py
+++ b/tests/distributions/beta/validation_test.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+
+from polars_stats import Beta
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Every public method must report an invalid shape (`a <= 0`, `b <= 0`, or a non-finite parameter)
+# as a ComputeError, not silently compute garbage or null the row. Each method builds the
+# distribution in Rust via `statrs`, which is what enforces this consistently across the surface,
+# and identically for scalar and column inputs.
+_METHODS: dict[str, Callable[[Beta], pl.Expr]] = {
+    "pdf": lambda d: d.pdf(pl.col("x")),
+    "log_pdf": lambda d: d.log_pdf(pl.col("x")),
+    "cdf": lambda d: d.cdf(pl.col("x")),
+    "log_cdf": lambda d: d.log_cdf(pl.col("x")),
+    "sf": lambda d: d.sf(pl.col("x")),
+    "log_sf": lambda d: d.log_sf(pl.col("x")),
+    "ppf": lambda d: d.ppf(pl.col("q")),
+    "isf": lambda d: d.isf(pl.col("q")),
+    "mean": lambda d: d.mean(),
+    "variance": lambda d: d.variance(),
+    "std": lambda d: d.std(),
+    "median": lambda d: d.median(),
+    "entropy": lambda d: d.entropy(),
+    "sample": lambda d: d.sample(seed=0),
+    "samples": lambda d: d.samples(size=4, seed=0),
+}
+
+
+@pytest.mark.parametrize("expr_fn", _METHODS.values(), ids=list(_METHODS))
+def test_method_raises_on_non_positive_shape_column(expr_fn: Callable[[Beta], pl.Expr]) -> None:
+    df = pl.DataFrame({"a": [2.0, -1.0], "b": [3.0, 2.0], "x": [0.5, 0.5], "q": [0.5, 0.5]})
+    dist = Beta(a=pl.col("a"), b=pl.col("b"))  # row 1: a = -1.0
+    with pytest.raises(pl.exceptions.ComputeError, match="a and b must be finite and strictly positive"):
+        df.select(r=expr_fn(dist))
+
+
+@pytest.mark.parametrize("expr_fn", _METHODS.values(), ids=list(_METHODS))
+def test_method_raises_on_non_positive_shape_scalar(expr_fn: Callable[[Beta], pl.Expr]) -> None:
+    df = pl.DataFrame({"x": [0.5], "q": [0.5]})
+    dist = Beta(a=2.0, b=-1.0)
+    with pytest.raises(pl.exceptions.ComputeError, match="a and b must be finite and strictly positive"):
+        df.select(r=expr_fn(dist))
+
+
+@pytest.mark.parametrize(
+    "dist",
+    [
+        Beta(a=float("inf"), b=1.0),
+        Beta(a=pl.repeat(float("inf"), n=pl.len(), dtype=pl.Float64()), b=1.0),
+    ],
+    ids=["scalar", "column"],
+)
+def test_infinite_shape_raises(dist: Beta) -> None:
+    # Unlike the Normal / LogNormal scale, statrs rejects an infinite Beta shape.
+    with pytest.raises(pl.exceptions.ComputeError, match="a and b must be finite and strictly positive"):
+        pl.DataFrame({"x": [0.5]}).select(r=dist.pdf(pl.col("x")))

--- a/tests/distributions/beta/variance_test.py
+++ b/tests/distributions/beta/variance_test.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import polars as pl
+from polars.testing import assert_series_equal
+
+from polars_stats import Beta
+
+
+def test_variance_formula_column_params() -> None:
+    # a * b / ((a + b)^2 * (a + b + 1)): Beta(2, 3) -> 6 / (25 * 6) = 0.04; Beta(1, 1) -> 1 / 12.
+    df = pl.DataFrame({"a": [2.0, 1.0], "b": [3.0, 1.0]})
+    result = df.select(r=Beta(a=pl.col("a"), b=pl.col("b")).variance())["r"]
+    expected = pl.Series("r", [0.04, 1.0 / 12.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_variance_propagates_null_params() -> None:
+    # A null in either parameter nulls the row (null a, then null b).
+    df = pl.DataFrame({"a": [2.0, None, 1.0], "b": [3.0, 2.0, None]}, schema={"a": pl.Float64, "b": pl.Float64})
+    result = df.select(r=Beta(a=pl.col("a"), b=pl.col("b")).variance())["r"]
+    expected = pl.Series("r", [0.04, None, None], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/moment_fast_path_test.py
+++ b/tests/distributions/moment_fast_path_test.py
@@ -2,7 +2,8 @@
 
 The closed-form moments (`mean` / `variance` / `std` / `entropy`) and the closed forms of `Uniform`
 / `Bernoulli` route their *validation* through a small Rust plugin (`normal_std_dev`, `uniform_range`,
-`bernoulli_proba`, `binomial_params`, `lognormal_sigma`, plus `binomial_entropy`'s support sum). For
+`bernoulli_proba`, `binomial_params`, `lognormal_sigma`, `beta_params`, plus the `binomial_entropy` /
+`beta_entropy` parameter-keyed formulas). For
 all-scalar parameters that plugin is called once on length-1 `pl.lit` inputs instead of per row.
 `tests/property/moment_test.py` pins bit-equality against the per-row path for *valid* parameters;
 this module pins the parts that test does not reach:
@@ -30,7 +31,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
-from polars_stats import Bernoulli, Binomial, LogNormal, Normal, Uniform
+from polars_stats import Bernoulli, Beta, Binomial, LogNormal, Normal, Uniform
 from tests._polars_compat import assert_series_equal
 
 if TYPE_CHECKING:
@@ -67,6 +68,11 @@ _CASES: dict[str, tuple[_UnivariateDistribution, _UnivariateDistribution, bool]]
     "binomial n=-1": (Binomial(-1, 0.5), Binomial(_col(-1, pl.Int64()), _col(0.5)), True),
     "binomial p=1.5": (Binomial(5, 1.5), Binomial(_col(5, pl.Int64()), _col(1.5)), True),
     "binomial p=nan": (Binomial(5, _NAN), Binomial(_col(5, pl.Int64()), _col(_NAN)), True),
+    "beta a=0": (Beta(0.0, 1.0), Beta(_col(0.0), _col(1.0)), True),
+    "beta b=-1": (Beta(2.0, -1.0), Beta(_col(2.0), _col(-1.0)), True),
+    "beta a=nan": (Beta(_NAN, 1.0), Beta(_col(_NAN), _col(1.0)), True),
+    # An infinite shape is *rejected* by statrs, unlike the Normal / LogNormal scale.
+    "beta a=inf (rejected)": (Beta(_INF, 1.0), Beta(_col(_INF), _col(1.0)), True),
 }
 
 

--- a/tests/distributions/output_name_test.py
+++ b/tests/distributions/output_name_test.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
-from polars_stats import Bernoulli, Binomial, Exponential, LogNormal, Normal, Uniform
+from polars_stats import Bernoulli, Beta, Binomial, Exponential, LogNormal, Normal, Uniform
 
 if TYPE_CHECKING:
     from polars_stats.distributions._base import _UnivariateDistribution
@@ -28,6 +28,7 @@ _SCALAR_PARAMS: dict[str, _UnivariateDistribution] = {
     "lognormal": LogNormal(mu=0.0, sigma=1.0),
     "uniform": Uniform(min=0.0, max=1.0),
     "exponential": Exponential(rate=1.0),
+    "beta": Beta(a=2.0, b=3.0),
 }
 
 # Distribution with a column-valued first parameter, paired with the root name the output inherits.
@@ -39,6 +40,8 @@ _COLUMN_PARAMS: dict[str, tuple[_UnivariateDistribution, str]] = {
     "uniform": (Uniform(min=pl.col("mu"), max=1.0), "mu"),
     # `mu` is all-zero (an invalid rate); the rate column reads the positive `p` column instead.
     "exponential": (Exponential(rate=pl.col("p")), "p"),
+    # Same for the first shape: `p` is positive on every row, a valid `a`.
+    "beta": (Beta(a=pl.col("p"), b=1.0), "p"),
 }
 
 

--- a/tests/distributions/value_arg_str_test.py
+++ b/tests/distributions/value_arg_str_test.py
@@ -14,7 +14,7 @@ import polars as pl
 import pytest
 from polars.testing import assert_series_equal
 
-from polars_stats import Bernoulli, Binomial, Exponential, LogNormal, Normal, Uniform
+from polars_stats import Bernoulli, Beta, Binomial, Exponential, LogNormal, Normal, Uniform
 from polars_stats.distributions._base import ContinuousDistribution
 
 if TYPE_CHECKING:
@@ -28,6 +28,7 @@ DISTRIBUTIONS: list[tuple[_UnivariateDistribution, str]] = [
     (Bernoulli(p="p"), "Bernoulli"),
     (Binomial(n="n", p="p"), "Binomial"),
     (Exponential(rate="p"), "Exponential"),  # `p` is positive on every row, a valid rate
+    (Beta(a="p", b="sigma"), "Beta"),  # both columns are positive on every row, valid shapes
 ]
 
 FRAME = pl.DataFrame(

--- a/tests/distributions/value_keyed_fast_path_test.py
+++ b/tests/distributions/value_keyed_fast_path_test.py
@@ -1,4 +1,4 @@
-"""Validation contract of the constant-parameter value-keyed fast path (Normal, LogNormal, Binomial).
+"""Validation contract of the constant-parameter value-keyed fast path (Normal, LogNormal, Binomial, Beta).
 
 `pdf` / `pmf` / `cdf` / `sf` / `ppf` with all-scalar parameters route through a dedicated ``<name>_<method>_scalar``
 plugin that validates and builds the `statrs` distribution once (via the shared `build_dist`), instead of rebuilding it
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
-from polars_stats import Binomial, LogNormal, Normal
+from polars_stats import Beta, Binomial, LogNormal, Normal
 from polars_stats.distributions._base import ContinuousDistribution
 from tests._polars_compat import assert_series_equal
 
@@ -68,6 +68,12 @@ _CASES: dict[str, tuple[Callable[[], _UnivariateDistribution], Callable[[], _Uni
     "binomial p=nan": (lambda: Binomial(5, _NAN), lambda: Binomial(_col(5, pl.Int64()), _col(_NAN)), True),
     "binomial p=1.5": (lambda: Binomial(5, 1.5), lambda: Binomial(_col(5, pl.Int64()), _col(1.5)), True),
     "binomial n=-1": (lambda: Binomial(-1, 0.5), lambda: Binomial(_col(-1, pl.Int64()), _col(0.5)), True),
+    "beta a=nan": (lambda: Beta(_NAN, 1.0), lambda: Beta(_col(_NAN), _col(1.0)), True),
+    "beta a=0": (lambda: Beta(0.0, 1.0), lambda: Beta(_col(0.0), _col(1.0)), True),
+    "beta b=-1": (lambda: Beta(2.0, -1.0), lambda: Beta(_col(2.0), _col(-1.0)), True),
+    # An infinite shape is *rejected* by statrs, unlike the Normal / LogNormal scale; both paths must
+    # agree on that too.
+    "beta a=inf (rejected)": (lambda: Beta(_INF, 1.0), lambda: Beta(_col(_INF), _col(1.0)), True),
 }
 
 

--- a/tests/property/_specs.py
+++ b/tests/property/_specs.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 import polars as pl
 from hypothesis import strategies as st
 
-from polars_stats import Bernoulli, Binomial, Exponential, LogNormal, Normal, Uniform
+from polars_stats import Bernoulli, Beta, Binomial, Exponential, LogNormal, Normal, Uniform
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -157,6 +157,22 @@ _EXPONENTIAL = DistSpec(
     integration_bounds=lambda p: (0.0, 30.0 / p[0]),
 )
 
-ALL_SPECS = [_BERNOULLI, _BINOMIAL, _NORMAL, _UNIFORM, _LOGNORMAL, _EXPONENTIAL]
+_BETA = DistSpec(
+    name="beta",
+    continuous=True,
+    # Shapes are kept >= 1 so the density stays bounded at the support endpoints: a shape < 1
+    # diverges at its boundary, which the trapezoidal mass check cannot integrate. Shapes below 1
+    # are covered directly by the functional and scipy-parity suites.
+    params=st.tuples(_finite(1.0, 10.0), _finite(1.0, 10.0)),
+    make=lambda p: Beta(a=p[0], b=p[1]),
+    make_columns=lambda p: Beta(a=_col(p[0]), b=_col(p[1])),
+    make_masked=lambda p, m: Beta(a=pl.when(~m).then(_col(p[0])), b=_col(p[1])),
+    density=lambda d, c: d.pdf(c),
+    # Support is [0, 1]; the grid spans the zero-density regions on both sides.
+    eval_range=lambda _: (-0.5, 1.5),
+    integration_bounds=lambda _: (0.0, 1.0),
+)
+
+ALL_SPECS = [_BERNOULLI, _BINOMIAL, _NORMAL, _UNIFORM, _LOGNORMAL, _EXPONENTIAL, _BETA]
 CONTINUOUS_SPECS = [s for s in ALL_SPECS if s.continuous]
 DISCRETE_SPECS = [s for s in ALL_SPECS if not s.continuous]

--- a/tests/scipy_parity/beta_test.py
+++ b/tests/scipy_parity/beta_test.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+from scipy.stats import beta as scipy_beta
+
+from polars_stats import Beta
+from tests.scipy_parity._harness import Case, assert_case_matches_scipy
+
+# Parameter and evaluation grids for the parity sweep. Owned by this test category and independent
+# of the per-method functional tests under `tests/distributions/beta`. The grid covers the distinct
+# shape regimes: unimodal, U-shaped (both shapes < 1), uniform (1, 1), J-shaped, skewed, and the
+# large-shape regime where statrs switches its pdf to `ln_pdf().exp()`.
+_PARAMS = [(2.0, 3.0), (0.5, 0.5), (1.0, 1.0), (5.0, 1.0), (2.0, 8.0), (90.0, 100.0)]
+_QUANTILES = [0.01, 0.1, 0.25, 0.5, 0.75, 0.9, 0.99]
+# The support is fixed to [0, 1], so one interior grid spanning both tails serves every shape pair.
+_VALUE_GRID = [0.01, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99]
+
+# Tolerance split, by upstream implementation rather than by aspiration:
+#   * cdf / sf (and their logs), ppf / isf (AS 64 + Newton inverse), the moments and the entropy
+#     agree with scipy's Cephes incomplete-beta family to ~1e-13 across the grid, holding the
+#     default 1e-12 target;
+#   * pdf goes through `ln_pdf().exp()` in statrs for shapes > 80, which costs a few digits of
+#     absolute accuracy at the large-shape pair (~1e-12 observed). 1e-11 is the honest, padded bound.
+_TOL_LARGE_SHAPE_PDF = 1e-11
+
+
+_CASES: list[Case[Beta]] = [
+    Case("pdf", "value", lambda d, c: d.pdf(c), "pdf", _TOL_LARGE_SHAPE_PDF),
+    Case("log_pdf", "value", lambda d, c: d.log_pdf(c), "logpdf"),
+    Case("cdf", "value", lambda d, c: d.cdf(c), "cdf"),
+    Case("log_cdf", "value", lambda d, c: d.log_cdf(c), "logcdf"),
+    Case("sf", "value", lambda d, c: d.sf(c), "sf"),
+    Case("log_sf", "value", lambda d, c: d.log_sf(c), "logsf"),
+    Case("ppf", "quantile", lambda d, c: d.ppf(c), "ppf"),
+    Case("isf", "quantile", lambda d, c: d.isf(c), "isf"),
+    Case("mean", "scalar", lambda d, _: d.mean(), "mean"),
+    Case("variance", "scalar", lambda d, _: d.variance(), "var"),
+    Case("std", "scalar", lambda d, _: d.std(), "std"),
+    Case("median", "scalar", lambda d, _: d.median(), "median"),
+    Case("entropy", "scalar", lambda d, _: d.entropy(), "entropy"),
+]
+
+
+@pytest.mark.parametrize(("a", "b"), _PARAMS, ids=[f"a={a},b={b}" for a, b in _PARAMS])
+@pytest.mark.parametrize("case", _CASES, ids=lambda c: c.name)
+def test_method_matches_scipy(case: Case[Beta], a: float, b: float) -> None:
+    """Every closed-form method matches `scipy.stats.beta` across the `(a, b)` grid.
+
+    Table-driven: adding a method is one row in `_CASES`. Method-specific behaviour (null
+    propagation, out-of-range quantiles, the support boundaries) is asserted in the per-method files.
+    """
+    assert_case_matches_scipy(
+        case,
+        dist=Beta(a=a, b=b),
+        scipy_frozen=scipy_beta(a=a, b=b),
+        value_grid=_VALUE_GRID,
+        quantiles=_QUANTILES,
+    )


### PR DESCRIPTION
Adds `Beta(a, b)`; equivalent to `scipy.stats.beta(a, b)`.
The parameter names follow scipy; `statrs` calls them `shape_a` and `shape_b`