### PR TITLE
build(deps): statrs 0.19 and the rand ecosystem it moves (rand 0.10, rand_distr 0.6, rand_pcg 0.10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,9 +730,34 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glam"
+version = "0.30.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+
+[[package]]
+name = "glam"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
+
+[[package]]
+name = "glam"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+
+[[package]]
+name = "glam"
+version = "0.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360bd2cd76e0cd9032d42cf2922155cecea2685b0cfa4630c3246df030bcfd6"
 
 [[package]]
 name = "glob"
@@ -1228,17 +1264,20 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.33.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d43ddcacf343185dfd6de2ee786d9e8b1c2301622afab66b6c73baf9882abfd"
+checksum = "adc43a60c217b0c6ff46e47f26911015ad8d2e5a8be1af668c67e370d99a4346"
 dependencies = [
  "approx",
+ "glam 0.30.10",
+ "glam 0.31.1",
+ "glam 0.32.1",
+ "glam 0.33.3",
  "matrixmultiply",
  "num-complex",
  "num-rational",
  "num-traits",
- "rand 0.8.6",
- "rand_distr 0.4.3",
+ "rand 0.10.2",
  "simba",
  "typenum",
 ]
@@ -1385,12 +1424,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1834,8 +1867,8 @@ dependencies = [
  "polars-core",
  "pyo3",
  "pyo3-polars",
- "rand 0.8.6",
- "rand_distr 0.4.3",
+ "rand 0.10.2",
+ "rand_distr 0.6.0",
  "rand_pcg",
  "serde",
  "statrs",
@@ -2176,33 +2209,23 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2217,15 +2240,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
@@ -2234,14 +2248,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_distr"
-version = "0.4.3"
+name = "rand_core"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
-dependencies = [
- "num-traits",
- "rand 0.8.6",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -2254,12 +2264,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_pcg"
-version = "0.3.1"
+name = "rand_distr"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
- "rand_core 0.6.4",
+ "num-traits",
+ "rand 0.10.2",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2510,9 +2530,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
-version = "0.7.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+checksum = "3a52ec151f024d703f9fd65abb7cbe81e7cdb39f18917a3a37e3014470dc7c59"
 dependencies = [
  "bytemuck",
 ]
@@ -2688,14 +2708,13 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.9.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
+checksum = "f1a7200d82ff1c7b4235efd12f11e2537a402c91cf83a5cb97ce80eef787fde7"
 dependencies = [
  "approx",
  "num-complex",
  "num-traits",
- "paste",
  "wide",
 ]
 
@@ -2776,14 +2795,15 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "statrs"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+checksum = "c78553aa710187998fc7c7945c18889c59ef199ff7d2146ab90998b431b29eea"
 dependencies = [
  "approx",
  "nalgebra",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.10.2",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3303,9 +3323,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.33"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+checksum = "de2aaf408e58689c2096682331b1f42bb2d9f2ed6b11560407d023cd0a6c634e"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,17 +30,20 @@ polars-core = { version = "0.52.0", default-features = false }
 # Trim statrs to what this crate uses. `default-features = false` drops the optional `nalgebra` feature
 # (and its matrixmultiply / num-complex / num-rational / num-integer subtree), which statrs pulls only for
 # its multivariate distributions (MultivariateNormal, Dirichlet, ...) that this crate does not use.
-# `rand` is re-enabled explicitly: the statrs-backed samplers (Normal, Bernoulli, Exponential, ...) draw via
-# statrs's `rand::distributions::Distribution` impl, so dropping it fails to compile. `nalgebra?/rand` inside
-# statrs's `rand` feature is inert while `nalgebra` is off, so no nalgebra returns. Compile-only trim,
+# `std` must be re-enabled explicitly: statrs 0.19 supports `no_std` and carries `std` as a default
+# feature, so switching defaults off without it silently builds a `no_std` statrs. `rand` is re-enabled
+# explicitly too: the statrs-backed samplers (Normal, Bernoulli, Exponential, ...) draw via statrs's
+# `rand::distr::Distribution` impl, so dropping it fails to compile. `nalgebra?/rand` inside statrs's
+# `rand` feature is inert while `nalgebra` is off, so no nalgebra returns. Compile-only trim,
 # identical output.
-statrs = { version = "0.18.0", default-features = false, features = ["rand"] }
-rand = "0.8"
-# The binomial sampler's seeded output depends on rand_distr's draw algorithm (BINV/BTPE) and its
-# per-draw uniform consumption: a bump can change it. The committed Cargo.lock pins the exact build
-# version; treat any update as a deliberate, changelog-recorded seeded-output change.
-rand_distr = "0.4"
-rand_pcg = "0.3"
+statrs = { version = "0.19.0", default-features = false, features = ["std", "rand"] }
+rand = "0.10"
+# The binomial sampler's seeded output depends on rand_distr's draw algorithm (BINV/BTPE, plus a
+# Poisson approximation when `1 - p == 1.0`) and its per-draw uniform consumption: a bump can change
+# it. The committed Cargo.lock pins the exact build version; treat any update as a deliberate,
+# changelog-recorded seeded-output change.
+rand_distr = "0.6"
+rand_pcg = "0.10"
 
 [profile.release]
 lto = "thin"  # "fat" is more aggressive; see trade-off

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -68,10 +68,10 @@ polars-stats/
 | `polars-core` | `POOL` and its `rayon` re-export, so the multi-draw fill runs on the thread pool Polars itself uses |
 | `pyo3-polars` | the `#[polars_expr]` macro and FFI glue (source of ABI churn) |
 | `pyo3` | Python FFI, abi3 for forward compatibility |
-| `statrs` 0.18 | distribution math, and sampling except the binomial and uniform draws |
-| `rand_distr` 0.4 | `O(1)`-amortised binomial draw (statrs' is `O(n)` per row); exact build version pinned by `Cargo.lock`, see [Design notes](explanation/design.md#binomial-sampling-uses-rand_distr-not-statrs) |
-| `rand` 0.8 | `RngCore` / `OsRng` for the unseeded root seed |
-| `rand_pcg` 0.3 | `Pcg64Mcg` per-row RNG for deterministic seeded sampling |
+| `statrs` 0.19 | distribution math, and sampling except the binomial and uniform draws |
+| `rand_distr` 0.6 | `O(1)`-amortised binomial draw (statrs' is `O(n)` per row); exact build version pinned by `Cargo.lock`, see [Design notes](explanation/design.md#binomial-sampling-uses-rand_distr-not-statrs) |
+| `rand` 0.10 | `TryRng` / `SysRng` for the unseeded root seed |
+| `rand_pcg` 0.10 | `Pcg64Mcg` per-row RNG for deterministic seeded sampling |
 | `serde` | deserialise the static `seed` kwarg |
 
 Deliberately excluded: `rand_chacha` (replaced by `rand_pcg`; per-row `ChaCha20`

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -78,7 +78,7 @@ error surface.
 consecutive values from the one per-row stream keyed `(seed, i)`, so `samples(size=1)` matches `sample` bit for bit
 and growing `size` extends each row's array without changing existing draws.
 
-**Per-row seeding**: the root seed is resolved once per plugin call (`OsRng` when `seed=None`), then each row derives
+**Per-row seeding**: the root seed is resolved once per plugin call (`SysRng` when `seed=None`), then each row derives
 its own `Pcg64Mcg` generator from `(root_seed, row_index)` via two splitmix64 mixing draws. The row index arrives as a
 regular input column (`pl.int_range(0, pl.len())`), so it tracks the partition under `over` / `group_by`.
 
@@ -114,8 +114,8 @@ bad column row surface identically.
 
 ## Stack
 
-The math runs on `statrs` 0.18; the plugin glue is `pyo3-polars` over `pyo3` (abi3); per-row seeded RNG is `rand_pcg`
-(`Pcg64Mcg`), with `rand` for `OsRng`; `serde` deserialises the static `seed` kwarg. The full dependency rationale and
+The math runs on `statrs` 0.19; the plugin glue is `pyo3-polars` over `pyo3` (abi3); per-row seeded RNG is `rand_pcg`
+(`Pcg64Mcg`), with `rand` for `SysRng`; `serde` deserialises the static `seed` kwarg. The full dependency rationale and
 the deliberately-excluded crates are in [Contributing / Stack](../contributing.md#stack), and the repository layout is
 in [Contributing / Repository layout](../contributing.md#repository-layout). Supported Python, Polars, and OS versions
 are in [Reference / Compatibility](../reference/index.md#compatibility).

--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -36,7 +36,7 @@ the input, so `sample` is genuinely elementwise.
 
 The generator is `Pcg64Mcg` (`rand_pcg`): cheap to construct (no key schedule), good statistical quality, and output
 stable across releases and platforms, so seeded results stay reproducible. The root seed is resolved once per call
-(`OsRng` when `seed=None`); each row then derives its own generator from `(root_seed, row_index)`.
+(`SysRng` when `seed=None`); each row then derives its own generator from `(root_seed, row_index)`.
 
 This replaced an earlier "single `ChaCha20Rng` advanced once per row in iteration order" design, which coupled rows
 across chunks (order-dependent, not streaming-safe). The naive fix, a `ChaCha20Rng` per row, made sampling markedly
@@ -94,10 +94,11 @@ earlier construction of `size` separate `sample` calls glued by `concat_arr`.
 
 ### Binomial sampling uses `rand_distr`, not `statrs`
 
-`statrs` 0.18 implements `Distribution<u64> for Binomial` as `(0..n).fold(...)`, one uniform draw per trial, so a sampled
-row costs `n` RNG draws. At `n = 10_000` that is 10,000 uniforms per row, turning the sampler `O(n)`; the constant-factor
-wins over scipy held only for small `n`. The binomial sampler therefore draws from `rand_distr::Binomial` (inversion for
-small `n*p`, BTPE otherwise, both `O(1)`-amortised), keeping sampling time flat in `n`. This is the one place sampling
+`statrs` (still true on 0.19) implements `Distribution<u64> for Binomial` as `(0..n).fold(...)`, one uniform draw per
+trial, so a sampled row costs `n` RNG draws. At `n = 10_000` that is 10,000 uniforms per row, turning the sampler
+`O(n)`; the constant-factor wins over scipy held only for small `n`. The binomial sampler therefore draws from
+`rand_distr::Binomial` (inversion for small `n*p`, BTPE otherwise, both `O(1)`-amortised), keeping sampling time flat
+in `n`. This is the one place sampling
 does not go through `statrs`; every value-keyed method (`pmf`, `cdf`, `ppf`, ...) still builds the `statrs` distribution.
 
 ### Invalid parameters raise, they never silently null

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -2,7 +2,7 @@
 use polars::prelude::arity::try_binary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
-use rand::distributions::Distribution;
+use rand::distr::Distribution;
 use statrs::distribution::Bernoulli;
 
 use crate::distributions::param_validator;
@@ -42,7 +42,7 @@ fn bernoulli_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Ser
     let index_ca = index.u64()?;
     let name = inputs[0].name().clone();
 
-    let rngs = kwargs.row_rngs();
+    let rngs = kwargs.row_rngs()?;
 
     let ca: BooleanChunked = try_binary_elementwise(
         proba_ca,

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -2,8 +2,9 @@
 use polars::prelude::arity::{try_binary_elementwise, try_ternary_elementwise};
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
-use rand::distributions::Distribution as RandDistribution;
+use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::{Beta, Continuous, ContinuousCDF};
+use statrs::function::beta::ln_beta;
 use statrs::statistics::Distribution as StatrsDistribution;
 
 use crate::distributions::{param_validator, value_keyed_per_row, value_keyed_scalar_plugins};
@@ -95,7 +96,7 @@ fn beta_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> 
     let index_ca = index.u64()?;
     let name = inputs[0].name().clone();
 
-    let rngs = kwargs.row_rngs();
+    let rngs = kwargs.row_rngs()?;
 
     let ca: Float64Chunked = try_ternary_elementwise(
         a_ca,
@@ -157,7 +158,18 @@ fn pdf_value(dist: &Beta, v: f64) -> Option<f64> {
     Some(dist.pdf(v))
 }
 
+/// Log-pdf via native `ln_pdf`, except on `v in [1 - 1e-9, 1)`, where the log-density is computed
+/// directly: `statrs` 0.19 compares `v` to `1.0` with an *absolute* epsilon of `1e-9`
+/// (`prec::ulps_eq!`), so its endpoint branch swallows that whole band and returns `-inf` where
+/// the true value is finite (`Beta(2, 3).ln_pdf(1 - 1e-9)` is `-38.96`, and
+/// `Beta(0.05, 0.05).ln_pdf(1 - 1e-9)` is `+16.00`; statrs 0.19 says `-inf` for both).
+/// `1 - v` is exact there (Sterbenz), so the direct form is correctly rounded; everywhere else the
+/// native path is unchanged.
 fn ln_pdf_value(dist: &Beta, v: f64) -> Option<f64> {
+    if (1.0 - v) <= 1e-9 && v < 1.0 {
+        let (a, b) = (dist.shape_a(), dist.shape_b());
+        return Some((a - 1.0) * v.ln() + (b - 1.0) * (1.0 - v).ln() - ln_beta(a, b));
+    }
     Some(dist.ln_pdf(v))
 }
 

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -165,6 +165,7 @@ fn pdf_value(dist: &Beta, v: f64) -> Option<f64> {
 /// `Beta(0.05, 0.05).ln_pdf(1 - 1e-9)` is `+16.00`; statrs 0.19 says `-inf` for both).
 /// `1 - v` is exact there (Sterbenz), so the direct form is correctly rounded; everywhere else the
 /// native path is unchanged.
+/// TODO(FBruzzesi): Rollback to `Some(dist.ln_pdf(v))` once regression is fixed
 fn ln_pdf_value(dist: &Beta, v: f64) -> Option<f64> {
     if (1.0 - v) <= 1e-9 && v < 1.0 {
         let (a, b) = (dist.shape_a(), dist.shape_b());

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -2,7 +2,7 @@
 use polars::prelude::arity::{try_binary_elementwise, try_ternary_elementwise};
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
-use rand::distributions::Distribution as RandDistribution;
+use rand::distr::Distribution as RandDistribution;
 use rand_distr::Binomial as BinomialSampler;
 use statrs::distribution::{Binomial, Discrete, DiscreteCDF};
 use statrs::statistics::Distribution as StatrsDistribution;
@@ -113,7 +113,7 @@ fn binomial_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Seri
     let index_ca = index.u64()?;
     let name = inputs[0].name().clone();
 
-    let rngs = kwargs.row_rngs();
+    let rngs = kwargs.row_rngs()?;
 
     let ca: UInt64Chunked = try_ternary_elementwise(
         n_ca,
@@ -236,8 +236,8 @@ const PPF_CDF_TOL: f64 = 1e-12;
 /// discrete CDF.
 ///
 /// This is the inverse-cdf statrs documents for `Binomial` (a search over the CDF), reimplemented
-/// here because `statrs`' generic `DiscreteCDF::inverse_cdf` panics for small `n` (it `unwrap`s a
-/// bisection that returns `None`).
+/// here so the cdf-step comparison carries the **relative** slack below, which `statrs`' generic
+/// `DiscreteCDF::inverse_cdf` does not provide.
 ///
 /// The step slack is **relative** ([`PPF_CDF_TOL`] scaled by `q`), not absolute: an absolute slack
 /// exceeds every quantile below it, so `cdf(0) + tol >= q` held for any `q <= 1e-12` and the search

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -2,7 +2,7 @@
 use polars::prelude::arity::try_binary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
-use rand::distributions::Distribution as RandDistribution;
+use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::Exp;
 
 use crate::distributions::param_validator;
@@ -55,7 +55,7 @@ fn exponential_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<S
     let index_ca = index.u64()?;
     let name = inputs[0].name().clone();
 
-    let rngs = kwargs.row_rngs();
+    let rngs = kwargs.row_rngs()?;
 
     let ca: Float64Chunked = try_binary_elementwise(
         rate_ca,

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -2,7 +2,7 @@
 use polars::prelude::arity::try_ternary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
-use rand::distributions::Distribution as RandDistribution;
+use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::{Continuous, ContinuousCDF, LogNormal, Normal};
 
 use crate::distributions::{
@@ -29,38 +29,24 @@ fn build_dist(mu: f64, sigma: f64) -> PolarsResult<LogNormal> {
     })
 }
 
-/// Construct the *underlying* `statrs::Normal` (mean `mu`, std-dev `sigma`) for the stable
-/// `log_cdf` / `log_sf`, which reuse the normal's `ln_erfc` form on `ln(x)`.
+/// The underlying `statrs::Normal` (mean `mu`, std-dev `sigma`) a built `LogNormal` wraps,
+/// recovered through the `location()` / `scale()` accessors. Backs the stable `log_cdf` / `log_sf`
+/// / `isf`, which reuse the normal's `ln_erfc` forms on `ln(x)`.
 ///
-/// `statrs::LogNormal` hides its `(location, scale)` (no accessors), so the value functions cannot
-/// recover `(mu, sigma)` from a built `LogNormal`; they receive this underlying `Normal` instead.
-/// Validation is delegated to [`build_dist`], so an invalid parameterisation reports the identical
-/// error (down to the statrs suffix) as every other method.
-fn build_underlying_normal(mu: f64, sigma: f64) -> PolarsResult<Normal> {
-    build_dist(mu, sigma)?;
-    Ok(Normal::new(mu, sigma)
-        .expect("Normal::new accepts every (mu, sigma) LogNormal::new accepts"))
+/// Infallible: any `(location, scale)` a built `LogNormal` carries is a valid `Normal`
+/// parameterisation, so validation stays with [`build_dist`] alone.
+fn underlying_normal(dist: &LogNormal) -> Normal {
+    Normal::new(dist.location(), dist.scale())
+        .expect("Normal::new accepts every (location, scale) a built LogNormal carries")
 }
 
 value_keyed_per_row! {
-    /// Apply a value-keyed `f(dist, value)` element-wise over `(value, mu, sigma)`; shared by
-    /// `pdf`, `ln_pdf`, `cdf`, `sf`, `ppf`. `null` propagates; an invalid parameterisation raises
+    /// Apply a value-keyed `f(dist, value)` element-wise over `(value, mu, sigma)`; shared by every
+    /// Rust-bound value-keyed method. `null` propagates; an invalid parameterisation raises
     /// via [`build_dist`]; `f` may return `None` to null a row on its own terms.
     fn value_keyed(&LogNormal);
     params = (DataType::Float64 => f64, DataType::Float64 => f64);
     build = build_dist;
-}
-
-value_keyed_per_row! {
-    /// Apply a value-keyed function `f(&Normal, value)` over `(value, mu, sigma)`, building the
-    /// *underlying* normal (see [`build_underlying_normal`]) rather than the `LogNormal`.
-    ///
-    /// Backs the stable `log_cdf` / `log_sf` only: they compute the underlying normal's log-cdf / log-sf
-    /// at `ln(value)`, which `statrs::LogNormal`'s hidden parameters would not let them reach via
-    /// [`value_keyed`]. Null / invalid-parameter contract is identical to [`value_keyed`].
-    fn value_keyed_norm(&Normal);
-    params = (DataType::Float64 => f64, DataType::Float64 => f64);
-    build = build_underlying_normal;
 }
 
 param_validator! {
@@ -90,7 +76,7 @@ fn lognormal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Ser
     let index_ca = index.u64()?;
     let name = inputs[0].name().clone();
 
-    let rngs = kwargs.row_rngs();
+    let rngs = kwargs.row_rngs()?;
 
     let ca: Float64Chunked = try_ternary_elementwise(
         mu_ca,
@@ -165,22 +151,22 @@ fn sf_value(dist: &LogNormal, v: f64) -> Option<f64> {
 }
 
 /// Stable log-cdf: the underlying normal's [`normal::ln_cdf_value`] at `ln(v)`; `-inf` for `v <= 0`
-/// (`cdf = 0` outside the support). `norm` is the underlying normal built by [`build_underlying_normal`].
-fn ln_cdf_value(norm: &Normal, v: f64) -> Option<f64> {
+/// (`cdf = 0` outside the support). See [`underlying_normal`] for the recovery.
+fn ln_cdf_value(dist: &LogNormal, v: f64) -> Option<f64> {
     if v <= 0.0 {
         Some(f64::NEG_INFINITY)
     } else {
-        normal::ln_cdf_value(norm, v.ln())
+        normal::ln_cdf_value(&underlying_normal(dist), v.ln())
     }
 }
 
 /// Stable log-sf: the underlying normal's [`normal::ln_sf_value`] at `ln(v)`; `0` for `v <= 0`
 /// (`sf = 1` outside the support).
-fn ln_sf_value(norm: &Normal, v: f64) -> Option<f64> {
+fn ln_sf_value(dist: &LogNormal, v: f64) -> Option<f64> {
     if v <= 0.0 {
         Some(0.0)
     } else {
-        normal::ln_sf_value(norm, v.ln())
+        normal::ln_sf_value(&underlying_normal(dist), v.ln())
     }
 }
 
@@ -202,8 +188,8 @@ fn ppf_value(dist: &LogNormal, q: f64) -> Option<f64> {
 ///
 /// The endpoints follow from the normal's: `isf(0) = exp(+inf) = +inf` and `isf(1) = exp(-inf) = 0`,
 /// which are the support boundaries `ppf` maps in the other order.
-fn isf_value(norm: &Normal, q: f64) -> Option<f64> {
-    normal::isf_value(norm, q).map(f64::exp)
+fn isf_value(dist: &LogNormal, q: f64) -> Option<f64> {
+    normal::isf_value(&underlying_normal(dist), q).map(f64::exp)
 }
 
 /// Element-wise pdf via `statrs` `Continuous::pdf`; `0` for `value <= 0` (outside the support).
@@ -237,14 +223,14 @@ fn lognormal_sf(inputs: &[Series]) -> PolarsResult<Series> {
 /// tail, unlike `cdf().ln()`); `-inf` for `value <= 0`.
 #[polars_expr(output_type=Float64)]
 fn lognormal_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_norm(inputs, ln_cdf_value)
+    value_keyed(inputs, ln_cdf_value)
 }
 
 /// Element-wise log-sf via the underlying normal's stable `ln_erfc` form (finite in the far-right
 /// tail, unlike `sf().ln()`); `0` for `value <= 0`.
 #[polars_expr(output_type=Float64)]
 fn lognormal_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_norm(inputs, ln_sf_value)
+    value_keyed(inputs, ln_sf_value)
 }
 
 /// Element-wise ppf (inverse cdf) via the closed-form `ContinuousCDF::inverse_cdf`.
@@ -258,7 +244,7 @@ fn lognormal_ppf(inputs: &[Series]) -> PolarsResult<Series> {
 /// See [`isf_value`] for why, and for the endpoint and out-of-range contract.
 #[polars_expr(output_type=Float64)]
 fn lognormal_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_norm(inputs, isf_value)
+    value_keyed(inputs, isf_value)
 }
 
 value_keyed_scalar_plugins! {
@@ -272,21 +258,6 @@ value_keyed_scalar_plugins! {
         fn lognormal_cdf_scalar => cdf_value;
         fn lognormal_sf_scalar => sf_value;
         fn lognormal_ppf_scalar => ppf_value;
-    }
-}
-
-value_keyed_scalar_plugins! {
-    /// Constant-parameter fast path for the stable `log_cdf` / `log_sf`, building the *underlying*
-    /// normal once (see [`build_underlying_normal`]) rather than the `LogNormal`.
-    ///
-    /// The scalar twin of [`value_keyed_norm`]: same field names as [`LogNormalParamsKwargs`]
-    /// (`mu`, `sigma`, so the Python layer routes either method's scalar params here unchanged), but
-    /// `build` returns the underlying `Normal` the `ln_erfc` bodies need.
-    struct LogNormalLogKwargs { mu: f64, sigma: f64 }
-
-    build = |kw| build_underlying_normal(kw.mu, kw.sigma)?;
-
-    methods {
         fn lognormal_ln_cdf_scalar => ln_cdf_value;
         fn lognormal_ln_sf_scalar => ln_sf_value;
         fn lognormal_isf_scalar => isf_value;

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -4,7 +4,7 @@ use std::f64::consts::{LN_2, SQRT_2};
 use polars::prelude::arity::try_ternary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
-use rand::distributions::Distribution as RandDistribution;
+use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::{Continuous, ContinuousCDF, Normal};
 use statrs::function::erf;
 use statrs::statistics::Distribution as StatrsDistribution;
@@ -64,7 +64,7 @@ fn normal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series
     let index_ca = index.u64()?;
     let name = inputs[0].name().clone();
 
-    let rngs = kwargs.row_rngs();
+    let rngs = kwargs.row_rngs()?;
 
     let ca: Float64Chunked = try_ternary_elementwise(
         mu_ca,

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -2,7 +2,7 @@
 use polars::prelude::arity::try_ternary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
-use rand::distributions::{Distribution, Standard};
+use rand::distr::{Distribution, StandardUniform};
 use statrs::distribution::Uniform;
 
 use crate::distributions::param_validator;
@@ -49,7 +49,7 @@ fn build_dist(min: f64, max: f64) -> PolarsResult<Uniform> {
 /// `hi.next_down() >= lo`.
 #[inline]
 fn draw_half_open(lo: f64, hi: f64, rng: &mut impl rand::Rng) -> f64 {
-    let u: f64 = Standard.sample(rng);
+    let u: f64 = StandardUniform.sample(rng);
     let x = lo + (hi - lo) * u;
     if x < hi {
         x
@@ -74,7 +74,7 @@ fn uniform_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Serie
     let index_ca = index.u64()?;
     let name = inputs[0].name().clone();
 
-    let rngs = kwargs.row_rngs();
+    let rngs = kwargs.row_rngs()?;
 
     let ca: Float64Chunked = try_ternary_elementwise(
         min_ca,

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -20,8 +20,8 @@ use polars_arrow::bitmap::Bitmap;
 use polars_arrow::datatypes::reshape::ReshapeDimension;
 use polars_core::utils::rayon::prelude::*;
 use polars_core::POOL;
-use rand::rngs::OsRng;
-use rand::RngCore;
+use rand::rngs::SysRng;
+use rand::TryRng;
 use rand_pcg::Pcg64Mcg;
 use serde::Deserialize;
 
@@ -40,9 +40,20 @@ fn splitmix64(mut z: u64) -> u64 {
 
 /// Resolve the root seed for a sampler call: the caller's seed if given, otherwise a
 /// fresh OS-entropy draw. Called once per plugin invocation, never per row.
+///
+/// An OS-entropy failure (`SysRng` is fallible) surfaces as a `ComputeError` and fails the
+/// evaluation, the same contract as an invalid parameter: it is a per-call error, deliberately
+/// not a panic out of the plugin.
 #[inline]
-fn resolve_root_seed(seed: Option<u64>) -> u64 {
-    seed.unwrap_or_else(|| OsRng.next_u64())
+fn resolve_root_seed(seed: Option<u64>) -> PolarsResult<u64> {
+    match seed {
+        Some(seed) => Ok(seed),
+        None => SysRng.try_next_u64().map_err(|e| {
+            PolarsError::ComputeError(
+                format!("failed to draw OS entropy for the sampler root seed: {e}").into(),
+            )
+        }),
+    }
 }
 
 /// Per-row RNG seeded by `(root_seed, index)`.
@@ -74,9 +85,9 @@ impl SampleKwargs {
     ///
     /// Call this a single time per plugin invocation, outside the elementwise loop: it
     /// draws OS entropy at most once here, after which every [`RowRngs::rng`] is a few
-    /// integer ops.
+    /// integer ops. Errs only when the OS entropy source fails (see [`resolve_root_seed`]).
     #[inline]
-    pub(crate) fn row_rngs(&self) -> RowRngs {
+    pub(crate) fn row_rngs(&self) -> PolarsResult<RowRngs> {
         row_rngs(self.seed)
     }
 }
@@ -89,10 +100,10 @@ impl SampleKwargs {
 /// through the same resolve-once-then-derive-per-row path, so seeded output is identical
 /// regardless of which entry point a distribution uses.
 #[inline]
-pub(crate) fn row_rngs(seed: Option<u64>) -> RowRngs {
-    RowRngs {
-        root_seed: resolve_root_seed(seed),
-    }
+pub(crate) fn row_rngs(seed: Option<u64>) -> PolarsResult<RowRngs> {
+    Ok(RowRngs {
+        root_seed: resolve_root_seed(seed)?,
+    })
 }
 
 /// Shared driver for the constant-parameter sampler fast paths.
@@ -120,7 +131,7 @@ where
 {
     let index = index.cast(&DataType::UInt64)?;
     let index_ca = index.u64()?;
-    let rngs = row_rngs(seed);
+    let rngs = row_rngs(seed)?;
     Ok(build(index_ca, &rngs).into_series())
 }
 
@@ -190,7 +201,7 @@ where
     }
     let index = index.cast(&DataType::UInt64)?;
     let indices: Vec<u64> = index.u64()?.into_no_null_iter().collect();
-    let rngs = row_rngs(seed);
+    let rngs = row_rngs(seed)?;
 
     let mut flat = vec![V::default(); indices.len() * size];
     fill_rows(&mut flat, size, |row, slot| {
@@ -245,7 +256,7 @@ where
     // which can raise) from the draw loop, whose rows then fill independently. A null row keeps
     // its `V::default()` slice; it is masked by the validity bitmaps below, never read.
     let states: Vec<Option<(u64, S)>> = rows.collect::<PolarsResult<_>>()?;
-    let rngs = row_rngs(seed);
+    let rngs = row_rngs(seed)?;
 
     let mut flat = vec![V::default(); states.len() * size];
     fill_rows(&mut flat, size, |row, slot| {

--- a/tests/distributions/beta/log_pdf_test.py
+++ b/tests/distributions/beta/log_pdf_test.py
@@ -15,6 +15,21 @@ def test_log_pdf_equals_log_of_pdf(value_grid: list[float]) -> None:
     assert_series_equal(result, expected, rel_tol=0.0, abs_tol=1e-12)
 
 
+def test_log_pdf_finite_in_the_upper_1e9_band() -> None:
+    # statrs 0.19 compares the evaluation point to 1.0 with an absolute epsilon of 1e-9
+    # (`prec::ulps_eq!`), so its endpoint branch swallows the whole band `1 - 1e-9 <= x < 1` and
+    # returns -inf regardless of shape, where the true log-density is finite (positive for
+    # small shapes). The Rust body computes that band directly; this pins several shape regimes.
+    x = 1.0 - 1e-9
+    df = pl.DataFrame({"x": [x]})
+    for a, b in [(2.0, 3.0), (0.05, 0.05), (5.0, 1e-3)]:
+        ln_beta = math.lgamma(a) + math.lgamma(b) - math.lgamma(a + b)
+        expected_val = (a - 1.0) * math.log(x) + (b - 1.0) * math.log(1.0 - x) - ln_beta
+        result = df.select(r=Beta(a=a, b=b).log_pdf(pl.col("x")))["r"]
+        expected = pl.Series("r", [expected_val], dtype=pl.Float64)
+        assert_series_equal(result, expected, rel_tol=1e-13, abs_tol=0.0)
+
+
 def test_log_pdf_outside_support_is_neg_inf() -> None:
     df = pl.DataFrame({"x": [-0.5, 1.5]})
     result = df.select(r=Beta(a=2.0, b=3.0).log_pdf(pl.col("x")))["r"]


### PR DESCRIPTION
## What moves and why now

| Crate | From | To |
| --- | --- | --- |
| `statrs` | 0.18.0 | 0.19.0 |
| `rand` | 0.8.6 | 0.10.2 |
| `rand_distr` | 0.4.3 | 0.6.0 |
| `rand_pcg` | 0.3.1 | 0.10.2 |

`statrs` 0.19 requires `rand ^0.10`, so the ecosystem moves as one. Taking the bump pre-release keeps any seeded-output consequence free; it also lands the `LogNormal` simplification before the Rust refactor redesigns that file.
