### PR TITLE
refactor(python): extract the parameter-keyed moment routing into `_param_plugin`

### DIFF
--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -62,7 +62,7 @@ path is selected only when the parameters are known scalars, so nothing column-v
 
 ### Constant parameters validate once, not per row
 
-The closed-form moments (`mean`, `variance`, `std`, `entropy`) and the closed-form methods of `Uniform` / `Bernoulli`
+The moments (`mean`, `variance`, `std`, `entropy`) and the closed-form methods of `Uniform` / `Bernoulli`
 / `Exponential` do not build a distribution; they compute a Polars expression. But they still route their *validation*
 through a small Rust plugin (`normal_sigma`, `uniform_range`, `bernoulli_proba`, `binomial_params`, `lognormal_sigma`,
 `exponential_rate`, `beta_params`) so an invalid
@@ -71,7 +71,7 @@ nonsense moment (see "Invalid parameters raise"). On the general path that plugi
 parameter columns, validating the *same constant* on every row.
 
 For all-scalar parameters the same plugin is instead called on length-1 `pl.lit` inputs, so its elementwise closure runs
-once. The validated quantity (or, for `Binomial.entropy`, the support-sum value) is returned behind a `pl.when(...)`
+once. The validated quantity (or, for `Beta.entropy` and `Binomial.entropy`, the entropy itself) is returned behind a `pl.when(...)`
 validity gate; the length-1 condition broadcasts, so the moment stays a length-n column byte-identical to the per-row
 path. A length-1 collapse is deliberately *not* used, because it would break that path equality (column parameters
 still yield length-n). This needs no new plugin and no kwargs: it reuses the existing validators, called on fewer rows.

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -331,6 +331,21 @@ class _UnivariateDistribution(ABC):
         validated_once = register_plugin(plugin_name, self._scalar_lit_args())
         return pl.when(validated_once.is_not_null()).then(validated)
 
+    def _param_plugin(self, function_name: str) -> pl.Expr:
+        """Register a parameter-keyed Rust plugin call `f(*params)` for a moment with no closed form.
+
+        The moment counterpart of `_value_plugin`: same constant-parameter routing, no `value` input. With
+        column parameters the plugin runs once per row over `_param_exprs`. With all-constant parameters it
+        runs **once** on length-1 `pl.lit` inputs and is broadcast to length-n behind the `_moment` validity
+        gate, so a constant's moment is not re-evaluated on every row.
+
+        The scalar branch routes through `_moment`, so a distribution must define `_checked_params` to
+        use this; `Uniform`, `Bernoulli` and `Exponential` deliberately do not.
+        """
+        if self._scalar_kwargs is None:
+            return register_plugin(function_name, self._param_exprs)
+        return self._moment(register_plugin(function_name, self._scalar_lit_args()))
+
     def cdf(self, value: float | IntoExprColumn) -> pl.Expr:
         """Cumulative distribution function, `P(X <= value)`. Nulls and NaNs in `value` are propagated."""
         v = as_expr(value)

--- a/polars_stats/distributions/_beta.py
+++ b/polars_stats/distributions/_beta.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, ClassVar
 from polars_stats.distributions._base import (
     ContinuousDistribution,
     coerce_param,
-    register_plugin,
     scalar_float,
     scalar_kwargs,
 )
@@ -96,11 +95,8 @@ class Beta(ContinuousDistribution):
         return self._moment(self._a * self._b / ((self._a + self._b) ** 2 * (self._a + self._b + 1)))
 
     def entropy(self) -> pl.Expr:
-        """Differential entropy in nats, ``ln B(a, b) - (a - 1) psi(a) - (b - 1) psi(b) + (a + b - 2) psi(a + b)``."""
-        # Unlike ``mean`` / ``variance`` there is no elementary closed form (log-Beta and digamma), so the
-        # formula is evaluated by ``beta_entropy`` in Rust. For column parameters that runs once per row; for
-        # scalar parameters it is computed **once** on length-1 inputs and broadcast to length-n behind the
-        # ``_moment`` validity gate, so a constant's entropy is not re-evaluated on every row.
-        if self._scalar_kwargs is None:
-            return register_plugin("beta_entropy", (self._a, self._b))
-        return self._moment(register_plugin("beta_entropy", self._scalar_lit_args()))
+        """Differential entropy in nats, ``ln B(a, b) - (a - 1) psi(a) - (b - 1) psi(b) + (a + b - 2) psi(a + b)``.
+
+        No elementary closed form (log-Beta and digamma), so ``beta_entropy`` evaluates it in Rust.
+        """
+        return self._param_plugin("beta_entropy")

--- a/polars_stats/distributions/_binomial.py
+++ b/polars_stats/distributions/_binomial.py
@@ -6,7 +6,6 @@ from polars_stats.distributions._base import (
     DiscreteDistribution,
     coerce_n,
     coerce_param,
-    register_plugin,
     scalar_float,
     scalar_int,
     scalar_kwargs,
@@ -99,12 +98,7 @@ class Binomial(DiscreteDistribution):
     def entropy(self) -> pl.Expr:
         """Shannon entropy in nats, the exact support sum ``-sum_k pmf(k) log pmf(k)``.
 
-        ``0`` at the degenerate endpoints ``p in {0, 1}``.
+        ``0`` at the degenerate endpoints ``p in {0, 1}``. There is no closed form, so
+        ``binomial_entropy`` evaluates the sum in Rust.
         """
-        # Unlike ``mean`` / ``variance`` there is no closed form, so the sum is evaluated by ``binomial_entropy``
-        # in Rust. For column parameters that runs once per row; for scalar parameters it is computed **once** on
-        # length-1 inputs and broadcast to length-n behind the ``_moment`` validity gate, so a constant's support sum is
-        # not re-evaluated on every row.
-        if self._scalar_kwargs is None:
-            return register_plugin("binomial_entropy", (self._n, self._p))
-        return self._moment(register_plugin("binomial_entropy", self._scalar_lit_args()))
+        return self._param_plugin("binomial_entropy")


### PR DESCRIPTION
`{Beta,Binomial}.entropy` carried an identical copy of the scalar-vs-column plugin routing; both now call one `_param_plugin` on the base class, the moment counterpart of `_value_plugin`. 