### PR TITLE
refactor(rust): replace `value_keyed_per_row!` macro with a generic driver

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -114,8 +114,8 @@ exact spec and checklist; that issue is canonical if it conflicts with this sect
       plugin and both shells; that shared call, not a test, is what keeps the three byte-identical.
     * When a method needs a **special function** (`erf`, log-gamma, regularized incomplete beta/gamma, ...) or has
       no elementary closed form: bind it in `statrs` (`pdf` / `pmf`, `cdf`, `ppf`, `ln_pdf` / `ln_pmf`, native `sf`,
-      native `median`). Each shares one named `*_value` body between the per-row `value_keyed` helper (from the
-      `value_keyed_per_row!` macro in `src/distributions/mod.rs`) and the constant-parameter
+      native `median`). Each shares one named `*_value` body between the per-row `value_keyed` helper (a hand-written
+      shell over the `value_keyed_per_row` driver in `src/distributions/mod.rs`) and the constant-parameter
       `<name>_<method>_scalar` twin, so the two paths are byte-identical by construction. Write each twin as a
       one-line `#[polars_expr]` shell over `kwargs.value_keyed(&inputs[0], <method>_value)`, an inherent method on
       the distribution's `<Name>ParamsKwargs` struct that validates and builds the distribution once per call and

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -69,13 +69,24 @@ fn beta_params(inputs: &[Series]) -> PolarsResult<Series> {
     })
 }
 
-value_keyed_per_row! {
-    /// Apply a value-keyed `f(dist, value)` element-wise over `(value, a, b)`; shared by `pdf`,
-    /// `ln_pdf`, `cdf`, `sf`, `ppf`. `null` propagates; an invalid shape raises via
-    /// [`build_dist`]; `f` may return `None` to null a row on its own terms.
-    fn value_keyed(&Beta);
-    params = (DataType::Float64 => f64, DataType::Float64 => f64);
-    build = build_dist;
+/// Apply a value-keyed `f(dist, value)` element-wise over `(value, a, b)`; shared by `pdf`,
+/// `ln_pdf`, `cdf`, `sf`, `ppf`. Null and `NaN` contracts in [`value_keyed_per_row`].
+fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
+where
+    F: Fn(&Beta, f64) -> Option<f64>,
+{
+    let value = inputs[0].cast(&DataType::Float64)?;
+    let a = inputs[1].cast(&DataType::Float64)?;
+    let b = inputs[2].cast(&DataType::Float64)?;
+
+    value_keyed_per_row(
+        value.f64()?,
+        a.f64()?,
+        b.f64()?,
+        inputs[0].name().clone(),
+        build_dist,
+        f,
+    )
 }
 
 /// Apply a parameter-keyed moment `f(dist)` element-wise over `(a, b)`.

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -94,13 +94,24 @@ fn support_point(value: f64) -> Option<u64> {
     }
 }
 
-value_keyed_per_row! {
-    /// Apply a value-keyed `f(dist, value)` element-wise over `(value, n, p)`; shared by `pmf`,
-    /// `ln_pmf`, `cdf`, `sf`, `ppf`. `null` propagates; an invalid parameterisation raises via
-    /// [`build_dist`]; `f` may return `None` to null a row on its own terms.
-    fn value_keyed(&Binomial);
-    params = (DataType::Int64 => i64, DataType::Float64 => f64);
-    build = build_dist;
+/// Apply a value-keyed `f(dist, value)` element-wise over `(value, n, p)`; shared by `pmf`,
+/// `ln_pmf`, `cdf`, `sf`, `ppf`. Null and `NaN` contracts in [`value_keyed_per_row`].
+fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
+where
+    F: Fn(&Binomial, f64) -> Option<f64>,
+{
+    let value = inputs[0].cast(&DataType::Float64)?;
+    let n = inputs[1].cast(&DataType::Int64)?;
+    let p = inputs[2].cast(&DataType::Float64)?;
+
+    value_keyed_per_row(
+        value.f64()?,
+        n.i64()?,
+        p.f64()?,
+        inputs[0].name().clone(),
+        build_dist,
+        f,
+    )
 }
 
 /// Apply a parameter-keyed moment `f(dist)` element-wise over `(n, p)`.

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -66,13 +66,24 @@ fn underlying_normal(dist: &LogNormal) -> Normal {
         .expect("Normal::new accepts every (location, scale) a built LogNormal carries")
 }
 
-value_keyed_per_row! {
-    /// Apply a value-keyed `f(dist, value)` element-wise over `(value, mu, sigma)`; shared by every
-    /// Rust-bound value-keyed method. `null` propagates; an invalid parameterisation raises
-    /// via [`build_dist`]; `f` may return `None` to null a row on its own terms.
-    fn value_keyed(&LogNormal);
-    params = (DataType::Float64 => f64, DataType::Float64 => f64);
-    build = build_dist;
+/// Apply a value-keyed `f(dist, value)` element-wise over `(value, mu, sigma)`; shared by every
+/// Rust-bound value-keyed method. Null and `NaN` contracts in [`value_keyed_per_row`].
+fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
+where
+    F: Fn(&LogNormal, f64) -> Option<f64>,
+{
+    let value = inputs[0].cast(&DataType::Float64)?;
+    let mu = inputs[1].cast(&DataType::Float64)?;
+    let sigma = inputs[2].cast(&DataType::Float64)?;
+
+    value_keyed_per_row(
+        value.f64()?,
+        mu.f64()?,
+        sigma.f64()?,
+        inputs[0].name().clone(),
+        build_dist,
+        f,
+    )
 }
 
 /// Validate the `(mu, sigma)` parameterisation and return the validated `sigma`.

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -6,7 +6,9 @@ pub mod lognormal;
 pub mod normal;
 pub mod uniform;
 
-use polars::prelude::arity::{try_binary_elementwise, try_unary_elementwise, unary_elementwise};
+use polars::prelude::arity::{
+    try_binary_elementwise, try_ternary_elementwise, try_unary_elementwise, unary_elementwise,
+};
 use polars::prelude::*;
 
 /// Shared driver for the constant-parameter value-keyed fast paths.
@@ -26,7 +28,7 @@ use polars::prelude::*;
 ///
 /// `NaN` contract: a `NaN` evaluation point short-circuits to `NaN` (scipy semantics) before `f`
 /// runs, for every method including `ppf`. The short-circuit is central (here and in
-/// [`value_keyed_per_row!`]) rather than per body, because two bodies genuinely need it and none
+/// [`value_keyed_per_row`]) rather than per body, because two bodies genuinely need it and none
 /// may be forgotten: the regularized incomplete beta behind `Beta` `cdf`/`sf` panics on `NaN`
 /// (aborting the whole query), and binomial's support mapping saturates (`NaN.floor() as u64` is
 /// `0`), returning a confident `P(X <= 0)`. The Python-side `propagate_null_and_nan` guard cannot
@@ -47,68 +49,63 @@ where
     Ok(ca.with_name(name).into_series())
 }
 
-/// Generates a distribution's per-row `value_keyed` helper: the column-parameter counterpart of
-/// [`value_keyed_scalar`], building and validating the distribution **once per row** over
-/// `(value, p1, p2)` and applying the per-method body `f`.
+/// Shared driver for the column-parameter value-keyed per-row paths.
 ///
-/// The general (non-fast-path) side of the value-keyed methods. Where the scalar fast path builds
-/// the distribution once per call, this rebuilds it per row because at least one parameter is a
-/// column. The three things that vary between distributions are the macro's inputs:
+/// The column-parameter counterpart of [`value_keyed_scalar`]: at least one distribution parameter
+/// is a column, so `build` validates and constructs once per row instead of once per call. `f` is
+/// the same named per-method body the fast path applies (`cdf_value`, `ppf_value`, ...), so the two
+/// paths cannot drift and agree bit for bit.
 ///
-/// * the distribution type, used in the `F: Fn(&$dist, f64) -> Option<f64>` bound;
-/// * each parameter's `<cast dtype> => <accessor>` pair (binomial's `n` is `Int64`/`.i64()`, the
-///   continuous scales are `Float64`/`.f64()`); the evaluation point is always cast to `Float64`;
-/// * `build`: the distribution constructor (`build_dist`), validating per row and raising on an
-///   invalid parameterisation (`?` is available inside the closure).
+/// The caller does the cast and the accessor (`.f64()` / `.i64()`), which fixes `A` and `B`, so a
+/// mixed `(i64, f64)` parameterisation (Binomial's `Int64` `n` beside its `Float64` `p`) fits, as in
+/// [`ternary_param_rows`](crate::rng::ternary_param_rows). `S` needs no trait bound: it is whatever
+/// `build` returns.
 ///
-/// `f` is the same named per-method body the scalar fast path applies, so the two paths share one
-/// body and cannot drift. A `NaN` evaluation point short-circuits to `NaN` after the distribution
-/// is built, so an invalid parameterisation still raises on a `NaN` row; see [`value_keyed_scalar`]
-/// for why the guard lives in the shared drivers. Only the 2-parameter (ternary) arm exists today,
-/// since every current distribution takes two parameters; a 1-parameter distribution would add a
-/// `try_binary_elementwise` arm here. Call sites are the distribution modules
-/// (`polars::prelude::*` in scope).
-macro_rules! value_keyed_per_row {
-    (
-        $(#[$meta:meta])*
-        fn $name:ident(&$dist:ty);
-        params = ($p1_dt:expr => $p1_acc:ident, $p2_dt:expr => $p2_acc:ident);
-        build = $build:path;
-    ) => {
-        $(#[$meta])*
-        fn $name<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
-        where
-            F: Fn(&$dist, f64) -> Option<f64>,
-        {
-            let value = inputs[0].cast(&DataType::Float64)?;
-            let value_ca = value.f64()?;
-            let p1 = inputs[1].cast(&$p1_dt)?;
-            let p1_ca = p1.$p1_acc()?;
-            let p2 = inputs[2].cast(&$p2_dt)?;
-            let p2_ca = p2.$p2_acc()?;
-            let name = inputs[0].name().clone();
-
-            let ca: Float64Chunked = polars::prelude::arity::try_ternary_elementwise(
-                value_ca,
-                p1_ca,
-                p2_ca,
-                |value_opt, p1_opt, p2_opt| -> PolarsResult<Option<f64>> {
-                    match (value_opt, p1_opt, p2_opt) {
-                        (Some(v), Some(a), Some(b)) => {
-                            // Build first so an invalid parameterisation raises on a `NaN` row.
-                            let dist = $build(a, b)?;
-                            Ok(if v.is_nan() { Some(f64::NAN) } else { f(&dist, v) })
-                        },
-                        _ => Ok(None),
-                    }
+/// Null contract: any null among `(value, p1, p2)` nulls the row without calling `build`, matching
+/// the samplers.
+///
+/// `NaN` contract: as in [`value_keyed_scalar`], except that the short-circuit runs after `build`,
+/// so an invalid parameterisation still raises on a `NaN` row.
+///
+/// Keep `build` and `f` generic `Fn`s: they monomorphise into the row loop, where a `&dyn Fn` or a
+/// `fn` pointer would cost an indirect call per row.
+pub(crate) fn value_keyed_per_row<A, B, S, Build, F>(
+    value: &Float64Chunked,
+    p1: &ChunkedArray<A>,
+    p2: &ChunkedArray<B>,
+    name: PlSmallStr,
+    build: Build,
+    f: F,
+) -> PolarsResult<Series>
+where
+    A: PolarsNumericType,
+    B: PolarsNumericType,
+    Build: Fn(A::Native, B::Native) -> PolarsResult<S>,
+    F: Fn(&S, f64) -> Option<f64>,
+{
+    let ca: Float64Chunked = try_ternary_elementwise(
+        value,
+        p1,
+        p2,
+        |value_opt, p1_opt, p2_opt| -> PolarsResult<Option<f64>> {
+            match (value_opt, p1_opt, p2_opt) {
+                (Some(value), Some(p1), Some(p2)) => {
+                    // Build before the `NaN` short-circuit, so an invalid parameterisation still
+                    // raises on a `NaN` row. Pinned by `tests/distributions/plugin_nan_test.py`.
+                    let dist = build(p1, p2)?;
+                    Ok(if value.is_nan() {
+                        Some(f64::NAN)
+                    } else {
+                        f(&dist, value)
+                    })
                 },
-            )?;
+                _ => Ok(None),
+            }
+        },
+    )?;
 
-            Ok(ca.with_name(name).into_series())
-        }
-    };
+    Ok(ca.with_name(name).into_series())
 }
-pub(crate) use value_keyed_per_row;
 
 /// Shared driver for the two-parameter validation plugins: validate `(a, b)` per row by
 /// constructing the distribution inside `validate`, and emit the `Float64` that closure returns.

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -71,13 +71,24 @@ fn normal_sigma(inputs: &[Series]) -> PolarsResult<Series> {
     })
 }
 
-value_keyed_per_row! {
-    /// Apply a value-keyed `f(dist, value)` element-wise over `(value, mu, sigma)`; shared by
-    /// `pdf`, `ln_pdf`, `cdf`, `sf`, `ppf`. `null` propagates; an invalid parameterisation raises
-    /// via [`build_dist`]; `f` may return `None` to null a row on its own terms.
-    fn value_keyed(&Normal);
-    params = (DataType::Float64 => f64, DataType::Float64 => f64);
-    build = build_dist;
+/// Apply a value-keyed `f(dist, value)` element-wise over `(value, mu, sigma)`; shared by `pdf`,
+/// `ln_pdf`, `cdf`, `sf`, `ppf`. Null and `NaN` contracts in [`value_keyed_per_row`].
+fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
+where
+    F: Fn(&Normal, f64) -> Option<f64>,
+{
+    let value = inputs[0].cast(&DataType::Float64)?;
+    let mu = inputs[1].cast(&DataType::Float64)?;
+    let sigma = inputs[2].cast(&DataType::Float64)?;
+
+    value_keyed_per_row(
+        value.f64()?,
+        mu.f64()?,
+        sigma.f64()?,
+        inputs[0].name().clone(),
+        build_dist,
+        f,
+    )
 }
 
 /// One Normal draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.

--- a/tests/distributions/plugin_nan_test.py
+++ b/tests/distributions/plugin_nan_test.py
@@ -4,7 +4,7 @@ The public wrappers overlay `propagate_null_and_nan` (`_base.py`), which rewrite
 regardless of what the plugins return, so this Rust-level contract is invisible through the public
 API; it is exercised here through the private `_x` hooks, which for the statrs-backed
 distributions are bare plugin calls. The `NaN` short-circuit lives centrally in the shared drivers
-(`value_keyed_scalar` / `value_keyed_per_row!` in `src/distributions/mod.rs`) and is load-bearing
+(`value_keyed_scalar` / `value_keyed_per_row` in `src/distributions/mod.rs`) and is load-bearing
 in two places:
 
 * `Beta` `cdf` / `sf`: statrs' regularized incomplete beta panics on a `NaN` evaluation point, and


### PR DESCRIPTION
Last of the four `macro_rules!`. Each distribution keeps a hand-written `value_keyed` helper under the same name, so all  `#[polars_expr]` per-row callers are untouched.