### PR TITLE
fix: Numerically stable `log_{cdf,df}` for `{Normal,LogNormal}`

### DIFF
--- a/benchmarks/_harness.py
+++ b/benchmarks/_harness.py
@@ -5,10 +5,11 @@ Two method families are compared:
 * **sampling**: `sample` (one variate per row) and `samples` (``n_samples`` variates per row),
   against ``scipy.rvs``. Independent RNGs mean values cannot match, so correctness is a shape-only
   gate.
-* **value-keyed**: `density` (`pdf` / `pmf` by family), `cdf`, `sf` and `ppf`, against the matching
-  frozen-scipy method. Both sides evaluate the *same* deterministic inputs (the distribution's own
-  seeded draws; open-interval quantiles for `ppf`), so here the `match` column is a real
-  ``np.allclose`` value check, not just a shape check.
+* **value-keyed**: `density` / `log_density` (`pdf` / `pmf` and `log_pdf` / `log_pmf` by family),
+  `cdf`, `log_cdf`, `sf`, `log_sf` and `ppf`, against the matching frozen-scipy method. Both sides
+  evaluate the *same* deterministic inputs (the distribution's own seeded draws; open-interval
+  quantiles for `ppf`), so here the `match` column is a real ``np.allclose`` value check, not just
+  a shape check.
 
 `run.py` owns the `Comparison` registry (one entry per distribution) and the CLI; it calls `run_comparison` over a
 `Sweep` of sizes. This module is *not* runnable; run ``uv run --group benchmarks benchmarks/run.py`` instead.
@@ -60,8 +61,23 @@ if TYPE_CHECKING:
     Side = Literal["polars_stats", "scipy"]
 
 
-Method = Literal["sample", "samples", "density", "cdf", "sf", "ppf", "mean", "variance", "std", "entropy"]
-"""A benchmarkable method. `density` resolves to `pdf` (continuous) or `pmf` (discrete) per distribution.
+Method = Literal[
+    "sample",
+    "samples",
+    "density",
+    "log_density",
+    "cdf",
+    "log_cdf",
+    "sf",
+    "log_sf",
+    "ppf",
+    "mean",
+    "variance",
+    "std",
+    "entropy",
+]
+"""A benchmarkable method. `density` / `log_density` resolve to `pdf` / `log_pdf` (continuous) or
+`pmf` / `log_pmf` (discrete) per distribution; `log_cdf` / `log_sf` call scipy's `logcdf` / `logsf`.
 
 `mean` / `variance` / `std` / `entropy` are the parameter-only moments: they take no value column, so
 polars_stats returns a length-`rows` column of the (constant, for scalar params) moment while scipy
@@ -73,8 +89,11 @@ ALL_METHODS: tuple[Method, ...] = (
     "sample",
     "samples",
     "density",
+    "log_density",
     "cdf",
+    "log_cdf",
     "sf",
+    "log_sf",
     "ppf",
     "mean",
     "variance",
@@ -82,7 +101,7 @@ ALL_METHODS: tuple[Method, ...] = (
     "entropy",
 )
 
-_VALUE_METHODS: frozenset[Method] = frozenset({"density", "cdf", "sf", "ppf"})
+_VALUE_METHODS: frozenset[Method] = frozenset({"density", "log_density", "cdf", "log_cdf", "sf", "log_sf", "ppf"})
 
 _MOMENT_METHODS: frozenset[Method] = frozenset({"mean", "variance", "std", "entropy"})
 """Parameter-only moments: no value column, one expression evaluated over the length frame."""
@@ -240,6 +259,20 @@ def _density_name(dist: Distribution) -> Literal["pdf", "pmf"]:
     return "pdf" if isinstance(dist, ContinuousDistribution) else "pmf"
 
 
+def _report_name(dist: Distribution, method: Method) -> str:
+    """The report label: the `polars_stats` method actually called (`density` -> `pdf` / `pmf`, ...)."""
+    if method == "density":
+        return _density_name(dist)
+    if method == "log_density":
+        return f"log_{_density_name(dist)}"
+    return method
+
+
+def _scipy_name(dist: Distribution, method: Method) -> str:
+    """The frozen-scipy attribute for a value-keyed method (`log_cdf` -> `logcdf`, `log_density` -> `logpdf`)."""
+    return _report_name(dist, method).replace("log_", "log")
+
+
 def _eval_inputs(comp: Comparison, config: RunConfig, method: Method) -> np.ndarray:
     """Deterministic evaluation inputs for a value-keyed method, shared by both sides.
 
@@ -254,19 +287,12 @@ def _eval_inputs(comp: Comparison, config: RunConfig, method: Method) -> np.ndar
 
 def _value_expr(dist: Distribution, method: Method) -> pl.Expr:
     """The `polars_stats` expression for a value-keyed method, evaluated on the shared `x` column."""
-    x = pl.col("x")
-    match method:
-        case "density":
-            return dist.pdf(x) if isinstance(dist, ContinuousDistribution) else dist.pmf(x)  # type: ignore[attr-defined]
-        case "cdf":
-            return dist.cdf(x)
-        case "sf":
-            return dist.sf(x)
-        case "ppf":
-            return dist.ppf(x)
-        case _:
-            msg = f"not a value-keyed method: {method}"
-            raise AssertionError(msg)
+    if method not in _VALUE_METHODS:
+        msg = f"not a value-keyed method: {method}"
+        raise AssertionError(msg)
+    # `_report_name` resolves `density` / `log_density` to the family-specific `pdf` / `log_pmf` / ...;
+    # the other tokens are the method names themselves.
+    return getattr(dist, _report_name(dist, method))(pl.col("x"))
 
 
 def _build_fn(comp: Comparison, method: Method, config: RunConfig, side: Side) -> Callable[[], object]:
@@ -282,8 +308,7 @@ def _build_fn(comp: Comparison, method: Method, config: RunConfig, side: Side) -
             frozen = comp.scipy_frozen
             if method in _VALUE_METHODS:
                 values = _eval_inputs(comp, config, method)
-                scipy_method = _density_name(comp.dist) if method == "density" else method
-                fn = getattr(frozen, scipy_method)
+                fn = getattr(frozen, _scipy_name(comp.dist, method))
                 return lambda: fn(values)
             if method in _MOMENT_METHODS:
                 # scipy's variance is `var`; `mean` / `std` / `entropy` share the name. Each is one
@@ -389,8 +414,8 @@ def _measure(comp: Comparison, method: Method, config: RunConfig) -> Result:
         for side in sides
     }
     return Result(
-        # `density` is the sweep token; the report shows the method actually called.
-        method=_density_name(comp.dist) if method == "density" else method,
+        # `density` / `log_density` are the sweep tokens; the report shows the method actually called.
+        method=_report_name(comp.dist, method),
         rows=config.rows,
         n_samples=config.n_samples if method == "samples" else None,
         polars_stats=measurements["polars_stats"],

--- a/benchmarks/_harness.py
+++ b/benchmarks/_harness.py
@@ -292,7 +292,7 @@ def _value_expr(dist: Distribution, method: Method) -> pl.Expr:
         raise AssertionError(msg)
     # `_report_name` resolves `density` / `log_density` to the family-specific `pdf` / `log_pmf` / ...;
     # the other tokens are the method names themselves.
-    return getattr(dist, _report_name(dist, method))(pl.col("x"))
+    return getattr(dist, _report_name(dist, method))(pl.col("x"))  # type: ignore[no-any-return]
 
 
 def _build_fn(comp: Comparison, method: Method, config: RunConfig, side: Side) -> Callable[[], object]:

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -1,8 +1,9 @@
 """Entrypoint for the ``polars_stats`` vs ``scipy.stats`` benchmarks.
 
 Compare the sampling methods (`sample` / `samples` vs ``scipy.rvs``) and the value-keyed methods
-(`pdf` / `pmf`, `cdf`, `sf`, `ppf` vs their frozen-scipy counterparts) on speed and peak memory,
-sweeping over one or more row counts and sample widths in a single report::
+(`pdf` / `pmf`, `log_pdf` / `log_pmf`, `cdf`, `log_cdf`, `sf`, `log_sf`, `ppf` vs their frozen-scipy
+counterparts) on speed and peak memory, sweeping over one or more row counts and sample widths in a
+single report::
 
     uv run --group benchmarks benchmarks/run.py                                   # all distributions and methods
     uv run --group benchmarks benchmarks/run.py normal binomial                   # a subset of distributions
@@ -61,8 +62,9 @@ def main(  # noqa: PLR0913
 
     Arguments:
         distributions: Distributions to compare (e.g. `normal binomial`). Defaults to all of them.
-        methods: Methods to compare (e.g. `--methods sample density ppf`); `density` resolves to
-            `pdf` / `pmf` per distribution family. Defaults to all of them.
+        methods: Methods to compare (e.g. `--methods sample density log_sf ppf`); `density` /
+            `log_density` resolve to `pdf` / `pmf` and `log_pdf` / `log_pmf` per distribution
+            family. Defaults to all of them.
         rows: Row counts to sweep over (e.g. `--rows 1_000_000 10_000_000`). Defaults to `[1_000_000]`.
         n_samples: Sample widths to sweep over for `samples` (e.g. `--n-samples 5 10 20`). Defaults to `[10]`.
         iterations: Timed runs per cell; runtime is reported as p50 +/- std.

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -13,9 +13,6 @@ if TYPE_CHECKING:
 
     from polars_stats._typing import IntoExprColumn, PolarsDataType
 
-# TODO(FBruzzesi): Investigate better implementations for log_* methods over
-# the naive ones due to concerns on numerical stability
-
 _ROW_INDEX_NAME = "__polars_stats_row_index__"
 ROW_INDEX_EXPR = pl.int_range(0, pl.len(), dtype=pl.UInt64).alias(_ROW_INDEX_NAME)
 """Per-row position `0..len` used to derive per-row sub-seeds in samplers.
@@ -362,6 +359,12 @@ class _UnivariateDistribution(ABC):
         return propagate_null(v, self._log_cdf(v))
 
     def _log_cdf(self, value: pl.Expr) -> pl.Expr:
+        """Default `log(cdf)`; underflows to `-inf` once `cdf` rounds to `0` deep in the left tail.
+
+        There is no native shortcut to bind (statrs exposes no `ln_cdf`, Polars no `erf`), so a
+        distribution with a genuine tail must override this with a stable form: a `log1p` / exact
+        closed form (Exponential, Uniform) or a special-function binding in Rust (Normal).
+        """
         return self._cdf(value).log()
 
     def sf(self, value: float | IntoExprColumn) -> pl.Expr:
@@ -379,6 +382,12 @@ class _UnivariateDistribution(ABC):
         return propagate_null(v, self._log_sf(v))
 
     def _log_sf(self, value: pl.Expr) -> pl.Expr:
+        """Default `log(sf)`; underflows to `-inf` once `sf` rounds to `0` deep in the right tail.
+
+        The flagship anomaly-scoring path (`log_sf` for many-sigma events); override it for any
+        distribution with a genuine tail. Same options as `_log_cdf`: a `log1p` / exact closed form
+        or a Rust special-function binding.
+        """
         return self._sf(value).log()
 
     def ppf(self, quantile: float | IntoExprColumn) -> pl.Expr:

--- a/polars_stats/distributions/_beta.py
+++ b/polars_stats/distributions/_beta.py
@@ -74,8 +74,10 @@ class Beta(ContinuousDistribution):
     def _sf(self, value: pl.Expr) -> pl.Expr:
         """Survival function via native ``ContinuousCDF::sf`` (accurate in the upper tail).
 
-        ``log_sf`` and ``isf`` inherit the base-class defaults, which compose this native ``sf`` and
-        ``ppf`` rather than the generic ``1 - cdf`` fallback.
+        ``isf`` inherits the base-class default ``ppf(1 - quantile)``. ``log_sf`` (and ``log_cdf``)
+        inherit the naive ``sf().log()`` / ``cdf().log()``, which underflow to ``-inf`` deep in the
+        tails: the regularized incomplete beta has no cheap stable log form (scipy's ``logsf`` /
+        ``logcdf`` are naive here too, so parity holds).
         """
         return self._value_plugin("beta_sf", value)
 

--- a/polars_stats/distributions/_binomial.py
+++ b/polars_stats/distributions/_binomial.py
@@ -77,8 +77,10 @@ class Binomial(DiscreteDistribution):
     def _sf(self, value: pl.Expr) -> pl.Expr:
         """Survival ``P(X > floor(value))`` via native ``DiscreteCDF::sf`` (accurate upper tail).
 
-        ``log_sf`` and ``isf`` inherit the base-class defaults, which compose this native ``sf`` and
-        ``ppf`` rather than the generic ``1 - cdf`` fallback.
+        ``isf`` inherits the base-class default ``ppf(1 - quantile)``. ``log_sf`` (and ``log_cdf``)
+        inherit the naive ``sf().log()`` / ``cdf().log()``, which underflow to ``-inf`` deep in the
+        tails: the regularized incomplete beta has no cheap stable log form (scipy's ``logsf`` /
+        ``logcdf`` are naive here too, so parity holds).
         """
         return self._value_plugin("binomial_sf", value)
 

--- a/polars_stats/distributions/_lognormal.py
+++ b/polars_stats/distributions/_lognormal.py
@@ -76,13 +76,28 @@ class LogNormal(ContinuousDistribution):
         """Cumulative distribution via native ``ContinuousCDF::cdf`` (``0`` for ``value <= 0``)."""
         return self._value_plugin("lognormal_cdf", value)
 
+    def _log_cdf(self, value: pl.Expr) -> pl.Expr:
+        """Log-cdf via the underlying normal's stable ``ln_erfc`` form; ``-inf`` for ``value <= 0``.
+
+        Finite far into the left tail, unlike ``cdf().log()``.
+        """
+        return self._value_plugin("lognormal_ln_cdf", value)
+
     def _sf(self, value: pl.Expr) -> pl.Expr:
         """Survival function via native ``ContinuousCDF::sf`` (accurate in the upper tail).
 
-        ``log_sf`` and ``isf`` inherit the base-class defaults, which compose this native ``sf`` and
-        ``ppf`` rather than the generic ``1 - cdf`` fallback.
+        ``isf`` inherits the base-class default ``ppf(1 - quantile)`` over the native ``ppf``.
         """
         return self._value_plugin("lognormal_sf", value)
+
+    def _log_sf(self, value: pl.Expr) -> pl.Expr:
+        """Log-sf via the underlying normal's stable ``ln_erfc`` form; ``0`` for ``value <= 0``.
+
+        Finite far into the right tail, unlike ``sf().log()``. The flagship anomaly-scoring path for a
+        heavy-tailed positive quantity: ``sf`` for a far-tail value underflows to ``0`` and its log to
+        ``-inf``; this stays finite.
+        """
+        return self._value_plugin("lognormal_ln_sf", value)
 
     def _ppf(self, quantile: pl.Expr) -> pl.Expr:
         """Inverse cdf via the closed-form ``ContinuousCDF::inverse_cdf``.

--- a/polars_stats/distributions/_normal.py
+++ b/polars_stats/distributions/_normal.py
@@ -76,13 +76,24 @@ class Normal(ContinuousDistribution):
         """Cumulative distribution via native ``ContinuousCDF::cdf``."""
         return self._value_plugin("normal_cdf", value)
 
+    def _log_cdf(self, value: pl.Expr) -> pl.Expr:
+        """Log-cdf via the native stable ``ln_erfc`` form (finite past ~38 std_dev, unlike ``cdf().log()``)."""
+        return self._value_plugin("normal_ln_cdf", value)
+
     def _sf(self, value: pl.Expr) -> pl.Expr:
         """Survival function via native ``ContinuousCDF::sf`` (accurate in the upper tail).
 
-        ``log_sf`` and ``isf`` inherit the base-class defaults, which compose this native ``sf`` and
-        ``ppf`` rather than the generic ``1 - cdf`` fallback.
+        ``isf`` inherits the base-class default ``ppf(1 - quantile)`` over the native ``ppf``.
         """
         return self._value_plugin("normal_sf", value)
+
+    def _log_sf(self, value: pl.Expr) -> pl.Expr:
+        """Log-sf via the native stable ``ln_erfc`` form (finite past ~38 std_dev, unlike ``sf().log()``).
+
+        The flagship anomaly-scoring path: ``sf`` for a many-sigma event underflows to ``0`` and its log to
+        ``-inf``; this stays finite (``scipy.stats.norm.logsf``-equivalent).
+        """
+        return self._value_plugin("normal_ln_sf", value)
 
     def _ppf(self, quantile: pl.Expr) -> pl.Expr:
         """Inverse cdf via the closed-form ``ContinuousCDF::inverse_cdf``.

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -3,9 +3,11 @@ use polars::prelude::arity::try_ternary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distributions::Distribution as RandDistribution;
-use statrs::distribution::{Continuous, ContinuousCDF, LogNormal};
+use statrs::distribution::{Continuous, ContinuousCDF, LogNormal, Normal};
 
-use crate::distributions::{param_validator, value_keyed_per_row, value_keyed_scalar_plugins};
+use crate::distributions::{
+    normal, param_validator, value_keyed_per_row, value_keyed_scalar_plugins,
+};
 use crate::rng::{
     sample_scalar_plugin, samples_f64_output, samples_per_row, ternary_param_rows, SampleKwargs,
     SamplesKwargs,
@@ -28,6 +30,19 @@ fn build_dist(mu: f64, sigma: f64) -> PolarsResult<LogNormal> {
     })
 }
 
+/// Construct the *underlying* `statrs::Normal` (mean `mu`, std-dev `sigma`) for the stable
+/// `log_cdf` / `log_sf`, which reuse the normal's `ln_erfc` form on `ln(x)`.
+///
+/// `statrs::LogNormal` hides its `(location, scale)` (no accessors), so the value functions cannot
+/// recover `(mu, sigma)` from a built `LogNormal`; they receive this underlying `Normal` instead.
+/// Validation is delegated to [`build_dist`], so an invalid parameterisation reports the identical
+/// error (down to the statrs suffix) as every other method.
+fn build_underlying_normal(mu: f64, sigma: f64) -> PolarsResult<Normal> {
+    build_dist(mu, sigma)?;
+    Ok(Normal::new(mu, sigma)
+        .expect("Normal::new accepts every (mu, sigma) LogNormal::new accepts"))
+}
+
 value_keyed_per_row! {
     /// Apply a value-keyed function `f(dist, value)` element-wise over `(value, mu, sigma)`.
     ///
@@ -38,6 +53,18 @@ value_keyed_per_row! {
     fn value_keyed(&LogNormal);
     params = (DataType::Float64 => f64, DataType::Float64 => f64);
     build = build_dist;
+}
+
+value_keyed_per_row! {
+    /// Apply a value-keyed function `f(&Normal, value)` over `(value, mu, sigma)`, building the
+    /// *underlying* normal (see [`build_underlying_normal`]) rather than the `LogNormal`.
+    ///
+    /// Backs the stable `log_cdf` / `log_sf` only: they compute the underlying normal's log-cdf / log-sf
+    /// at `ln(value)`, which `statrs::LogNormal`'s hidden parameters would not let them reach via
+    /// [`value_keyed`]. Null / invalid-parameter contract is identical to [`value_keyed`].
+    fn value_keyed_norm(&Normal);
+    params = (DataType::Float64 => f64, DataType::Float64 => f64);
+    build = build_underlying_normal;
 }
 
 param_validator! {
@@ -164,6 +191,26 @@ fn sf_value(dist: &LogNormal, v: f64) -> Option<f64> {
     Some(dist.sf(v))
 }
 
+/// Stable log-cdf: the underlying normal's [`normal::ln_cdf_value`] at `ln(v)`; `-inf` for `v <= 0`
+/// (`cdf = 0` outside the support). `norm` is the underlying normal built by [`build_underlying_normal`].
+fn ln_cdf_value(norm: &Normal, v: f64) -> Option<f64> {
+    if v <= 0.0 {
+        Some(f64::NEG_INFINITY)
+    } else {
+        normal::ln_cdf_value(norm, v.ln())
+    }
+}
+
+/// Stable log-sf: the underlying normal's [`normal::ln_sf_value`] at `ln(v)`; `0` for `v <= 0`
+/// (`sf = 1` outside the support).
+fn ln_sf_value(norm: &Normal, v: f64) -> Option<f64> {
+    if v <= 0.0 {
+        Some(0.0)
+    } else {
+        normal::ln_sf_value(norm, v.ln())
+    }
+}
+
 /// A quantile outside `[0, 1]` yields `null` (guarding the `statrs` panic). The closed endpoints
 /// map to the support boundaries (`ppf(0) = 0`, `ppf(1) = +inf`), matching `scipy.stats.lognorm.ppf`.
 fn ppf_value(dist: &LogNormal, q: f64) -> Option<f64> {
@@ -201,6 +248,20 @@ fn lognormal_sf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, sf_value)
 }
 
+/// Element-wise log-cdf via the underlying normal's stable `ln_erfc` form (finite in the far-left
+/// tail, unlike `cdf().ln()`); `-inf` for `value <= 0`.
+#[polars_expr(output_type=Float64)]
+fn lognormal_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_norm(inputs, ln_cdf_value)
+}
+
+/// Element-wise log-sf via the underlying normal's stable `ln_erfc` form (finite in the far-right
+/// tail, unlike `sf().ln()`); `0` for `value <= 0`.
+#[polars_expr(output_type=Float64)]
+fn lognormal_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_norm(inputs, ln_sf_value)
+}
+
 /// Element-wise ppf (inverse cdf) via the closed-form `ContinuousCDF::inverse_cdf`.
 /// See [`ppf_value`] for the endpoint and out-of-range contract.
 #[polars_expr(output_type=Float64)]
@@ -234,5 +295,25 @@ value_keyed_scalar_plugins! {
 
         /// Constant-parameter ppf; same body as [`lognormal_ppf`] via [`ppf_value`], dist built once.
         fn lognormal_ppf_scalar => ppf_value;
+    }
+}
+
+value_keyed_scalar_plugins! {
+    /// Constant-parameter fast path for the stable `log_cdf` / `log_sf`, building the *underlying*
+    /// normal once (see [`build_underlying_normal`]) rather than the `LogNormal`.
+    ///
+    /// The scalar twin of [`value_keyed_norm`]: same field names as [`LogNormalParamsKwargs`]
+    /// (`mu`, `sigma`, so the Python layer routes either method's scalar params here unchanged), but
+    /// `build` returns the underlying `Normal` the `ln_erfc` bodies need.
+    struct LogNormalLogKwargs { mu: f64, sigma: f64 }
+
+    build = |kw| build_underlying_normal(kw.mu, kw.sigma)?;
+
+    methods {
+        /// Constant-parameter log-cdf; same body as [`lognormal_ln_cdf`] via [`ln_cdf_value`], normal built once.
+        fn lognormal_ln_cdf_scalar => ln_cdf_value;
+
+        /// Constant-parameter log-sf; same body as [`lognormal_ln_sf`] via [`ln_sf_value`], normal built once.
+        fn lognormal_ln_sf_scalar => ln_sf_value;
     }
 }

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -158,9 +158,8 @@ pub(crate) use value_keyed_per_row;
 /// These plugins exist so the closed-form moments and (for Uniform / Bernoulli) value-keyed
 /// methods, which are pure Polars expressions, still report an invalid parameterisation through
 /// the same Rust `build_dist` rather than silently producing a garbage result. The constant-
-/// parameter fast path (issue 20 item 6) calls the very same plugin on length-1 `pl.lit` inputs,
-/// so it is built once instead of per row. The four knobs that vary between distributions are the
-/// macro's inputs:
+/// parameter fast path calls the very same plugin on length-1 `pl.lit` inputs, so it is built
+/// once instead of per row. The four knobs that vary between distributions are the macro's inputs:
 ///
 /// * each parameter's `<name>: <cast dtype> => <accessor>` (binomial's `n` is `Int64`/`.i64()`,
 ///   the continuous parameters are `Float64`/`.f64()`); the matched values bind to `<name>`;

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -1,9 +1,13 @@
 #![allow(clippy::unused_unit)]
+use std::f64::consts::{LN_2, SQRT_2};
+
 use polars::prelude::arity::try_ternary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distributions::Distribution as RandDistribution;
 use statrs::distribution::{Continuous, ContinuousCDF, Normal};
+use statrs::function::erf;
+use statrs::statistics::Distribution as StatrsDistribution;
 
 use crate::distributions::{param_validator, value_keyed_per_row, value_keyed_scalar_plugins};
 use crate::rng::{
@@ -163,6 +167,65 @@ fn sf_value(dist: &Normal, v: f64) -> Option<f64> {
     Some(dist.sf(v))
 }
 
+/// Point past which `erfc(t)` is close enough to underflowing (`erfc ~ 1e-274` at `t = 25`,
+/// underflow near `t = 26.6`) that we switch `ln_erfc` to the asymptotic series.
+const LN_ERFC_ASYMPTOTIC_MIN: f64 = 25.0;
+
+/// Natural log of the complementary error function, stable in the right tail.
+///
+/// `erfc(t).ln()` returns `-inf` once `erfc(t)` rounds to `0` (`t` above ~26.6), the regime `log_cdf`
+/// / `log_sf` exist to serve. Past [`LN_ERFC_ASYMPTOTIC_MIN`] we switch to the asymptotic expansion
+/// `erfc(t) = exp(-t^2) / (t * sqrt(pi)) * (1 - 1/(2t^2) + 3/(4t^4) - 15/(8t^6) + ...)`, whose log is a
+/// large finite negative number; below it, statrs `erfc` holds full relative precision so the direct
+/// form is exact. The two branches agree to ~1e-13 at the crossover, so the join is seamless.
+fn ln_erfc(t: f64) -> f64 {
+    if t < LN_ERFC_ASYMPTOTIC_MIN {
+        erf::erfc(t).ln()
+    } else {
+        let t2 = t * t;
+        let u = 0.5 / t2;
+        let series = 1.0 - u * (1.0 - 3.0 * u * (1.0 - 5.0 * u * (1.0 - 7.0 * u)));
+        -t2 - t.ln() - 0.5 * statrs::consts::LN_PI + series.ln()
+    }
+}
+
+/// `ln(0.5 * erfc(s))` with full relative precision on both sides: [`ln_erfc`] for the small half
+/// (`s >= 0`), `ln_1p` for the near-one half (`s < 0`, where `erfc(s) = 2 - erfc(-s)` rounds to `2`
+/// and the direct log collapses to `0` instead of the true tiny negative, e.g. `-7.6e-24` at
+/// 10 std_dev; scipy's `log_ndtr` takes the same branch).
+fn ln_half_erfc(s: f64) -> f64 {
+    if s >= 0.0 {
+        -LN_2 + ln_erfc(s)
+    } else {
+        (-0.5 * erf::erfc(-s)).ln_1p()
+    }
+}
+
+/// Standardise `x` into the `erfc` argument `t = (x - mean) / (std_dev * sqrt(2))`, so that
+/// `cdf(x) = 0.5 * erfc(-t)` and `sf(x) = 0.5 * erfc(t)` (statrs' own `cdf` / `sf` definition).
+fn erfc_arg(dist: &Normal, x: f64) -> f64 {
+    let mean = dist.mean().expect("Normal always has a mean");
+    let std_dev = dist.std_dev().expect("Normal always has a std_dev");
+    (x - mean) / (std_dev * SQRT_2)
+}
+
+/// Native log-cdf via `ln(0.5 * erfc(-t))`: finite in the left tail (no `cdf().ln()` underflow) and
+/// full relative precision in the right one (see [`ln_half_erfc`]).
+///
+/// `pub(crate)` so `LogNormal` reuses it on the underlying normal at `ln(x)` (log-normal log-cdf is
+/// the underlying normal's log-cdf composed with `ln`).
+pub(crate) fn ln_cdf_value(dist: &Normal, v: f64) -> Option<f64> {
+    Some(ln_half_erfc(-erfc_arg(dist, v)))
+}
+
+/// Native log-sf via `ln(0.5 * erfc(t))`: finite in the right tail (no `sf().ln()` underflow) and
+/// full relative precision in the left one (see [`ln_half_erfc`]).
+///
+/// `pub(crate)` for the same reason as [`ln_cdf_value`].
+pub(crate) fn ln_sf_value(dist: &Normal, v: f64) -> Option<f64> {
+    Some(ln_half_erfc(erfc_arg(dist, v)))
+}
+
 /// A quantile outside `[0, 1]` yields `null`; the closed endpoints map to the infinite tails
 /// (`ppf(0) = -inf`, `ppf(1) = +inf`), matching `scipy.stats.norm.ppf`.
 fn ppf_value(dist: &Normal, q: f64) -> Option<f64> {
@@ -201,6 +264,18 @@ fn normal_sf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, sf_value)
 }
 
+/// Element-wise log-cdf via the stable [`ln_erfc`] form (finite in the left tail, unlike `cdf().ln()`).
+#[polars_expr(output_type=Float64)]
+fn normal_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, ln_cdf_value)
+}
+
+/// Element-wise log-sf via the stable [`ln_erfc`] form (finite in the right tail, unlike `sf().ln()`).
+#[polars_expr(output_type=Float64)]
+fn normal_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, ln_sf_value)
+}
+
 /// Element-wise ppf (inverse cdf) via the closed-form `ContinuousCDF::inverse_cdf`.
 /// See [`ppf_value`] for the endpoint and out-of-range contract.
 #[polars_expr(output_type=Float64)]
@@ -231,6 +306,12 @@ value_keyed_scalar_plugins! {
 
         /// Constant-parameter sf; same body as [`normal_sf`] via [`sf_value`], dist built once.
         fn normal_sf_scalar => sf_value;
+
+        /// Constant-parameter log-cdf; same body as [`normal_ln_cdf`] via [`ln_cdf_value`], dist built once.
+        fn normal_ln_cdf_scalar => ln_cdf_value;
+
+        /// Constant-parameter log-sf; same body as [`normal_ln_sf`] via [`ln_sf_value`], dist built once.
+        fn normal_ln_sf_scalar => ln_sf_value;
 
         /// Constant-parameter ppf; same body as [`normal_ppf`] via [`ppf_value`], dist built once.
         fn normal_ppf_scalar => ppf_value;

--- a/tests/distributions/beta/pdf_test.py
+++ b/tests/distributions/beta/pdf_test.py
@@ -21,7 +21,7 @@ def test_pdf_outside_support_is_zero() -> None:
 
 
 def test_pdf_diverges_at_boundaries_for_shapes_below_one() -> None:
-    # A shape < 1 makes the density divergent at the matching boundary (the issue caveat).
+    # A shape < 1 makes the density divergent at the matching boundary .
     df = pl.DataFrame({"x": [0.0, 1.0]})
     result = df.select(r=Beta(a=0.5, b=0.5).pdf(pl.col("x")))["r"]
     expected = pl.Series("r", [float("inf"), float("inf")], dtype=pl.Float64)

--- a/tests/distributions/lognormal/conftest.py
+++ b/tests/distributions/lognormal/conftest.py
@@ -14,7 +14,7 @@ DEFAULT_SIZE = 1000
 
 # `(mu, sigma)` grid exposed through the `params` fixture so no test file redeclares it. `sigma` is
 # kept moderate: the LogNormal mean/variance grow exponentially in `sigma` and lose absolute
-# precision against scipy past `sigma > 5` (see the issue caveat).
+# precision against scipy past `sigma > 5`.
 PARAMS = [(0.0, 1.0), (0.5, 0.5), (-1.0, 0.25), (1.0, 0.75), (0.0, 0.1)]
 
 

--- a/tests/distributions/lognormal/log_cdf_test.py
+++ b/tests/distributions/lognormal/log_cdf_test.py
@@ -4,6 +4,7 @@ import math
 from typing import TYPE_CHECKING
 
 import polars as pl
+import pytest
 
 from polars_stats import LogNormal
 from tests._polars_compat import assert_series_equal
@@ -26,3 +27,13 @@ def test_log_cdf_propagates_null_in_value() -> None:
     result = df.select(r=LogNormal().log_cdf(pl.col("x")))["r"]
     expected = pl.Series("r", [math.log(0.5), None], dtype=pl.Float64)
     assert_series_equal(result, expected)
+
+
+def test_log_cdf_finite_in_deep_tail() -> None:
+    # For x = exp(-40) (far-left tail), cdf underflows to 0 (naive cdf().log() is -inf); the
+    # underlying-normal ln_erfc form stays finite and equals scipy.stats.norm.logcdf(-40).
+    df = pl.DataFrame({"x": [math.exp(-40.0)]})
+    result = df.select(r=LogNormal().log_cdf(pl.col("x")))["r"]
+    naive = df.select(r=LogNormal().cdf(pl.col("x")).log())["r"]
+    assert naive.item(0) == float("-inf")
+    assert result.item(0) == pytest.approx(-804.608442, rel=1e-6)

--- a/tests/distributions/lognormal/log_sf_test.py
+++ b/tests/distributions/lognormal/log_sf_test.py
@@ -4,6 +4,7 @@ import math
 from typing import TYPE_CHECKING
 
 import polars as pl
+import pytest
 
 from polars_stats import LogNormal
 from tests._polars_compat import assert_series_equal
@@ -26,3 +27,13 @@ def test_log_sf_propagates_null_in_value() -> None:
     result = df.select(r=LogNormal().log_sf(pl.col("x")))["r"]
     expected = pl.Series("r", [math.log(0.5), None], dtype=pl.Float64)
     assert_series_equal(result, expected)
+
+
+def test_log_sf_finite_in_deep_tail() -> None:
+    # For x = exp(40), sf underflows to 0 (naive sf().log() is -inf); the underlying-normal ln_erfc
+    # form stays finite and equals scipy.stats.norm.logsf(40) (= lognorm.logsf(exp(40)) at mu=0,sigma=1).
+    df = pl.DataFrame({"x": [math.exp(40.0)]})
+    result = df.select(r=LogNormal().log_sf(pl.col("x")))["r"]
+    naive = df.select(r=LogNormal().sf(pl.col("x")).log())["r"]
+    assert naive.item(0) == float("-inf")
+    assert result.item(0) == pytest.approx(-804.608442, rel=1e-6)

--- a/tests/distributions/moment_fast_path_test.py
+++ b/tests/distributions/moment_fast_path_test.py
@@ -1,4 +1,4 @@
-"""Validation contract of the constant-parameter moment fast path (validate-once, issue 20 item 6).
+"""Validation contract of the constant-parameter moment fast path (validate-once).
 
 The closed-form moments (`mean` / `variance` / `std` / `entropy`) and the closed forms of `Uniform`
 / `Bernoulli` route their *validation* through a small Rust plugin (`normal_std_dev`, `uniform_range`,

--- a/tests/distributions/normal/log_cdf_test.py
+++ b/tests/distributions/normal/log_cdf_test.py
@@ -4,6 +4,7 @@ import math
 from typing import TYPE_CHECKING
 
 import polars as pl
+import pytest
 
 from polars_stats import Normal
 from tests._polars_compat import assert_series_equal
@@ -26,3 +27,13 @@ def test_log_cdf_propagates_null_in_value() -> None:
     result = df.select(r=Normal().log_cdf(pl.col("x")))["r"]
     expected = pl.Series("r", [math.log(0.5), None], dtype=pl.Float64)
     assert_series_equal(result, expected)
+
+
+def test_log_cdf_finite_in_deep_tail() -> None:
+    # `cdf(-40)` underflows to `0`, so the naive `cdf().log()` is `-inf`; the native `ln_erfc` form
+    # stays finite. Reference value is `scipy.stats.norm.logcdf(-40)`.
+    df = pl.DataFrame({"x": [-40.0]})
+    result = df.select(r=Normal().log_cdf(pl.col("x")))["r"]
+    naive = df.select(r=Normal().cdf(pl.col("x")).log())["r"]
+    assert naive.item(0) == float("-inf")
+    assert result.item(0) == pytest.approx(-804.608442, rel=1e-6)

--- a/tests/distributions/normal/log_sf_test.py
+++ b/tests/distributions/normal/log_sf_test.py
@@ -4,6 +4,7 @@ import math
 from typing import TYPE_CHECKING
 
 import polars as pl
+import pytest
 
 from polars_stats import Normal
 from tests._polars_compat import assert_series_equal
@@ -26,3 +27,13 @@ def test_log_sf_propagates_null_in_value() -> None:
     result = df.select(r=Normal().log_sf(pl.col("x")))["r"]
     expected = pl.Series("r", [math.log(0.5), None], dtype=pl.Float64)
     assert_series_equal(result, expected)
+
+
+def test_log_sf_finite_in_deep_tail() -> None:
+    # `sf(40)` underflows to `0`, so the naive `sf().log()` is `-inf`; the native `ln_erfc` form stays
+    # finite. Reference value is `scipy.stats.norm.logsf(40)`.
+    df = pl.DataFrame({"x": [40.0]})
+    result = df.select(r=Normal().log_sf(pl.col("x")))["r"]
+    naive = df.select(r=Normal().sf(pl.col("x")).log())["r"]
+    assert naive.item(0) == float("-inf")
+    assert result.item(0) == pytest.approx(-804.608442, rel=1e-6)

--- a/tests/property/fast_path_context_test.py
+++ b/tests/property/fast_path_context_test.py
@@ -1,10 +1,10 @@
 """Constant-parameter fast paths stay byte-identical to the per-row path across polars contexts.
 
-The scalar moment and closed-form value-keyed fast paths (issue 20 item 6) build a length-1
-validity gate, `pl.when(validated_once.is_not_null()).then(<context-length value>)`, where
-`validated_once` is a validating plugin called on length-1 `pl.lit` inputs. The bit-equality tests
-`moment_test.py` and `value_keyed_test.py` pin the fast path against the per-row path under a plain
-`select`, where the gate broadcasts a length-1 condition against a whole-frame value.
+The scalar moment and closed-form value-keyed fast paths build a length-1 validity gate,
+`pl.when(validated_once.is_not_null()).then(<context-length value>)`, where `validated_once` is a validating plugin
+called on length-1 `pl.lit` inputs. The bit-equality tests `moment_test.py` and `value_keyed_test.py` pin the fast path
+against the per-row path under a plain `select`, where the gate broadcasts a length-1 condition against a
+whole-frame value.
 
 This module pins the same equality under the contexts where the broadcast target length is *not* the
 whole frame, the cases a `select`-only test cannot see:

--- a/tests/property/value_keyed_test.py
+++ b/tests/property/value_keyed_test.py
@@ -1,7 +1,7 @@
 """Bit-equality of the constant-parameter value-keyed fast path against the per-row path.
 
-Constant scalar parameters route the value-keyed methods (density, log-density, cdf, sf, ppf)
-through a dedicated ``<name>_<method>_scalar`` plugin: parameters are validated once and passed as
+Constant scalar parameters route the value-keyed methods (density, log-density, cdf, log-cdf, sf,
+log-sf, ppf) through a dedicated ``<name>_<method>_scalar`` plugin: parameters are validated once and passed as
 kwargs, with only the value column crossing FFI. Column parameters take the general per-row plugin.
 In Rust both plugins call the same named per-method body, so for any parameterisation the two paths
 must agree bit for bit, including null propagation and ppf's null-outside-``[0, 1]`` contract. A
@@ -68,7 +68,9 @@ def test_value_keyed_scalar_fast_path_matches_per_row(spec: DistSpec, data: st.D
         (values, spec.density(scalar, x), spec.density(per_row, x)),
         (values, _log_density(scalar, x), _log_density(per_row, x)),
         (values, scalar.cdf(x), per_row.cdf(x)),
+        (values, scalar.log_cdf(x), per_row.log_cdf(x)),
         (values, scalar.sf(x), per_row.sf(x)),
+        (values, scalar.log_sf(x), per_row.log_sf(x)),
         (quantiles, scalar.ppf(q), per_row.ppf(q)),
     ]
     for frame, fast_expr, per_row_expr in cases:

--- a/tests/scipy_parity/lognormal_test.py
+++ b/tests/scipy_parity/lognormal_test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from math import exp
 
+import numpy as np
 import polars as pl
 import pytest
 from scipy.stats import lognorm as scipy_lognorm
@@ -9,10 +10,10 @@ from scipy.stats import lognorm as scipy_lognorm
 from polars_stats import LogNormal
 from tests.scipy_parity._harness import Case, assert_case_matches_scipy
 
-# Parameter and evaluation grids for the parity sweep. Owned by this test category and independent
-# of the per-method functional tests under `tests/distributions/lognormal`. `sigma` is kept moderate:
-# the mean / variance grow exponentially in `sigma` and lose absolute precision against scipy past
-# `sigma > 5` (see the issue caveat).
+# Parameter and evaluation grids for the parity sweep.
+# Owned by this test category and independent of the per-method functional tests under `tests/distributions/lognormal`.
+# `sigma` is kept moderate: the mean / variance grow exponentially in `sigma` and
+# lose absolute precision against scipy past `sigma > 5`.
 _PARAMS = [(0.0, 1.0), (0.5, 0.5), (-1.0, 0.25), (1.0, 0.75), (0.0, 0.1)]
 _QUANTILES = [0.01, 0.1, 0.25, 0.5, 0.75, 0.9, 0.99]
 
@@ -67,3 +68,51 @@ def test_method_matches_scipy(case: Case[LogNormal], mu: float, sigma: float) ->
         value_grid=_value_grid(mu, sigma),
         quantiles=_QUANTILES,
     )
+
+
+# Standardised deviations of ln(x): `x = exp(mu + sigma * z)` probes both the far-right (large z)
+# and far-left (x -> 0+, large negative z) tails where the naive `sf().log()` / `cdf().log()` are
+# `-inf`, plus the direct-erfc band and the `ln_erfc` branch crossover (`z ~ 35.36`, bracketed by
+# 35 and 36), mirroring the Normal grid.
+_TAIL_HALF = (5.0, 10.0, 20.0, 30.0, 35.0, 36.0, 37.0, 38.0, 40.0, 50.0, 100.0)
+_TAIL_Z = (*(-z for z in _TAIL_HALF), *_TAIL_HALF)
+
+
+@pytest.mark.parametrize(("mu", "sigma"), [(0.0, 1.0), (1.0, 2.0)], ids=["mu=0,sigma=1", "mu=1,sigma=2"])
+def test_log_tail_matches_scipy(mu: float, sigma: float) -> None:
+    """`log_cdf` / `log_sf` stay finite and match scipy far into both tails, where `sf().log()` is `-inf`.
+
+    Mirrors the Normal tail exemplar (the log-normal log-cdf / log-sf are the underlying normal's,
+    composed with `ln`): probe *beyond* the underflow threshold, the regime the geometric
+    `test_method_matches_scipy` grid never reaches.
+    """
+    xs = [exp(mu + sigma * z) for z in _TAIL_Z]
+    dist = LogNormal(mu=mu, sigma=sigma)
+    frozen = scipy_lognorm(s=sigma, scale=exp(mu))
+
+    got = pl.DataFrame({"x": xs}).select(log_cdf=dist.log_cdf("x"), log_sf=dist.log_sf("x"))
+    assert got["log_cdf"].is_finite().all(), "log_cdf underflowed to -inf in the tail"
+    assert got["log_sf"].is_finite().all(), "log_sf underflowed to -inf in the tail"
+    np.testing.assert_allclose(got["log_cdf"].to_numpy(), frozen.logcdf(xs), rtol=1e-8, atol=1e-10)
+    np.testing.assert_allclose(got["log_sf"].to_numpy(), frozen.logsf(xs), rtol=1e-8, atol=1e-10)
+
+
+@pytest.mark.parametrize(("mu", "sigma"), [(0.0, 1.0), (1.0, 2.0)], ids=["mu=0,sigma=1", "mu=1,sigma=2"])
+def test_log_near_one_side_keeps_relative_precision(mu: float, sigma: float) -> None:
+    """The near-certain side matches scipy in *relative* terms (``atol=0``), not just within slack.
+
+    Mirrors the Normal pin of the ``log1p`` branch: ``log_cdf`` far right of the median (and
+    ``log_sf`` far left) is a tiny negative number the erfc reflection would round to ``0.0``.
+    """
+    zs = [1.0, 5.0, 10.0, 20.0, 30.0]
+    dist = LogNormal(mu=mu, sigma=sigma)
+    frozen = scipy_lognorm(s=sigma, scale=exp(mu))
+
+    upper = [exp(mu + sigma * z) for z in zs]
+    lower = [exp(mu - sigma * z) for z in zs]
+    got = pl.DataFrame({"hi": upper, "lo": lower}).select(
+        log_cdf=dist.log_cdf(pl.col("hi")),
+        log_sf=dist.log_sf(pl.col("lo")),
+    )
+    np.testing.assert_allclose(got["log_cdf"].to_numpy(), frozen.logcdf(upper), rtol=1e-9, atol=0.0)
+    np.testing.assert_allclose(got["log_sf"].to_numpy(), frozen.logsf(lower), rtol=1e-9, atol=0.0)

--- a/tests/scipy_parity/normal_test.py
+++ b/tests/scipy_parity/normal_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import numpy as np
+import polars as pl
 import pytest
 from scipy.stats import norm as scipy_norm
 
@@ -56,3 +58,56 @@ def test_method_matches_scipy(case: Case[Normal], mean: float, std: float) -> No
         value_grid=_value_grid(mean, std),
         quantiles=_QUANTILES,
     )
+
+
+# Deviations (in std_dev units) spanning the direct-erfc band, the `ln_erfc` branch crossover
+# (`t = 25`, i.e. `z = 25 * sqrt(2) ~ 35.36`, bracketed by 35 and 36), and the far tail past the
+# ~38 std_dev point where `sf` / `cdf` underflow to `0` and the naive `sf().log()` / `cdf().log()`
+# return `-inf`. Both signs, so each method covers its active tail and the near-one opposite side.
+_TAIL_HALF = (5.0, 10.0, 20.0, 30.0, 35.0, 36.0, 37.0, 38.0, 40.0, 50.0, 100.0)
+_TAIL_Z = (*(-z for z in _TAIL_HALF), *_TAIL_HALF)
+
+
+@pytest.mark.parametrize(("mean", "std"), [(0.0, 1.0), (2.0, 3.0)], ids=["std-normal", "mean=2,std=3"])
+def test_log_tail_matches_scipy(mean: float, std: float) -> None:
+    """`log_cdf` / `log_sf` stay finite and match scipy far into the tails, where `sf().log()` is `-inf`.
+
+    The regime C1 targets (anomaly scoring on many-sigma events) and the exemplar every future
+    distribution with a genuine tail must reproduce: probe *beyond* the underflow threshold, not
+    merely `sf ~ 1e-300` where the naive path is still finite. `test_method_matches_scipy` stops at
+    3 std_dev and never reaches here.
+    """
+    xs = [mean + std * z for z in _TAIL_Z]
+    dist = Normal(mean=mean, std_dev=std)
+    frozen = scipy_norm(loc=mean, scale=std)
+
+    got = pl.DataFrame({"x": xs}).select(
+        log_cdf=dist.log_cdf(pl.col("x")),
+        log_sf=dist.log_sf(pl.col("x")),
+    )
+    assert got["log_cdf"].is_finite().all(), "log_cdf underflowed to -inf in the tail"
+    assert got["log_sf"].is_finite().all(), "log_sf underflowed to -inf in the tail"
+    np.testing.assert_allclose(got["log_cdf"].to_numpy(), frozen.logcdf(xs), rtol=1e-8, atol=1e-10)
+    np.testing.assert_allclose(got["log_sf"].to_numpy(), frozen.logsf(xs), rtol=1e-8, atol=1e-10)
+
+
+@pytest.mark.parametrize(("mean", "std"), [(0.0, 1.0), (2.0, 3.0)], ids=["std-normal", "mean=2,std=3"])
+def test_log_near_one_side_keeps_relative_precision(mean: float, std: float) -> None:
+    """The near-certain side matches scipy in *relative* terms (``atol=0``), not just within slack.
+
+    ``log_cdf`` far above the mean (and ``log_sf`` far below) is a tiny negative number, e.g.
+    ``-7.6e-24`` at 10 std_dev; the erfc reflection ``2 - erfc(t)`` would round it to exactly
+    ``0.0``, an error invisible to the ``atol``-padded tail test above. Pins the ``log1p`` branch.
+    """
+    zs = [1.0, 5.0, 10.0, 20.0, 30.0]
+    dist = Normal(mean=mean, std_dev=std)
+    frozen = scipy_norm(loc=mean, scale=std)
+
+    upper = [mean + std * z for z in zs]
+    lower = [mean - std * z for z in zs]
+    got = pl.DataFrame({"hi": upper, "lo": lower}).select(
+        log_cdf=dist.log_cdf(pl.col("hi")),
+        log_sf=dist.log_sf(pl.col("lo")),
+    )
+    np.testing.assert_allclose(got["log_cdf"].to_numpy(), frozen.logcdf(upper), rtol=1e-9, atol=0.0)
+    np.testing.assert_allclose(got["log_sf"].to_numpy(), frozen.logsf(lower), rtol=1e-9, atol=0.0)


### PR DESCRIPTION
The naive base defaults `{cdf,sf}.log()` underflow to `-inf` past ~38 std_dev. This ports a stable `ln_erfc` (direct log, asymptotic series past `t = 25`, `log1p` on the near-certain side) into `normal.rs`, reused by `LogNormal` on the underlying normal at `ln(x)`; results match `scipy.stats.norm.logcdf` / `logsf` to full relative precision on both sides.
