### PR TITLE
refactor(rust): replace param_validator! macro with generic functions

### DIFF
--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -5,7 +5,7 @@ use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution;
 use statrs::distribution::Bernoulli;
 
-use crate::distributions::param_validator;
+use crate::distributions::validate_params_unary;
 use crate::rng::{
     binary_param_rows, sample_scalar_plugin, samples_bool_output, samples_per_row, SampleKwargs,
     SamplesKwargs,
@@ -17,17 +17,20 @@ fn build_dist(proba: f64) -> PolarsResult<Bernoulli> {
     })
 }
 
-param_validator! {
-    /// Element-wise validation of the success probability: returns `p` unchanged, raising
-    /// `InvalidOperation` if `p` is outside `[0, 1]`. `null` propagates.
-    ///
-    /// The closed-form Python methods derive from this so they report an invalid `p` consistently
-    /// with `bernoulli_sample`, instead of silently computing a negative probability.
-    fn bernoulli_proba;
-    params = (proba: DataType::Float64 => f64);
-    build = build_dist;
-    returns = proba;
-    output_name = inputs[0];
+/// Element-wise validation of the success probability: returns `p` unchanged, raising
+/// `InvalidOperation` if `p` is outside `[0, 1]`. `null` propagates.
+///
+/// The closed-form Python methods derive from this so they report an invalid `p` consistently
+/// with `bernoulli_sample`, instead of silently computing a negative probability.
+#[polars_expr(output_type=Float64)]
+fn bernoulli_proba(inputs: &[Series]) -> PolarsResult<Series> {
+    let proba = inputs[0].cast(&DataType::Float64)?;
+    let name = inputs[0].name().clone();
+
+    validate_params_unary(proba.f64()?, name, |proba| {
+        build_dist(proba)?;
+        Ok(proba)
+    })
 }
 
 /// Element-wise Bernoulli sampler over `(p, row_index)`, returning `Boolean`.

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -7,7 +7,9 @@ use statrs::distribution::{Beta, Continuous, ContinuousCDF};
 use statrs::function::beta::ln_beta;
 use statrs::statistics::Distribution as StatrsDistribution;
 
-use crate::distributions::{param_validator, value_keyed_per_row, value_keyed_scalar_plugins};
+use crate::distributions::{
+    validate_params_binary, value_keyed_per_row, value_keyed_scalar_plugins,
+};
 use crate::rng::{
     sample_scalar_plugin, samples_f64_output, samples_per_row, ternary_param_rows, SampleKwargs,
     SamplesKwargs,
@@ -25,18 +27,22 @@ fn build_dist(a: f64, b: f64) -> PolarsResult<Beta> {
     })
 }
 
-param_validator! {
-    /// Validate the `(a, b)` parameterisation and return the validated `b`.
-    ///
-    /// `inputs[0]` is `a`, `inputs[1]` is `b`. The Python closed-form moments (`mean = a / (a + b)`,
-    /// `variance = a * b / ((a + b)^2 * (a + b + 1))`) are gated on this single FFI round-trip, so
-    /// they raise on an invalid parameterisation exactly like the value-keyed methods. `null` in
-    /// either input propagates; invalid raises via [`build_dist`].
-    fn beta_params;
-    params = (a: DataType::Float64 => f64, b: DataType::Float64 => f64);
-    build = build_dist;
-    returns = b;
-    output_name = inputs[1];
+/// Validate the `(a, b)` parameterisation and return the validated `b`.
+///
+/// `inputs[0]` is `a`, `inputs[1]` is `b`. The Python closed-form moments (`mean = a / (a + b)`,
+/// `variance = a * b / ((a + b)^2 * (a + b + 1))`) are gated on this single FFI round-trip, so
+/// they raise on an invalid parameterisation exactly like the value-keyed methods. `null` in
+/// either input propagates; invalid raises via [`build_dist`].
+#[polars_expr(output_type=Float64)]
+fn beta_params(inputs: &[Series]) -> PolarsResult<Series> {
+    let a = inputs[0].cast(&DataType::Float64)?;
+    let b = inputs[1].cast(&DataType::Float64)?;
+    let name = inputs[1].name().clone();
+
+    validate_params_binary(a.f64()?, b.f64()?, name, |a, b| {
+        build_dist(a, b)?;
+        Ok(b)
+    })
 }
 
 value_keyed_per_row! {

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -7,7 +7,9 @@ use rand_distr::Binomial as BinomialSampler;
 use statrs::distribution::{Binomial, Discrete, DiscreteCDF};
 use statrs::statistics::Distribution as StatrsDistribution;
 
-use crate::distributions::{param_validator, value_keyed_per_row, value_keyed_scalar_plugins};
+use crate::distributions::{
+    validate_params_binary, value_keyed_per_row, value_keyed_scalar_plugins,
+};
 use crate::rng::{
     sample_scalar_plugin, samples_per_row, samples_u64_output, ternary_param_rows, SampleKwargs,
     SamplesKwargs,
@@ -296,18 +298,22 @@ value_keyed_scalar_plugins! {
     }
 }
 
-param_validator! {
-    /// Validate the `(n, p)` parameterisation and return the validated `p`.
-    ///
-    /// `inputs[0]` is `n`, `inputs[1]` is `p`. The Python closed-form moments (`mean = n * p`,
-    /// `variance = n * p * (1 - p)`) are gated on this single FFI round-trip, so they raise on an
-    /// invalid parameterisation exactly like the value-keyed methods. `null` in either input
-    /// propagates; invalid raises via [`build_dist`].
-    fn binomial_params;
-    params = (n: DataType::Int64 => i64, p: DataType::Float64 => f64);
-    build = build_dist;
-    returns = p;
-    output_name = inputs[1];
+/// Validate the `(n, p)` parameterisation and return the validated `p`.
+///
+/// `inputs[0]` is `n`, `inputs[1]` is `p`. The Python closed-form moments (`mean = n * p`,
+/// `variance = n * p * (1 - p)`) are gated on this single FFI round-trip, so they raise on an
+/// invalid parameterisation exactly like the value-keyed methods. `null` in either input
+/// propagates; invalid raises via [`build_dist`].
+#[polars_expr(output_type=Float64)]
+fn binomial_params(inputs: &[Series]) -> PolarsResult<Series> {
+    let n = inputs[0].cast(&DataType::Int64)?;
+    let p = inputs[1].cast(&DataType::Float64)?;
+    let name = inputs[1].name().clone();
+
+    validate_params_binary(n.i64()?, p.f64()?, name, |n, p| {
+        build_dist(n, p)?;
+        Ok(p)
+    })
 }
 
 /// Element-wise Shannon entropy (in nats) via `statrs` `Distribution::entropy`, the exact support

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -5,7 +5,7 @@ use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::Exp;
 
-use crate::distributions::param_validator;
+use crate::distributions::validate_params_unary;
 use crate::rng::{
     binary_param_rows, sample_scalar_plugin, samples_f64_output, samples_per_row, SampleKwargs,
     SamplesKwargs,
@@ -24,19 +24,22 @@ fn build_dist(rate: f64) -> PolarsResult<Exp> {
     })
 }
 
-param_validator! {
-    /// Element-wise validation of the rate (λ): returns `rate` unchanged, raising `InvalidOperation`
-    /// if `rate` is `NaN` or `rate <= 0`. `null` propagates.
-    ///
-    /// Exponential is an elementary closed-form distribution, so its pdf / cdf / ppf and moments are
-    /// pure Polars expressions; routing the rate through this validator is what lets them report an
-    /// invalid parameterisation consistently with `exponential_sample`, instead of silently computing
-    /// with a non-positive rate.
-    fn exponential_rate;
-    params = (rate: DataType::Float64 => f64);
-    build = build_dist;
-    returns = rate;
-    output_name = inputs[0];
+/// Element-wise validation of the rate (λ): returns `rate` unchanged, raising `InvalidOperation`
+/// if `rate` is `NaN` or `rate <= 0`. `null` propagates.
+///
+/// Exponential is an elementary closed-form distribution, so its pdf / cdf / ppf and moments are
+/// pure Polars expressions; routing the rate through this validator is what lets them report an
+/// invalid parameterisation consistently with `exponential_sample`, instead of silently computing
+/// with a non-positive rate.
+#[polars_expr(output_type=Float64)]
+fn exponential_rate(inputs: &[Series]) -> PolarsResult<Series> {
+    let rate = inputs[0].cast(&DataType::Float64)?;
+    let name = inputs[0].name().clone();
+
+    validate_params_unary(rate.f64()?, name, |rate| {
+        build_dist(rate)?;
+        Ok(rate)
+    })
 }
 
 /// Element-wise Exponential sampler over `(rate, row_index)`, returning `Float64`.

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -6,7 +6,7 @@ use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::{Continuous, ContinuousCDF, LogNormal, Normal};
 
 use crate::distributions::{
-    normal, param_validator, value_keyed_per_row, value_keyed_scalar_plugins,
+    normal, validate_params_binary, value_keyed_per_row, value_keyed_scalar_plugins,
 };
 use crate::rng::{
     sample_scalar_plugin, samples_f64_output, samples_per_row, ternary_param_rows, SampleKwargs,
@@ -49,17 +49,21 @@ value_keyed_per_row! {
     build = build_dist;
 }
 
-param_validator! {
-    /// Validate the `(mu, sigma)` parameterisation and return the validated `sigma`.
-    ///
-    /// `inputs[0]` is `mu`, `inputs[1]` is `sigma`. The Python closed-form moments all derive from
-    /// this single FFI round-trip, so they raise on an invalid parameterisation exactly like the
-    /// value-keyed methods. `null` in either input propagates; invalid raises via [`build_dist`].
-    fn lognormal_sigma;
-    params = (mu: DataType::Float64 => f64, sigma: DataType::Float64 => f64);
-    build = build_dist;
-    returns = sigma;
-    output_name = inputs[1];
+/// Validate the `(mu, sigma)` parameterisation and return the validated `sigma`.
+///
+/// `inputs[0]` is `mu`, `inputs[1]` is `sigma`. The Python closed-form moments all derive from
+/// this single FFI round-trip, so they raise on an invalid parameterisation exactly like the
+/// value-keyed methods. `null` in either input propagates; invalid raises via [`build_dist`].
+#[polars_expr(output_type=Float64)]
+fn lognormal_sigma(inputs: &[Series]) -> PolarsResult<Series> {
+    let mu = inputs[0].cast(&DataType::Float64)?;
+    let sigma = inputs[1].cast(&DataType::Float64)?;
+    let name = inputs[1].name().clone();
+
+    validate_params_binary(mu.f64()?, sigma.f64()?, name, |mu, sigma| {
+        build_dist(mu, sigma)?;
+        Ok(sigma)
+    })
 }
 
 /// Element-wise LogNormal sampler over `(mu, sigma, row_index)`, returning `Float64`.

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -6,7 +6,7 @@ pub mod lognormal;
 pub mod normal;
 pub mod uniform;
 
-use polars::prelude::arity::unary_elementwise;
+use polars::prelude::arity::{try_binary_elementwise, try_unary_elementwise, unary_elementwise};
 use polars::prelude::*;
 
 /// Shared driver for the constant-parameter value-keyed fast paths.
@@ -168,93 +168,71 @@ macro_rules! value_keyed_per_row {
 }
 pub(crate) use value_keyed_per_row;
 
-/// Generates a two-parameter validation plugin: validate `(p1, p2)` per row by constructing the
-/// distribution, then return a derived `Float64` the closed-form Python methods can build on,
-/// raising identically to the sampler on an invalid parameterisation.
+/// Shared driver for the two-parameter validation plugins: validate `(a, b)` per row by
+/// constructing the distribution inside `validate`, and emit the `Float64` that closure returns.
 ///
 /// These plugins exist so the closed-form moments and (for Uniform / Bernoulli) value-keyed
-/// methods, which are pure Polars expressions, still report an invalid parameterisation through
-/// the same Rust `build_dist` rather than silently producing a garbage result. The constant-
-/// parameter fast path calls the very same plugin on length-1 `pl.lit` inputs, so it is built
-/// once instead of per row. The four knobs that vary between distributions are the macro's inputs:
+/// methods, which are pure Polars expressions, still report an invalid parameterisation through the
+/// same Rust `build_dist` rather than silently producing a garbage result. The constant-parameter
+/// fast path calls the same plugin on length-1 `pl.lit` inputs, so it is built once instead of per
+/// row.
 ///
-/// * each parameter's `<name>: <cast dtype> => <accessor>` (binomial's `n` is `Int64`/`.i64()`,
-///   the continuous parameters are `Float64`/`.f64()`); the matched values bind to `<name>`;
-/// * `build`: the constructor (`build_dist`), validating per row (`?` is available);
-/// * `returns`: the `Float64` to emit, an expression over the parameter names (a parameter itself,
-///   e.g. `sigma`, or a derived width, e.g. `max - min`);
-/// * `output_name = inputs[i]`: which input column names the output (most return the second
-///   parameter and name after it; Uniform's width names after the first).
+/// `validate` validates and derives in one step: it `?`-propagates the `InvalidOperation` out of
+/// `build_dist` and returns the value to emit, either a parameter itself (`sigma`) or a quantity
+/// derived from both (Uniform's `max - min`).
 ///
-/// Two arms that differ only in arity: a binary one (`normal_sigma`, `lognormal_sigma`,
-/// `binomial_params`, `uniform_range`) and a unary one (`bernoulli_proba`, `exponential_rate`).
-/// A unary validator's `output_name` is always `inputs[0]` (its only input). Call sites are the
-/// distribution modules (`polars::prelude::*` in scope).
-macro_rules! param_validator {
-    (
-        $(#[$meta:meta])*
-        fn $name:ident;
-        params = ($p1:ident: $p1_dt:expr => $p1_acc:ident, $p2:ident: $p2_dt:expr => $p2_acc:ident);
-        build = $build:path;
-        returns = $ret:expr;
-        output_name = inputs[$out_idx:literal];
-    ) => {
-        $(#[$meta])*
-        #[pyo3_polars::derive::polars_expr(output_type=Float64)]
-        fn $name(inputs: &[Series]) -> PolarsResult<Series> {
-            let p1 = inputs[0].cast(&$p1_dt)?;
-            let p1_ca = p1.$p1_acc()?;
-            let p2 = inputs[1].cast(&$p2_dt)?;
-            let p2_ca = p2.$p2_acc()?;
-            let name = inputs[$out_idx].name().clone();
+/// The two parameter dtypes are independent, so a mixed `(i64, f64)` parameterisation (Binomial)
+/// fits, as in [`ternary_param_rows`](crate::rng::ternary_param_rows): the caller does the cast and
+/// the accessor (`.f64()` / `.i64()`), which fixes `A` and `B`.
+///
+/// Null contract: any null input nulls the row without calling `validate`, matching the samplers.
+///
+/// Polars resolves a plugin expression's output name from its first input and ignores the name set
+/// here, so the frame column follows `inputs[0]` whichever input is passed (pinned by
+/// `tests/distributions/output_name_test.py`). `name` labels the returned `Series` only; callers
+/// pass the input whose quantity they return.
+///
+/// Keep `validate` a generic `F: Fn`: it monomorphises into the row loop, where a `&dyn Fn` or a
+/// `fn` pointer would cost an indirect call per row.
+pub(crate) fn validate_params_binary<A, B, F>(
+    a: &ChunkedArray<A>,
+    b: &ChunkedArray<B>,
+    name: PlSmallStr,
+    validate: F,
+) -> PolarsResult<Series>
+where
+    A: PolarsNumericType,
+    B: PolarsNumericType,
+    F: Fn(A::Native, B::Native) -> PolarsResult<f64>,
+{
+    let ca: Float64Chunked =
+        try_binary_elementwise(a, b, |a_opt, b_opt| -> PolarsResult<Option<f64>> {
+            match (a_opt, b_opt) {
+                (Some(a), Some(b)) => Ok(Some(validate(a, b)?)),
+                _ => Ok(None),
+            }
+        })?;
 
-            let ca: Float64Chunked = polars::prelude::arity::try_binary_elementwise(
-                p1_ca,
-                p2_ca,
-                |o1, o2| -> PolarsResult<Option<f64>> {
-                    match (o1, o2) {
-                        (Some($p1), Some($p2)) => {
-                            $build($p1, $p2)?;
-                            Ok(Some($ret))
-                        },
-                        _ => Ok(None),
-                    }
-                },
-            )?;
-
-            Ok(ca.with_name(name).into_series())
-        }
-    };
-    (
-        $(#[$meta:meta])*
-        fn $name:ident;
-        params = ($p1:ident: $p1_dt:expr => $p1_acc:ident);
-        build = $build:path;
-        returns = $ret:expr;
-        output_name = inputs[$out_idx:literal];
-    ) => {
-        $(#[$meta])*
-        #[pyo3_polars::derive::polars_expr(output_type=Float64)]
-        fn $name(inputs: &[Series]) -> PolarsResult<Series> {
-            let p1 = inputs[0].cast(&$p1_dt)?;
-            let p1_ca = p1.$p1_acc()?;
-            let name = inputs[$out_idx].name().clone();
-
-            let ca: Float64Chunked = polars::prelude::arity::try_unary_elementwise(
-                p1_ca,
-                |o1| -> PolarsResult<Option<f64>> {
-                    match o1 {
-                        Some($p1) => {
-                            $build($p1)?;
-                            Ok(Some($ret))
-                        },
-                        None => Ok(None),
-                    }
-                },
-            )?;
-
-            Ok(ca.with_name(name).into_series())
-        }
-    };
+    Ok(ca.with_name(name).into_series())
 }
-pub(crate) use param_validator;
+
+/// Single-parameter counterpart of [`validate_params_binary`], same contracts
+/// (`bernoulli_proba`, `exponential_rate`).
+pub(crate) fn validate_params_unary<A, F>(
+    a: &ChunkedArray<A>,
+    name: PlSmallStr,
+    validate: F,
+) -> PolarsResult<Series>
+where
+    A: PolarsNumericType,
+    F: Fn(A::Native) -> PolarsResult<f64>,
+{
+    let ca: Float64Chunked = try_unary_elementwise(a, |a_opt| -> PolarsResult<Option<f64>> {
+        match a_opt {
+            Some(a) => Ok(Some(validate(a)?)),
+            None => Ok(None),
+        }
+    })?;
+
+    Ok(ca.with_name(name).into_series())
+}

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -9,7 +9,9 @@ use statrs::distribution::{Continuous, ContinuousCDF, Normal};
 use statrs::function::erf;
 use statrs::statistics::Distribution as StatrsDistribution;
 
-use crate::distributions::{param_validator, value_keyed_per_row, value_keyed_scalar_plugins};
+use crate::distributions::{
+    validate_params_binary, value_keyed_per_row, value_keyed_scalar_plugins,
+};
 use crate::rng::{
     sample_scalar_plugin, samples_f64_output, samples_per_row, ternary_param_rows, SampleKwargs,
     SamplesKwargs,
@@ -28,17 +30,21 @@ fn build_dist(mu: f64, sigma: f64) -> PolarsResult<Normal> {
     })
 }
 
-param_validator! {
-    /// Validate the `(mu, sigma)` parameterisation and return the validated `sigma`.
-    ///
-    /// `inputs[0]` is `mu`, `inputs[1]` is `sigma`. The Python closed-form moments all derive from
-    /// this single FFI round-trip, so they raise on an invalid parameterisation exactly like the
-    /// value-keyed methods. `null` in either input propagates; invalid raises via [`build_dist`].
-    fn normal_sigma;
-    params = (mu: DataType::Float64 => f64, sigma: DataType::Float64 => f64);
-    build = build_dist;
-    returns = sigma;
-    output_name = inputs[1];
+/// Validate the `(mu, sigma)` parameterisation and return the validated `sigma`.
+///
+/// `inputs[0]` is `mu`, `inputs[1]` is `sigma`. The Python closed-form moments all derive from
+/// this single FFI round-trip, so they raise on an invalid parameterisation exactly like the
+/// value-keyed methods. `null` in either input propagates; invalid raises via [`build_dist`].
+#[polars_expr(output_type=Float64)]
+fn normal_sigma(inputs: &[Series]) -> PolarsResult<Series> {
+    let mu = inputs[0].cast(&DataType::Float64)?;
+    let sigma = inputs[1].cast(&DataType::Float64)?;
+    let name = inputs[1].name().clone();
+
+    validate_params_binary(mu.f64()?, sigma.f64()?, name, |mu, sigma| {
+        build_dist(mu, sigma)?;
+        Ok(sigma)
+    })
 }
 
 value_keyed_per_row! {

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -5,7 +5,7 @@ use pyo3_polars::derive::polars_expr;
 use rand::distr::{Distribution, StandardUniform};
 use statrs::distribution::Uniform;
 
-use crate::distributions::param_validator;
+use crate::distributions::validate_params_binary;
 use crate::rng::{
     sample_scalar_plugin, samples_f64_output, samples_per_row, ternary_param_rows, SampleKwargs,
     SamplesKwargs,
@@ -139,19 +139,23 @@ fn uniform_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Ser
     )
 }
 
-param_validator! {
-    /// Element-wise support width `max - min`, validating the parameterisation.
-    ///
-    /// `inputs[0]` is the lower bound, `inputs[1]` the upper bound. `null` in either propagates;
-    /// `max <= min`, non-finite bounds, or a width overflowing `f64` raise `InvalidOperation`
-    /// (surfaces as a `ComputeError`).
-    ///
-    /// Every closed-form Python method derives from this width, so routing it through Rust is what
-    /// lets them report an invalid parameterisation consistently with `uniform_sample`, instead of
-    /// silently producing a negative or infinite result.
-    fn uniform_range;
-    params = (min: DataType::Float64 => f64, max: DataType::Float64 => f64);
-    build = build_dist;
-    returns = max - min;
-    output_name = inputs[0];
+/// Element-wise support width `max - min`, validating the parameterisation.
+///
+/// `inputs[0]` is the lower bound, `inputs[1]` the upper bound. `null` in either propagates;
+/// `max <= min`, non-finite bounds, or a width overflowing `f64` raise `InvalidOperation`
+/// (surfaces as a `ComputeError`).
+///
+/// Every closed-form Python method derives from this width, so routing it through Rust is what
+/// lets them report an invalid parameterisation consistently with `uniform_sample`, instead of
+/// silently producing a negative or infinite result.
+#[polars_expr(output_type=Float64)]
+fn uniform_range(inputs: &[Series]) -> PolarsResult<Series> {
+    let min = inputs[0].cast(&DataType::Float64)?;
+    let max = inputs[1].cast(&DataType::Float64)?;
+    let name = inputs[0].name().clone();
+
+    validate_params_binary(min.f64()?, max.f64()?, name, |lo, hi| {
+        build_dist(lo, hi)?;
+        Ok(hi - lo)
+    })
 }

--- a/tests/distributions/output_name_test.py
+++ b/tests/distributions/output_name_test.py
@@ -1,4 +1,4 @@
-"""Output-name contract of `sample` / `samples` and the value-keyed methods.
+"""Output-name contract of `sample` / `samples`, the value-keyed methods and the parameter validators.
 
 With all-constant parameters there is no input column to inherit a name from, so the samplers get
 the deliberate default names `"sample"` / `"samples"` (rather than leaking an internal expression
@@ -9,6 +9,10 @@ and `.name.*` modifiers work.
 Value-keyed methods are named after the evaluation column: `propagate_null_and_nan` re-aliases its
 output to `value`'s resolved name, since its leading `pl.lit(None)` branch would otherwise name
 every value-keyed output `"literal"`.
+
+The parameter validators follow the same first-parameter rule. Polars resolves a plugin
+expression's output name from its first input and ignores the name the plugin set on its `Series`,
+so `beta_params` naming that `Series` after `b` never reaches the frame.
 """
 
 from __future__ import annotations
@@ -78,3 +82,39 @@ def test_value_keyed_keeps_value_root_name(dist: _UnivariateDistribution) -> Non
     closed-form hooks is the `pl.len()` inside a scalar parameter's `pl.repeat` expansion).
     """
     assert _FRAME.select(dist.cdf(pl.col("p"))).columns == ["p"]
+
+
+# The four binary validators name their Rust `Series` after the second parameter, so giving every
+# second parameter a different column name from its first is what makes these cases discriminating:
+# an assertion on the first name fails if the plugin's own name ever reaches the frame.
+# `_checked_params` is the unaliased read for the four routed through `_moment`, whose
+# `pl.when(...).then(value)` gate would otherwise rename the output and make any assertion pass.
+_VALIDATOR_FRAME = pl.DataFrame(
+    {
+        "lo": [0.0, 0.0],
+        "hi": [1.0, 2.0],
+        "mu": [0.0, 0.0],
+        "sigma": [1.0, 1.0],
+        "a": [2.0, 2.0],
+        "b": [3.0, 3.0],
+        "n": [5, 5],
+        "p": [0.5, 0.5],
+        "rate": [1.0, 2.0],
+    }
+)
+
+# Validating plugin -> (the expression that reaches it unaliased, the root name it inherits).
+_VALIDATOR_EXPRS: dict[str, tuple[pl.Expr, str]] = {
+    "bernoulli_proba": (Bernoulli(p=pl.col("p"))._checked_p, "p"),
+    "exponential_rate": (Exponential(rate=pl.col("rate"))._checked_rate, "rate"),
+    "uniform_range": (Uniform(min=pl.col("lo"), max=pl.col("hi")).range, "lo"),
+    "normal_sigma": (Normal(mu=pl.col("mu"), sigma=pl.col("sigma"))._checked_params, "mu"),
+    "lognormal_sigma": (LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma"))._checked_params, "mu"),
+    "beta_params": (Beta(a=pl.col("a"), b=pl.col("b"))._checked_params, "a"),
+    "binomial_params": (Binomial(n=pl.col("n"), p=pl.col("p"))._checked_params, "n"),
+}
+
+
+@pytest.mark.parametrize(("expr", "root"), _VALIDATOR_EXPRS.values(), ids=list(_VALIDATOR_EXPRS))
+def test_validator_with_column_params_keeps_first_parameter_root_name(expr: pl.Expr, root: str) -> None:
+    assert _VALIDATOR_FRAME.select(expr).columns == [root]


### PR DESCRIPTION
Deletes `param_validator!` in favour of `validate_params_{binary,unary}` and hand-written `#[polars_expr]` shells, so a validator reads as ordinary Rust from plugin name to `build_dist`. Both drivers take `validate` as a generic `F: Fn`, never `&dyn Fn` and never a bare `fn` pointer, so the per-row build inlines rather than costing an indirect call per row.