### PR TITLE
fix: Propagate `NaN` evaluation points as `NaN` across all value-keyed methods

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -24,9 +24,10 @@ The method surface (`pdf`/`pmf`, `cdf`, `sf`, `ppf`, `isf`, the `log_*` family, 
 `DiscreteDistribution`. The catalogue and the full table live in the [API reference](../reference/index.md#method-surface).
 
 **Template-method split**: every value-keyed method is *concrete in the base*: it coerces the argument with `as_expr`,
-applies `propagate_null`, then delegates the maths to a private hook (`_pdf`, `_cdf`, `_ppf`, ...). **Subclasses
+applies `propagate_null_and_nan`, then delegates the maths to a private hook (`_pdf`, `_cdf`, `_ppf`, ...). **Subclasses
 implement and override the `_x` hooks, never the public methods.** The hook receives an already-coerced `pl.Expr` and
-returns the formula with no null handling; the base guarantees the null contract and input coercion uniformly.
+returns the formula with no null or NaN handling; the base guarantees the input contract uniformly (null in, null out;
+`NaN` in, `NaN` out, matching scipy) along with input coercion.
 
 Composing defaults live in the base and call the other hooks:
 

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -158,17 +158,19 @@ def register_plugin(
     )
 
 
-def propagate_null(value: pl.Expr, result: pl.Expr) -> pl.Expr:
-    """Return `result`, overridden to null on rows where `value` is null.
+def propagate_null_and_nan(value: pl.Expr, result: pl.Expr) -> pl.Expr:
+    """Return `result`, overridden to null where `value` is null and to `NaN` where it is `NaN`.
 
-    A null predicate in `pl.when` collapses to the `otherwise` branch, so a method whose `otherwise` is a non-null
-    constant (e.g. `pdf` returning `0.0` outside the support) would silently emit that constant for a null input.
+    Applied by every public value-keyed wrapper (scipy semantics: null in, null out; `NaN` in,
+    `NaN` out). The closed-form hooks cannot guarantee this themselves: a null or `NaN` evaluation
+    point sorts into a `pl.when` branch (polars orders `NaN` greater than every float) and returns
+    that branch's constant, e.g. `Uniform.cdf(NaN) = 1.0`. The Rust plugins propagate both
+    natively (`NaN` short-circuited centrally in the shared drivers, `src/distributions/mod.rs`).
 
-    Guarding on `value.is_null()` first makes every value-keyed method propagate input nulls uniformly.
-
-    The null literal is untyped so the output dtype follows `result`.
+    `is_nan` runs on `value` as-is: `False` for integer dtypes on every supported polars, raises
+    for non-numeric ones (both pinned by `tests/property/value_dtype_test.py`).
     """
-    return pl.when(value.is_null()).then(pl.lit(None)).otherwise(result)
+    return pl.when(value.is_null()).then(pl.lit(None)).when(value.is_nan()).then(float("nan")).otherwise(result)
 
 
 class _UnivariateDistribution(ABC):
@@ -345,18 +347,18 @@ class _UnivariateDistribution(ABC):
         return pl.when(validated_once.is_not_null()).then(validated)
 
     def cdf(self, value: float | IntoExprColumn) -> pl.Expr:
-        """Cumulative distribution function, `P(X <= value)`. Nulls in `value` are propagated."""
+        """Cumulative distribution function, `P(X <= value)`. Nulls and NaNs in `value` are propagated."""
         v = as_expr(value)
-        return propagate_null(v, self._cdf(v))
+        return propagate_null_and_nan(v, self._cdf(v))
 
     @abstractmethod
     def _cdf(self, value: pl.Expr) -> pl.Expr:
         """Core cdf formula on a coerced expr; null handling is applied by `cdf`."""
 
     def log_cdf(self, value: float | IntoExprColumn) -> pl.Expr:
-        """Natural logarithm of the cdf. Nulls in `value` are propagated."""
+        """Natural logarithm of the cdf. Nulls and NaNs in `value` are propagated."""
         v = as_expr(value)
-        return propagate_null(v, self._log_cdf(v))
+        return propagate_null_and_nan(v, self._log_cdf(v))
 
     def _log_cdf(self, value: pl.Expr) -> pl.Expr:
         """Default `log(cdf)`; underflows to `-inf` once `cdf` rounds to `0` deep in the left tail.
@@ -368,18 +370,18 @@ class _UnivariateDistribution(ABC):
         return self._cdf(value).log()
 
     def sf(self, value: float | IntoExprColumn) -> pl.Expr:
-        """Survival function, `P(X > value) = 1 - cdf(value)`. Nulls in `value` are propagated."""
+        """Survival function, `P(X > value) = 1 - cdf(value)`. Nulls and NaNs in `value` are propagated."""
         v = as_expr(value)
-        return propagate_null(v, self._sf(v))
+        return propagate_null_and_nan(v, self._sf(v))
 
     def _sf(self, value: pl.Expr) -> pl.Expr:
         """Default `1 - cdf`; subclasses override when a closed form is more accurate in the upper tail."""
         return 1 - self._cdf(value)
 
     def log_sf(self, value: float | IntoExprColumn) -> pl.Expr:
-        """Natural logarithm of the survival function. Nulls in `value` are propagated."""
+        """Natural logarithm of the survival function. Nulls and NaNs in `value` are propagated."""
         v = as_expr(value)
-        return propagate_null(v, self._log_sf(v))
+        return propagate_null_and_nan(v, self._log_sf(v))
 
     def _log_sf(self, value: pl.Expr) -> pl.Expr:
         """Default `log(sf)`; underflows to `-inf` once `sf` rounds to `0` deep in the right tail.
@@ -393,21 +395,21 @@ class _UnivariateDistribution(ABC):
     def ppf(self, quantile: float | IntoExprColumn) -> pl.Expr:
         """Percent point function (inverse cdf).
 
-        `quantile` is expected to lie in `[0, 1]`; nulls are propagated. Behaviour for out-of-range quantiles is
-        implementation-defined and should not be relied on; callers are responsible for bounding `quantile` upstream
-        when the source allows invalid values.
+        `quantile` is expected to lie in `[0, 1]`; nulls are propagated and a `NaN` quantile yields `NaN`
+        (matching scipy). Behaviour for other out-of-range quantiles is implementation-defined and should not be
+        relied on; callers are responsible for bounding `quantile` upstream when the source allows invalid values.
         """
         q = as_expr(quantile)
-        return propagate_null(q, self._ppf(q))
+        return propagate_null_and_nan(q, self._ppf(q))
 
     @abstractmethod
     def _ppf(self, quantile: pl.Expr) -> pl.Expr:
         """Core inverse-cdf formula on a coerced expr; null handling is applied by `ppf`."""
 
     def isf(self, quantile: float | IntoExprColumn) -> pl.Expr:
-        """Inverse survival function, `ppf(1 - quantile)`. Nulls in `quantile` are propagated."""
+        """Inverse survival function, `ppf(1 - quantile)`. Nulls in `quantile` are propagated; `NaN` yields `NaN`."""
         q = as_expr(quantile)
-        return propagate_null(q, self._isf(q))
+        return propagate_null_and_nan(q, self._isf(q))
 
     def _isf(self, quantile: pl.Expr) -> pl.Expr:
         return self._ppf(1 - quantile)
@@ -464,18 +466,18 @@ class DiscreteDistribution(_UnivariateDistribution, ABC):
     """Abstract base class for discrete univariate distributions."""
 
     def pmf(self, value: float | IntoExprColumn) -> pl.Expr:
-        """Probability mass function, `P(X = value)`. Nulls in `value` are propagated."""
+        """Probability mass function, `P(X = value)`. Nulls and NaNs in `value` are propagated."""
         v = as_expr(value)
-        return propagate_null(v, self._pmf(v))
+        return propagate_null_and_nan(v, self._pmf(v))
 
     @abstractmethod
     def _pmf(self, value: pl.Expr) -> pl.Expr:
         """Core pmf formula on a coerced expr; null handling is applied by `pmf`."""
 
     def log_pmf(self, value: float | IntoExprColumn) -> pl.Expr:
-        """Natural logarithm of the pmf. Nulls in `value` are propagated."""
+        """Natural logarithm of the pmf. Nulls and NaNs in `value` are propagated."""
         v = as_expr(value)
-        return propagate_null(v, self._log_pmf(v))
+        return propagate_null_and_nan(v, self._log_pmf(v))
 
     def _log_pmf(self, value: pl.Expr) -> pl.Expr:
         return self._pmf(value).log()
@@ -485,18 +487,18 @@ class ContinuousDistribution(_UnivariateDistribution, ABC):
     """Abstract base class for continuous univariate distributions."""
 
     def pdf(self, value: float | IntoExprColumn) -> pl.Expr:
-        """Probability density function evaluated at `value`. Nulls in `value` are propagated."""
+        """Probability density function evaluated at `value`. Nulls and NaNs in `value` are propagated."""
         v = as_expr(value)
-        return propagate_null(v, self._pdf(v))
+        return propagate_null_and_nan(v, self._pdf(v))
 
     @abstractmethod
     def _pdf(self, value: pl.Expr) -> pl.Expr:
         """Core pdf formula on a coerced expr; null handling is applied by `pdf`."""
 
     def log_pdf(self, value: float | IntoExprColumn) -> pl.Expr:
-        """Natural logarithm of the pdf. Nulls in `value` are propagated."""
+        """Natural logarithm of the pdf. Nulls and NaNs in `value` are propagated."""
         v = as_expr(value)
-        return propagate_null(v, self._log_pdf(v))
+        return propagate_null_and_nan(v, self._log_pdf(v))
 
     def _log_pdf(self, value: pl.Expr) -> pl.Expr:
         return self._pdf(value).log()

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -159,18 +159,13 @@ def register_plugin(
 
 
 def propagate_null_and_nan(value: pl.Expr, result: pl.Expr) -> pl.Expr:
-    """Return `result`, overridden to null where `value` is null and to `NaN` where it is `NaN`.
+    """Return `result`, overridden to null/NaN where `value` is null/NaN respectively.
 
-    Applied by every public value-keyed wrapper (scipy semantics: null in, null out; `NaN` in,
-    `NaN` out). The closed-form hooks cannot guarantee this themselves: a null or `NaN` evaluation
-    point sorts into a `pl.when` branch (polars orders `NaN` greater than every float) and returns
-    that branch's constant, e.g. `Uniform.cdf(NaN) = 1.0`. The Rust plugins propagate both
-    natively (`NaN` short-circuited centrally in the shared drivers, `src/distributions/mod.rs`).
-
-    `is_nan` runs on `value` as-is: `False` for integer dtypes on every supported polars, raises
-    for non-numeric ones (both pinned by `tests/property/value_dtype_test.py`).
+    Applied by every public value-keyed wrapper (scipy semantics: null in, null out; `NaN` in, `NaN` out).
     """
-    return pl.when(value.is_null()).then(pl.lit(None)).when(value.is_nan()).then(float("nan")).otherwise(result)
+    guarded = pl.when(value.is_null()).then(pl.lit(None)).when(value.is_nan()).then(float("nan")).otherwise(result)
+    name = value.meta.output_name(raise_if_undetermined=False)
+    return guarded if name is None else guarded.alias(name)
 
 
 class _UnivariateDistribution(ABC):

--- a/polars_stats/distributions/_bernoulli.py
+++ b/polars_stats/distributions/_bernoulli.py
@@ -56,8 +56,13 @@ class Bernoulli(DiscreteDistribution):
         return pl.when(value.lt(0)).then(0.0).when(value.lt(1)).then(1 - self._checked_p).otherwise(1.0)
 
     def _ppf(self, quantile: pl.Expr) -> pl.Expr:
-        """Smallest ``x`` with ``cdf(x) >= quantile``: ``0`` if ``quantile <= 1 - p`` else ``1`` (``Boolean``)."""
-        return quantile > 1 - self._checked_p
+        """Smallest ``x`` with ``cdf(x) >= quantile``: ``0.0`` if ``quantile <= 1 - p`` else ``1.0``.
+
+        The comparison's ``Boolean`` is cast to ``Float64`` so ``ppf`` / ``isf`` / ``median`` return the
+        support point numerically, matching scipy and every other distribution and leaving the wrapper's
+        ``NaN -> NaN`` contract representable (``Boolean`` has no ``NaN``).
+        """
+        return (quantile > 1 - self._checked_p).cast(pl.Float64())
 
     def mean(self) -> pl.Expr:
         """Expected value, ``p``."""

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-10-24"
+channel = "nightly-2026-04-01"
 components = ["rustfmt", "clippy"]

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -172,6 +172,10 @@ fn ln_pdf_value(dist: &Beta, v: f64) -> Option<f64> {
     Some(dist.ln_pdf(v))
 }
 
+// `cdf` / `sf` rely on the shared drivers' `NaN` short-circuit (see `value_keyed_scalar` in
+// `mod.rs`): unlike `pdf` / `ln_pdf`, which compute through to `NaN`, the regularized incomplete
+// beta behind them panics on a `NaN` evaluation point, which would abort the whole query.
+
 fn cdf_value(dist: &Beta, v: f64) -> Option<f64> {
     Some(dist.cdf(v))
 }
@@ -207,14 +211,16 @@ fn beta_ln_pdf(inputs: &[Series]) -> PolarsResult<Series> {
 }
 
 /// Element-wise cdf via `statrs` `ContinuousCDF::cdf` (regularized incomplete beta); `0` below the
-/// support, `1` at/above `1`.
+/// support, `1` at/above `1`, `NaN` for a `NaN` value (short-circuited in the shared drivers:
+/// statrs panics on it).
 #[polars_expr(output_type=Float64)]
 fn beta_cdf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, cdf_value)
 }
 
 /// Element-wise survival function via native `ContinuousCDF::sf` (accurate in the upper tail);
-/// `1` below the support, `0` at/above `1`.
+/// `1` below the support, `0` at/above `1`, `NaN` for a `NaN` value (short-circuited in the shared
+/// drivers: statrs panics on it).
 #[polars_expr(output_type=Float64)]
 fn beta_sf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, sf_value)

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -178,6 +178,11 @@ fn binomial_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Se
 // Per-method bodies, named so the per-row plugins and the constant-parameter `*_scalar` twins
 // share one definition each and cannot drift (the property test pinning their bit-equality only
 // samples parameterisations; sharing the body makes it structural).
+//
+// The bodies never see a `NaN` value: the shared drivers short-circuit it to `NaN` first (see
+// `value_keyed_scalar` in `mod.rs`). That guard is load-bearing here: `NaN < 0.0` is false and
+// `NaN.floor() as u64` saturates to `0`, so an unguarded body would confidently return
+// `P(X <= 0)` (and `pmf` a confident `0.0`) instead of propagating `NaN` (scipy semantics).
 
 fn pmf_value(dist: &Binomial, v: f64) -> Option<f64> {
     Some(support_point(v).map_or(0.0, |k| dist.pmf(k)))
@@ -204,28 +209,29 @@ fn sf_value(dist: &Binomial, v: f64) -> Option<f64> {
 }
 
 /// Element-wise pmf via `statrs` `Discrete::pmf`; zero off the integer support (`value < 0`,
-/// non-integer, or `value > n`). See [`value_keyed`] for the null/error contract.
+/// non-integer, or `value > n`), `NaN` for a `NaN` value. See [`value_keyed`] for the null/error
+/// contract.
 #[polars_expr(output_type=Float64)]
 fn binomial_pmf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, pmf_value)
 }
 
 /// Element-wise log-pmf via native `Discrete::ln_pmf` (more accurate than `pmf().ln()`);
-/// `-inf` off the integer support.
+/// `-inf` off the integer support, `NaN` for a `NaN` value.
 #[polars_expr(output_type=Float64)]
 fn binomial_ln_pmf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, ln_pmf_value)
 }
 
 /// Element-wise cdf `P(X <= floor(value))` via `statrs` `DiscreteCDF::cdf`; `0` for `value < 0`,
-/// `1` for `value >= n`.
+/// `1` for `value >= n`, `NaN` for a `NaN` value.
 #[polars_expr(output_type=Float64)]
 fn binomial_cdf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, cdf_value)
 }
 
 /// Element-wise survival function `P(X > floor(value))` via native `DiscreteCDF::sf` (accurate in
-/// the upper tail); `1` for `value < 0`, `0` for `value >= n`.
+/// the upper tail); `1` for `value < 0`, `0` for `value >= n`, `NaN` for a `NaN` value.
 #[polars_expr(output_type=Float64)]
 fn binomial_sf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, sf_value)

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -23,6 +23,16 @@ use polars::prelude::*;
 /// into `f` through a pre-built `dist`. So a null `value` propagates to null, and `f` returning
 /// `None` nulls the row on the method's own terms (e.g. `ppf` outside `[0, 1]`), matching the
 /// per-row path element for element.
+///
+/// `NaN` contract: a `NaN` evaluation point short-circuits to `NaN` (scipy semantics) before `f`
+/// runs, for every method including `ppf`. The short-circuit is central — here and in
+/// [`value_keyed_per_row!`] — rather than per body, because two bodies genuinely need it and none
+/// may be forgotten: the regularized incomplete beta behind `Beta` `cdf`/`sf` panics on `NaN`
+/// (aborting the whole query), and binomial's support mapping saturates (`NaN.floor() as u64` is
+/// `0`), returning a confident `P(X <= 0)`. The Python-side `propagate_null_and_nan` guard cannot
+/// substitute: polars evaluates every `when`/`then`/`otherwise` branch over the full column, so a
+/// plugin runs on the `NaN` rows even though the guard discards their output. Pinned by
+/// `tests/distributions/plugin_nan_test.py`.
 pub(crate) fn value_keyed_scalar<F>(value: &Series, f: F) -> PolarsResult<Series>
 where
     F: Fn(f64) -> Option<f64>,
@@ -31,7 +41,9 @@ where
     let value_ca = value.f64()?;
     let name = value_ca.name().clone();
 
-    let ca: Float64Chunked = unary_elementwise(value_ca, |opt| opt.and_then(&f));
+    let ca: Float64Chunked = unary_elementwise(value_ca, |opt| {
+        opt.and_then(|v| if v.is_nan() { Some(f64::NAN) } else { f(v) })
+    });
     Ok(ca.with_name(name).into_series())
 }
 
@@ -107,9 +119,12 @@ pub(crate) use value_keyed_scalar_plugins;
 ///   invalid parameterisation (`?` is available inside the closure).
 ///
 /// `f` is the same named per-method body the scalar fast path applies, so the two paths share one
-/// body and cannot drift. Only the 2-parameter (ternary) arm exists today, since every current
-/// distribution takes two parameters; a 1-parameter distribution would add a `try_binary_elementwise`
-/// arm here. Call sites are the distribution modules (`polars::prelude::*` in scope).
+/// body and cannot drift. A `NaN` evaluation point short-circuits to `NaN` after the distribution
+/// is built, so an invalid parameterisation still raises on a `NaN` row; see [`value_keyed_scalar`]
+/// for why the guard lives in the shared drivers. Only the 2-parameter (ternary) arm exists today,
+/// since every current distribution takes two parameters; a 1-parameter distribution would add a
+/// `try_binary_elementwise` arm here. Call sites are the distribution modules
+/// (`polars::prelude::*` in scope).
 macro_rules! value_keyed_per_row {
     (
         $(#[$meta:meta])*
@@ -137,8 +152,9 @@ macro_rules! value_keyed_per_row {
                 |value_opt, p1_opt, p2_opt| -> PolarsResult<Option<f64>> {
                     match (value_opt, p1_opt, p2_opt) {
                         (Some(v), Some(a), Some(b)) => {
+                            // Build first so an invalid parameterisation raises on a `NaN` row.
                             let dist = $build(a, b)?;
-                            Ok(f(&dist, v))
+                            Ok(if v.is_nan() { Some(f64::NAN) } else { f(&dist, v) })
                         },
                         _ => Ok(None),
                     }

--- a/tests/_polars_compat.py
+++ b/tests/_polars_compat.py
@@ -10,6 +10,10 @@ forwarded untouched.
 
 `linear_space` backfills `polars.linear_space`, which is missing on older supported polars; the implementation here
 reproduces its evenly spaced, inclusive-endpoint grid on every supported version.
+
+`arr_explode` wraps `Series.arr.explode`: polars 1.36 added the `empty_as_null` flag and 1.42 deprecated its
+default (a warning `filterwarnings = ["error"]` escalates), so newer polars needs the explicit kwarg while older
+supported polars does not accept it.
 """
 
 from __future__ import annotations
@@ -24,12 +28,26 @@ from polars.testing import assert_series_equal as _assert_series_equal
 if TYPE_CHECKING:
     from polars import DataFrame, LazyFrame, Series
 
-__all__ = ("assert_frame_equal", "assert_series_equal", "linear_space")
+__all__ = ("arr_explode", "assert_frame_equal", "assert_series_equal", "linear_space")
 
 PL_VERSION = Version(pl.__version__)
 _NEEDS_RENAMING = Version("1.32.3") > PL_VERSION
 _REL_NAME = "rtol" if _NEEDS_RENAMING else "rel_tol"
 _ABS_NAME = "atol" if _NEEDS_RENAMING else "abs_tol"
+_EXPLODE_HAS_EMPTY_AS_NULL = Version("1.36.0") <= PL_VERSION
+
+
+def arr_explode(series: Series) -> Series:
+    """Version-agnostic `Series.arr.explode` with empty-as-empty semantics.
+
+    Passes `empty_as_null=False` where the kwarg exists (polars >= 1.36; from 1.42 omitting it warns
+    about the default flipping, which the suite's `filterwarnings = ["error"]` escalates) and calls
+    plain `explode` on older supported polars, which has no kwarg and no warning. Every call site
+    explodes an `Array` column, whose rows are never empty, so the two paths return identical output.
+    """
+    if _EXPLODE_HAS_EMPTY_AS_NULL:
+        return series.arr.explode(empty_as_null=False)
+    return series.arr.explode()
 
 
 def linear_space(start: float, end: float, num_samples: int) -> Series:

--- a/tests/distributions/bernoulli/isf_test.py
+++ b/tests/distributions/bernoulli/isf_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import polars as pl
 import pytest
 from polars.testing import assert_series_equal
@@ -13,19 +15,25 @@ def test_isf_is_ppf_of_complement(unit_frame: pl.DataFrame, q: float) -> None:
     p = 0.3
     isf = unit_frame.select(v=Bernoulli(p=p).isf(q)).item(0, "v")
     ppf_comp = unit_frame.select(v=Bernoulli(p=p).ppf(1 - q)).item(0, "v")
-    assert isf is ppf_comp
+    assert isf == ppf_comp
 
 
 def test_isf_propagates_null_in_quantile() -> None:
-    # isf(0.1) = ppf(0.9) = True for p=0.3; isf(0.9) = ppf(0.1) = False.
+    # isf(0.1) = ppf(0.9) = 1.0 for p=0.3; isf(0.9) = ppf(0.1) = 0.0.
     df = pl.DataFrame({"q": [0.1, None, 0.9]}, schema={"q": pl.Float64})
     result = df.select(v=Bernoulli(p=0.3).isf(pl.col("q")))["v"]
-    expected = pl.Series("v", [True, None, False], dtype=pl.Boolean)
+    expected = pl.Series("v", [1.0, None, 0.0], dtype=pl.Float64)
     assert_series_equal(result, expected)
 
 
+def test_isf_propagates_nan_in_quantile(unit_frame: pl.DataFrame) -> None:
+    # Same NaN contract as `ppf`: a NaN quantile propagates as NaN (scipy semantics).
+    result = unit_frame.select(v=Bernoulli(p=0.3).isf(float("nan"))).item(0, "v")
+    assert math.isnan(result)
+
+
 def test_isf_propagates_null_in_p(p_with_null: pl.DataFrame) -> None:
-    # isf(0.5) == ppf(0.5): False when p <= 0.5, True when p > 0.5, null when p is null.
+    # isf(0.5) == ppf(0.5): 0.0 when p <= 0.5, 1.0 when p > 0.5, null when p is null.
     result = p_with_null.select(v=Bernoulli(p=pl.col("p")).isf(0.5))["v"]
-    expected = pl.Series("v", [False, None, True], dtype=pl.Boolean)
+    expected = pl.Series("v", [0.0, None, 1.0], dtype=pl.Float64)
     assert_series_equal(result, expected)

--- a/tests/distributions/bernoulli/median_test.py
+++ b/tests/distributions/bernoulli/median_test.py
@@ -7,14 +7,14 @@ from polars.testing import assert_series_equal
 from polars_stats import Bernoulli
 
 
-@pytest.mark.parametrize(("p", "expected"), [(0.3, False), (0.5, False), (0.7, True)])
-def test_median(p: float, *, expected: bool, unit_frame: pl.DataFrame) -> None:
-    # median = ppf(0.5) = (0.5 > 1 - p)
+@pytest.mark.parametrize(("p", "expected"), [(0.3, 0.0), (0.5, 0.0), (0.7, 1.0)])
+def test_median(p: float, expected: float, unit_frame: pl.DataFrame) -> None:
+    # median = ppf(0.5) = (0.5 > 1 - p), as the Float64 support point.
     result = unit_frame.select(v=Bernoulli(p=p).median()).item(0, "v")
-    assert result is expected
+    assert result == expected
 
 
 def test_median_propagates_null_in_p(p_with_null: pl.DataFrame) -> None:
     result = p_with_null.select(v=Bernoulli(p=pl.col("p")).median())["v"]
-    expected = pl.Series("v", [False, None, True], dtype=pl.Boolean)
+    expected = pl.Series("v", [0.0, None, 1.0], dtype=pl.Float64)
     assert_series_equal(result, expected)

--- a/tests/distributions/bernoulli/ppf_test.py
+++ b/tests/distributions/bernoulli/ppf_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import polars as pl
 import pytest
 from polars.testing import assert_series_equal
@@ -10,30 +12,37 @@ from polars_stats import Bernoulli
 @pytest.mark.parametrize(
     ("p", "quantile", "expected"),
     [
-        (0.3, 0.0, False),
-        (0.3, 0.5, False),  # 0.5 <= 1 - 0.3 = 0.7
-        (0.3, 0.7, False),  # boundary: q <= 1 - p → 0
-        (0.3, 0.8, True),
-        (0.3, 1.0, True),
-        (0.0, 0.5, False),
-        (1.0, 0.5, True),
-        (1.0, 0.0, False),  # 0 > 1 - 1 = 0 is False
+        (0.3, 0.0, 0.0),
+        (0.3, 0.5, 0.0),  # 0.5 <= 1 - 0.3 = 0.7
+        (0.3, 0.7, 0.0),  # boundary: q <= 1 - p → 0
+        (0.3, 0.8, 1.0),
+        (0.3, 1.0, 1.0),
+        (0.0, 0.5, 0.0),
+        (1.0, 0.5, 1.0),
+        (1.0, 0.0, 0.0),  # 0 > 1 - 1 = 0 is False
     ],
 )
-def test_ppf_scalar(p: float, quantile: float, *, expected: bool, unit_frame: pl.DataFrame) -> None:
+def test_ppf_scalar(p: float, quantile: float, expected: float, unit_frame: pl.DataFrame) -> None:
     result = unit_frame.select(v=Bernoulli(p=p).ppf(quantile)).item(0, "v")
-    assert result is expected
+    assert result == expected
 
 
 def test_ppf_propagates_null_in_quantile() -> None:
     df = pl.DataFrame({"q": [0.1, None, 0.9]}, schema={"q": pl.Float64})
     result = df.select(v=Bernoulli(p=0.3).ppf(pl.col("q")))["v"]
-    expected = pl.Series("v", [False, None, True], dtype=pl.Boolean)
+    expected = pl.Series("v", [0.0, None, 1.0], dtype=pl.Float64)
     assert_series_equal(result, expected)
 
 
+def test_ppf_propagates_nan_in_quantile(unit_frame: pl.DataFrame) -> None:
+    # A NaN quantile propagates as NaN (scipy semantics) rather than falling through
+    # `NaN > 1 - p` (true under polars' NaN-greatest ordering) to a confident 1.0.
+    result = unit_frame.select(v=Bernoulli(p=0.3).ppf(float("nan"))).item(0, "v")
+    assert math.isnan(result)
+
+
 def test_ppf_propagates_null_in_p(p_with_null: pl.DataFrame) -> None:
-    # ppf(0.5) is False when p <= 0.5, True when p > 0.5, null when p is null.
+    # ppf(0.5) is 0.0 when p <= 0.5, 1.0 when p > 0.5, null when p is null.
     result = p_with_null.select(v=Bernoulli(p=pl.col("p")).ppf(0.5))["v"]
-    expected = pl.Series("v", [False, None, True], dtype=pl.Boolean)
+    expected = pl.Series("v", [0.0, None, 1.0], dtype=pl.Float64)
     assert_series_equal(result, expected)

--- a/tests/distributions/bernoulli/samples_test.py
+++ b/tests/distributions/bernoulli/samples_test.py
@@ -7,6 +7,7 @@ import pytest
 from polars.testing import assert_series_equal
 
 from polars_stats import Bernoulli
+from tests._polars_compat import arr_explode
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -51,7 +52,7 @@ def test_samples_mean_close_to_p_for_large_total(
 ) -> None:
     n, size, p = 4_000, 16, 0.3
     tolerance = 0.01
-    result = frame(n).select(s=Bernoulli(p=p).samples(size=size, seed=seed))["s"].arr.explode(empty_as_null=False)
+    result = arr_explode(frame(n).select(s=Bernoulli(p=p).samples(size=size, seed=seed))["s"])
     mean = cast("float", result.mean())
     assert abs(mean - p) < tolerance
 

--- a/tests/distributions/beta/samples_test.py
+++ b/tests/distributions/beta/samples_test.py
@@ -8,6 +8,7 @@ import pytest
 from polars.testing import assert_series_equal
 
 from polars_stats import Beta
+from tests._polars_compat import arr_explode
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -29,9 +30,7 @@ def test_samples_seed_reproducible(frame: Callable[..., pl.DataFrame], seed: int
 
 
 def test_samples_within_support(frame: Callable[..., pl.DataFrame], seed: int) -> None:
-    result = (
-        frame(size=512).select(s=Beta(a=0.5, b=0.5).samples(size=8, seed=seed))["s"].arr.explode(empty_as_null=False)
-    )
+    result = arr_explode(frame(size=512).select(s=Beta(a=0.5, b=0.5).samples(size=8, seed=seed))["s"])
     assert result.is_between(0.0, 1.0).all()
 
 
@@ -48,9 +47,7 @@ def test_samples_moments_close(frame: Callable[..., pl.DataFrame], seed: int) ->
     a, b = 2.0, 3.0
     mean = a / (a + b)
     std = math.sqrt(a * b / ((a + b) ** 2 * (a + b + 1)))
-    result = (
-        frame(size=4_000).select(s=Beta(a=a, b=b).samples(size=16, seed=seed))["s"].arr.explode(empty_as_null=False)
-    )
+    result = arr_explode(frame(size=4_000).select(s=Beta(a=a, b=b).samples(size=16, seed=seed))["s"])
     _mean, _std = cast("float", result.mean()), cast("float", result.std())
     assert abs(_mean - mean) < 0.05 * std
     assert abs(_std - std) < 0.05 * std

--- a/tests/distributions/binomial/bernoulli_equivalence_test.py
+++ b/tests/distributions/binomial/bernoulli_equivalence_test.py
@@ -33,7 +33,6 @@ def test_scalar_methods_match_bernoulli(p: float, method: str, unit_frame: pl.Da
 @pytest.mark.parametrize("p", [0.2, 0.5, 0.8])
 @pytest.mark.parametrize("q", _QUANTILES)
 def test_ppf_matches_bernoulli(p: float, q: float, unit_frame: pl.DataFrame) -> None:
-    # Bernoulli ppf is Boolean {False, True}; Binomial ppf is the integer support {0.0, 1.0}.
     binom = unit_frame.select(r=Binomial(1, p).ppf(q)).item(0, "r")
     bern = unit_frame.select(r=Bernoulli(p).ppf(q)).item(0, "r")
-    assert binom == float(bern)
+    assert binom == bern

--- a/tests/distributions/binomial/samples_test.py
+++ b/tests/distributions/binomial/samples_test.py
@@ -7,6 +7,7 @@ import pytest
 from polars.testing import assert_series_equal
 
 from polars_stats import Binomial
+from tests._polars_compat import arr_explode
 from tests.distributions.binomial.conftest import N_TRIALS
 
 if TYPE_CHECKING:
@@ -40,11 +41,7 @@ def test_samples_columns_are_not_all_equal(frame: Callable[..., pl.DataFrame], s
 def test_samples_mean_close_to_np_for_large_total(frame: Callable[..., pl.DataFrame], seed: int) -> None:
     n_rows, size, p = 4_000, 16, 0.3
     tolerance = 0.05
-    result = (
-        frame(n_rows)
-        .select(s=Binomial(N_TRIALS, p).samples(size=size, seed=seed))["s"]
-        .arr.explode(empty_as_null=False)
-    )
+    result = arr_explode(frame(n_rows).select(s=Binomial(N_TRIALS, p).samples(size=size, seed=seed))["s"])
     mean = cast("float", result.mean())
     assert abs(mean - N_TRIALS * p) < tolerance
 

--- a/tests/distributions/exponential/samples_test.py
+++ b/tests/distributions/exponential/samples_test.py
@@ -7,6 +7,7 @@ import pytest
 from polars.testing import assert_series_equal
 
 from polars_stats import Exponential
+from tests._polars_compat import arr_explode
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -37,20 +38,12 @@ def test_samples_columns_are_not_all_equal(frame: Callable[..., pl.DataFrame], s
 
 
 def test_samples_non_negative(frame: Callable[..., pl.DataFrame], seed: int) -> None:
-    series = (
-        frame(size=2_000)
-        .select(s=Exponential(rate=2.0).samples(size=8, seed=seed))["s"]
-        .arr.explode(empty_as_null=False)
-    )
+    series = arr_explode(frame(size=2_000).select(s=Exponential(rate=2.0).samples(size=8, seed=seed))["s"])
     assert (series >= 0.0).all()
 
 
 def test_samples_mean_close_to_inverse_rate(frame: Callable[..., pl.DataFrame], seed: int) -> None:
-    series = (
-        frame(size=4_000)
-        .select(s=Exponential(rate=2.0).samples(size=16, seed=seed))["s"]
-        .arr.explode(empty_as_null=False)
-    )
+    series = arr_explode(frame(size=4_000).select(s=Exponential(rate=2.0).samples(size=16, seed=seed))["s"])
     mean = cast("float", series.mean())
     assert abs(mean - 0.5) < 0.03 * 0.5
 

--- a/tests/distributions/lognormal/samples_test.py
+++ b/tests/distributions/lognormal/samples_test.py
@@ -7,6 +7,7 @@ import pytest
 from polars.testing import assert_series_equal
 
 from polars_stats import LogNormal
+from tests._polars_compat import arr_explode
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -38,12 +39,7 @@ def test_samples_columns_are_not_all_equal(frame: Callable[..., pl.DataFrame], s
 
 def test_samples_log_moments_close(frame: Callable[..., pl.DataFrame], seed: int) -> None:
     mu, sigma = 0.5, 0.75
-    logs = (
-        frame(size=4_000)
-        .select(s=LogNormal(mu=mu, sigma=sigma).samples(size=16, seed=seed))["s"]
-        .arr.explode(empty_as_null=False)
-        .log()
-    )
+    logs = arr_explode(frame(size=4_000).select(s=LogNormal(mu=mu, sigma=sigma).samples(size=16, seed=seed))["s"]).log()
     _mean, _std = cast("float", logs.mean()), cast("float", logs.std())
     assert abs(_mean - mu) < 0.05 * sigma
     assert abs(_std - sigma) < 0.05 * sigma

--- a/tests/distributions/normal/samples_test.py
+++ b/tests/distributions/normal/samples_test.py
@@ -7,6 +7,7 @@ import pytest
 from polars.testing import assert_series_equal
 
 from polars_stats import Normal
+from tests._polars_compat import arr_explode
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -38,11 +39,7 @@ def test_samples_columns_are_not_all_equal(frame: Callable[..., pl.DataFrame], s
 
 def test_samples_moments_close(frame: Callable[..., pl.DataFrame], seed: int) -> None:
     mean, std = 2.0, 1.5
-    result = (
-        frame(size=4_000)
-        .select(s=Normal(mu=mean, sigma=std).samples(size=16, seed=seed))["s"]
-        .arr.explode(empty_as_null=False)
-    )
+    result = arr_explode(frame(size=4_000).select(s=Normal(mu=mean, sigma=std).samples(size=16, seed=seed))["s"])
     _mean, _std = cast("float", result.mean()), cast("float", result.std())
     assert abs(_mean - mean) < 0.05 * std
     assert abs(_std - std) < 0.05 * std

--- a/tests/distributions/output_name_test.py
+++ b/tests/distributions/output_name_test.py
@@ -5,6 +5,10 @@ the deliberate default names `"sample"` / `"samples"` (rather than leaking an in
 name). With column-valued parameters the output keeps polars root-name semantics: it is named after
 the first parameter expression, which is what lets multi-column parameters (`pl.col("p1", "p2")`)
 and `.name.*` modifiers work.
+
+Value-keyed methods are named after the evaluation column: `propagate_null_and_nan` re-aliases its
+output to `value`'s resolved name, since its leading `pl.lit(None)` branch would otherwise name
+every value-keyed output `"literal"`.
 """
 
 from __future__ import annotations
@@ -67,6 +71,10 @@ def test_samples_with_column_params_keeps_root_name(dist: _UnivariateDistributio
 
 @pytest.mark.parametrize("dist", _SCALAR_PARAMS.values(), ids=list(_SCALAR_PARAMS))
 def test_value_keyed_keeps_value_root_name(dist: _UnivariateDistribution) -> None:
-    """`cdf(pl.col("p"))` is named `"p"`, so `.name.*` modifiers work on value-keyed outputs."""
+    """`cdf(pl.col("p"))` is named `"p"` via the guard's alias.
+
+    Only the output name is pinned: how a downstream `.name.*` modifier resolves it is polars'
+    call and differs across supported versions (old polars resolves the *root* name, which for the
+    closed-form hooks is the `pl.len()` inside a scalar parameter's `pl.repeat` expansion).
+    """
     assert _FRAME.select(dist.cdf(pl.col("p"))).columns == ["p"]
-    assert _FRAME.select(dist.cdf(pl.col("p")).name.suffix("_cdf")).columns == ["p_cdf"]

--- a/tests/distributions/output_name_test.py
+++ b/tests/distributions/output_name_test.py
@@ -1,4 +1,4 @@
-"""Output-name contract of `sample` / `samples`.
+"""Output-name contract of `sample` / `samples` and the value-keyed methods.
 
 With all-constant parameters there is no input column to inherit a name from, so the samplers get
 the deliberate default names `"sample"` / `"samples"` (rather than leaking an internal expression
@@ -63,3 +63,10 @@ def test_sample_with_column_params_keeps_root_name(dist: _UnivariateDistribution
 @pytest.mark.parametrize(("dist", "root"), _COLUMN_PARAMS.values(), ids=list(_COLUMN_PARAMS))
 def test_samples_with_column_params_keeps_root_name(dist: _UnivariateDistribution, root: str) -> None:
     assert _FRAME.select(dist.samples(size=3, seed=0)).columns == [root]
+
+
+@pytest.mark.parametrize("dist", _SCALAR_PARAMS.values(), ids=list(_SCALAR_PARAMS))
+def test_value_keyed_keeps_value_root_name(dist: _UnivariateDistribution) -> None:
+    """`cdf(pl.col("p"))` is named `"p"`, so `.name.*` modifiers work on value-keyed outputs."""
+    assert _FRAME.select(dist.cdf(pl.col("p"))).columns == ["p"]
+    assert _FRAME.select(dist.cdf(pl.col("p")).name.suffix("_cdf")).columns == ["p_cdf"]

--- a/tests/distributions/plugin_nan_test.py
+++ b/tests/distributions/plugin_nan_test.py
@@ -1,0 +1,67 @@
+"""The raw value-keyed plugins propagate a `NaN` evaluation point as `NaN`, `ppf` / `isf` included.
+
+The public wrappers overlay `propagate_null_and_nan` (`_base.py`), which rewrites `NaN` rows
+regardless of what the plugins return, so this Rust-level contract is invisible through the public
+API; it is exercised here through the private `_x` hooks, which for the statrs-backed
+distributions are bare plugin calls. The `NaN` short-circuit lives centrally in the shared drivers
+(`value_keyed_scalar` / `value_keyed_per_row!` in `src/distributions/mod.rs`) and is load-bearing
+in two places:
+
+* `Beta` `cdf` / `sf`: statrs' regularized incomplete beta panics on a `NaN` evaluation point, and
+  polars evaluates every `when`/`then`/`otherwise` branch over the full column, so the plugin runs
+  on `NaN` rows even though the Python guard discards their output there; without the
+  short-circuit the whole query aborts.
+* `Binomial`: `NaN < 0.0` is false and `NaN.floor() as u64` saturates to `0`, so unguarded bodies
+  would return a confident `P(X <= 0)` (and a `pmf` of `0.0`).
+
+Both plugin shapes are covered: scalar-parameter instances route to the `<method>_scalar` twins,
+column-parameter instances to the per-row plugins.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+
+from polars_stats import Beta, Binomial, LogNormal, Normal
+from polars_stats.distributions._base import DiscreteDistribution
+
+if TYPE_CHECKING:
+    from polars_stats._typing import PolarsDataType
+    from polars_stats.distributions._base import _UnivariateDistribution
+
+
+def _col(value: float, dtype: PolarsDataType | None = None) -> pl.Expr:
+    """A full-length constant column expr (`pl.repeat`), forcing the per-row plugin path."""
+    return pl.repeat(value, n=pl.len(), dtype=dtype)
+
+
+_CASES = [
+    ("normal-scalar", Normal(mu=0.5, sigma=2.0)),
+    ("normal-columns", Normal(mu=_col(0.5), sigma=_col(2.0))),
+    ("lognormal-scalar", LogNormal(mu=0.5, sigma=2.0)),
+    ("lognormal-columns", LogNormal(mu=_col(0.5), sigma=_col(2.0))),
+    ("beta-scalar", Beta(a=2.0, b=3.0)),
+    ("beta-columns", Beta(a=_col(2.0), b=_col(3.0))),
+    ("binomial-scalar", Binomial(n=5, p=0.4)),
+    ("binomial-columns", Binomial(n=_col(5, pl.Int64()), p=_col(0.4))),
+]
+
+
+def _value_hooks(dist: _UnivariateDistribution) -> tuple[str, ...]:
+    """Every value-keyed `_x` hook of `dist`, density methods named by family."""
+    density = ("_pmf", "_log_pmf") if isinstance(dist, DiscreteDistribution) else ("_pdf", "_log_pdf")
+    return (*density, "_cdf", "_log_cdf", "_sf", "_log_sf", "_ppf", "_isf")
+
+
+@pytest.mark.parametrize(("label", "dist"), _CASES, ids=[label for label, _ in _CASES])
+def test_raw_plugin_propagates_nan(label: str, dist: _UnivariateDistribution) -> None:
+    """Each hook yields `NaN` (not null, not a confident constant) for a `NaN` evaluation point."""
+    frame = pl.DataFrame({"x": [float("nan")]})
+    for hook in _value_hooks(dist):
+        out = frame.select(r=getattr(dist, hook)(pl.col("x")))["r"]
+        assert out.null_count() == 0, f"{label}.{hook} nulled a NaN evaluation point"
+        assert math.isnan(out.item()), f"{label}.{hook} did not propagate NaN"

--- a/tests/distributions/uniform/samples_test.py
+++ b/tests/distributions/uniform/samples_test.py
@@ -7,6 +7,7 @@ import pytest
 from polars.testing import assert_series_equal
 
 from polars_stats import Uniform
+from tests._polars_compat import arr_explode
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -38,20 +39,12 @@ def test_samples_columns_are_not_all_equal(frame: Callable[..., pl.DataFrame], s
 
 def test_samples_within_bounds(frame: Callable[..., pl.DataFrame], seed: int) -> None:
     mn, mx = -3.0, 2.0
-    series = (
-        frame(size=2_000)
-        .select(s=Uniform(min=mn, max=mx).samples(size=8, seed=seed))["s"]
-        .arr.explode(empty_as_null=False)
-    )
+    series = arr_explode(frame(size=2_000).select(s=Uniform(min=mn, max=mx).samples(size=8, seed=seed))["s"])
     assert series.is_between(mn, mx).all()
 
 
 def test_samples_mean_close_to_midpoint(frame: Callable[..., pl.DataFrame], seed: int) -> None:
-    series = (
-        frame(size=4_000)
-        .select(s=Uniform(min=2.0, max=5.0).samples(size=16, seed=seed))["s"]
-        .arr.explode(empty_as_null=False)
-    )
+    series = arr_explode(frame(size=4_000).select(s=Uniform(min=2.0, max=5.0).samples(size=16, seed=seed))["s"])
     mean = cast("float", series.mean())
     assert abs(mean - 3.5) < 0.01 * 3.0
 

--- a/tests/property/cdf_test.py
+++ b/tests/property/cdf_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -30,14 +31,20 @@ def _eval(expr: pl.Expr, xs: Iterable[float]) -> pl.Series:
 @pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
 @given(data=st.data())
 def test_cdf_bounded_and_monotone(spec: DistSpec, data: st.DataObject) -> None:
-    """`0 <= cdf(x) <= 1` and `cdf` is non-decreasing in `x`, across the parameter space."""
+    """`0 <= cdf(x) <= 1` and `cdf` is non-decreasing in `x`, across the parameter space.
+
+    A trailing `NaN` evaluation point must propagate as `NaN` (scipy semantics) rather than collapse
+    into a bounds branch; the finite-grid assertions exclude it.
+    """
     params = data.draw(spec.params)
     dist = spec.make(params)
     lo, hi = spec.eval_range(params)
     xs = linear_space(lo, hi, _GRID_SIZE)
 
-    cdf = _eval(dist.cdf(pl.col("x")), xs)
+    cdf = _eval(dist.cdf(pl.col("x")), [*xs, float("nan")])
 
+    assert math.isnan(cdf.item(_GRID_SIZE))
+    cdf = cdf.head(_GRID_SIZE)
     assert not cdf.is_nan().any()
     assert cdf.is_between(0.0, 1.0).all()
     # Allow only float noise against strict monotonicity, not a real decrease.

--- a/tests/property/pdf_test.py
+++ b/tests/property/pdf_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -30,14 +31,20 @@ def _eval(expr: pl.Expr, xs: Iterable[float]) -> pl.Series:
 @pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
 @given(data=st.data())
 def test_density_non_negative(spec: DistSpec, data: st.DataObject) -> None:
-    """`pdf(x) >= 0` (continuous) / `pmf(x) >= 0` (discrete), across the parameter space."""
+    """`pdf(x) >= 0` (continuous) / `pmf(x) >= 0` (discrete), across the parameter space.
+
+    A trailing `NaN` evaluation point must propagate as `NaN` (scipy semantics) rather than collapse
+    into the zero-density branch; the finite-grid assertions exclude it.
+    """
     params = data.draw(spec.params)
     dist = spec.make(params)
     lo, hi = spec.eval_range(params)
     xs = linear_space(lo, hi, _GRID_SIZE)
 
-    density = _eval(spec.density(dist, pl.col("x")), xs)
+    density = _eval(spec.density(dist, pl.col("x")), [*xs, float("nan")])
 
+    assert math.isnan(density.item(_GRID_SIZE))
+    density = density.head(_GRID_SIZE)
     assert not density.is_nan().any()
     assert density.ge(0.0).all()
 

--- a/tests/property/value_dtype_test.py
+++ b/tests/property/value_dtype_test.py
@@ -1,0 +1,133 @@
+"""Value-keyed methods accept integer-typed evaluation points; non-numeric dtypes fail fast.
+
+`propagate_null_and_nan` in `_base.py` applies `is_nan` to the coerced value expression as-is,
+with no `Float64` cast. That relies on two polars behaviours, both verified on every supported
+version (1.15.0 through current) and pinned here so a regression in either direction surfaces:
+
+* `is_nan` returns `False` for integer dtypes (an integer can never hold a `NaN`), so an
+  integer-typed value column, or the integer `pl.repeat` expansion of a scalar like `cdf(0)`,
+  flows through the guard and must evaluate exactly as its `Float64`-cast equivalent. The Rust
+  plugins cast the evaluation point to `Float64` internally; the closed-form hooks combine it
+  under polars supertype rules; both are exact for the integer grids used here.
+* `is_nan` raises `InvalidOperationError` for non-numeric dtypes (`Boolean`, `String`, temporal),
+  so an invalid value column is rejected up front, before any hook or plugin sees it. This is the
+  strict half of the contract: a numeric `String` column must not silently parse through the
+  statrs-backed paths (both a Python-side `cast` and the plugin's internal Rust cast would
+  otherwise accept it).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from polars_stats import Normal, Uniform
+from polars_stats.distributions._base import ContinuousDistribution, DiscreteDistribution
+from tests._polars_compat import assert_series_equal
+from tests.property._specs import ALL_SPECS
+
+if TYPE_CHECKING:
+    from polars_stats.distributions._base import _UnivariateDistribution
+    from tests.property._specs import DistSpec
+
+_INT_DTYPES = (pl.Int64(), pl.UInt32())
+"""One signed and one unsigned integer dtype; the guard and the hooks are dtype-generic past that."""
+
+_MAX_GRID = 16
+
+
+def _int_grid(lo: float, hi: float, dtype: pl.DataType) -> list[int | None]:
+    """Integers spanning `[floor(lo), ceil(hi)]`, thinned to at most ~`_MAX_GRID` points, plus a null probe.
+
+    An unsigned dtype clamps the window at 0 (kept non-empty), since it cannot represent the
+    negative part of a signed evaluation range.
+    """
+    lo_i, hi_i = math.floor(lo), math.ceil(hi)
+    if dtype in (pl.UInt8(), pl.UInt16(), pl.UInt32(), pl.UInt64()):
+        lo_i = max(lo_i, 0)
+        hi_i = max(hi_i, lo_i)
+    step = max(1, (hi_i - lo_i) // _MAX_GRID)
+    return [*range(lo_i, hi_i + 1, step), None]
+
+
+def _log_density(dist: _UnivariateDistribution, value: pl.Expr) -> pl.Expr:
+    """`log_pdf` / `log_pmf` by family; the method lives on the family subclass, hence the narrowing."""
+    if isinstance(dist, ContinuousDistribution):
+        return dist.log_pdf(value)
+    if isinstance(dist, DiscreteDistribution):
+        return dist.log_pmf(value)
+    msg = f"unsupported distribution family: {type(dist)}"  # pragma: no cover
+    raise TypeError(msg)  # pragma: no cover
+
+
+@pytest.mark.parametrize("dtype", _INT_DTYPES, ids=str)
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@given(data=st.data())
+def test_integer_value_column_matches_float64(spec: DistSpec, dtype: pl.DataType, data: st.DataObject) -> None:
+    """Every value-keyed method evaluates an integer value column exactly as its `Float64` cast.
+
+    A null in the integer column must also propagate identically (the guard's null branch is
+    dtype-agnostic, but this pins it on the integer path specifically).
+    """
+    params = data.draw(spec.params)
+    dist = spec.make(params)
+    lo, hi = spec.eval_range(params)
+    values = pl.DataFrame({"x": _int_grid(lo, hi, dtype)}, schema={"x": dtype})
+    quantiles = pl.DataFrame({"q": [0, 1, None]}, schema={"q": dtype})
+
+    x, q = pl.col("x"), pl.col("q")
+    cases = [
+        (values, spec.density(dist, x), spec.density(dist, x.cast(pl.Float64()))),
+        (values, _log_density(dist, x), _log_density(dist, x.cast(pl.Float64()))),
+        (values, dist.cdf(x), dist.cdf(x.cast(pl.Float64()))),
+        (values, dist.log_cdf(x), dist.log_cdf(x.cast(pl.Float64()))),
+        (values, dist.sf(x), dist.sf(x.cast(pl.Float64()))),
+        (values, dist.log_sf(x), dist.log_sf(x.cast(pl.Float64()))),
+        (quantiles, dist.ppf(q), dist.ppf(q.cast(pl.Float64()))),
+        (quantiles, dist.isf(q), dist.isf(q.cast(pl.Float64()))),
+    ]
+    for frame, int_expr, float_expr in cases:
+        as_int = frame.select(r=int_expr)["r"]
+        as_float = frame.select(r=float_expr)["r"]
+        assert_series_equal(as_int, as_float, check_exact=True)
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@given(data=st.data())
+def test_integer_scalar_value_matches_float_scalar(spec: DistSpec, data: st.DataObject) -> None:
+    """`cdf(1)` (expanded by `as_expr` to an integer `pl.repeat` column) equals `cdf(1.0)`.
+
+    One method suffices: the `as_expr` coercion and the `propagate_null_and_nan` guard this scalar
+    routes through are shared by every value-keyed method.
+    """
+    params = data.draw(spec.params)
+    dist = spec.make(params)
+    frame = pl.DataFrame({"rows": [0.0, 0.0, 0.0]})
+    assert_series_equal(frame.select(r=dist.cdf(1))["r"], frame.select(r=dist.cdf(1.0))["r"], check_exact=True)
+
+
+@pytest.mark.parametrize(
+    "dist",
+    [Normal(mu=0.0, sigma=1.0), Uniform(min=0.0, max=1.0)],
+    ids=["normal", "uniform"],
+)
+@pytest.mark.parametrize(
+    "series",
+    [pl.Series("x", [True, False]), pl.Series("x", ["0.5", "1.0"])],
+    ids=["boolean", "string"],
+)
+def test_non_numeric_value_column_raises(dist: _UnivariateDistribution, series: pl.Series) -> None:
+    """A `Boolean` or `String` value column is rejected up front, plugin-backed or closed-form alike.
+
+    Only the exception type is pinned, not the message: whether the guard's `is_nan` or a hook
+    operation (e.g. `Uniform`'s division on a `String`) resolves first is a polars
+    schema-resolution ordering detail. The contract is that the query errors instead of silently
+    computing (`InvalidOperationError` on every supported polars for both operators).
+    """
+    with pytest.raises(pl.exceptions.InvalidOperationError):
+        series.to_frame().select(dist.cdf(pl.col("x")))

--- a/tests/property/value_keyed_test.py
+++ b/tests/property/value_keyed_test.py
@@ -31,10 +31,10 @@ if TYPE_CHECKING:
 
 _GRID_SIZE = 64
 
-_PPF_EDGE_QUANTILES = (-0.5, 0.0, 1.0, 1.5, None)
+_PPF_EDGE_QUANTILES = (-0.5, 0.0, 1.0, 1.5, None, float("nan"))
 """Out-of-range quantiles exercise ppf's null path; the closed endpoints exercise its boundary mapping.
 
-A null in the value column must propagate on both paths.
+A null or NaN in the value column must propagate on both paths.
 """
 
 
@@ -57,7 +57,7 @@ def test_value_keyed_scalar_fast_path_matches_per_row(spec: DistSpec, data: st.D
     per_row = spec.make_columns(params)
 
     lo, hi = spec.eval_range(params)
-    values = pl.DataFrame({"x": [*linear_space(lo, hi, _GRID_SIZE), None]}, schema={"x": pl.Float64})
+    values = pl.DataFrame({"x": [*linear_space(lo, hi, _GRID_SIZE), None, float("nan")]}, schema={"x": pl.Float64})
     quantiles = pl.DataFrame(
         {"q": [*linear_space(1e-3, 1.0 - 1e-3, _GRID_SIZE), *_PPF_EDGE_QUANTILES]},
         schema={"q": pl.Float64},

--- a/tests/scipy_parity/_harness.py
+++ b/tests/scipy_parity/_harness.py
@@ -60,15 +60,16 @@ def assert_case_matches_scipy(
 ) -> None:
     """Assert one `Case` reproduces its scipy oracle across the grid selected by `case.kind`.
 
-    Boolean outputs (a discrete `ppf`/`isf`/`median`) are cast to `0.0`/`1.0` before comparison, so the
-    same helper serves discrete and continuous distributions. `value_grid` / `quantiles` are owned by
-    the calling test module because their support spans are distribution-specific.
+    `value_grid` / `quantiles` are owned by the calling test module because their support spans are
+    distribution-specific.
     """
     if case.kind == "scalar":
         result = pl.DataFrame({"_": [0]}).select(r=case.pl_fn(dist, pl.lit(0.0)))["r"]
         expected = [getattr(scipy_frozen, case.scipy_attr)()]
     else:
-        xs = list(value_grid if case.kind == "value" else quantiles)
+        # scipy propagates a NaN evaluation point as NaN for every value- and quantile-keyed
+        # method; appending it here pins that contract for every method of every distribution.
+        xs = [*(value_grid if case.kind == "value" else quantiles), float("nan")]
         result = pl.DataFrame({"x": xs}).select(r=case.pl_fn(dist, pl.col("x")))["r"]
         expected = getattr(scipy_frozen, case.scipy_attr)(xs)
 

--- a/tests/scipy_parity/bernoulli_test.py
+++ b/tests/scipy_parity/bernoulli_test.py
@@ -10,7 +10,7 @@ from tests.scipy_parity._harness import Case, assert_case_matches_scipy
 # of the per-method functional tests under `tests/distributions/bernoulli`.
 _PROBS = [0.0, 0.25, 0.5, 0.75, 1.0]
 # Interior quantiles only: scipy's discrete ppf/isf return the below-support sentinel -1 at the
-# exact endpoints q in {0, 1}, which the Boolean-valued `ppf` here (range {False, True}) does not
+# exact endpoints q in {0, 1}, which the support-clamped `ppf` here (range {0.0, 1.0}) does not
 # reproduce. The interior is where the two definitions agree.
 _QUANTILES = [0.1, 0.25, 0.5, 0.75, 0.9]
 # Bernoulli support is {0, 1}; the grid spans below, both support points, a non-integer, and above.
@@ -41,7 +41,7 @@ def test_method_matches_scipy(case: Case[Bernoulli], p: float) -> None:
 
     Table-driven: adding a method is one row in `_CASES`. `ppf`/`isf` use interior quantiles only,
     since scipy's discrete inverse returns the below-support sentinel -1 at `q` in `{0, 1}`, which
-    the Boolean-valued `ppf` here does not reproduce. Method-specific behaviour (support handling,
+    the support-clamped `ppf` here does not reproduce. Method-specific behaviour (support handling,
     null propagation) is asserted in the per-method test files.
     """
     assert_case_matches_scipy(


### PR DESCRIPTION
A `NaN` evaluation point previously sorted through polars' `NaN`-greatest comparisons into a confident constant (`Uniform.cdf(NaN) = 1.0`, `Binomial.cdf(NaN) = P(X <= 0)`), and `Beta.{cdf,sf}` panicked inside `statrs`, aborting the whole query.. Every value-keyed method now matches scipy (`NaN` in, `NaN` out; null in, null out) via the shared `propagate_null_and_nan` guard in Python and a single central `NaN` short-circuit in the shared Rust plugin drivers.

**Breaking**: `Bernoulli.{ppf, isf, median}` return Float64 (0.0/1.0) instead of Boolean, matching scipy and every other distribution. New tests pin the `NaN` parity grids, the value-dtype contract (integer columns work, non-numeric dtypes fail fast), and the raw-plugin NaN contract.