### PR TITLE
refactor(rust): replace `sample_scalar_plugin!` macro with generic kwargs

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -42,7 +42,7 @@ polars-stats/
 ├── rust-toolchain.toml
 ├── src/
 │   ├── lib.rs                # pymodule entry + global allocator
-│   ├── rng.rs                # per-row RNG + sampler drivers (sample_by_index, samples_per_row, sample_scalar_plugin!)
+│   ├── rng.rs                # per-row RNG + sampler drivers (sample_by_index, samples_by_index, samples_per_row)
 │   └── distributions/        # one Rust file per distribution
 ├── polars_stats/
 │   ├── __init__.py           # public exports
@@ -108,9 +108,10 @@ exact spec and checklist; that issue is canonical if it conflicts with this sect
       then `rngs.rng(i)` inside; never reseed from chunk position; `try_*_elementwise` so a `null` in any input
       propagates and an invalid parameter raises). The per-row `<name>_sample` / `<name>_samples` (multi-draw, backing
       `samples`) take the parameter columns plus a row index as the last input; the constant-parameter fast paths
-      `<name>_sample_scalar` / `<name>_samples_scalar` (parameters validated once in `kwargs`) come from the
-      `sample_scalar_plugin!` macro in `src/rng.rs`, generated from one shared `build` / `draw` so they stay
-      byte-identical to the per-row path.
+      `<name>_sample_scalar` / `<name>_samples_scalar` are hand-written shells over `sample_by_index` /
+      `samples_by_index`, taking `SampleScalarKwargs<<Name>ParamsKwargs>` / `SamplesScalarKwargs<<Name>ParamsKwargs>`
+      so the parameters are validated once. Give the distribution one named `fn draw` and call it from the per-row
+      plugin and both shells; that shared call, not a test, is what keeps the three byte-identical.
     * When a method needs a **special function** (`erf`, log-gamma, regularized incomplete beta/gamma, ...) or has
       no elementary closed form: bind it in `statrs` (`pdf` / `pmf`, `cdf`, `ppf`, `ln_pdf` / `ln_pmf`, native `sf`,
       native `median`). Each shares one named `*_value` body between the per-row `value_keyed` helper (from the

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -91,11 +91,12 @@ reproducible across OS and architecture.
 takes a dedicated plugin, `<name>_sample_scalar`. The parameters travel in `kwargs` and are validated once; only the row
 index crosses FFI, instead of one full-length `pl.repeat` column per parameter that the general plugin would marshal and
 re-validate on every row. The shared `sample_by_index` helper in `rng.rs` resolves the seed once and maps the dense,
-non-null index straight into the typed output. Each distribution declares its fast path through the
-`sample_scalar_plugin!` macro in `rng.rs` (kwargs struct, output dtype, one-time `build`, per-row `draw`), which
-generates the kwargs struct and the plugin function, so a new distribution cannot drift from the pattern. It reuses
-the same `(root_seed, row_index)` seeding and the same draw as the per-row path, so output is byte-identical for the
-same seed (a property test pins that equality); column-valued parameters still take the general per-row plugin.
+non-null index straight into the typed output. Each distribution writes the two fast-path shells by hand over
+`sample_by_index` / `samples_by_index`, carrying its parameters in `SampleScalarKwargs<P>` / `SamplesScalarKwargs<P>`,
+the generic `seed` / `size` wrappers in `rng.rs` around the distribution's own `<Name>ParamsKwargs`. The shells reuse
+the same `(root_seed, row_index)` seeding and call the same named `draw` as the per-row path, so output is
+byte-identical for the same seed (a property test pins that equality); column-valued parameters still take the general
+per-row plugin.
 
 !!! info "Earlier `ChaCha20` design (removed)"
 

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -7,14 +7,26 @@ use statrs::distribution::Bernoulli;
 
 use crate::distributions::validate_params_unary;
 use crate::rng::{
-    binary_param_rows, sample_scalar_plugin, samples_bool_output, samples_per_row, SampleKwargs,
-    SamplesKwargs,
+    binary_param_rows, sample_by_index, samples_bool_output, samples_by_index, samples_per_row,
+    SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
 fn build_dist(proba: f64) -> PolarsResult<Bernoulli> {
     Bernoulli::new(proba).map_err(|e| {
         PolarsError::InvalidOperation(format!("p must be in [0, 1], got {proba}: {e}").into())
     })
+}
+
+/// Bernoulli's constant success probability, deserialised once per call.
+#[derive(serde::Deserialize)]
+struct BernoulliParamsKwargs {
+    p: f64,
+}
+
+impl BernoulliParamsKwargs {
+    fn build(&self) -> PolarsResult<Bernoulli> {
+        build_dist(self.p)
+    }
 }
 
 /// Element-wise validation of the success probability: returns `p` unchanged, raising
@@ -31,6 +43,15 @@ fn bernoulli_proba(inputs: &[Series]) -> PolarsResult<Series> {
         build_dist(proba)?;
         Ok(proba)
     })
+}
+
+/// One Bernoulli draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
+///
+/// Every Bernoulli sampler draws through here, per-row and fast path alike, so their bit-equality is
+/// structural rather than only sampled by `sample_test.py`.
+#[inline]
+fn draw(dist: &Bernoulli, rng: &mut impl rand::Rng) -> bool {
+    <Bernoulli as Distribution<bool>>::sample(dist, rng)
 }
 
 /// Element-wise Bernoulli sampler over `(p, row_index)`, returning `Boolean`.
@@ -55,9 +76,7 @@ fn bernoulli_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Ser
                 (Some(p), Some(i)) => {
                     let dist = build_dist(p)?;
                     let mut rng = rngs.rng(i);
-                    Ok(Some(<Bernoulli as Distribution<bool>>::sample(
-                        &dist, &mut rng,
-                    )))
+                    Ok(Some(draw(&dist, &mut rng)))
                 },
                 _ => Ok(None),
             }
@@ -67,16 +86,33 @@ fn bernoulli_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Ser
     Ok(ca.with_name(name).into_series())
 }
 
-sample_scalar_plugin! {
-    struct BernoulliScalarKwargs { p: f64 }
+/// Constant-parameter fast path for [`bernoulli_sample`].
+#[polars_expr(output_type=Boolean)]
+fn bernoulli_sample_scalar(
+    inputs: &[Series],
+    kwargs: SampleScalarKwargs<BernoulliParamsKwargs>,
+) -> PolarsResult<Series> {
+    let dist = kwargs.params.build()?;
+    let name = inputs[0].name().clone();
 
-    /// Constant-parameter fast path for [`bernoulli_sample`].
-    fn bernoulli_sample_scalar(output_type = Boolean, physical = BooleanType);
+    sample_by_index::<BooleanType, _, _>(name, &inputs[0], kwargs.seed, |rng| draw(&dist, rng))
+}
 
-    samples = bernoulli_samples_scalar as BernoulliSamplesScalarKwargs -> samples_bool_output;
+/// Constant-parameter multi-draw fast path: the `samples` twin of [`bernoulli_sample_scalar`].
+///
+/// `size` consecutive draws from each row's stream, so `samples(size=1)` matches `sample` bit for
+/// bit and the distribution is built once per call. Returns `Array(Boolean, size)`.
+#[polars_expr(output_type_func_with_kwargs=samples_bool_output)]
+fn bernoulli_samples_scalar(
+    inputs: &[Series],
+    kwargs: SamplesScalarKwargs<BernoulliParamsKwargs>,
+) -> PolarsResult<Series> {
+    let dist = kwargs.params.build()?;
+    let name = inputs[0].name().clone();
 
-    build = |kw| build_dist(kw.p)?;
-    draw = |dist, rng| <Bernoulli as Distribution<bool>>::sample(&dist, rng);
+    samples_by_index::<BooleanType, _, _>(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
+        draw(&dist, rng)
+    })
 }
 
 /// Element-wise multi-draw Bernoulli sampler: `size` draws per row in one call, the distribution
@@ -91,11 +127,5 @@ fn bernoulli_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<S
 
     let rows = binary_param_rows(proba.f64()?, index.u64()?, build_dist);
 
-    samples_per_row::<BooleanType, _, _, _, _>(
-        name,
-        kwargs.seed,
-        kwargs.size,
-        rows,
-        <Bernoulli as Distribution<bool>>::sample,
-    )
+    samples_per_row::<BooleanType, _, _, _, _>(name, kwargs.seed, kwargs.size, rows, draw)
 }

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -9,8 +9,8 @@ use statrs::statistics::Distribution as StatrsDistribution;
 
 use crate::distributions::{validate_params_binary, value_keyed_per_row, value_keyed_scalar};
 use crate::rng::{
-    sample_scalar_plugin, samples_f64_output, samples_per_row, ternary_param_rows, SampleKwargs,
-    SamplesKwargs,
+    sample_by_index, samples_by_index, samples_f64_output, samples_per_row, ternary_param_rows,
+    SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
 /// Construct a `statrs::Beta`, mapping the invalid-parameter case to a `ComputeError`.
@@ -23,6 +23,32 @@ fn build_dist(a: f64, b: f64) -> PolarsResult<Beta> {
             format!("a and b must be finite and strictly positive, got a={a}, b={b}: {e}").into(),
         )
     })
+}
+
+/// Beta's constant shapes, deserialised once per call.
+///
+/// The one place this file spells `(a, b)`: every fast path, sampler or value-keyed, reaches the
+/// constructor through [`Self::build`], so the order cannot drift between them.
+#[derive(serde::Deserialize)]
+struct BetaParamsKwargs {
+    a: f64,
+    b: f64,
+}
+
+impl BetaParamsKwargs {
+    fn build(&self) -> PolarsResult<Beta> {
+        build_dist(self.a, self.b)
+    }
+
+    /// Constant-parameter twin of the per-row [`value_keyed`], sharing its `<method>_value`
+    /// bodies: build once per call, then map `f` over the evaluation-point column.
+    fn value_keyed<F>(&self, value: &Series, f: F) -> PolarsResult<Series>
+    where
+        F: Fn(&Beta, f64) -> Option<f64>,
+    {
+        let dist = self.build()?;
+        value_keyed_scalar(value, |v| f(&dist, v))
+    }
 }
 
 /// Validate the `(a, b)` parameterisation and return the validated `b`.
@@ -82,6 +108,15 @@ where
     Ok(ca.with_name(name).into_series())
 }
 
+/// One Beta draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
+///
+/// Every Beta sampler draws through here, per-row and fast path alike, so their bit-equality is
+/// structural rather than only sampled by `sample_test.py`.
+#[inline]
+fn draw(dist: &Beta, rng: &mut impl rand::Rng) -> f64 {
+    RandDistribution::sample(dist, rng)
+}
+
 /// Element-wise Beta sampler over `(a, b, row_index)`, returning `Float64`.
 ///
 /// Per row, `null` propagates and an invalid shape raises via [`build_dist`]. Seeding and
@@ -111,8 +146,7 @@ fn beta_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> 
                 (Some(a), Some(b), Some(i)) => {
                     let dist = build_dist(a, b)?;
                     let mut rng = rngs.rng(i);
-                    let draw: f64 = RandDistribution::sample(&dist, &mut rng);
-                    Ok(Some(draw))
+                    Ok(Some(draw(&dist, &mut rng)))
                 },
                 _ => Ok(None),
             }
@@ -122,16 +156,33 @@ fn beta_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> 
     Ok(ca.with_name(name).into_series())
 }
 
-sample_scalar_plugin! {
-    struct BetaScalarKwargs { a: f64, b: f64 }
+/// Constant-parameter fast path for [`beta_sample`].
+#[polars_expr(output_type=Float64)]
+fn beta_sample_scalar(
+    inputs: &[Series],
+    kwargs: SampleScalarKwargs<BetaParamsKwargs>,
+) -> PolarsResult<Series> {
+    let dist = kwargs.params.build()?;
+    let name = inputs[0].name().clone();
 
-    /// Constant-parameter fast path for [`beta_sample`].
-    fn beta_sample_scalar(output_type = Float64, physical = Float64Type);
+    sample_by_index::<Float64Type, _, _>(name, &inputs[0], kwargs.seed, |rng| draw(&dist, rng))
+}
 
-    samples = beta_samples_scalar as BetaSamplesScalarKwargs -> samples_f64_output;
+/// Constant-parameter multi-draw fast path: the `samples` twin of [`beta_sample_scalar`].
+///
+/// `size` consecutive draws from each row's stream, so `samples(size=1)` matches `sample` bit for
+/// bit and the distribution is built once per call. Returns `Array(Float64, size)`.
+#[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
+fn beta_samples_scalar(
+    inputs: &[Series],
+    kwargs: SamplesScalarKwargs<BetaParamsKwargs>,
+) -> PolarsResult<Series> {
+    let dist = kwargs.params.build()?;
+    let name = inputs[0].name().clone();
 
-    build = |kw| build_dist(kw.a, kw.b)?;
-    draw = |dist, rng| RandDistribution::sample(&dist, rng);
+    samples_by_index::<Float64Type, _, _>(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
+        draw(&dist, rng)
+    })
 }
 
 /// Element-wise multi-draw Beta sampler: `size` draws per row in one call, the distribution built
@@ -147,13 +198,7 @@ fn beta_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series
 
     let rows = ternary_param_rows(a.f64()?, b.f64()?, index.u64()?, build_dist);
 
-    samples_per_row::<Float64Type, _, _, _, _>(
-        name,
-        kwargs.seed,
-        kwargs.size,
-        rows,
-        RandDistribution::sample,
-    )
+    samples_per_row::<Float64Type, _, _, _, _>(name, kwargs.seed, kwargs.size, rows, draw)
 }
 
 // Per-method bodies, shared by the per-row plugins and their `*_scalar` twins.
@@ -237,26 +282,6 @@ fn beta_sf(inputs: &[Series]) -> PolarsResult<Series> {
 #[polars_expr(output_type=Float64)]
 fn beta_ppf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, ppf_value)
-}
-
-/// Constant parameters for Beta's value-keyed fast paths, deserialised once per call.
-#[derive(serde::Deserialize)]
-struct BetaParamsKwargs {
-    a: f64,
-    b: f64,
-}
-
-impl BetaParamsKwargs {
-    /// Constant-parameter twin of the per-row [`value_keyed`], sharing its `<method>_value`
-    /// bodies: build once per call, then map `f` over the evaluation-point column. A swapped
-    /// field compiles and returns wrong numbers; `value_keyed_test.py` is what catches it.
-    fn value_keyed<F>(&self, value: &Series, f: F) -> PolarsResult<Series>
-    where
-        F: Fn(&Beta, f64) -> Option<f64>,
-    {
-        let dist = build_dist(self.a, self.b)?;
-        value_keyed_scalar(value, |v| f(&dist, v))
-    }
 }
 
 /// Constant-parameter fast path for [`beta_pdf`].

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -9,8 +9,8 @@ use statrs::statistics::Distribution as StatrsDistribution;
 
 use crate::distributions::{validate_params_binary, value_keyed_per_row, value_keyed_scalar};
 use crate::rng::{
-    sample_scalar_plugin, samples_per_row, samples_u64_output, ternary_param_rows, SampleKwargs,
-    SamplesKwargs,
+    sample_by_index, samples_by_index, samples_per_row, samples_u64_output, ternary_param_rows,
+    SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
 /// Construct a `statrs::Binomial`, mapping both invalid-parameter cases to a `ComputeError`.
@@ -44,6 +44,40 @@ fn build_sampler(n: i64, p: f64) -> PolarsResult<BinomialSampler> {
     BinomialSampler::new(trials, p).map_err(|e| {
         PolarsError::InvalidOperation(format!("p must be in [0, 1], got {p}: {e}").into())
     })
+}
+
+/// Binomial's constant parameters, deserialised once per call.
+///
+/// The one place this file spells `(n, p)`. The two families build different types from it: the
+/// value-keyed twins take the `statrs` distribution via [`Self::build`], the samplers take the
+/// `rand_distr` sampler via [`Self::build_sampler`].
+#[derive(serde::Deserialize)]
+struct BinomialParamsKwargs {
+    n: i64,
+    p: f64,
+}
+
+impl BinomialParamsKwargs {
+    /// The `statrs` distribution, for the value-keyed methods.
+    fn build(&self) -> PolarsResult<Binomial> {
+        build_dist(self.n, self.p)
+    }
+
+    /// The `rand_distr` sampler, for the samplers. The free [`build_sampler`] carries the note on
+    /// why the two families use different distribution types.
+    fn build_sampler(&self) -> PolarsResult<BinomialSampler> {
+        build_sampler(self.n, self.p)
+    }
+
+    /// Constant-parameter twin of the per-row [`value_keyed`], sharing its `<method>_value`
+    /// bodies: build once per call, then map `f` over the evaluation-point column.
+    fn value_keyed<F>(&self, value: &Series, f: F) -> PolarsResult<Series>
+    where
+        F: Fn(&Binomial, f64) -> Option<f64>,
+    {
+        let dist = self.build()?;
+        value_keyed_scalar(value, |v| f(&dist, v))
+    }
 }
 
 /// `value` as a binomial support point: `Some(k)` when `value` is a non-negative integer, else
@@ -99,6 +133,16 @@ where
     Ok(ca.with_name(name).into_series())
 }
 
+/// One Binomial draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
+///
+/// The state is a [`BinomialSampler`] (`rand_distr`), built by [`build_sampler`] and not by
+/// [`build_dist`]. Every Binomial sampler draws through here, per-row and fast path alike, so their
+/// bit-equality is structural rather than only sampled by `sample_test.py`.
+#[inline]
+fn draw(dist: &BinomialSampler, rng: &mut impl rand::Rng) -> u64 {
+    dist.sample(rng)
+}
+
 /// Element-wise Binomial sampler over `(n, p, row_index)`, returning `UInt64`.
 ///
 /// Per row, `null` propagates and an invalid parameterisation raises via [`build_sampler`].
@@ -124,7 +168,7 @@ fn binomial_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Seri
                 (Some(n), Some(p), Some(i)) => {
                     let dist = build_sampler(n, p)?;
                     let mut rng = rngs.rng(i);
-                    Ok(Some(dist.sample(&mut rng)))
+                    Ok(Some(draw(&dist, &mut rng)))
                 },
                 _ => Ok(None),
             }
@@ -134,16 +178,34 @@ fn binomial_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Seri
     Ok(ca.with_name(name).into_series())
 }
 
-sample_scalar_plugin! {
-    struct BinomialScalarKwargs { n: i64, p: f64 }
+/// Constant-parameter fast path for [`binomial_sample`], on the same [`build_sampler`].
+#[polars_expr(output_type=UInt64)]
+fn binomial_sample_scalar(
+    inputs: &[Series],
+    kwargs: SampleScalarKwargs<BinomialParamsKwargs>,
+) -> PolarsResult<Series> {
+    let dist = kwargs.params.build_sampler()?;
+    let name = inputs[0].name().clone();
 
-    /// Constant-parameter fast path for [`binomial_sample`], on the same [`build_sampler`].
-    fn binomial_sample_scalar(output_type = UInt64, physical = UInt64Type);
+    sample_by_index::<UInt64Type, _, _>(name, &inputs[0], kwargs.seed, |rng| draw(&dist, rng))
+}
 
-    samples = binomial_samples_scalar as BinomialSamplesScalarKwargs -> samples_u64_output;
+/// Constant-parameter multi-draw fast path: the `samples` twin of [`binomial_sample_scalar`].
+///
+/// `size` consecutive draws from each row's stream, so `samples(size=1)` matches `sample` bit for
+/// bit and the sampler (whose BINV/BTPE setup is the expensive part) is built once per call rather
+/// than once per draw. Returns `Array(UInt64, size)`.
+#[polars_expr(output_type_func_with_kwargs=samples_u64_output)]
+fn binomial_samples_scalar(
+    inputs: &[Series],
+    kwargs: SamplesScalarKwargs<BinomialParamsKwargs>,
+) -> PolarsResult<Series> {
+    let dist = kwargs.params.build_sampler()?;
+    let name = inputs[0].name().clone();
 
-    build = |kw| build_sampler(kw.n, kw.p)?;
-    draw = |dist, rng| dist.sample(rng);
+    samples_by_index::<UInt64Type, _, _>(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
+        draw(&dist, rng)
+    })
 }
 
 /// Element-wise multi-draw Binomial sampler: `size` draws per row in one call, the `rand_distr`
@@ -160,9 +222,7 @@ fn binomial_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Se
 
     let rows = ternary_param_rows(n.i64()?, p.f64()?, index.u64()?, build_sampler);
 
-    samples_per_row::<UInt64Type, _, _, _, _>(name, kwargs.seed, kwargs.size, rows, |dist, rng| {
-        dist.sample(rng)
-    })
+    samples_per_row::<UInt64Type, _, _, _, _>(name, kwargs.seed, kwargs.size, rows, draw)
 }
 
 // Per-method bodies, shared by the per-row plugins and their `*_scalar` twins.
@@ -280,26 +340,6 @@ fn ppf_value(dist: &Binomial, q: f64) -> Option<f64> {
 #[polars_expr(output_type=Float64)]
 fn binomial_ppf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, ppf_value)
-}
-
-/// Constant parameters for Binomial's value-keyed fast paths, deserialised once per call.
-#[derive(serde::Deserialize)]
-struct BinomialParamsKwargs {
-    n: i64,
-    p: f64,
-}
-
-impl BinomialParamsKwargs {
-    /// Constant-parameter twin of the per-row [`value_keyed`], sharing its `<method>_value`
-    /// bodies: build once per call, then map `f` over the evaluation-point column. A swapped
-    /// field compiles and returns wrong numbers; `value_keyed_test.py` is what catches it.
-    fn value_keyed<F>(&self, value: &Series, f: F) -> PolarsResult<Series>
-    where
-        F: Fn(&Binomial, f64) -> Option<f64>,
-    {
-        let dist = build_dist(self.n, self.p)?;
-        value_keyed_scalar(value, |v| f(&dist, v))
-    }
 }
 
 /// Constant-parameter fast path for [`binomial_pmf`].

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -7,8 +7,8 @@ use statrs::distribution::Exp;
 
 use crate::distributions::validate_params_unary;
 use crate::rng::{
-    binary_param_rows, sample_scalar_plugin, samples_f64_output, samples_per_row, SampleKwargs,
-    SamplesKwargs,
+    binary_param_rows, sample_by_index, samples_by_index, samples_f64_output, samples_per_row,
+    SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
 /// Construct a `statrs::Exp`, mapping the invalid-parameter case to a `ComputeError`.
@@ -22,6 +22,18 @@ fn build_dist(rate: f64) -> PolarsResult<Exp> {
             format!("rate must be strictly positive, got rate={rate}: {e}").into(),
         )
     })
+}
+
+/// Exponential's constant rate, deserialised once per call.
+#[derive(serde::Deserialize)]
+struct ExponentialParamsKwargs {
+    rate: f64,
+}
+
+impl ExponentialParamsKwargs {
+    fn build(&self) -> PolarsResult<Exp> {
+        build_dist(self.rate)
+    }
 }
 
 /// Element-wise validation of the rate (λ): returns `rate` unchanged, raising `InvalidOperation`
@@ -40,6 +52,15 @@ fn exponential_rate(inputs: &[Series]) -> PolarsResult<Series> {
         build_dist(rate)?;
         Ok(rate)
     })
+}
+
+/// One Exponential draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
+///
+/// Every Exponential sampler draws through here, per-row and fast path alike, so their bit-equality is
+/// structural rather than only sampled by `sample_test.py`.
+#[inline]
+fn draw(dist: &Exp, rng: &mut impl rand::Rng) -> f64 {
+    RandDistribution::sample(dist, rng)
 }
 
 /// Element-wise Exponential sampler over `(rate, row_index)`, returning `Float64`.
@@ -68,8 +89,7 @@ fn exponential_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<S
                 (Some(r), Some(i)) => {
                     let dist = build_dist(r)?;
                     let mut rng = rngs.rng(i);
-                    let draw: f64 = RandDistribution::sample(&dist, &mut rng);
-                    Ok(Some(draw))
+                    Ok(Some(draw(&dist, &mut rng)))
                 },
                 _ => Ok(None),
             }
@@ -79,16 +99,33 @@ fn exponential_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<S
     Ok(ca.with_name(name).into_series())
 }
 
-sample_scalar_plugin! {
-    struct ExponentialScalarKwargs { rate: f64 }
+/// Constant-rate fast path for [`exponential_sample`].
+#[polars_expr(output_type=Float64)]
+fn exponential_sample_scalar(
+    inputs: &[Series],
+    kwargs: SampleScalarKwargs<ExponentialParamsKwargs>,
+) -> PolarsResult<Series> {
+    let dist = kwargs.params.build()?;
+    let name = inputs[0].name().clone();
 
-    /// Constant-rate fast path for [`exponential_sample`].
-    fn exponential_sample_scalar(output_type = Float64, physical = Float64Type);
+    sample_by_index::<Float64Type, _, _>(name, &inputs[0], kwargs.seed, |rng| draw(&dist, rng))
+}
 
-    samples = exponential_samples_scalar as ExponentialSamplesScalarKwargs -> samples_f64_output;
+/// Constant-parameter multi-draw fast path: the `samples` twin of [`exponential_sample_scalar`].
+///
+/// `size` consecutive draws from each row's stream, so `samples(size=1)` matches `sample` bit for
+/// bit and the distribution is built once per call. Returns `Array(Float64, size)`.
+#[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
+fn exponential_samples_scalar(
+    inputs: &[Series],
+    kwargs: SamplesScalarKwargs<ExponentialParamsKwargs>,
+) -> PolarsResult<Series> {
+    let dist = kwargs.params.build()?;
+    let name = inputs[0].name().clone();
 
-    build = |kw| build_dist(kw.rate)?;
-    draw = |dist, rng| RandDistribution::sample(&dist, rng);
+    samples_by_index::<Float64Type, _, _>(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
+        draw(&dist, rng)
+    })
 }
 
 /// Element-wise multi-draw Exponential sampler: `size` draws per row in one call, the distribution
@@ -103,11 +140,5 @@ fn exponential_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult
 
     let rows = binary_param_rows(rate.f64()?, index.u64()?, build_dist);
 
-    samples_per_row::<Float64Type, _, _, _, _>(
-        name,
-        kwargs.seed,
-        kwargs.size,
-        rows,
-        RandDistribution::sample,
-    )
+    samples_per_row::<Float64Type, _, _, _, _>(name, kwargs.seed, kwargs.size, rows, draw)
 }

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -9,8 +9,8 @@ use crate::distributions::{
     normal, validate_params_binary, value_keyed_per_row, value_keyed_scalar,
 };
 use crate::rng::{
-    sample_scalar_plugin, samples_f64_output, samples_per_row, ternary_param_rows, SampleKwargs,
-    SamplesKwargs,
+    sample_by_index, samples_by_index, samples_f64_output, samples_per_row, ternary_param_rows,
+    SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
 /// Construct a `statrs::LogNormal`, mapping the invalid-parameter case to a `ComputeError`.
@@ -27,6 +27,32 @@ fn build_dist(mu: f64, sigma: f64) -> PolarsResult<LogNormal> {
             .into(),
         )
     })
+}
+
+/// LogNormal's constant parameters, deserialised once per call.
+///
+/// The one place this file spells `(mu, sigma)`: every fast path, sampler or value-keyed, reaches the
+/// constructor through [`Self::build`], so the order cannot drift between them.
+#[derive(serde::Deserialize)]
+struct LogNormalParamsKwargs {
+    mu: f64,
+    sigma: f64,
+}
+
+impl LogNormalParamsKwargs {
+    fn build(&self) -> PolarsResult<LogNormal> {
+        build_dist(self.mu, self.sigma)
+    }
+
+    /// Constant-parameter twin of the per-row [`value_keyed`], sharing its `<method>_value`
+    /// bodies: build once per call, then map `f` over the evaluation-point column.
+    fn value_keyed<F>(&self, value: &Series, f: F) -> PolarsResult<Series>
+    where
+        F: Fn(&LogNormal, f64) -> Option<f64>,
+    {
+        let dist = self.build()?;
+        value_keyed_scalar(value, |v| f(&dist, v))
+    }
 }
 
 /// The underlying `statrs::Normal` (mean `mu`, std-dev `sigma`) a built `LogNormal` wraps,
@@ -66,6 +92,15 @@ fn lognormal_sigma(inputs: &[Series]) -> PolarsResult<Series> {
     })
 }
 
+/// One LogNormal draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
+///
+/// Every LogNormal sampler draws through here, per-row and fast path alike, so their bit-equality is
+/// structural rather than only sampled by `sample_test.py`.
+#[inline]
+fn draw(dist: &LogNormal, rng: &mut impl rand::Rng) -> f64 {
+    RandDistribution::sample(dist, rng)
+}
+
 /// Element-wise LogNormal sampler over `(mu, sigma, row_index)`, returning `Float64`.
 ///
 /// Per row, `null` propagates and an invalid parameterisation raises via [`build_dist`]. Seeding
@@ -91,8 +126,7 @@ fn lognormal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Ser
                 (Some(m), Some(s), Some(i)) => {
                     let dist = build_dist(m, s)?;
                     let mut rng = rngs.rng(i);
-                    let draw: f64 = RandDistribution::sample(&dist, &mut rng);
-                    Ok(Some(draw))
+                    Ok(Some(draw(&dist, &mut rng)))
                 },
                 _ => Ok(None),
             }
@@ -102,16 +136,33 @@ fn lognormal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Ser
     Ok(ca.with_name(name).into_series())
 }
 
-sample_scalar_plugin! {
-    struct LogNormalScalarKwargs { mu: f64, sigma: f64 }
+/// Constant-parameter fast path for [`lognormal_sample`].
+#[polars_expr(output_type=Float64)]
+fn lognormal_sample_scalar(
+    inputs: &[Series],
+    kwargs: SampleScalarKwargs<LogNormalParamsKwargs>,
+) -> PolarsResult<Series> {
+    let dist = kwargs.params.build()?;
+    let name = inputs[0].name().clone();
 
-    /// Constant-parameter fast path for [`lognormal_sample`].
-    fn lognormal_sample_scalar(output_type = Float64, physical = Float64Type);
+    sample_by_index::<Float64Type, _, _>(name, &inputs[0], kwargs.seed, |rng| draw(&dist, rng))
+}
 
-    samples = lognormal_samples_scalar as LogNormalSamplesScalarKwargs -> samples_f64_output;
+/// Constant-parameter multi-draw fast path: the `samples` twin of [`lognormal_sample_scalar`].
+///
+/// `size` consecutive draws from each row's stream, so `samples(size=1)` matches `sample` bit for
+/// bit and the distribution is built once per call. Returns `Array(Float64, size)`.
+#[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
+fn lognormal_samples_scalar(
+    inputs: &[Series],
+    kwargs: SamplesScalarKwargs<LogNormalParamsKwargs>,
+) -> PolarsResult<Series> {
+    let dist = kwargs.params.build()?;
+    let name = inputs[0].name().clone();
 
-    build = |kw| build_dist(kw.mu, kw.sigma)?;
-    draw = |dist, rng| RandDistribution::sample(&dist, rng);
+    samples_by_index::<Float64Type, _, _>(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
+        draw(&dist, rng)
+    })
 }
 
 /// Element-wise multi-draw LogNormal sampler: `size` draws per row in one call, the distribution
@@ -127,13 +178,7 @@ fn lognormal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<S
 
     let rows = ternary_param_rows(mu.f64()?, sigma.f64()?, index.u64()?, build_dist);
 
-    samples_per_row::<Float64Type, _, _, _, _>(
-        name,
-        kwargs.seed,
-        kwargs.size,
-        rows,
-        RandDistribution::sample,
-    )
+    samples_per_row::<Float64Type, _, _, _, _>(name, kwargs.seed, kwargs.size, rows, draw)
 }
 
 // Per-method bodies, shared by the per-row plugins and their `*_scalar` twins.
@@ -249,26 +294,6 @@ fn lognormal_ppf(inputs: &[Series]) -> PolarsResult<Series> {
 #[polars_expr(output_type=Float64)]
 fn lognormal_isf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, isf_value)
-}
-
-/// Constant parameters for LogNormal's value-keyed fast paths, deserialised once per call.
-#[derive(serde::Deserialize)]
-struct LogNormalParamsKwargs {
-    mu: f64,
-    sigma: f64,
-}
-
-impl LogNormalParamsKwargs {
-    /// Constant-parameter twin of the per-row [`value_keyed`], sharing its `<method>_value`
-    /// bodies: build once per call, then map `f` over the evaluation-point column. A swapped
-    /// field compiles and returns wrong numbers; `value_keyed_test.py` is what catches it.
-    fn value_keyed<F>(&self, value: &Series, f: F) -> PolarsResult<Series>
-    where
-        F: Fn(&LogNormal, f64) -> Option<f64>,
-    {
-        let dist = build_dist(self.mu, self.sigma)?;
-        value_keyed_scalar(value, |v| f(&dist, v))
-    }
 }
 
 /// Constant-parameter fast path for [`lognormal_pdf`].

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -11,8 +11,8 @@ use statrs::statistics::Distribution as StatrsDistribution;
 
 use crate::distributions::{validate_params_binary, value_keyed_per_row, value_keyed_scalar};
 use crate::rng::{
-    sample_scalar_plugin, samples_f64_output, samples_per_row, ternary_param_rows, SampleKwargs,
-    SamplesKwargs,
+    sample_by_index, samples_by_index, samples_f64_output, samples_per_row, ternary_param_rows,
+    SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
 /// Construct a `statrs::Normal`, mapping the invalid-parameter case to a `ComputeError`.
@@ -26,6 +26,32 @@ fn build_dist(mu: f64, sigma: f64) -> PolarsResult<Normal> {
                 .into(),
         )
     })
+}
+
+/// Normal's constant parameters, deserialised once per call.
+///
+/// The one place this file spells `(mu, sigma)`: every fast path, sampler or value-keyed, reaches the
+/// constructor through [`Self::build`], so the order cannot drift between them.
+#[derive(serde::Deserialize)]
+struct NormalParamsKwargs {
+    mu: f64,
+    sigma: f64,
+}
+
+impl NormalParamsKwargs {
+    fn build(&self) -> PolarsResult<Normal> {
+        build_dist(self.mu, self.sigma)
+    }
+
+    /// Constant-parameter twin of the per-row [`value_keyed`], sharing its `<method>_value`
+    /// bodies: build once per call, then map `f` over the evaluation-point column.
+    fn value_keyed<F>(&self, value: &Series, f: F) -> PolarsResult<Series>
+    where
+        F: Fn(&Normal, f64) -> Option<f64>,
+    {
+        let dist = self.build()?;
+        value_keyed_scalar(value, |v| f(&dist, v))
+    }
 }
 
 /// Validate the `(mu, sigma)` parameterisation and return the validated `sigma`.
@@ -54,6 +80,15 @@ value_keyed_per_row! {
     build = build_dist;
 }
 
+/// One Normal draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
+///
+/// Every Normal sampler draws through here, per-row and fast path alike, so their bit-equality is
+/// structural rather than only sampled by `sample_test.py`.
+#[inline]
+fn draw(dist: &Normal, rng: &mut impl rand::Rng) -> f64 {
+    RandDistribution::sample(dist, rng)
+}
+
 /// Element-wise Normal sampler over `(mu, sigma, row_index)`, returning `Float64`.
 ///
 /// Per row, `null` propagates and an invalid parameterisation raises via [`build_dist`]. Seeding
@@ -79,8 +114,7 @@ fn normal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series
                 (Some(m), Some(s), Some(i)) => {
                     let dist = build_dist(m, s)?;
                     let mut rng = rngs.rng(i);
-                    let draw: f64 = RandDistribution::sample(&dist, &mut rng);
-                    Ok(Some(draw))
+                    Ok(Some(draw(&dist, &mut rng)))
                 },
                 _ => Ok(None),
             }
@@ -90,16 +124,33 @@ fn normal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series
     Ok(ca.with_name(name).into_series())
 }
 
-sample_scalar_plugin! {
-    struct NormalScalarKwargs { mu: f64, sigma: f64 }
+/// Constant-parameter fast path for [`normal_sample`].
+#[polars_expr(output_type=Float64)]
+fn normal_sample_scalar(
+    inputs: &[Series],
+    kwargs: SampleScalarKwargs<NormalParamsKwargs>,
+) -> PolarsResult<Series> {
+    let dist = kwargs.params.build()?;
+    let name = inputs[0].name().clone();
 
-    /// Constant-parameter fast path for [`normal_sample`].
-    fn normal_sample_scalar(output_type = Float64, physical = Float64Type);
+    sample_by_index::<Float64Type, _, _>(name, &inputs[0], kwargs.seed, |rng| draw(&dist, rng))
+}
 
-    samples = normal_samples_scalar as NormalSamplesScalarKwargs -> samples_f64_output;
+/// Constant-parameter multi-draw fast path: the `samples` twin of [`normal_sample_scalar`].
+///
+/// `size` consecutive draws from each row's stream, so `samples(size=1)` matches `sample` bit for
+/// bit and the distribution is built once per call. Returns `Array(Float64, size)`.
+#[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
+fn normal_samples_scalar(
+    inputs: &[Series],
+    kwargs: SamplesScalarKwargs<NormalParamsKwargs>,
+) -> PolarsResult<Series> {
+    let dist = kwargs.params.build()?;
+    let name = inputs[0].name().clone();
 
-    build = |kw| build_dist(kw.mu, kw.sigma)?;
-    draw = |dist, rng| RandDistribution::sample(&dist, rng);
+    samples_by_index::<Float64Type, _, _>(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
+        draw(&dist, rng)
+    })
 }
 
 /// Element-wise multi-draw Normal sampler: `size` draws per row in one call, the distribution
@@ -115,13 +166,7 @@ fn normal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Seri
 
     let rows = ternary_param_rows(mu.f64()?, sigma.f64()?, index.u64()?, build_dist);
 
-    samples_per_row::<Float64Type, _, _, _, _>(
-        name,
-        kwargs.seed,
-        kwargs.size,
-        rows,
-        RandDistribution::sample,
-    )
+    samples_per_row::<Float64Type, _, _, _, _>(name, kwargs.seed, kwargs.size, rows, draw)
 }
 
 // Per-method bodies, shared by the per-row plugins and their `*_scalar` twins.
@@ -287,26 +332,6 @@ fn normal_ppf(inputs: &[Series]) -> PolarsResult<Series> {
 #[polars_expr(output_type=Float64)]
 fn normal_isf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, isf_value)
-}
-
-/// Constant parameters for Normal's value-keyed fast paths, deserialised once per call.
-#[derive(serde::Deserialize)]
-struct NormalParamsKwargs {
-    mu: f64,
-    sigma: f64,
-}
-
-impl NormalParamsKwargs {
-    /// Constant-parameter twin of the per-row [`value_keyed`], sharing its `<method>_value`
-    /// bodies: build once per call, then map `f` over the evaluation-point column. A swapped
-    /// field compiles and returns wrong numbers; `value_keyed_test.py` is what catches it.
-    fn value_keyed<F>(&self, value: &Series, f: F) -> PolarsResult<Series>
-    where
-        F: Fn(&Normal, f64) -> Option<f64>,
-    {
-        let dist = build_dist(self.mu, self.sigma)?;
-        value_keyed_scalar(value, |v| f(&dist, v))
-    }
 }
 
 /// Constant-parameter fast path for [`normal_pdf`].

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -7,8 +7,8 @@ use statrs::distribution::Uniform;
 
 use crate::distributions::validate_params_binary;
 use crate::rng::{
-    sample_scalar_plugin, samples_f64_output, samples_per_row, ternary_param_rows, SampleKwargs,
-    SamplesKwargs,
+    sample_by_index, samples_by_index, samples_f64_output, samples_per_row, ternary_param_rows,
+    SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
 fn build_dist(min: f64, max: f64) -> PolarsResult<Uniform> {
@@ -31,12 +31,33 @@ fn build_dist(min: f64, max: f64) -> PolarsResult<Uniform> {
     })
 }
 
+/// Uniform's constant bounds, deserialised once per call.
+///
+/// The one place this file spells `(min, max)`: both samplers validate through
+/// [`Self::validated_bounds`], so the order cannot drift between them.
+#[derive(serde::Deserialize)]
+struct UniformParamsKwargs {
+    min: f64,
+    max: f64,
+}
+
+impl UniformParamsKwargs {
+    /// Validate the constant bounds once per call and return them raw.
+    ///
+    /// The built distribution is discarded on purpose: [`draw_half_open`] wants the `(lo, hi)` pair,
+    /// not a `statrs::Uniform`.
+    fn validated_bounds(&self) -> PolarsResult<(f64, f64)> {
+        build_dist(self.min, self.max)?;
+        Ok((self.min, self.max))
+    }
+}
+
 /// One half-open `[lo, hi)` draw: `lo + (hi - lo) * U[0, 1)`, matching scipy's
 /// `loc + scale * U[0, 1)`.
 ///
-/// Shared by [`uniform_sample`] and [`uniform_sample_scalar`] so the two paths cannot drift; the
-/// property test pinning their bit-equality only samples parameterisations, this makes it
-/// structural.
+/// Uniform's counterpart of the other distributions' `fn draw`: every Uniform sampler draws through
+/// here, per-row and fast path alike, so their bit-equality is structural rather than only sampled
+/// by `sample_test.py`.
 ///
 /// This deliberately bypasses `statrs`' `Distribution::sample`, which rebuilds a
 /// `rand::distributions::Uniform` float sampler (scale/bias/rejection-zone setup) on *every*
@@ -98,17 +119,36 @@ fn uniform_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Serie
     Ok(ca.with_name(name).into_series())
 }
 
-sample_scalar_plugin! {
-    struct UniformScalarKwargs { min: f64, max: f64 }
+/// Constant-bounds fast path for [`uniform_sample`]. The built distribution is intentionally
+/// unused; the draw is [`draw_half_open`] over the raw bounds.
+#[polars_expr(output_type=Float64)]
+fn uniform_sample_scalar(
+    inputs: &[Series],
+    kwargs: SampleScalarKwargs<UniformParamsKwargs>,
+) -> PolarsResult<Series> {
+    let (lo, hi) = kwargs.params.validated_bounds()?;
+    let name = inputs[0].name().clone();
 
-    /// Constant-bounds fast path for [`uniform_sample`]. The built distribution is intentionally
-    /// unused; the draw is [`draw_half_open`] over the raw bounds.
-    fn uniform_sample_scalar(output_type = Float64, physical = Float64Type);
+    sample_by_index::<Float64Type, _, _>(name, &inputs[0], kwargs.seed, |rng| {
+        draw_half_open(lo, hi, rng)
+    })
+}
 
-    samples = uniform_samples_scalar as UniformSamplesScalarKwargs -> samples_f64_output;
+/// Constant-bounds multi-draw fast path: the `samples` twin of [`uniform_sample_scalar`].
+///
+/// `size` consecutive draws from each row's stream, so `samples(size=1)` matches `sample` bit for
+/// bit and the bounds are validated once per call. Returns `Array(Float64, size)`.
+#[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
+fn uniform_samples_scalar(
+    inputs: &[Series],
+    kwargs: SamplesScalarKwargs<UniformParamsKwargs>,
+) -> PolarsResult<Series> {
+    let (lo, hi) = kwargs.params.validated_bounds()?;
+    let name = inputs[0].name().clone();
 
-    build = |kw| { build_dist(kw.min, kw.max)?; (kw.min, kw.max) };
-    draw = |(lo, hi), rng| draw_half_open(lo, hi, rng);
+    samples_by_index::<Float64Type, _, _>(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
+        draw_half_open(lo, hi, rng)
+    })
 }
 
 /// Element-wise multi-draw Uniform sampler over `[min, max)`: `size` draws per row in one call,

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -114,25 +114,34 @@ pub(crate) fn row_rngs(seed: Option<u64>) -> PolarsResult<RowRngs> {
 /// the per-row `Option`/validity bookkeeping the general `try_*_elementwise` paths must carry.
 ///
 /// This factors out the boilerplate every fast path shares: cast the index to `UInt64`, resolve the
-/// root seed once, then build the typed output by mapping each row index through `build`. The
-/// builder owns the output element type (so float-, integer- and boolean-valued samplers all reuse
-/// this), and the per-row draw seeds from `(root_seed, index)` exactly as the general path does, so
-/// seeded output is identical between the two.
+/// root seed once, then collect one `draw` per row into the typed output. `draw` is one draw from a
+/// `&mut` per-row RNG already seeded `(root_seed, i)`, the same draw the distribution's per-row
+/// plugin performs, so seeded output is identical between the two. `V` owns the output element
+/// type, so float-, integer- and boolean-valued samplers all reuse this.
 #[inline]
-pub(crate) fn sample_by_index<T, F>(
+pub(crate) fn sample_by_index<T, V, F>(
+    name: PlSmallStr,
     index: &Series,
     seed: Option<u64>,
-    build: F,
+    draw: F,
 ) -> PolarsResult<Series>
 where
     T: PolarsDataType,
-    ChunkedArray<T>: IntoSeries,
-    F: FnOnce(&UInt64Chunked, &RowRngs) -> ChunkedArray<T>,
+    ChunkedArray<T>: NewChunkedArray<T, V> + IntoSeries,
+    F: Fn(&mut Pcg64Mcg) -> V,
 {
     let index = index.cast(&DataType::UInt64)?;
     let index_ca = index.u64()?;
     let rngs = row_rngs(seed)?;
-    Ok(build(index_ca, &rngs).into_series())
+
+    let ca = ChunkedArray::<T>::from_iter_values(
+        name,
+        index_ca.into_no_null_iter().map(|i| {
+            let mut rng = rngs.rng(i);
+            draw(&mut rng)
+        }),
+    );
+    Ok(ca.into_series())
 }
 
 /// Total draw count below which the multi-draw row fill runs serially: a fork-join dispatch
@@ -348,6 +357,31 @@ pub(crate) struct SamplesKwargs {
     pub(crate) size: usize,
 }
 
+/// Single-draw fast-path kwargs: a distribution's constant parameters `P` plus the optional root seed.
+///
+/// `P` is flattened, so the wire shape is one flat mapping with `seed` next to the parameter keys.
+/// Composing keeps each distribution's parameter list, and its constructor order, in the one struct
+/// its value-keyed fast paths already use.
+#[derive(Deserialize)]
+pub(crate) struct SampleScalarKwargs<P> {
+    pub(crate) seed: Option<u64>,
+    #[serde(flatten)]
+    pub(crate) params: P,
+}
+
+/// Multi-draw counterpart of [`SampleScalarKwargs`], plus the draw count `size` (the output `Array`
+/// width).
+///
+/// `seed` and `size` sit outside `P` and flatten alongside the parameter keys, so the shared output
+/// functions can read `size` by deserialising the same bytes into [`SamplesKwargs`].
+#[derive(Deserialize)]
+pub(crate) struct SamplesScalarKwargs<P> {
+    pub(crate) seed: Option<u64>,
+    pub(crate) size: usize,
+    #[serde(flatten)]
+    pub(crate) params: P,
+}
+
 fn samples_output(fields: &[Field], width: usize, inner: DataType) -> PolarsResult<Field> {
     Ok(Field::new(
         fields[0].name().clone(),
@@ -369,106 +403,6 @@ pub(crate) fn samples_u64_output(fields: &[Field], kwargs: SamplesKwargs) -> Pol
 pub(crate) fn samples_bool_output(fields: &[Field], kwargs: SamplesKwargs) -> PolarsResult<Field> {
     samples_output(fields, kwargs.size, DataType::Boolean)
 }
-
-/// Generates a distribution's constant-parameter fast paths: both the single-draw `sample`
-/// plugin (driving [`sample_by_index`]) and the multi-draw `samples` plugin (driving
-/// [`samples_by_index`]), from one shared `build` / `draw`.
-///
-/// Emitting the two from one definition is what keeps them from drifting: the multi-draw fast
-/// path is just the single-draw one repeated `size` times on the same per-row stream, so they
-/// must share the exact `build` and `draw`. The five things that vary between distributions are
-/// the macro's inputs:
-///
-/// * the kwargs fields (parameter names and types), reused by both kwargs structs;
-/// * the single-draw output dtype, as the `(logical, physical)` pair `output_type = Float64,
-///   physical = Float64Type` (the two must agree; the logical name feeds `#[polars_expr]`, the
-///   physical one the output `ChunkedArray`);
-/// * the multi-draw twin, named by the `samples = <fn> as <kwargs> -> <output_fn>` clause: the
-///   plugin fn, its kwargs struct (the same parameters plus `size`), and the `Array`-typed
-///   output function (`samples_f64_output` / `_u64_` / `_bool_`);
-/// * `build`: validates the parameters and returns the per-call sampler state, built **once**
-///   (`?` is available). Usually the built distribution; Uniform validates and keeps the raw
-///   bounds instead;
-/// * `draw`: one draw from that state, given a `&mut` per-row RNG already seeded from
-///   `(root_seed, index)`.
-///
-/// `draw` must be the *same* draw the general per-row plugins perform, so the fast paths stay
-/// byte-identical to them for the same `(seed, index, params)`; pinned by
-/// `test_sample_scalar_fast_path_matches_per_row` and `test_samples_scalar_fast_path_matches_per_row`.
-/// Call sites are the distribution modules, which all have `polars::prelude::*` in scope and
-/// import the `samples_*_output` function they name (the expansion relies on both).
-macro_rules! sample_scalar_plugin {
-    (
-        $(#[$kwargs_meta:meta])*
-        struct $kwargs:ident { $($param:ident: $param_ty:ty),+ $(,)? }
-
-        $(#[$fn_meta:meta])*
-        fn $fn_name:ident(output_type = $logical:ident, physical = $physical:ty);
-
-        samples = $samples_fn:ident as $samples_kwargs:ident -> $samples_output:ident;
-
-        build = |$kw:ident| $build:expr;
-        draw = |$state:pat_param, $rng:ident| $draw:expr;
-    ) => {
-        $(#[$kwargs_meta])*
-        #[derive(serde::Deserialize)]
-        struct $kwargs {
-            seed: Option<u64>,
-            $($param: $param_ty,)+
-        }
-
-        $(#[$fn_meta])*
-        #[pyo3_polars::derive::polars_expr(output_type=$logical)]
-        fn $fn_name(inputs: &[Series], kwargs: $kwargs) -> PolarsResult<Series> {
-            let $kw = &kwargs;
-            let $state = $build;
-            let name = inputs[0].name().clone();
-
-            $crate::rng::sample_by_index::<$physical, _>(&inputs[0], kwargs.seed, |index_ca, rngs| {
-                ChunkedArray::<$physical>::from_iter_values(
-                    name,
-                    index_ca.into_no_null_iter().map(|i| {
-                        let mut rng = rngs.rng(i);
-                        let $rng = &mut rng;
-                        $draw
-                    }),
-                )
-            })
-        }
-
-        /// Constant-parameter kwargs for the multi-draw fast path: the single-draw parameters
-        /// plus the draw count `size` (the output `Array` width).
-        #[derive(serde::Deserialize)]
-        struct $samples_kwargs {
-            seed: Option<u64>,
-            size: usize,
-            $($param: $param_ty,)+
-        }
-
-        #[doc = concat!(
-            "Constant-parameter multi-draw fast path: the `samples` twin of [`", stringify!($fn_name),
-            "`]. `size` draws per row in one call, taken as consecutive values from the same \
-             `(seed, row_index)` per-row stream, so `samples(size=1)` matches `sample` bit for bit \
-             and the state is built once per call rather than once per draw. Returns \
-             `Array(inner, size)`."
-        )]
-        #[pyo3_polars::derive::polars_expr(output_type_func_with_kwargs=$samples_output)]
-        fn $samples_fn(inputs: &[Series], kwargs: $samples_kwargs) -> PolarsResult<Series> {
-            let $kw = &kwargs;
-            let $state = $build;
-            let name = inputs[0].name().clone();
-
-            $crate::rng::samples_by_index::<$physical, _, _>(
-                name,
-                &inputs[0],
-                kwargs.seed,
-                kwargs.size,
-                |$rng| $draw,
-            )
-        }
-    };
-}
-pub(crate) use sample_scalar_plugin;
 
 /// Per-call source of per-row RNGs, all derived from one already-resolved root seed.
 ///


### PR DESCRIPTION
Deletes the last sampler macro. The 14 constant-parameter plugins are now hand-written `#[polars_expr]` shells over `{sample,samples}_by_index`, with parameters carried by generic `{Sample,Samples}ScalarKwargs<P>` wrappers around each distribution's existing `<Name>ParamsKwargs`, so a parameter list is spelled once per file instead of three times. `sample_by_index` was given the same per-draw closure signature as its multi-draw twin, collapsing seven identical 10-line shell bodies to one line each.