### PR TITLE
fix!: broadcast length-1 plugin inputs instead of silently truncating the result

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,12 @@ What matters specifically for an agent:
    input rather than raising. Padding at the Python end cannot replace it, because `.first()` and `.max()` are
    length-1 expressions the user writes. `tests/distributions/broadcast_test.py` catches a missed funnel.
 
+* **The samplers' row index is not a parameter, so it must never be broadcast.** A per-row sampler takes
+   `row_index_expr(params)`, not `ROW_INDEX_EXPR`. A parameter can outrun the frame, and a `pl.len()`-sized index
+   is then length 1, broadcasts to position 0 on every row, and returns one draw repeated at full height with no
+   error. The plugin cannot repair it, because the streaming engine splits such a call into one-row morsels and
+   the flattened index is all it ever sees.
+
 * **The constant-parameter sampler fast path must match the per-row path bit for bit.** `<name>_sample_scalar` and the
    general sampler share `(root_seed, row_index)` seeding and the same draw, so for one seed they must agree. The fast
    path is the *only* place a distribution parameter rides in `kwargs`: a wrong field name or argument order silently

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,10 +61,11 @@ What matters specifically for an agent:
 
 ## Common pitfalls
 
-* **Row-alignment of scalar params.** Scalars must be coerced via `pl.repeat(value, n=pl.len(), dtype=pl.Float64())`,
-   not `pl.lit(value)`. The reason: `is_elementwise=True` plugins under `over` / `group_by` expect length to track the
-   partition. A bare `pl.lit` breaks this. This applies to the general (per-row) plugins; the sampler's
-   constant-parameter fast path sidesteps it by passing the scalars in `kwargs` rather than as inputs.
+* **Row-alignment belongs to Rust.** Scalars coerce to `pl.lit(value, dtype=...)`, and `align_inputs` broadcasts
+   every length-1 input up to the call's row count. Any new `#[polars_expr]` taking more than one input must call it
+   first, before the casts: polars broadcasts nothing into a plugin, and `try_*_elementwise` truncates to the shortest
+   input rather than raising. Padding at the Python end cannot replace it, because `.first()` and `.max()` are
+   length-1 expressions the user writes. `tests/distributions/broadcast_test.py` catches a missed funnel.
 
 * **The constant-parameter sampler fast path must match the per-row path bit for bit.** `<name>_sample_scalar` and the
    general sampler share `(root_seed, row_index)` seeding and the same draw, so for one seed they must agree. The fast

--- a/docs/explanation/accuracy.md
+++ b/docs/explanation/accuracy.md
@@ -52,6 +52,13 @@ magnitudes are in the inherited limits below.
   cdf's own precision, so a quantile within `1e-12` *relative* of a cdf step may return the
   neighbouring support point. Parity with `scipy` is gated at integer equality rather than at a
   float tolerance.
+* **A constant parameter and a column parameter can differ in the last bit.** `Uniform(-2.5, 7.5).cdf("x")`
+  and `Uniform(pl.col("lo"), pl.col("hi")).cdf("x")` evaluate the same closed form, but polars folds the
+  constant spelling over one row and the column spelling over `n`, and the two kernels do not round
+  identically. It reaches the methods evaluated as polars expressions rather than in Rust: `Uniform`'s
+  moments and value-keyed methods, and `Exponential`'s value-keyed methods. The difference is at or below
+  `1e-15` relative, roughly 4x a double's ULP. Everything backed by `statrs` runs the same Rust body either
+  way and stays bit-identical.
 * **`float64` range, not algorithm.** Some quantities genuinely exceed the type: `LogNormal`'s
   variance overflows above `sigma ~ 18.8`, and `Exponential.pdf` lands in the subnormal range once
   `rate * x` passes ~708, where only one or two significant digits remain. `log_pdf` is exact well

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -9,8 +9,8 @@ questions, see [Design notes](design.md).
 
 ## Three layers
 
-* Python API layer (`polars_stats/`): Distribution classes (Normal, Bernoulli, ...). Coerce params into row-aligned
-    `pl.Expr`, register plugin calls. Implement methods directly as `pl.Expr` when the closed form is trivial.
+* Python API layer (`polars_stats/`): Distribution classes (Normal, Bernoulli, ...). Coerce params into `pl.Expr`,
+    register plugin calls. Implement methods directly as `pl.Expr` when the closed form is trivial.
 
 * FFI layer (`pyo3-polars` plugin functions). One `#[polars_expr]` per (distribution, method) where Rust is required.
     Per-row null propagation; an invalid parameter on a row raises.
@@ -45,9 +45,14 @@ Every distribution `__init__` coerces each parameter with a single shared helper
 parameters like Binomial's `n`). The accepted inputs and their coercions are tabulated in
 [Reference / Parameters and contracts](../reference/parameters-and-contracts.md#accepted-inputs).
 
-A scalar is expanded with `pl.repeat(value, n=pl.len())`, a length-`N` expression rather than `pl.lit`, on purpose: the
-plugin always receives a row-aligned
-input, so it stays elementwise and `over` / `group_by` invoke it once per partition rather than as an aggregation.
+A scalar becomes `pl.lit(value)`, a length-1 scalar column, and Rust owns row-alignment: polars broadcasts nothing
+into a plugin, so `align_inputs` broadcasts every length-1 input up to the call's row count before any cast. It
+aligns by *length*, not by expression kind, so a user-written `.first()` or `.max()` parameter is handled like a
+literal.
+
+An expression whose inputs are *all* constant is therefore a scalar column, so `df.select(Normal(0.0, 1.0).mean())`
+is one row; any column-valued input sets the length instead. See
+[Reference / Parameters and contracts](../reference/parameters-and-contracts.md#accepted-inputs).
 
 On the Rust side, a plugin function receives `inputs: &[Series]` of `(value, param_1, ..., param_k)`, casts each to
 `Float64Chunked`, iterates per chunk, propagates nulls, and constructs the `statrs` distribution per row. `kwargs`
@@ -89,8 +94,8 @@ reproducible across OS and architecture.
 
 **Constant-parameter fast path**: when every distribution parameter is a Python scalar (the common case), the sampler
 takes a dedicated plugin, `<name>_sample_scalar`. The parameters travel in `kwargs` and are validated once; only the row
-index crosses FFI, instead of one full-length `pl.repeat` column per parameter that the general plugin would marshal and
-re-validate on every row. The shared `sample_by_index` helper in `rng.rs` resolves the seed once and maps the dense,
+index crosses FFI, instead of one broadcast column per parameter that the general plugin would marshal and re-validate
+on every row. The shared `sample_by_index` helper in `rng.rs` resolves the seed once and maps the dense,
 non-null index straight into the typed output. Each distribution writes the two fast-path shells by hand over
 `sample_by_index` / `samples_by_index`, carrying its parameters in `SampleScalarKwargs<P>` / `SamplesScalarKwargs<P>`,
 the generic `seed` / `size` wrappers in `rng.rs` around the distribution's own `<Name>ParamsKwargs`. The shells reuse

--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -73,9 +73,10 @@ validating each row.
 For all-scalar parameters the same plugin is called on length-1 `pl.lit` inputs, so its elementwise closure runs once.
 The validated quantity (or, for `Beta.entropy` and `Binomial.entropy`, the entropy itself) is returned behind a
 `pl.when(...)` validity gate. Nothing in the expression is longer than one row, so the moment is a *scalar* column that
-polars broadcasts wherever it meets a longer one: values still match the per-row path bit for bit, only the standalone
-height differs (`df.select(Normal(0.0, 1.0).variance())` is one row). This needs no new plugin and no kwargs, only the
-existing validators called on fewer rows.
+polars broadcasts wherever it meets a longer one; only the standalone height differs
+(`df.select(Normal(0.0, 1.0).variance())` is one row). This needs no new plugin and no kwargs, only the existing
+validators called on fewer rows. The two spellings can disagree in the last bit; see
+[Numerical accuracy](accuracy.md#structural).
 
 It is the same "constant parameters take a fast path" idea as the sampler, applied to validation: nothing leaves Rust,
 and the raise contract is unchanged (pinned by `moment_test.py` and the `*_scalar` validation tests). For a constant,

--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -47,7 +47,7 @@ serves distributions needing a single uniform per draw, so it is deliberately no
 
 `sample` ships a second plugin, `<name>_sample_scalar`, used when every parameter is a Python scalar. The general
 sampler is built for the differentiator (column-valued parameters), but it makes the common constant-parameter case pay
-for machinery it does not use: each scalar is expanded to a full-length `pl.repeat` column, marshalled across FFI, and
+for machinery it does not use: each scalar is broadcast to a full-length column, marshalled across FFI, and
 re-validated on every row, and the distribution is rebuilt per row. For a cheap draw (uniform is one multiply-add) that
 fixed overhead dominates the draw itself.
 
@@ -67,14 +67,15 @@ The moments (`mean`, `variance`, `std`, `entropy`) and the closed-form methods o
 through a small Rust plugin (`normal_sigma`, `uniform_range`, `bernoulli_proba`, `binomial_params`, `lognormal_sigma`,
 `exponential_rate`, `beta_params`) so an invalid
 parameterisation raises the same `ComputeError` as the sampler and value-keyed methods rather than silently producing a
-nonsense moment (see "Invalid parameters raise"). On the general path that plugin runs over the full-length `pl.repeat`
-parameter columns, validating the *same constant* on every row.
+nonsense moment (see "Invalid parameters raise"). With column parameters that plugin runs over the parameter columns,
+validating each row.
 
-For all-scalar parameters the same plugin is instead called on length-1 `pl.lit` inputs, so its elementwise closure runs
-once. The validated quantity (or, for `Beta.entropy` and `Binomial.entropy`, the entropy itself) is returned behind a `pl.when(...)`
-validity gate; the length-1 condition broadcasts, so the moment stays a length-n column byte-identical to the per-row
-path. A length-1 collapse is deliberately *not* used, because it would break that path equality (column parameters
-still yield length-n). This needs no new plugin and no kwargs: it reuses the existing validators, called on fewer rows.
+For all-scalar parameters the same plugin is called on length-1 `pl.lit` inputs, so its elementwise closure runs once.
+The validated quantity (or, for `Beta.entropy` and `Binomial.entropy`, the entropy itself) is returned behind a
+`pl.when(...)` validity gate. Nothing in the expression is longer than one row, so the moment is a *scalar* column that
+polars broadcasts wherever it meets a longer one: values still match the per-row path bit for bit, only the standalone
+height differs (`df.select(Normal(0.0, 1.0).variance())` is one row). This needs no new plugin and no kwargs, only the
+existing validators called on fewer rows.
 
 It is the same "constant parameters take a fast path" idea as the sampler, applied to validation: nothing leaves Rust,
 and the raise contract is unchanged (pinned by `moment_test.py` and the `*_scalar` validation tests). For a constant,

--- a/docs/how-to/column-parameters.md
+++ b/docs/how-to/column-parameters.md
@@ -36,6 +36,12 @@ print(df.with_columns(p=ps.Normal(mu="mu", sigma="sigma").pdf("x")))
 Method arguments follow the same rule: `pdf("x")` reads column `x`, exactly like `pdf(pl.col("x"))`. A bare string is
 always a column reference, never a literal.
 
+!!! tip "A constant parameter is faster as a plain number"
+
+    `ps.Normal(mu=0.0, sigma=1.0)` and `ps.Normal(mu=pl.lit(0.0), sigma=pl.lit(1.0))` return the same rows, but only
+    the first takes the constant-parameter fast path, where the parameters ride as plugin kwargs and build one
+    distribution per call. An `Expr` parameter gives that up and rebuilds it per row.
+
 !!! warning "Floats are strict"
 
     A float parameter rejects an `int`: `ps.Normal(mu=0, sigma=1)` raises `TypeError`. Write `0.0` and `1.0`.

--- a/docs/how-to/lazy-pipelines.md
+++ b/docs/how-to/lazy-pipelines.md
@@ -79,5 +79,5 @@ Wrap it in an aggregation if you want a single number per group, for example
 ## Related
 
 * [Use column-valued parameters](column-parameters.md): where those `mu` / `sigma` columns come from.
-* [Explanation / Architecture](../explanation/architecture.md#column-valued-parameters): why a scalar parameter is
-    expanded to a row-aligned expression, and why that keeps these methods elementwise under partitioning.
+* [Explanation / Architecture](../explanation/architecture.md#column-valued-parameters): why a scalar parameter is a
+    length-1 literal, and how Rust broadcasts it so these methods stay elementwise under partitioning.

--- a/docs/reference/parameters-and-contracts.md
+++ b/docs/reference/parameters-and-contracts.md
@@ -30,6 +30,9 @@ Polars' own scalar semantics then apply. An expression whose inputs are *all* co
 `df.select(Normal(0.0, 1.0).mean())` returns **one row**, `group_by().agg()` returns a scalar rather than a list per
 group, and a 0-row frame still returns one row. Any column-valued input sets the length instead.
 
+`sample()` and `samples()` are the exception. They pass a per-row index as a hidden full-length input, so they are
+full height whatever the parameters are, and a 0-row frame returns no rows.
+
 A length-1 *expression* is accepted wherever a column is and broadcasts rather than truncating, so
 `Normal(mu=pl.col("mu").mean(), sigma=1.0).pdf("x")` is full height. Lengths that are neither equal nor 1 raise.
 

--- a/docs/reference/parameters-and-contracts.md
+++ b/docs/reference/parameters-and-contracts.md
@@ -33,6 +33,27 @@ group, and a 0-row frame still returns one row. Any column-valued input sets the
 A length-1 *expression* is accepted wherever a column is and broadcasts rather than truncating, so
 `Normal(mu=pl.col("mu").mean(), sigma=1.0).pdf("x")` is full height. Lengths that are neither equal nor 1 raise.
 
+!!! warning "Length-1 inputs inside `over()` and `group_by().agg()` need polars 1.34"
+
+    Before polars 1.34 a length-1 input is mishandled by polars itself once the expression is evaluated *inside* a
+    partition context. Depending on the distribution and method you get either a `PanicException` or, below 1.33,
+    values returned in group order rather than scattered back to row order. Both defects are fixed upstream and
+    need no change here.
+
+    Nothing else is affected. `select` and `with_columns` broadcast correctly on every supported version, and so
+    does the pattern of aggregating first and applying the distribution to the result:
+
+    ```python
+    (
+        frame.group_by("g")
+        .agg(mu=pl.col("x").mean(), sigma=pl.col("x").std())
+        .with_columns(p=ps.Normal(mu="mu", sigma="sigma").cdf(1.0))
+    )
+    ```
+
+    Computing a parameter with `.over("g")` and using it in a plain `select` is fine too; it is only putting the
+    distribution expression itself inside `over()` or `agg()` that is affected.
+
 Numeric columns of any width are cast to `Float64` at evaluation, so an integer column works wherever a float is
 expected. The count parameter `n` is the exception: its column must already hold integers, of any width up to
 `UInt64`, because casting a float one would silently truncate a fractional count. The rule is judged on the

--- a/docs/reference/parameters-and-contracts.md
+++ b/docs/reference/parameters-and-contracts.md
@@ -22,9 +22,16 @@ parameter rejects an `int`, while a method argument accepts either.
 | `pl.Series` | wrapped as `pl.lit(series)` | wrapped as `pl.lit(series)` | wrapped as `pl.lit(series)` |
 | anything else | `TypeError` | `TypeError` | `TypeError` |
 
-A `str` is always a column reference, never a literal value. A Python scalar is expanded to a row-aligned expression
-rather than a broadcast literal, which is what keeps every method elementwise under `over` and `group_by`
+A `str` is always a column reference, never a literal value. A Python scalar becomes `pl.lit(value)`, a length-1
+scalar column that the Rust plugin broadcasts to the call's row count
 (see [Architecture](../explanation/architecture.md#column-valued-parameters)).
+
+Polars' own scalar semantics then apply. An expression whose inputs are *all* constant is a scalar column:
+`df.select(Normal(0.0, 1.0).mean())` returns **one row**, `group_by().agg()` returns a scalar rather than a list per
+group, and a 0-row frame still returns one row. Any column-valued input sets the length instead.
+
+A length-1 *expression* is accepted wherever a column is and broadcasts rather than truncating, so
+`Normal(mu=pl.col("mu").mean(), sigma=1.0).pdf("x")` is full height. Lengths that are neither equal nor 1 raise.
 
 Numeric columns of any width are cast to `Float64` at evaluation, so an integer column works wherever a float is
 expected. The count parameter `n` is the exception: its column must already hold integers, of any width up to

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -15,11 +15,29 @@ if TYPE_CHECKING:
 
 _ROW_INDEX_NAME = "__polars_stats_row_index__"
 ROW_INDEX_EXPR = pl.int_range(0, pl.len(), dtype=pl.UInt64).alias(_ROW_INDEX_NAME)
-"""Per-row position `0..len` used to derive per-row sub-seeds in samplers.
+"""Per-row position `0..len` used to derive per-row sub-seeds in the constant-parameter samplers.
 
 Evaluated inside the surrounding context, so `pl.len()` is the frame length under
 `select` / `with_columns` and the partition length under `over` / `group_by`.
+
+Usable only when no parameter crosses FFI, i.e. the `*_scalar` fast paths; the per-row samplers take `row_index_expr`.
 """
+
+
+def row_index_expr(params: Iterable[pl.Expr]) -> pl.Expr:
+    """`ROW_INDEX_EXPR` sized by the call's row count instead of the frame height.
+
+    A parameter longer than the frame sets the row count. A `pl.len()`-sized index is then length 1,
+    polars broadcasts it, and every row seeds from position 0 and silently draws the same value. The
+    plugin cannot repair it, because the streaming engine splits such a call into one-row morsels.
+
+    The maximum ignores length-1 parameters, as `align_inputs` does, so a 0-row frame beside a
+    `pl.lit` parameter stays empty. Keep `p.len()` to one mention per parameter: polars evaluates a
+    repeated subexpression once per occurrence, so spelling this as `when(p.len() == 1)...otherwise(
+    p.len())` runs each parameter twice more than the plugin call already does.
+    """
+    spans = (p.len().replace(1, 0) for p in params)
+    return pl.int_range(0, pl.max_horizontal(pl.len(), *spans), dtype=pl.UInt64).alias(_ROW_INDEX_NAME)
 
 
 def _coerce(
@@ -220,7 +238,7 @@ class _UnivariateDistribution(ABC):
     def _param_exprs(self) -> tuple[pl.Expr, ...]:
         """The distribution's parameters as coerced exprs, in plugin-input order.
 
-        The per-row plugins take these as positional inputs, ahead of `ROW_INDEX_EXPR` for the samplers
+        The per-row plugins take these as positional inputs, ahead of `row_index_expr` for the samplers
         and after `value` for the value-keyed methods.
         The order is part of the contract: output naming follows the first expression (polars root-name semantics,
         pinned by `output_name_test.py`), and the Rust side reads them positionally.
@@ -247,8 +265,9 @@ class _UnivariateDistribution(ABC):
                 (ROW_INDEX_EXPR,),
                 kwargs={"seed": seed, **self._scalar_kwargs},
             ).alias("sample")
+        params = self._param_exprs
         return register_plugin(
-            f"{self._plugin_prefix}_sample", (*self._param_exprs, ROW_INDEX_EXPR), kwargs={"seed": seed}
+            f"{self._plugin_prefix}_sample", (*params, row_index_expr(params)), kwargs={"seed": seed}
         )
 
     def samples(self, size: int, seed: int | None = None) -> pl.Expr:
@@ -292,13 +311,14 @@ class _UnivariateDistribution(ABC):
     def _samples_columns(self, size: int, seed: int | None) -> pl.Expr:
         """Register the `<prefix>_samples` multi-draw plugin call for column-valued parameters.
 
-        Mirrors `sample`'s per-row plugin shape: the parameter exprs plus `ROW_INDEX_EXPR` as inputs, the root
+        Mirrors `sample`'s per-row plugin shape: the parameter exprs plus `row_index_expr` as inputs, the root
         `seed` and draw count `size` as kwargs. Called by `_samples`; naming is applied by `samples`, and a
         null-parameter row becomes a null array element inside the plugin.
         """
+        params = self._param_exprs
         return register_plugin(
             f"{self._plugin_prefix}_samples",
-            (*self._param_exprs, ROW_INDEX_EXPR),
+            (*params, row_index_expr(params)),
             kwargs={"seed": seed, "size": size},
         )
 

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, ClassVar
 
 import polars as pl
+from polars.exceptions import PolarsError
 from polars.plugins import register_plugin_function
 
 from polars_stats._lib import LIB
@@ -12,6 +13,9 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
 
     from polars_stats._typing import IntoExprColumn, PolarsDataType
+
+_LITERAL_LEN_IN_AGG = tuple(int(part) for part in pl.__version__.split(".", 2)[:2]) >= (1, 35)
+"""Whether `pl.lit(...).len()` survives inside `over` / `group_by().agg()`."""
 
 _ROW_INDEX_NAME = "__polars_stats_row_index__"
 ROW_INDEX_EXPR = pl.int_range(0, pl.len(), dtype=pl.UInt64).alias(_ROW_INDEX_NAME)
@@ -24,6 +28,14 @@ Usable only when no parameter crosses FFI, i.e. the `*_scalar` fast paths; the p
 """
 
 
+def _frame_free_length(param: pl.Expr) -> int | None:
+    """The parameter's length if it can be evaluated without a frame, else `None`."""
+    try:
+        return pl.select(param).height
+    except PolarsError:
+        return None
+
+
 def row_index_expr(params: Iterable[pl.Expr]) -> pl.Expr:
     """`ROW_INDEX_EXPR` sized by the call's row count instead of the frame height.
 
@@ -31,12 +43,32 @@ def row_index_expr(params: Iterable[pl.Expr]) -> pl.Expr:
     polars broadcasts it, and every row seeds from position 0 and silently draws the same value. The
     plugin cannot repair it, because the streaming engine splits such a call into one-row morsels.
 
-    The maximum ignores length-1 parameters, as `align_inputs` does, so a 0-row frame beside a
-    `pl.lit` parameter stays empty. Keep `p.len()` to one mention per parameter: polars evaluates a
-    repeated subexpression once per occurrence, so spelling this as `when(p.len() == 1)...otherwise(
-    p.len())` runs each parameter twice more than the plugin call already does.
+    Length-1 parameters never set the row count, as in `align_inputs`, so a 0-row frame beside a
+    `pl.lit` parameter stays empty. Keep `param.len()` to one mention per parameter: polars evaluates
+    a repeated subexpression once per occurrence, so `when(param.len() == 1)...otherwise(param.len())`
+    would run each parameter twice more than the plugin call already does.
+
+    Below polars 1.35 a literal's length cannot be asked for inside a partition context (see
+    [`_LITERAL_LEN_IN_AGG`]), so the lengths that can be resolved without a frame are resolved here,
+    by `pl.select`, and only the frame-dependent ones are left to `.len()`.
     """
-    spans = (p.len().replace(1, 0) for p in params)
+    # A bare column always has the frame's length, so it can never set the row count.
+    sized = (param for param in params if not param.meta.is_column())
+    spans: list[int | pl.Expr]
+    if _LITERAL_LEN_IN_AGG:
+        spans = [param.len().replace(1, 0) for param in sized]
+    else:
+        spans, fixed = [], 0
+        for param in sized:
+            if (length := _frame_free_length(param)) is None:
+                spans.append(param.len().replace(1, 0))
+            else:
+                fixed = max(fixed, 0 if length == 1 else length)
+        if fixed:
+            spans.insert(0, fixed)
+
+    if not spans:
+        return ROW_INDEX_EXPR
     return pl.int_range(0, pl.max_horizontal(pl.len(), *spans), dtype=pl.UInt64).alias(_ROW_INDEX_NAME)
 
 

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -159,8 +159,8 @@ def register_plugin(
 
     Wraps `register_plugin_function` so each call site spells only what varies (the function name, its input exprs,
     and an optional sampler `seed` or constant-parameter kwargs). `plugin_path=LIB`, `is_elementwise` is fixed to
-    `True`: every distribution plugin is per-row by contract (see `coerce_param`), and an aggregating plugin would
-    break `over` / `group_by`, so this is a guard rather than a default.
+    `True`: every distribution plugin is per-row by contract, and an aggregating plugin would break `over` /
+    `group_by`, so this is a guard rather than a default.
 
     Arguments:
         function_name: The `#[polars_expr]` function exported by the Rust crate.
@@ -336,16 +336,18 @@ class _UnivariateDistribution(ABC):
 
         The validating plugins (`normal_sigma`, `uniform_range`, `bernoulli_proba`, ...) are
         elementwise and return the quantity they are named for (the validated `sigma`, the width
-        `max - min`, the validated `p`, ...). Both paths are byte-identical for the same parameters:
+        `max - min`, the validated `p`, ...). Both paths raise on the same parameters:
 
         * **Column parameters**: the per-row plugin over `_param_exprs`, validating each row and
           propagating per-row nulls.
         * **All-scalar parameters**: the same plugin on length-1 `pl.lit` inputs, so it validates a
           single time and still raises the same `ComputeError` on an invalid constant. `validated`
-          (a length-n expr recomputing that quantity from the raw parameter columns, e.g.
-          `self._sigma` or `self._max - self._min`) is returned behind the length-1 validity gate;
-          `pl.when` broadcasts the condition, so the result stays length-n and equals the per-row
-          output element for element.
+          (the same quantity recomputed from the parameters, e.g. `self._sigma` or
+          `self._max - self._min`) is returned behind that length-1 gate, so the whole expression is
+          a scalar column polars broadcasts wherever it meets a longer one.
+
+        The two paths agree bit for bit except where polars folds the scalar branch's arithmetic
+        with a different kernel than the length-n columns of the per-row branch.
         """
         if self._scalar_kwargs is None:
             return register_plugin(plugin_name, self._param_exprs)
@@ -357,8 +359,8 @@ class _UnivariateDistribution(ABC):
 
         The moment counterpart of `_value_plugin`: same constant-parameter routing, no `value` input. With
         column parameters the plugin runs once per row over `_param_exprs`. With all-constant parameters it
-        runs **once** on length-1 `pl.lit` inputs and is broadcast to length-n behind the `_moment` validity
-        gate, so a constant's moment is not re-evaluated on every row.
+        runs **once** on length-1 `pl.lit` inputs behind the `_moment` validity gate, so a constant's moment is
+        a scalar column rather than a value re-evaluated on every row.
 
         The scalar branch routes through `_moment`, so a distribution must define `_checked_params` to
         use this; `Uniform`, `Bernoulli` and `Exponential` deliberately do not.

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -30,29 +30,30 @@ def _coerce(
     scalar_types: type | tuple[type, ...],
     dtype: PolarsDataType | None = None,
 ) -> pl.Expr:
-    """Coerce a scalar-or-`IntoExprColumn` input into a row-aligned `pl.Expr`.
+    """Coerce a scalar-or-`IntoExprColumn` input into a `pl.Expr`.
 
     Every distribution input (constructor parameter or value-keyed method argument) is one of two things, handled
     identically here so the contract lives in one place:
 
     * An `IntoExprColumn`: a `pl.Expr` passes through; a column name `str` becomes `pl.col(name)`, a `pl.Series`
         becomes `pl.lit(series)`.
-    * A Python scalar: expanded with `pl.repeat(value, n=pl.len())` rather than `pl.lit(value)`.
+    * A Python scalar: `pl.lit(value)`, a length-1 scalar column.
 
-    NOTE: The scalar expansion is required to keep the plugin calls `is_elementwise=True`, which is what makes
-    `over` / `group_by` invoke them once per partition rather than as an aggregation. It also guards correctness:
-    the Rust plugins zip their inputs element-wise via `try_*_elementwise`, which truncates to the shortest input rather
-    than broadcasting a length-1 literal. Mixed with a column-valued input, a scalar `pl.lit(value)` would collapse the
-    result to length 1 and silently drop every row past the first. Some Polars versions broadcast the literal upstream
-    and hide this; not all do, so the plugin contract must own row-alignment rather than rely on it.
+    NOTE: Row-alignment belongs to the plugin (`align_inputs` in `src/distributions/mod.rs`), which broadcasts every
+    length-1 input up to the call's row count. Padding scalars here cannot replace it, since `.first()` and `.max()`
+    are length-1 expressions we do not construct.
+
+    A constant parameter therefore stays length 1, so an expression built only from constants is a scalar column with
+    polars' own semantics: height 1 under `select`, broadcast per partition under `over`, a scalar per group under
+    `group_by().agg()`. Any column-valued input sets the length, so a mixed call is full length.
 
     Arguments:
         value: A Python scalar of one of `scalar_types`, or an `IntoExprColumn`.
         name: Input name, used only to build the error message.
         scalar_label: Human description of the accepted scalar (e.g. `"a float"`), for the error.
-        scalar_types: Python scalar type(s) accepted for expansion. `bool` is always rejected
+        scalar_types: Python scalar type(s) accepted as a literal. `bool` is always rejected
             (it is an `int` subclass but never a valid numeric input, so `scalar_types=int` still excludes it).
-        dtype: Dtype for the expanded scalar; `None` lets Polars infer it from `value`.
+        dtype: Dtype for the scalar literal; `None` lets Polars infer it from `value`.
     """
     if isinstance(value, pl.Expr):
         return value
@@ -61,16 +62,16 @@ def _coerce(
     if isinstance(value, pl.Series):
         return pl.lit(value)
     if isinstance(value, scalar_types) and not isinstance(value, bool):
-        return pl.repeat(value, n=pl.len(), dtype=dtype)
+        return pl.lit(value, dtype=dtype)
     msg = f"{name} should be {scalar_label} or IntoExprColumn (pl.Expr, str, pl.Series), found {type(value)}"
     raise TypeError(msg)
 
 
 def coerce_param(value: float | IntoExprColumn, *, name: str) -> pl.Expr:
-    """Coerce a float distribution parameter (e.g. `mu`, `sigma`, `p`) into a row-aligned `pl.Expr`.
+    """Coerce a float distribution parameter (e.g. `mu`, `sigma`, `p`) into a `pl.Expr`.
 
     Accepts a strict Python `float` or an `IntoExprColumn`; an `int` or `bool` raises `TypeError`
-    (a probability or scale is a float, not a count). See `_coerce` for the row-alignment rationale.
+    (a probability or scale is a float, not a count). See `_coerce` for the coercion rules.
     """
     return _coerce(value, name=name, scalar_label="a float", scalar_types=float, dtype=pl.Float64())
 
@@ -86,12 +87,12 @@ limit: Rust widens it to `UInt64` and the whole range is a valid trial count.
 
 
 def coerce_n(value: int | IntoExprColumn, *, name: str = "n") -> pl.Expr:
-    """Coerce an integer count parameter (e.g. binomial trial count `n`) into a row-aligned `pl.Expr`.
+    """Coerce an integer count parameter (e.g. binomial trial count `n`) into a `pl.Expr`.
 
     Accepts a Python `int` or an `IntoExprColumn`; a `bool` (an `int` subclass, but not a sensible count),
     a `float`, or any other type raises `TypeError`. An `int` outside `[0, _MAX_SCALAR_COUNT]` raises
     `ValueError`, the one parameter *value* judged at construction rather than at evaluation, because the
-    expanded scalar is `UInt64` (the dtype the Rust plugins read `n` as) and polars would otherwise refuse
+    scalar literal is `UInt64` (the dtype the Rust plugins read `n` as) and polars would otherwise refuse
     it with a message about `i64` and `u64`. A column keeps its dtype until Rust widens it to `UInt64`,
     which requires an integer dtype and every value `>= 0`. See `_coerce` for the rationale.
     """
@@ -110,7 +111,7 @@ def scalar_float(value: float | IntoExprColumn) -> float | None:
 
     Used by samplers to detect a constant (non-`Expr`) parameter and route it through the
     constant-parameter fast path, which passes it as a plugin kwarg validated once in Rust rather
-    than expanding it into a per-row `pl.repeat` column (see `_coerce`). `bool` is an `int` subclass
+    than as a length-1 input the plugin must broadcast (see `_coerce`). `bool` is an `int` subclass
     but never a valid parameter, so it is excluded and falls back to the per-row path.
     """
     return float(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else None
@@ -138,12 +139,12 @@ def scalar_kwargs(**params: float | None) -> dict[str, float | int] | None:
 
 
 def as_expr(value: float | IntoExprColumn) -> pl.Expr:
-    """Coerce a value-keyed method input (`value` / `quantile`) into a row-aligned `pl.Expr`.
+    """Coerce a value-keyed method input (`value` / `quantile`) into a `pl.Expr`.
 
     More permissive on scalars than `coerce_param`: a support point or quantile may be an `int` (`cdf(0)`, `pmf(1)`) or
-    a `float`, so both are accepted and the expanded dtype is left to Polars to infer.
+    a `float`, so both are accepted and the literal's dtype is left to Polars to infer.
 
-    A `bool` or other non-numeric type raises `TypeError`. See `_coerce` for the row-alignment rationale.
+    A `bool` or other non-numeric type raises `TypeError`. See `_coerce` for the coercion rules.
     """
     return _coerce(value, name="value", scalar_label="a number (int or float)", scalar_types=(int, float))
 
@@ -217,7 +218,7 @@ class _UnivariateDistribution(ABC):
     @property
     @abstractmethod
     def _param_exprs(self) -> tuple[pl.Expr, ...]:
-        """The distribution's parameters as coerced, row-aligned exprs, in plugin-input order.
+        """The distribution's parameters as coerced exprs, in plugin-input order.
 
         The per-row plugins take these as positional inputs, ahead of `ROW_INDEX_EXPR` for the samplers
         and after `value` for the value-keyed methods.

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -4,7 +4,7 @@ use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution;
 use statrs::distribution::Bernoulli;
 
-use crate::distributions::validate_params_unary;
+use crate::distributions::{align_inputs, validate_params_unary};
 use crate::rng::{
     binary_param_rows, sample_by_index, sample_per_row_binary, samples_bool_output,
     samples_by_index, samples_per_row, SampleKwargs, SampleScalarKwargs, SamplesKwargs,
@@ -59,6 +59,7 @@ fn draw(dist: &Bernoulli, rng: &mut impl rand::Rng) -> bool {
 /// chunk-invariance follow [`sample_per_row_binary`].
 #[polars_expr(output_type=Boolean)]
 fn bernoulli_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
     let proba = inputs[0].cast(&DataType::Float64)?;
     let index = inputs[1].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
@@ -108,6 +109,7 @@ fn bernoulli_samples_scalar(
 /// Seeding and the null/error contract follow [`samples_per_row`] and [`bernoulli_sample`].
 #[polars_expr(output_type_func_with_kwargs=samples_bool_output)]
 fn bernoulli_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
     let proba = inputs[0].cast(&DataType::Float64)?;
     let index = inputs[1].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -6,7 +6,9 @@ use statrs::distribution::{Beta, Continuous, ContinuousCDF};
 use statrs::function::beta::ln_beta;
 use statrs::statistics::Distribution as StatrsDistribution;
 
-use crate::distributions::{validate_params_binary, value_keyed_per_row, value_keyed_scalar};
+use crate::distributions::{
+    align_inputs, validate_params_binary, value_keyed_per_row, value_keyed_scalar,
+};
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
@@ -58,6 +60,7 @@ impl BetaParamsKwargs {
 /// either input propagates; invalid raises via [`build_dist`].
 #[polars_expr(output_type=Float64)]
 fn beta_params(inputs: &[Series]) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
     let a = inputs[0].cast(&DataType::Float64)?;
     let b = inputs[1].cast(&DataType::Float64)?;
 
@@ -73,6 +76,7 @@ fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
 where
     F: Fn(&Beta, f64) -> Option<f64>,
 {
+    let inputs = align_inputs(inputs)?;
     let value = inputs[0].cast(&DataType::Float64)?;
     let a = inputs[1].cast(&DataType::Float64)?;
     let b = inputs[2].cast(&DataType::Float64)?;
@@ -97,6 +101,7 @@ fn params_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
 where
     F: Fn(&Beta) -> f64,
 {
+    let inputs = align_inputs(inputs)?;
     let a = inputs[0].cast(&DataType::Float64)?;
     let b = inputs[1].cast(&DataType::Float64)?;
 
@@ -122,6 +127,7 @@ fn draw(dist: &Beta, rng: &mut impl rand::Rng) -> f64 {
 /// binomial draw, see docs/explanation/design.md).
 #[polars_expr(output_type=Float64)]
 fn beta_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
     let a = inputs[0].cast(&DataType::Float64)?;
     let b = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
@@ -173,6 +179,7 @@ fn beta_samples_scalar(
 /// Seeding and the null/error contract follow [`samples_per_row`] and [`beta_sample`].
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn beta_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
     let a = inputs[0].cast(&DataType::Float64)?;
     let b = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -6,7 +6,9 @@ use rand_distr::Binomial as BinomialSampler;
 use statrs::distribution::{Binomial, Discrete, DiscreteCDF};
 use statrs::statistics::Distribution as StatrsDistribution;
 
-use crate::distributions::{validate_params_binary, value_keyed_per_row, value_keyed_scalar};
+use crate::distributions::{
+    align_inputs, validate_params_binary, value_keyed_per_row, value_keyed_scalar,
+};
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_per_row, samples_u64_output,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
@@ -136,6 +138,7 @@ fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
 where
     F: Fn(&Binomial, f64) -> Option<f64>,
 {
+    let inputs = align_inputs(inputs)?;
     let value = inputs[0].cast(&DataType::Float64)?;
     let n = coerce_n(&inputs[1])?;
     let p = inputs[2].cast(&DataType::Float64)?;
@@ -164,6 +167,7 @@ fn params_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
 where
     F: Fn(&Binomial) -> f64,
 {
+    let inputs = align_inputs(inputs)?;
     let n = coerce_n(&inputs[0])?;
     let p = inputs[1].cast(&DataType::Float64)?;
 
@@ -194,6 +198,7 @@ fn draw(dist: &BinomialSampler, rng: &mut impl rand::Rng) -> u64 {
 /// Seeding and chunk-invariance follow [`sample_per_row_ternary`].
 #[polars_expr(output_type=UInt64)]
 fn binomial_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
     let n = coerce_n(&inputs[0])?;
     let p = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
@@ -247,6 +252,7 @@ fn binomial_samples_scalar(
 /// Seeding and the null/error contract follow [`samples_per_row`] and [`binomial_sample`].
 #[polars_expr(output_type_func_with_kwargs=samples_u64_output)]
 fn binomial_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
     let n = coerce_n(&inputs[0])?;
     let p = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
@@ -412,6 +418,7 @@ fn binomial_ppf_scalar(inputs: &[Series], kwargs: BinomialParamsKwargs) -> Polar
 /// propagates; invalid raises via [`build_dist`].
 #[polars_expr(output_type=Float64)]
 fn binomial_params(inputs: &[Series]) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
     let n = coerce_n(&inputs[0])?;
     let p = inputs[1].cast(&DataType::Float64)?;
 

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -4,7 +4,7 @@ use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::Exp;
 
-use crate::distributions::validate_params_unary;
+use crate::distributions::{align_inputs, validate_params_unary};
 use crate::rng::{
     binary_param_rows, sample_by_index, sample_per_row_binary, samples_by_index,
     samples_f64_output, samples_per_row, SampleKwargs, SampleScalarKwargs, SamplesKwargs,
@@ -72,6 +72,7 @@ fn draw(dist: &Exp, rng: &mut impl rand::Rng) -> f64 {
 /// the binomial draw, see docs/explanation/design.md).
 #[polars_expr(output_type=Float64)]
 fn exponential_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
     let rate = inputs[0].cast(&DataType::Float64)?;
     let index = inputs[1].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
@@ -121,6 +122,7 @@ fn exponential_samples_scalar(
 /// Seeding and the null/error contract follow [`samples_per_row`] and [`exponential_sample`].
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn exponential_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
     let rate = inputs[0].cast(&DataType::Float64)?;
     let index = inputs[1].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -5,7 +5,7 @@ use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::{Continuous, ContinuousCDF, LogNormal, Normal};
 
 use crate::distributions::{
-    normal, validate_params_binary, value_keyed_per_row, value_keyed_scalar,
+    align_inputs, normal, validate_params_binary, value_keyed_per_row, value_keyed_scalar,
 };
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
@@ -71,6 +71,7 @@ fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
 where
     F: Fn(&LogNormal, f64) -> Option<f64>,
 {
+    let inputs = align_inputs(inputs)?;
     let value = inputs[0].cast(&DataType::Float64)?;
     let mu = inputs[1].cast(&DataType::Float64)?;
     let sigma = inputs[2].cast(&DataType::Float64)?;
@@ -92,6 +93,7 @@ where
 /// value-keyed methods. `null` in either input propagates; invalid raises via [`build_dist`].
 #[polars_expr(output_type=Float64)]
 fn lognormal_sigma(inputs: &[Series]) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
     let mu = inputs[0].cast(&DataType::Float64)?;
     let sigma = inputs[1].cast(&DataType::Float64)?;
 
@@ -116,6 +118,7 @@ fn draw(dist: &LogNormal, rng: &mut impl rand::Rng) -> f64 {
 /// and chunk-invariance follow [`sample_per_row_ternary`].
 #[polars_expr(output_type=Float64)]
 fn lognormal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
     let mu = inputs[0].cast(&DataType::Float64)?;
     let sigma = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
@@ -167,6 +170,7 @@ fn lognormal_samples_scalar(
 /// Seeding and the null/error contract follow [`samples_per_row`] and [`lognormal_sample`].
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn lognormal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
     let mu = inputs[0].cast(&DataType::Float64)?;
     let sigma = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -6,10 +6,61 @@ pub mod lognormal;
 pub mod normal;
 pub mod uniform;
 
+use std::borrow::Cow;
+
 use polars::prelude::arity::{
     try_binary_elementwise, try_ternary_elementwise, try_unary_elementwise, unary_elementwise,
 };
 use polars::prelude::*;
+
+/// Broadcast every length-1 input to ensure all of `series` have the same length,
+/// and reject lengths that cannot align.
+///
+/// One pass over `inputs`: the first non-unit input anchors the target length, every later
+/// non-unit input must match it, and `has_unit` records whether anything needs expanding at all.
+pub(crate) fn align_inputs(inputs: &[Series]) -> PolarsResult<Cow<'_, [Series]>> {
+    let mut anchor: Option<(&Series, usize)> = None;
+    let mut has_unit = false;
+
+    for input in inputs {
+        let length = input.len();
+        if length == 1 {
+            has_unit = true;
+        } else if let Some((anchor, target_length)) = anchor {
+            polars_ensure!(
+                length == target_length,
+                ShapeMismatch:
+                "inputs have incompatible lengths: '{}' has length {} but '{}' has length {}. \
+                 Every input must share one length, or be length 1 to broadcast",
+                anchor.name(), target_length, input.name(), length
+            );
+        } else {
+            anchor = Some((input, length));
+        }
+    }
+
+    // Nothing to expand borrows instead: `anchor` is `None` when every input is length 1 (or there
+    // are none), and `has_unit` is false when the inputs already agree, which is every call whose
+    // parameters are plain columns.
+    let target_length = match anchor {
+        Some((_, target_length)) if has_unit => target_length,
+        _ => return Ok(Cow::Borrowed(inputs)),
+    };
+
+    // `target_length != 1`, so only the length-1 inputs need expanding.
+    Ok(Cow::Owned(
+        inputs
+            .iter()
+            .map(|input| {
+                if input.len() == 1 {
+                    input.new_from_index(0, target_length)
+                } else {
+                    input.clone()
+                }
+            })
+            .collect(),
+    ))
+}
 
 /// Shared driver for the constant-parameter value-keyed fast paths.
 ///

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -13,47 +13,43 @@ use polars::prelude::arity::{
 };
 use polars::prelude::*;
 
-/// Broadcast every length-1 input to ensure all of `series` have the same length,
-/// and reject lengths that cannot align.
+/// Broadcast every length-1 input up to the call's row count, and reject lengths that cannot align.
 ///
-/// One pass over `inputs`: the first non-unit input anchors the target length, every later
-/// non-unit input must match it, and `has_unit` records whether anything needs expanding at all.
+/// The row count is the one input length that is not 1, so length-1 inputs never set it: an
+/// all-length-1 call stays length 1, and a 0-row frame beside a `pl.lit` stays empty.
 pub(crate) fn align_inputs(inputs: &[Series]) -> PolarsResult<Cow<'_, [Series]>> {
-    let mut anchor: Option<(&Series, usize)> = None;
-    let mut has_unit = false;
+    let mut anchor: Option<&Series> = None;
+    let mut needs_broadcast = false;
 
     for input in inputs {
-        let length = input.len();
-        if length == 1 {
-            has_unit = true;
-        } else if let Some((anchor, target_length)) = anchor {
+        if input.len() == 1 {
+            needs_broadcast = true;
+        } else if let Some(anchor) = anchor {
             polars_ensure!(
-                length == target_length,
+                input.len() == anchor.len(),
                 ShapeMismatch:
                 "inputs have incompatible lengths: '{}' has length {} but '{}' has length {}. \
                  Every input must share one length, or be length 1 to broadcast",
-                anchor.name(), target_length, input.name(), length
+                anchor.name(), anchor.len(), input.name(), input.len()
             );
         } else {
-            anchor = Some((input, length));
+            anchor = Some(input);
         }
     }
 
-    // Nothing to expand borrows instead: `anchor` is `None` when every input is length 1 (or there
-    // are none), and `has_unit` is false when the inputs already agree, which is every call whose
-    // parameters are plain columns.
-    let target_length = match anchor {
-        Some((_, target_length)) if has_unit => target_length,
+    // Borrow when there is nothing to expand: no anchor means every input is already length 1, and
+    // `!needs_broadcast` means they already agree, which is every call whose parameters are columns.
+    let row_count = match anchor {
+        Some(anchor) if needs_broadcast => anchor.len(),
         _ => return Ok(Cow::Borrowed(inputs)),
     };
 
-    // `target_length != 1`, so only the length-1 inputs need expanding.
     Ok(Cow::Owned(
         inputs
             .iter()
             .map(|input| {
                 if input.len() == 1 {
-                    input.new_from_index(0, target_length)
+                    input.new_from_index(0, row_count)
                 } else {
                     input.clone()
                 }

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -8,7 +8,9 @@ use statrs::distribution::{Continuous, ContinuousCDF, Normal};
 use statrs::function::erf;
 use statrs::statistics::Distribution as StatrsDistribution;
 
-use crate::distributions::{validate_params_binary, value_keyed_per_row, value_keyed_scalar};
+use crate::distributions::{
+    align_inputs, validate_params_binary, value_keyed_per_row, value_keyed_scalar,
+};
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
@@ -60,6 +62,7 @@ impl NormalParamsKwargs {
 /// value-keyed methods. `null` in either input propagates; invalid raises via [`build_dist`].
 #[polars_expr(output_type=Float64)]
 fn normal_sigma(inputs: &[Series]) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
     let mu = inputs[0].cast(&DataType::Float64)?;
     let sigma = inputs[1].cast(&DataType::Float64)?;
 
@@ -75,6 +78,7 @@ fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
 where
     F: Fn(&Normal, f64) -> Option<f64>,
 {
+    let inputs = align_inputs(inputs)?;
     let value = inputs[0].cast(&DataType::Float64)?;
     let mu = inputs[1].cast(&DataType::Float64)?;
     let sigma = inputs[2].cast(&DataType::Float64)?;
@@ -104,6 +108,7 @@ fn draw(dist: &Normal, rng: &mut impl rand::Rng) -> f64 {
 /// and chunk-invariance follow [`sample_per_row_ternary`].
 #[polars_expr(output_type=Float64)]
 fn normal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
     let mu = inputs[0].cast(&DataType::Float64)?;
     let sigma = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
@@ -155,6 +160,7 @@ fn normal_samples_scalar(
 /// Seeding and the null/error contract follow [`samples_per_row`] and [`normal_sample`].
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn normal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
     let mu = inputs[0].cast(&DataType::Float64)?;
     let sigma = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -4,7 +4,7 @@ use pyo3_polars::derive::polars_expr;
 use rand::distr::{Distribution, StandardUniform};
 use statrs::distribution::Uniform;
 
-use crate::distributions::validate_params_binary;
+use crate::distributions::{align_inputs, validate_params_binary};
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
@@ -89,6 +89,7 @@ fn draw_half_open(lo: f64, hi: f64, rng: &mut impl rand::Rng) -> f64 {
 /// [`draw_half_open`] draws from.
 #[polars_expr(output_type=Float64)]
 fn uniform_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
     let min = inputs[0].cast(&DataType::Float64)?;
     let max = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
@@ -147,6 +148,7 @@ fn uniform_samples_scalar(
 /// draw is the shared [`draw_half_open`].
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn uniform_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
     let min = inputs[0].cast(&DataType::Float64)?;
     let max = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
@@ -175,6 +177,7 @@ fn uniform_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Ser
 /// silently producing a negative or infinite result.
 #[polars_expr(output_type=Float64)]
 fn uniform_range(inputs: &[Series]) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
     let min = inputs[0].cast(&DataType::Float64)?;
     let max = inputs[1].cast(&DataType::Float64)?;
 

--- a/tests/_polars_compat.py
+++ b/tests/_polars_compat.py
@@ -28,13 +28,36 @@ from polars.testing import assert_series_equal as _assert_series_equal
 if TYPE_CHECKING:
     from polars import DataFrame, LazyFrame, Series
 
-__all__ = ("arr_explode", "assert_frame_equal", "assert_series_equal", "linear_space")
+__all__ = (
+    "PARTITIONED_BROADCAST_AVAILABLE",
+    "arr_explode",
+    "assert_frame_equal",
+    "assert_series_equal",
+    "linear_space",
+)
 
 PL_VERSION = Version(pl.__version__)
 _NEEDS_RENAMING = Version("1.32.3") > PL_VERSION
 _REL_NAME = "rtol" if _NEEDS_RENAMING else "rel_tol"
 _ABS_NAME = "atol" if _NEEDS_RENAMING else "abs_tol"
 _EXPLODE_HAS_EMPTY_AS_NULL = Version("1.36.0") <= PL_VERSION
+
+PARTITIONED_BROADCAST_AVAILABLE = Version("1.34.0") <= PL_VERSION
+"""Whether polars handles a length-1 input *inside* `over` / `group_by().agg()` correctly.
+
+`align_inputs` broadcasts a length-1 plugin input on every supported version, and a plain `select` /
+`with_columns` is correct throughout. Partitioned contexts are not before polars v1.34, and the two
+upstream defects are the reason the partition suites are gated rather than the broadcast itself:
+
+* an expression whose plugin inputs are **all** length 1 panics under `over` / `group_by().agg()`
+  (`impl error, should be a list at this point`). Broken through 1.33, fixed in 1.34;
+* a length-1 *value* (`pl.col("x").max()`) beside length-n parameters makes `over` return results in
+  group order instead of scattering back to row order. Broken through 1.32, fixed in 1.33.
+
+Both are polars defects, not plugin defects: the same expressions are correct on 1.34 and above with
+an unchanged plugin. Documented for users in `docs/reference/parameters-and-contracts.md`.
+When the polars floor reaches 1.34 this constant and every gate on it can be deleted.
+"""
 
 
 def arr_explode(series: Series) -> Series:

--- a/tests/distributions/broadcast_test.py
+++ b/tests/distributions/broadcast_test.py
@@ -10,7 +10,7 @@ import pytest
 from polars_stats import Binomial, Normal
 from polars_stats.distributions._base import ContinuousDistribution, DiscreteDistribution
 from tests._polars_compat import PARTITIONED_BROADCAST_AVAILABLE, assert_series_equal, linear_space
-from tests.property._specs import ALL_SPECS, ULP_ABS_TOL, ULP_REL_TOL
+from tests.property._specs import ALL_SPECS, SERIES_ROWS, ULP_ABS_TOL, ULP_REL_TOL
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -152,6 +152,29 @@ def test_sampler_draws_differ_per_row_under_literals(spec: DistSpec) -> None:
         height=_ROWS,
         exact=True,
     )
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@pytest.mark.parametrize("method", ["sample", "samples"])
+def test_sampler_reseeds_when_a_parameter_outruns_the_frame(spec: DistSpec, method: str) -> None:
+    """A parameter longer than the frame sets the row count, and every row still gets its own seed.
+
+    The row index is the *shorter* input here, and broadcasting it like a parameter would return one
+    draw repeated at the right height, with no error.
+    """
+    call: Callable[[_UnivariateDistribution], pl.Expr] = (
+        (lambda d: d.sample(seed=0)) if method == "sample" else (lambda d: d.samples(size=2, seed=0))
+    )
+    one_row = pl.DataFrame({"a": [0]})
+    drawn = one_row.select(r=call(spec.make_series(spec.example)))["r"]
+
+    assert drawn.len() == SERIES_ROWS
+    assert drawn.n_unique() > 1, "a broadcast row index would seed every row identically"
+
+    # Bit-equal to the frame-shaped spelling, so the index really is `0..n` and not merely non-constant.
+    full_length = pl.DataFrame({"a": range(SERIES_ROWS)})
+    expected = full_length.select(r=call(spec.make_columns(spec.example)))["r"]
+    assert_series_equal(drawn, expected, check_exact=True)
 
 
 @pytest.mark.parametrize("reducer", ["first", "max"])

--- a/tests/distributions/broadcast_test.py
+++ b/tests/distributions/broadcast_test.py
@@ -1,0 +1,293 @@
+"""Row-alignment contract: a length-1 input expression broadcasts, it does not drop rows."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+
+from polars_stats import Binomial, Normal
+from polars_stats.distributions._base import ContinuousDistribution, DiscreteDistribution
+from tests._polars_compat import assert_series_equal, linear_space
+from tests.property._specs import ALL_SPECS, ULP_ABS_TOL, ULP_REL_TOL
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from polars_stats.distributions._base import _UnivariateDistribution
+    from tests.property._specs import DistSpec
+
+_ROWS = 4096
+_GROUPS = 4
+"""`_ROWS` is divisible by it, so no partition is empty."""
+
+_VALUE_METHODS: tuple[tuple[str, str], ...] = (
+    ("density", "x"),
+    ("log_density", "x"),
+    ("cdf", "x"),
+    ("log_cdf", "x"),
+    ("sf", "x"),
+    ("log_sf", "x"),
+    ("ppf", "q"),
+    ("isf", "q"),
+)
+"""Every value-keyed method, with the column whose domain it accepts (`x` a support point, `q` a quantile)."""
+
+_SAMPLERS: tuple[tuple[str, None], ...] = (("sample", None), ("samples", None))
+"""The two sampler funnels. `None` marks "no value argument", which is also the bit-exact axis."""
+
+_ALL_METHODS = _VALUE_METHODS + _SAMPLERS
+
+
+def _frame(spec: DistSpec) -> pl.DataFrame:
+    """A `_ROWS`-row frame: support points in the spec's evaluation window, quantiles, a partition key."""
+    lo, hi = spec.eval_range(spec.example)
+    return pl.DataFrame(
+        {
+            "x": linear_space(lo, hi, _ROWS),
+            "q": linear_space(1e-3, 1.0 - 1e-3, _ROWS),
+            "g": pl.int_range(0, _ROWS, eager=True) % _GROUPS,
+        }
+    )
+
+
+_FRAMES = {spec.name: _frame(spec) for spec in ALL_SPECS}
+"""One frame per spec, built once: no test mutates it."""
+
+
+def _call(spec: DistSpec, dist: _UnivariateDistribution, method: str, value: pl.Expr | None) -> pl.Expr:
+    """One public method by name: a value-keyed call on `value`, or a seeded draw when `value` is `None`."""
+    if value is None:
+        return dist.sample(seed=0) if method == "sample" else dist.samples(size=3, seed=0)
+    if method == "density":
+        return spec.density(dist, value)
+    if method == "log_density":
+        if isinstance(dist, ContinuousDistribution):
+            return dist.log_pdf(value)
+        if isinstance(dist, DiscreteDistribution):
+            return dist.log_pmf(value)
+        msg = f"unsupported distribution family: {type(dist)}"  # pragma: no cover
+        raise TypeError(msg)  # pragma: no cover
+    call: Callable[[pl.Expr], pl.Expr] = getattr(dist, method)
+    return call(value)
+
+
+def _assert_same_rows(frame: pl.DataFrame, got: pl.Expr, want: pl.Expr, *, height: int, exact: bool = False) -> None:
+    """`got` and `want` evaluate to the same `height` rows, element for element."""
+    left = frame.select(got.alias("r"))["r"]
+    right = frame.select(want.alias("r"))["r"]
+    assert left.len() == height, f"expected {height} rows, got {left.len()}"
+    assert_series_equal(left, right, check_exact=exact, rel_tol=ULP_REL_TOL, abs_tol=ULP_ABS_TOL)
+
+
+def _assert_same_partitions(frame: pl.DataFrame, got: pl.Expr, want: pl.Expr, *, exact: bool = False) -> None:
+    """`got` and `want` agree under both partition contexts, where `pl.len()` is the partition's length."""
+    assert_series_equal(
+        frame.with_columns(r=got.over("g"))["r"],
+        frame.with_columns(r=want.over("g"))["r"],
+        check_exact=exact,
+        rel_tol=ULP_REL_TOL,
+        abs_tol=ULP_ABS_TOL,
+    )
+    grouped = frame.group_by("g", maintain_order=True).agg(got=got, want=want)
+    assert_series_equal(
+        grouped["got"], grouped["want"], check_names=False, check_exact=exact, rel_tol=ULP_REL_TOL, abs_tol=ULP_ABS_TOL
+    )
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@pytest.mark.parametrize(("method", "column"), _ALL_METHODS)
+def test_length_one_parameters_broadcast(spec: DistSpec, method: str, column: str | None) -> None:
+    """Length-1 parameters give the same rows as the same constants at full length, on every method."""
+    frame = _FRAMES[spec.name]
+    value = None if column is None else pl.col(column)
+    broadcast, full_length = spec.make_literals(spec.example), spec.make_columns(spec.example)
+
+    _assert_same_rows(
+        frame,
+        _call(spec, broadcast, method, value),
+        _call(spec, full_length, method, value),
+        height=_ROWS,
+        exact=column is None,
+    )
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@pytest.mark.parametrize(("method", "column"), _VALUE_METHODS)
+def test_length_one_value_broadcasts(spec: DistSpec, method: str, column: str) -> None:
+    """A length-1 *value* gives the same rows as the same value at full length, on every method."""
+    frame = _FRAMES[spec.name]
+    dist = spec.make_columns(spec.example)
+    scalar = frame[column][0]
+
+    _assert_same_rows(
+        frame,
+        _call(spec, dist, method, pl.lit(scalar)),
+        _call(spec, dist, method, pl.repeat(scalar, n=pl.len())),
+        height=_ROWS,
+    )
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+def test_sampler_draws_differ_per_row_under_literals(spec: DistSpec) -> None:
+    """All-literal parameters still draw *per row*, and draw what the fast path draws.
+
+    The load-bearing test in this file: a broadcast applied to the plugin's *result* rather than its *inputs*
+    would return a constant column at the right height and pass everything else here.
+    """
+    frame = _FRAMES[spec.name]
+    drawn = frame.select(r=spec.make_literals(spec.example).sample(seed=0))["r"]
+    assert drawn.n_unique() > 1, "a broadcast result would make every row identical"
+    _assert_same_rows(
+        frame,
+        spec.make_literals(spec.example).sample(seed=0),
+        spec.make(spec.example).sample(seed=0),
+        height=_ROWS,
+        exact=True,
+    )
+
+
+@pytest.mark.parametrize("reducer", ["first", "max"])
+def test_reduced_value_expressions_broadcast(reducer: str) -> None:
+    """A reduced value is length 1 too, so the alignment is by length, not by expression kind.
+
+    `expr.meta.is_literal()` catches `pl.lit` and misses both of these. One distribution suffices: the
+    spelling is what is under test.
+    """
+    frame = _FRAMES["normal"]
+    dist = Normal(mu=pl.repeat(1.5, n=pl.len()), sigma=pl.repeat(2.0, n=pl.len()))
+    scalar = getattr(frame["x"], reducer)()
+
+    _assert_same_rows(
+        frame,
+        dist.cdf(getattr(pl.col("x"), reducer)()),
+        dist.cdf(pl.repeat(scalar, n=pl.len())),
+        height=_ROWS,
+    )
+
+
+@pytest.mark.parametrize("moment", ["mean", "variance", "std", "median", "entropy"])
+def test_length_one_parameter_beside_a_column_moment(moment: str) -> None:
+    """A length-1 parameter beside a full-length one gives a full-length moment.
+
+    With *every* parameter length 1 the moment is legitimately a scalar column instead, which is `pl.lit`'s
+    own semantics and is pinned by `tests/property/moment_test.py`.
+    """
+    mixed = Normal(mu=pl.lit(1.5), sigma=pl.repeat(2.0, n=pl.len()))
+    full_length = Normal(mu=pl.repeat(1.5, n=pl.len()), sigma=pl.repeat(2.0, n=pl.len()))
+
+    _assert_same_rows(_FRAMES["normal"], getattr(mixed, moment)(), getattr(full_length, moment)(), height=_ROWS)
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@pytest.mark.parametrize(("method", "column"), _ALL_METHODS)
+def test_zero_row_frame_stays_empty(spec: DistSpec, method: str, column: str | None) -> None:
+    """A length-1 input over a 0-row frame yields 0 rows, not 1.
+
+    Every method here keeps one full-length input (the value column, or the sampler's row index), so this is
+    not the all-constant case, which is one row by design.
+    """
+    empty = _FRAMES[spec.name].head(0)
+    value = None if column is None else pl.col(column)
+
+    assert empty.select(_call(spec, spec.make_literals(spec.example), method, value).alias("r")).height == 0
+
+
+def test_mismatched_lengths_raise() -> None:
+    """Lengths that are neither equal nor 1 have no defined broadcast, so they raise.
+
+    Only the in-memory engine surfaces `align_inputs`' own message, which names both lengths; the streaming
+    engine rejects the shape in its own zip node first, so only the raise itself is common to both.
+    """
+    frame = pl.DataFrame({"x": [0.0, 1.0, 2.0, 3.0], "p": [0.5] * 4})
+    mismatched = Binomial(n=pl.Series("n", [1, 2, 3]), p=pl.col("p")).pmf(pl.col("x"))
+
+    with pytest.raises(pl.exceptions.PolarsError):
+        frame.select(mismatched)
+
+    with pytest.raises(pl.exceptions.ComputeError, match=r"length 3.*length 4|length 4.*length 3"):
+        frame.lazy().select(mismatched).collect(engine="in-memory")
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+def test_partition_contexts_broadcast_length_one_parameters(spec: DistSpec) -> None:
+    """Under `over` and `group_by().agg()`, length-1 parameters broadcast to the *partition* length."""
+    x = pl.col("x")
+    _assert_same_partitions(
+        _FRAMES[spec.name],
+        spec.density(spec.make_literals(spec.example), x),
+        spec.density(spec.make_columns(spec.example), x),
+    )
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+def test_partition_contexts_broadcast_a_partition_local_value(spec: DistSpec) -> None:
+    """A value reduced *within* the partition is the case a fix written against whole-frame length survives."""
+    dist = spec.make_columns(spec.example)
+    reduced = pl.col("x").max()
+    _assert_same_partitions(
+        _FRAMES[spec.name], spec.density(dist, reduced), spec.density(dist, pl.repeat(reduced, n=pl.len()))
+    )
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+def test_partition_contexts_keep_sampler_bit_equality(spec: DistSpec) -> None:
+    """The sampler funnel keeps its per-row seed under partitioning, where the row index is partition-local."""
+    _assert_same_partitions(
+        _FRAMES[spec.name],
+        spec.make_literals(spec.example).sample(seed=0),
+        spec.make_columns(spec.example).sample(seed=0),
+        exact=True,
+    )
+
+
+def test_multi_chunk_frame_broadcasts() -> None:
+    """A broadcast input is single-chunk; the column it is zipped against need not be.
+
+    `try_*_elementwise` calls `align_chunks_*` itself and the `*_param_rows` iterators walk chunks in order,
+    so length alignment is all the funnels owe. Nothing else pinned that.
+    """
+    parts = [pl.DataFrame({"x": [float(i) for i in range(k, k + 8)]}) for k in (0, 8, 16)]
+    chunked = pl.concat(parts, rechunk=False)
+    assert chunked.n_chunks() > 1
+
+    broadcast = Binomial(n=pl.lit(20, dtype=pl.Int64), p=pl.lit(0.3)).pmf("x")
+    full_length = Binomial(n=pl.repeat(20, n=pl.len(), dtype=pl.Int64), p=pl.repeat(0.3, n=pl.len())).pmf("x")
+    _assert_same_rows(chunked, broadcast, full_length, height=chunked.height, exact=True)
+    assert_series_equal(chunked.select(r=broadcast)["r"], chunked.rechunk().select(r=broadcast)["r"], check_exact=True)
+
+
+@pytest.mark.parametrize(
+    ("n", "message"),
+    [
+        (pl.lit(5.0), "n must be an integer column"),
+        (pl.lit(-5, dtype=pl.Int64), "n must be a non-negative integer"),
+    ],
+)
+def test_broadcast_n_still_rejects_a_bad_dtype(n: pl.Expr, message: str) -> None:
+    """Alignment runs *before* the cast, so `coerce_n` judges the expanded column and still rejects it.
+
+    `n` is the one parameter whose cast can reject, so it is the one place the order is observable.
+    """
+    frame = pl.DataFrame({"x": [0.0, 1.0, 2.0, 3.0], "p": [0.5] * 4})
+
+    with pytest.raises(pl.exceptions.ComputeError, match=message):
+        frame.select(r=Binomial(n=n, p="p").pmf("x"))
+
+
+def test_broadcast_n_propagates_nulls_and_widens() -> None:
+    """A null length-1 `n` nulls every row, and a `UInt64` one passes the widening cast unchanged."""
+    frame = pl.DataFrame({"x": [0.0, 1.0, 2.0, 3.0], "p": [0.5] * 4})
+
+    nulls = frame.select(r=Binomial(n=pl.lit(None, dtype=pl.Int64), p="p").pmf("x"))["r"]
+    assert nulls.len() == frame.height
+    assert nulls.null_count() == frame.height
+
+    _assert_same_rows(
+        frame,
+        Binomial(n=pl.lit(5, dtype=pl.UInt64), p="p").pmf("x"),
+        Binomial(n=pl.repeat(5, n=pl.len(), dtype=pl.UInt64), p="p").pmf("x"),
+        height=frame.height,
+        exact=True,
+    )

--- a/tests/distributions/broadcast_test.py
+++ b/tests/distributions/broadcast_test.py
@@ -9,7 +9,12 @@ import pytest
 
 from polars_stats import Binomial, Normal
 from polars_stats.distributions._base import ContinuousDistribution, DiscreteDistribution
-from tests._polars_compat import PARTITIONED_BROADCAST_AVAILABLE, assert_series_equal, linear_space
+from tests._polars_compat import (
+    PARTITIONED_BROADCAST_AVAILABLE,
+    arr_explode,
+    assert_series_equal,
+    linear_space,
+)
 from tests.property._specs import ALL_SPECS, SERIES_ROWS, ULP_ABS_TOL, ULP_REL_TOL
 
 if TYPE_CHECKING:
@@ -169,7 +174,9 @@ def test_sampler_reseeds_when_a_parameter_outruns_the_frame(spec: DistSpec, meth
     drawn = one_row.select(r=call(spec.make_series(spec.example)))["r"]
 
     assert drawn.len() == SERIES_ROWS
-    assert drawn.n_unique() > 1, "a broadcast row index would seed every row identically"
+    # `samples` returns `Array`, whose `n_unique` the oldest supported polars does not implement.
+    per_draw = arr_explode(drawn) if method == "samples" else drawn
+    assert per_draw.n_unique() > 1, "a broadcast row index would seed every row identically"
 
     # Bit-equal to the frame-shaped spelling, so the index really is `0..n` and not merely non-constant.
     full_length = pl.DataFrame({"a": range(SERIES_ROWS)})

--- a/tests/distributions/broadcast_test.py
+++ b/tests/distributions/broadcast_test.py
@@ -9,7 +9,7 @@ import pytest
 
 from polars_stats import Binomial, Normal
 from polars_stats.distributions._base import ContinuousDistribution, DiscreteDistribution
-from tests._polars_compat import assert_series_equal, linear_space
+from tests._polars_compat import PARTITIONED_BROADCAST_AVAILABLE, assert_series_equal, linear_space
 from tests.property._specs import ALL_SPECS, ULP_ABS_TOL, ULP_REL_TOL
 
 if TYPE_CHECKING:
@@ -54,6 +54,12 @@ def _frame(spec: DistSpec) -> pl.DataFrame:
 
 _FRAMES = {spec.name: _frame(spec) for spec in ALL_SPECS}
 """One frame per spec, built once: no test mutates it."""
+
+_needs_partitioned_broadcast = pytest.mark.skipif(
+    not PARTITIONED_BROADCAST_AVAILABLE,
+    reason="polars < 1.34 mishandles a length-1 input inside over / group_by().agg()",
+)
+"""Gate for the two partition suites below. The plain-`select` suites run on every supported version."""
 
 
 def _call(spec: DistSpec, dist: _UnivariateDistribution, method: str, value: pl.Expr | None) -> pl.Expr:
@@ -197,19 +203,24 @@ def test_zero_row_frame_stays_empty(spec: DistSpec, method: str, column: str | N
 def test_mismatched_lengths_raise() -> None:
     """Lengths that are neither equal nor 1 have no defined broadcast, so they raise.
 
-    Only the in-memory engine surfaces `align_inputs`' own message, which names both lengths; the streaming
-    engine rejects the shape in its own zip node first, so only the raise itself is common to both.
+    *Which layer* rejects the shape is a polars scheduling detail that moves with the version and the engine:
+    `align_inputs` names both lengths, while polars' own zip node reports `non-equal length inputs` when it
+    gets there first. Both are correct rejections, so the message is matched loosely and the raise itself,
+    which is the contract, is asserted strictly. `engine=` is deliberately not passed: `"in-memory"` is not a
+    valid engine name on the oldest supported polars.
     """
     frame = pl.DataFrame({"x": [0.0, 1.0, 2.0, 3.0], "p": [0.5] * 4})
     mismatched = Binomial(n=pl.Series("n", [1, 2, 3]), p=pl.col("p")).pmf(pl.col("x"))
+    message = r"incompatible lengths|non-equal length"
 
-    with pytest.raises(pl.exceptions.PolarsError):
+    with pytest.raises(pl.exceptions.PolarsError, match=message):
         frame.select(mismatched)
 
-    with pytest.raises(pl.exceptions.ComputeError, match=r"length 3.*length 4|length 4.*length 3"):
-        frame.lazy().select(mismatched).collect(engine="in-memory")
+    with pytest.raises(pl.exceptions.PolarsError, match=message):
+        frame.lazy().select(mismatched).collect()
 
 
+@_needs_partitioned_broadcast
 @pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
 def test_partition_contexts_broadcast_length_one_parameters(spec: DistSpec) -> None:
     """Under `over` and `group_by().agg()`, length-1 parameters broadcast to the *partition* length."""
@@ -221,6 +232,7 @@ def test_partition_contexts_broadcast_length_one_parameters(spec: DistSpec) -> N
     )
 
 
+@_needs_partitioned_broadcast
 @pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
 def test_partition_contexts_broadcast_a_partition_local_value(spec: DistSpec) -> None:
     """A value reduced *within* the partition is the case a fix written against whole-frame length survives."""

--- a/tests/distributions/moment_fast_path_test.py
+++ b/tests/distributions/moment_fast_path_test.py
@@ -14,11 +14,10 @@ this module pins the parts that test does not reach:
   accept or reject something the per-row path does not. Unlike the value-keyed fast-path test, this
   covers `Uniform` and `Bernoulli` too: their moments *do* route through a validator, so the scalar
   path can drift there.
-* **The validator runs once but only when there is work.** Because the scalar validator rides as a
-  *gated* length-1 plugin input (not as kwargs), an empty frame skips it entirely: both paths return
-  an empty column and neither raises. This differs from the value-keyed fast path, whose kwargs
-  validation raises even on a zero-row frame (`value_keyed_fast_path_test.py`); it is pinned here so
-  the asymmetry is intentional and cannot regress silently.
+* **The validator runs once, whatever the frame height.** A length-1 plugin input exists independently
+  of the frame, so an empty frame still validates and an invalid scalar parameterisation still raises,
+  matching the value-keyed kwargs fast path (`value_keyed_fast_path_test.py`). The scalar moment is then
+  one row on a zero-row frame while the per-row path is empty; that asymmetry is pinned here.
 
 A Python `None` parameter cannot reach either path (`coerce_param` rejects it at construction), so
 there is no null-scalar case here. Binomial's `n = -1` is absent for the same reason: `coerce_n` raises
@@ -90,9 +89,11 @@ def test_scalar_and_column_paths_agree_on_validation(
         with pytest.raises(pl.exceptions.ComputeError):
             frame.select(r=per_row.variance())
     else:
-        fast = frame.select(r=scalar.variance())["r"]
-        slow = frame.select(r=per_row.variance())["r"]
-        assert_series_equal(fast, slow, check_exact=True)
+        # A scalar column beside the per-row column: polars broadcasts it, and every row must agree.
+        both = frame.select(fast=scalar.variance(), slow=per_row.variance())
+        assert frame.select(r=scalar.variance()).height == 1
+        assert both.height == frame.height
+        assert_series_equal(both["fast"], both["slow"], check_names=False, check_exact=True)
 
 
 @pytest.mark.parametrize(
@@ -113,23 +114,24 @@ def test_binomial_entropy_scalar_and_column_paths_agree_on_validation(scalar: Bi
         frame.select(r=per_row.entropy())
 
 
-def test_moment_fast_path_on_empty_frame_matches_per_row() -> None:
-    """On a zero-row frame, valid scalar params give an empty column matching the per-row path.
+def test_moment_fast_path_on_empty_frame_is_a_scalar() -> None:
+    """On a zero-row frame the scalar moment is still one row, and still validates.
 
-    The invalid-parameter case on an empty frame is deliberately *not* asserted. Unlike the
-    value-keyed fast path (whose kwargs validation raises unconditionally, pinned by
-    `value_keyed_fast_path_test.py`), the moment fast path validates via a *gated* length-1 plugin
-    input, and whether polars evaluates that input when the gated output is empty is
-    optimizer-dependent: some versions elide it and return empty, others run it and raise. Both are
-    acceptable for an invalid parameterisation over zero rows, so it is left unspecified rather than
-    pinned to one version's behaviour.
+    Both follow from the scalar path being built from length-1 literals, exactly as
+    `df.head(0).select(pl.lit(1.0))` is one row. The per-row path validates inside its row closure,
+    which never runs on an empty frame, so it returns empty without raising.
     """
     empty = pl.DataFrame({"_": []}, schema={"_": pl.Int64})
 
     valid_fast = empty.select(r=Normal(0.0, 2.0).variance())
     valid_slow = empty.select(r=Normal(_col(0.0), _col(2.0)).variance())
-    assert valid_fast.height == 0
-    assert_series_equal(valid_fast["r"], valid_slow["r"], check_exact=True)
+    assert valid_fast.height == 1
+    assert valid_fast["r"].to_list() == [4.0]
+    assert valid_slow.height == 0
+
+    with pytest.raises(pl.exceptions.ComputeError):
+        empty.select(r=Normal(0.0, -1.0).variance())
+    assert empty.select(r=Normal(_col(0.0), _col(-1.0)).variance()).height == 0
 
 
 # id -> (scalar instance, equivalent per-row instance, expected constant moment value). Degenerate
@@ -152,7 +154,7 @@ def test_degenerate_valid_params_entropy(
     """Mass-collapsing endpoints (`p in {0, 1}`, `n = 0`) give a finite entropy on both paths."""
     frame = pl.DataFrame({"_": range(4)})
 
-    fast = frame.select(r=scalar.entropy())["r"]
-    slow = frame.select(r=per_row.entropy())["r"]
-    assert_series_equal(fast, slow, check_exact=True)
-    assert fast.to_list() == [expected] * 4
+    assert frame.select(r=scalar.entropy())["r"].to_list() == [expected]
+    both = frame.select(fast=scalar.entropy(), slow=per_row.entropy())
+    assert_series_equal(both["fast"], both["slow"], check_names=False, check_exact=True)
+    assert both["slow"].to_list() == [expected] * 4

--- a/tests/distributions/output_name_test.py
+++ b/tests/distributions/output_name_test.py
@@ -79,7 +79,7 @@ def test_value_keyed_keeps_value_root_name(dist: _UnivariateDistribution) -> Non
 
     Only the output name is pinned: how a downstream `.name.*` modifier resolves it is polars'
     call and differs across supported versions (old polars resolves the *root* name, which for the
-    closed-form hooks is the `pl.len()` inside a scalar parameter's `pl.repeat` expansion).
+    closed-form hooks is a scalar parameter's `pl.lit`).
     """
     assert _FRAME.select(dist.cdf(pl.col("p"))).columns == ["p"]
 

--- a/tests/property/_specs.py
+++ b/tests/property/_specs.py
@@ -33,6 +33,19 @@ def _lit(value: float, dtype: PolarsDataType | None = None) -> pl.Expr:
     return pl.lit(value, dtype=dtype)
 
 
+SERIES_ROWS = 64
+"""Length of a `_series` parameter. Longer than any frame a test evaluates it on, and long enough that
+a per-row seeded sampler will not repeat one value by chance."""
+
+
+def _series(value: float, dtype: PolarsDataType | None = None) -> pl.Expr:
+    """The same constant as `_col` but a fixed-length `pl.Series` literal, independent of frame height.
+
+    `_col` follows `pl.len()` and can never outrun the frame. This one can, so the sampler's row
+    index is the *shorter* input."""
+    return pl.lit(pl.Series([value] * SERIES_ROWS, dtype=dtype))
+
+
 def _finite(min_value: float, max_value: float) -> SearchStrategy[float]:
     """Bounded, non-degenerate floats (no NaN/inf), the only inputs a parameter sweep should explore."""
     return st.floats(min_value=min_value, max_value=max_value, allow_nan=False, allow_infinity=False)
@@ -60,6 +73,8 @@ class DistSpec:
             assert the per-row path's null contract without knowing the distribution's parameter names.
         make_literals: Like `make_columns`, but every parameter is a length-1 `pl.lit`, so the plugin has to
             broadcast. Must agree with `make_columns` row for row.
+        make_series: Like `make_columns`, but every parameter is a `SERIES_ROWS`-long `pl.Series` literal, so
+            the parameters outrun the frame and set the call's row count.
         example: One valid parameterisation, for tests that need a fixed frame rather than a sweep.
         density: `pdf` or `pmf` as `(dist, expr) -> expr`. Typed loosely because the method differs by family;
             the concrete distribution is fixed per spec.
@@ -76,6 +91,7 @@ class DistSpec:
     make_columns: Callable[[tuple[float, ...]], _UnivariateDistribution]
     make_masked: Callable[[tuple[float, ...], pl.Expr], _UnivariateDistribution]
     make_literals: Callable[[tuple[float, ...]], _UnivariateDistribution]
+    make_series: Callable[[tuple[float, ...]], _UnivariateDistribution]
     example: tuple[float, ...]
     density: Callable[[Any, pl.Expr], pl.Expr]
     eval_range: Callable[[tuple[float, ...]], tuple[float, float]]
@@ -91,6 +107,7 @@ _BERNOULLI = DistSpec(
     make_columns=lambda p: Bernoulli(p=_col(p[0])),
     make_masked=lambda p, m: Bernoulli(p=pl.when(~m).then(_col(p[0]))),
     make_literals=lambda p: Bernoulli(p=_lit(p[0])),
+    make_series=lambda p: Bernoulli(p=_series(p[0])),
     example=(0.3,),
     density=lambda d, c: d.pmf(c),
     eval_range=lambda _: (-1.0, 2.0),
@@ -107,6 +124,7 @@ _BINOMIAL = DistSpec(
     make_columns=lambda p: Binomial(n=_col(int(p[0]), pl.Int64()), p=_col(p[1])),
     make_masked=lambda p, m: Binomial(n=pl.when(~m).then(_col(int(p[0]), pl.Int64())), p=_col(p[1])),
     make_literals=lambda p: Binomial(n=_lit(int(p[0]), pl.Int64()), p=_lit(p[1])),
+    make_series=lambda p: Binomial(n=_series(int(p[0]), pl.Int64()), p=_series(p[1])),
     example=(7, 0.35),
     density=lambda d, c: d.pmf(c),
     eval_range=lambda p: (-1.0, p[0] + 1.0),
@@ -121,6 +139,7 @@ _NORMAL = DistSpec(
     make_columns=lambda p: Normal(mu=_col(p[0]), sigma=_col(p[1])),
     make_masked=lambda p, m: Normal(mu=pl.when(~m).then(_col(p[0])), sigma=_col(p[1])),
     make_literals=lambda p: Normal(mu=_lit(p[0]), sigma=_lit(p[1])),
+    make_series=lambda p: Normal(mu=_series(p[0]), sigma=_series(p[1])),
     example=(1.5, 2.0),
     density=lambda d, c: d.pdf(c),
     eval_range=lambda p: (p[0] - 6.0 * p[1], p[0] + 6.0 * p[1]),
@@ -137,6 +156,7 @@ _UNIFORM = DistSpec(
     make_columns=lambda p: Uniform(min=_col(p[0]), max=_col(p[1])),
     make_masked=lambda p, m: Uniform(min=pl.when(~m).then(_col(p[0])), max=_col(p[1])),
     make_literals=lambda p: Uniform(min=_lit(p[0]), max=_lit(p[1])),
+    make_series=lambda p: Uniform(min=_series(p[0]), max=_series(p[1])),
     example=(-1.0, 3.0),
     density=lambda d, c: d.pdf(c),
     eval_range=lambda p: (p[0] - 0.5 * (p[1] - p[0]), p[1] + 0.5 * (p[1] - p[0])),
@@ -154,6 +174,7 @@ _LOGNORMAL = DistSpec(
     make_columns=lambda p: LogNormal(mu=_col(p[0]), sigma=_col(p[1])),
     make_masked=lambda p, m: LogNormal(mu=pl.when(~m).then(_col(p[0])), sigma=_col(p[1])),
     make_literals=lambda p: LogNormal(mu=_lit(p[0]), sigma=_lit(p[1])),
+    make_series=lambda p: LogNormal(mu=_series(p[0]), sigma=_series(p[1])),
     example=(0.5, 0.75),
     density=lambda d, c: d.pdf(c),
     # Support is (0, inf); the grid stays on the positive side and out to a 4-sigma-in-log upper tail.
@@ -171,6 +192,7 @@ _EXPONENTIAL = DistSpec(
     make_columns=lambda p: Exponential(rate=_col(p[0])),
     make_masked=lambda p, m: Exponential(rate=pl.when(~m).then(_col(p[0]))),
     make_literals=lambda p: Exponential(rate=_lit(p[0])),
+    make_series=lambda p: Exponential(rate=_series(p[0])),
     example=(1.5,),
     density=lambda d, c: d.pdf(c),
     # Support is [0, inf); the grid spans the `x < 0` zero region through several means.
@@ -192,6 +214,7 @@ _BETA = DistSpec(
     make_columns=lambda p: Beta(a=_col(p[0]), b=_col(p[1])),
     make_masked=lambda p, m: Beta(a=pl.when(~m).then(_col(p[0])), b=_col(p[1])),
     make_literals=lambda p: Beta(a=_lit(p[0]), b=_lit(p[1])),
+    make_series=lambda p: Beta(a=_series(p[0]), b=_series(p[1])),
     example=(2.0, 3.0),
     density=lambda d, c: d.pdf(c),
     # Support is [0, 1]; the grid spans the zero-density regions on both sides.

--- a/tests/property/_specs.py
+++ b/tests/property/_specs.py
@@ -28,6 +28,11 @@ def _col(value: float, dtype: PolarsDataType | None = None) -> pl.Expr:
     return pl.repeat(value, n=pl.len(), dtype=dtype)
 
 
+def _lit(value: float, dtype: PolarsDataType | None = None) -> pl.Expr:
+    """The same constant as `_col` but length 1: the input `align_inputs` has to broadcast."""
+    return pl.lit(value, dtype=dtype)
+
+
 def _finite(min_value: float, max_value: float) -> SearchStrategy[float]:
     """Bounded, non-degenerate floats (no NaN/inf), the only inputs a parameter sweep should explore."""
     return st.floats(min_value=min_value, max_value=max_value, allow_nan=False, allow_infinity=False)
@@ -53,6 +58,9 @@ class DistSpec:
         make_masked: Like `make_columns`, but the first parameter is null on rows where the given boolean
             mask expr is true (null in any one parameter is enough to null a sampler row). Lets a test
             assert the per-row path's null contract without knowing the distribution's parameter names.
+        make_literals: Like `make_columns`, but every parameter is a length-1 `pl.lit`, so the plugin has to
+            broadcast. Must agree with `make_columns` row for row.
+        example: One valid parameterisation, for tests that need a fixed frame rather than a sweep.
         density: `pdf` or `pmf` as `(dist, expr) -> expr`. Typed loosely because the method differs by family;
             the concrete distribution is fixed per spec.
         eval_range: `(lo, hi)` finite window for evaluating cdf / density on a grid.
@@ -67,6 +75,8 @@ class DistSpec:
     make: Callable[[tuple[float, ...]], _UnivariateDistribution]
     make_columns: Callable[[tuple[float, ...]], _UnivariateDistribution]
     make_masked: Callable[[tuple[float, ...], pl.Expr], _UnivariateDistribution]
+    make_literals: Callable[[tuple[float, ...]], _UnivariateDistribution]
+    example: tuple[float, ...]
     density: Callable[[Any, pl.Expr], pl.Expr]
     eval_range: Callable[[tuple[float, ...]], tuple[float, float]]
     integration_bounds: Callable[[tuple[float, ...]], tuple[float, float]] | None = None
@@ -80,6 +90,8 @@ _BERNOULLI = DistSpec(
     make=lambda p: Bernoulli(p=p[0]),
     make_columns=lambda p: Bernoulli(p=_col(p[0])),
     make_masked=lambda p, m: Bernoulli(p=pl.when(~m).then(_col(p[0]))),
+    make_literals=lambda p: Bernoulli(p=_lit(p[0])),
+    example=(0.3,),
     density=lambda d, c: d.pmf(c),
     eval_range=lambda _: (-1.0, 2.0),
     support=lambda _: [0.0, 1.0],
@@ -94,6 +106,8 @@ _BINOMIAL = DistSpec(
     make=lambda p: Binomial(n=int(p[0]), p=p[1]),
     make_columns=lambda p: Binomial(n=_col(int(p[0]), pl.Int64()), p=_col(p[1])),
     make_masked=lambda p, m: Binomial(n=pl.when(~m).then(_col(int(p[0]), pl.Int64())), p=_col(p[1])),
+    make_literals=lambda p: Binomial(n=_lit(int(p[0]), pl.Int64()), p=_lit(p[1])),
+    example=(7, 0.35),
     density=lambda d, c: d.pmf(c),
     eval_range=lambda p: (-1.0, p[0] + 1.0),
     support=lambda p: [float(k) for k in range(int(p[0]) + 1)],
@@ -106,6 +120,8 @@ _NORMAL = DistSpec(
     make=lambda p: Normal(mu=p[0], sigma=p[1]),
     make_columns=lambda p: Normal(mu=_col(p[0]), sigma=_col(p[1])),
     make_masked=lambda p, m: Normal(mu=pl.when(~m).then(_col(p[0])), sigma=_col(p[1])),
+    make_literals=lambda p: Normal(mu=_lit(p[0]), sigma=_lit(p[1])),
+    example=(1.5, 2.0),
     density=lambda d, c: d.pdf(c),
     eval_range=lambda p: (p[0] - 6.0 * p[1], p[0] + 6.0 * p[1]),
     integration_bounds=lambda p: (p[0] - 12.0 * p[1], p[0] + 12.0 * p[1]),
@@ -120,6 +136,8 @@ _UNIFORM = DistSpec(
     make=lambda p: Uniform(min=p[0], max=p[1]),
     make_columns=lambda p: Uniform(min=_col(p[0]), max=_col(p[1])),
     make_masked=lambda p, m: Uniform(min=pl.when(~m).then(_col(p[0])), max=_col(p[1])),
+    make_literals=lambda p: Uniform(min=_lit(p[0]), max=_lit(p[1])),
+    example=(-1.0, 3.0),
     density=lambda d, c: d.pdf(c),
     eval_range=lambda p: (p[0] - 0.5 * (p[1] - p[0]), p[1] + 0.5 * (p[1] - p[0])),
     integration_bounds=lambda p: (p[0], p[1]),
@@ -135,6 +153,8 @@ _LOGNORMAL = DistSpec(
     make=lambda p: LogNormal(mu=p[0], sigma=p[1]),
     make_columns=lambda p: LogNormal(mu=_col(p[0]), sigma=_col(p[1])),
     make_masked=lambda p, m: LogNormal(mu=pl.when(~m).then(_col(p[0])), sigma=_col(p[1])),
+    make_literals=lambda p: LogNormal(mu=_lit(p[0]), sigma=_lit(p[1])),
+    example=(0.5, 0.75),
     density=lambda d, c: d.pdf(c),
     # Support is (0, inf); the grid stays on the positive side and out to a 4-sigma-in-log upper tail.
     eval_range=lambda p: (0.0, exp(p[0] + 4.0 * p[1])),
@@ -150,6 +170,8 @@ _EXPONENTIAL = DistSpec(
     make=lambda p: Exponential(rate=p[0]),
     make_columns=lambda p: Exponential(rate=_col(p[0])),
     make_masked=lambda p, m: Exponential(rate=pl.when(~m).then(_col(p[0]))),
+    make_literals=lambda p: Exponential(rate=_lit(p[0])),
+    example=(1.5,),
     density=lambda d, c: d.pdf(c),
     # Support is [0, inf); the grid spans the `x < 0` zero region through several means.
     eval_range=lambda p: (-1.0 / p[0], 5.0 / p[0]),
@@ -169,6 +191,8 @@ _BETA = DistSpec(
     make=lambda p: Beta(a=p[0], b=p[1]),
     make_columns=lambda p: Beta(a=_col(p[0]), b=_col(p[1])),
     make_masked=lambda p, m: Beta(a=pl.when(~m).then(_col(p[0])), b=_col(p[1])),
+    make_literals=lambda p: Beta(a=_lit(p[0]), b=_lit(p[1])),
+    example=(2.0, 3.0),
     density=lambda d, c: d.pdf(c),
     # Support is [0, 1]; the grid spans the zero-density regions on both sides.
     eval_range=lambda _: (-0.5, 1.5),
@@ -178,3 +202,20 @@ _BETA = DistSpec(
 ALL_SPECS = [_BERNOULLI, _BINOMIAL, _NORMAL, _UNIFORM, _LOGNORMAL, _EXPONENTIAL, _BETA]
 CONTINUOUS_SPECS = [s for s in ALL_SPECS if s.continuous]
 DISCRETE_SPECS = [s for s in ALL_SPECS if not s.continuous]
+
+# These specs compute in Polars, not in a Rust body, so with constant parameters their operands are
+# length-1 literals that polars may fold differently from the column kernel. Every IEEE operation is
+# exactly rounded, so the measured 1-ULP gap (`Exponential.ppf`, Uniform's `variance` / `std`) is a
+# different operation *order*, not a different formula. Extend from a failing assertion, never by
+# widening the tolerance.
+ULP_TOLERANT_VALUE_SPECS = frozenset({"uniform", "exponential"})
+"""Specs whose value-keyed methods compare to `ULP_REL_TOL` instead of bit-exactly."""
+
+ULP_TOLERANT_MOMENT_SPECS = frozenset({"uniform"})
+"""Specs whose moments compare to `ULP_REL_TOL` instead of bit-exactly."""
+
+ULP_REL_TOL = 1e-15
+"""~4x a double's ULP."""
+
+ULP_ABS_TOL = 0.0
+"""No absolute slack, so a tiny unequal pair cannot pass for free."""

--- a/tests/property/fast_path_context_test.py
+++ b/tests/property/fast_path_context_test.py
@@ -11,6 +11,9 @@ polars decides per context what that means. `moment_test.py` and `value_keyed_te
   is the scalar.
 * **the streaming engine** ingests the source in morsels rather than as one contiguous block.
 
+The two partition contexts are gated on `PARTITIONED_BROADCAST_AVAILABLE`: polars below 1.34 mishandles a
+length-1 input inside them, so there is nothing of ours left to pin there.
+
 A validating plugin that mishandled its length-1 input under partitioning, or a scalar path that stopped being a
 scalar, would fail here while still passing the `select`-only suites.
 """
@@ -26,7 +29,7 @@ from hypothesis import strategies as st
 from packaging.version import Version
 
 from polars_stats.distributions._base import ContinuousDistribution, DiscreteDistribution
-from tests._polars_compat import PL_VERSION, assert_series_equal, linear_space
+from tests._polars_compat import PARTITIONED_BROADCAST_AVAILABLE, PL_VERSION, assert_series_equal, linear_space
 from tests.property._specs import (
     ALL_SPECS,
     ULP_ABS_TOL,
@@ -83,26 +86,29 @@ def _assert_matches_across_contexts(
         both["fast"], both["slow"], check_names=False, check_exact=exact, rel_tol=ULP_REL_TOL, abs_tol=ULP_ABS_TOL
     )
 
-    # `over`: polars broadcasts a scalar to each (uneven) partition's length, then scatters back.
-    assert_series_equal(
-        frame.select(r=fast.over("g"))["r"],
-        frame.select(r=slow.over("g"))["r"],
-        check_exact=exact,
-        rel_tol=ULP_REL_TOL,
-        abs_tol=ULP_ABS_TOL,
-    )
+    # The two partition contexts, on the polars versions that get them right (see
+    # `PARTITIONED_BROADCAST_AVAILABLE`). `select` and the streaming engine still run below that floor.
+    if PARTITIONED_BROADCAST_AVAILABLE:
+        # `over`: polars broadcasts a scalar to each (uneven) partition's length, then scatters back.
+        assert_series_equal(
+            frame.select(r=fast.over("g"))["r"],
+            frame.select(r=slow.over("g"))["r"],
+            check_exact=exact,
+            rel_tol=ULP_REL_TOL,
+            abs_tol=ULP_ABS_TOL,
+        )
 
-    # `group_by().agg()`: a scalar expression aggregates to one scalar per group while the per-row path
-    # gives one (constant) list per group; a full-length expression gives a list on both paths.
-    grouped = frame.group_by("g", maintain_order=True).agg(fast=fast, slow=slow)
-    if fast_height == 1:
-        assert grouped.select(pl.col("slow").list.n_unique())["slow"].to_list() == [1] * grouped.height
-        expected = grouped["slow"].list.first()
-    else:
-        expected = grouped["slow"]
-    assert_series_equal(
-        grouped["fast"], expected, check_names=False, check_exact=exact, rel_tol=ULP_REL_TOL, abs_tol=ULP_ABS_TOL
-    )
+        # `group_by().agg()`: a scalar expression aggregates to one scalar per group while the per-row path
+        # gives one (constant) list per group; a full-length expression gives a list on both paths.
+        grouped = frame.group_by("g", maintain_order=True).agg(fast=fast, slow=slow)
+        if fast_height == 1:
+            assert grouped.select(pl.col("slow").list.n_unique())["slow"].to_list() == [1] * grouped.height
+            expected = grouped["slow"].list.first()
+        else:
+            expected = grouped["slow"]
+        assert_series_equal(
+            grouped["fast"], expected, check_names=False, check_exact=exact, rel_tol=ULP_REL_TOL, abs_tol=ULP_ABS_TOL
+        )
 
     # streaming engine: the source is split across morsels; non-positional exprs must be invariant.
     if _STREAMING_AVAILABLE:

--- a/tests/property/fast_path_context_test.py
+++ b/tests/property/fast_path_context_test.py
@@ -1,22 +1,18 @@
 """Constant-parameter fast paths stay byte-identical to the per-row path across polars contexts.
 
-The scalar moment and closed-form value-keyed fast paths build a length-1 validity gate,
-`pl.when(validated_once.is_not_null()).then(<context-length value>)`, where `validated_once` is a validating plugin
-called on length-1 `pl.lit` inputs. The bit-equality tests `moment_test.py` and `value_keyed_test.py` pin the fast path
-against the per-row path under a plain `select`, where the gate broadcasts a length-1 condition against a
-whole-frame value.
+With constant parameters the whole expression is built from length-1 `pl.lit` inputs, so it is a scalar column and
+polars decides per context what that means. `moment_test.py` and `value_keyed_test.py` pin the values under a plain
+`select`; this module pins them where the *shape* differs, which a `select`-only test cannot see:
 
-This module pins the same equality under the contexts where the broadcast target length is *not* the
-whole frame, the cases a `select`-only test cannot see:
+* **`over(group)`** broadcasts the scalar per partition, so both paths are full length there. The partitions here are
+  deliberately uneven, so a path that assumed whole-frame length would diverge.
+* **`group_by(group).agg(...)`** makes the scalar path one *scalar per group* (like `pl.col("x").mean()`) while the
+  per-row path gives one *list per group*. That asymmetry is the contract; the list is constant, so its first element
+  is the scalar.
+* **the streaming engine** ingests the source in morsels rather than as one contiguous block.
 
-* `over(group)` and `group_by(group).agg(...)` partition the frame, so `pl.len()` (the length the
-  length-1 gate must broadcast to) differs per partition, and the partitions here are deliberately
-  uneven;
-* the streaming engine ingests the source in morsels rather than as one contiguous block.
-
-A gate that silently assumed whole-frame length, or a validating plugin that mishandled its length-1
-input under partitioning, would diverge from the per-row path here while still passing the
-`select`-only suites.
+A validating plugin that mishandled its length-1 input under partitioning, or a scalar path that stopped being a
+scalar, would fail here while still passing the `select`-only suites.
 """
 
 from __future__ import annotations
@@ -31,7 +27,13 @@ from packaging.version import Version
 
 from polars_stats.distributions._base import ContinuousDistribution, DiscreteDistribution
 from tests._polars_compat import PL_VERSION, assert_series_equal, linear_space
-from tests.property._specs import ALL_SPECS
+from tests.property._specs import (
+    ALL_SPECS,
+    ULP_ABS_TOL,
+    ULP_REL_TOL,
+    ULP_TOLERANT_MOMENT_SPECS,
+    ULP_TOLERANT_VALUE_SPECS,
+)
 
 if TYPE_CHECKING:
     from polars_stats.distributions._base import _UnivariateDistribution
@@ -60,29 +62,54 @@ def _log_density(dist: _UnivariateDistribution, value: pl.Expr) -> pl.Expr:
     raise TypeError(msg)  # pragma: no cover
 
 
-def _assert_matches_across_contexts(frame: pl.DataFrame, fast: pl.Expr, slow: pl.Expr) -> None:
+def _assert_matches_across_contexts(
+    frame: pl.DataFrame, fast: pl.Expr, slow: pl.Expr, *, fast_height: int, exact: bool = True
+) -> None:
     """The scalar fast-path expr equals the per-row expr in every context the frame supports.
 
     `frame` must carry a `"g"` grouping column. Each context is checked independently so a failure
-    names the context that diverged. `check_exact` because the two paths compute the identical value
-    (same Polars formula or same Rust body); only the validation differs, so any difference is a bug.
+    names the context that diverged.
+
+    `fast_height` is the fast path's own height under a plain `select`: 1 when every input is constant
+    (a moment), the frame height when a column-valued `value` sets the length. Asserting it is what
+    keeps this test pinning a *shape* and not only values. `exact` is the default because both paths
+    compute the identical value; the caller relaxes it only for the `ULP_TOLERANT_*` specs.
     """
-    # `select`: the whole-frame context the other suites already cover, re-checked here as the anchor.
-    assert_series_equal(frame.select(r=fast)["r"], frame.select(r=slow)["r"], check_exact=True)
+    # `select`: the fast path holds its own height, and broadcasts against the per-row column beside it.
+    assert frame.select(r=fast).height == fast_height
+    both = frame.select(fast=fast, slow=slow)
+    assert both.height == frame.height
+    assert_series_equal(
+        both["fast"], both["slow"], check_names=False, check_exact=exact, rel_tol=ULP_REL_TOL, abs_tol=ULP_ABS_TOL
+    )
 
-    # `over`: the gate must broadcast to each (uneven) partition's length, then scatter back.
-    assert_series_equal(frame.select(r=fast.over("g"))["r"], frame.select(r=slow.over("g"))["r"], check_exact=True)
+    # `over`: polars broadcasts a scalar to each (uneven) partition's length, then scatters back.
+    assert_series_equal(
+        frame.select(r=fast.over("g"))["r"],
+        frame.select(r=slow.over("g"))["r"],
+        check_exact=exact,
+        rel_tol=ULP_REL_TOL,
+        abs_tol=ULP_ABS_TOL,
+    )
 
-    # `group_by().agg()`: the moment / value-keyed column aggregates to one list per group.
-    grouped_fast = frame.group_by("g", maintain_order=True).agg(r=fast)["r"]
-    grouped_slow = frame.group_by("g", maintain_order=True).agg(r=slow)["r"]
-    assert_series_equal(grouped_fast, grouped_slow, check_exact=True)
+    # `group_by().agg()`: a scalar expression aggregates to one scalar per group while the per-row path
+    # gives one (constant) list per group; a full-length expression gives a list on both paths.
+    grouped = frame.group_by("g", maintain_order=True).agg(fast=fast, slow=slow)
+    if fast_height == 1:
+        assert grouped.select(pl.col("slow").list.n_unique())["slow"].to_list() == [1] * grouped.height
+        expected = grouped["slow"].list.first()
+    else:
+        expected = grouped["slow"]
+    assert_series_equal(
+        grouped["fast"], expected, check_names=False, check_exact=exact, rel_tol=ULP_REL_TOL, abs_tol=ULP_ABS_TOL
+    )
 
     # streaming engine: the source is split across morsels; non-positional exprs must be invariant.
     if _STREAMING_AVAILABLE:
-        lazy_fast = frame.lazy().select(r=fast).collect(engine="streaming")["r"]
-        lazy_slow = frame.lazy().select(r=slow).collect(engine="streaming")["r"]
-        assert_series_equal(lazy_fast, lazy_slow, check_exact=True)
+        lazy = frame.lazy().select(fast=fast, slow=slow).collect(engine="streaming")
+        assert_series_equal(
+            lazy["fast"], lazy["slow"], check_names=False, check_exact=exact, rel_tol=ULP_REL_TOL, abs_tol=ULP_ABS_TOL
+        )
 
 
 @settings(max_examples=10)
@@ -96,7 +123,8 @@ def test_moment_fast_path_matches_per_row_across_contexts(spec: DistSpec, moment
 
     fast = getattr(spec.make(params), moment)()
     slow = getattr(spec.make_columns(params), moment)()
-    _assert_matches_across_contexts(frame, fast, slow)
+    # Every input is constant, so the moment is a scalar column.
+    _assert_matches_across_contexts(frame, fast, slow, fast_height=1, exact=spec.name not in ULP_TOLERANT_MOMENT_SPECS)
 
 
 @settings(max_examples=10)
@@ -130,4 +158,7 @@ def test_value_keyed_fast_path_matches_per_row_across_contexts(spec: DistSpec, d
         (scalar.ppf(q), per_row.ppf(q)),
     )
     for fast, slow in cases:
-        _assert_matches_across_contexts(frame, fast, slow)
+        # The `value` argument is a column, so it sets the length on both paths.
+        _assert_matches_across_contexts(
+            frame, fast, slow, fast_height=_N_ROWS, exact=spec.name not in ULP_TOLERANT_VALUE_SPECS
+        )

--- a/tests/property/moment_test.py
+++ b/tests/property/moment_test.py
@@ -4,12 +4,13 @@ The parameter-only moments (`mean`, `variance`, `std`, `entropy`) validate their
 parameterisation raises consistently with the value-keyed methods.
 
 With constant scalar parameters that validation runs **once** (the validating plugin is called on length-1 `pl.lit`
-inputs); with column parameters it runs per row. Both return a length-n column and gate the same closed form, so for any
-valid parameterisation the two paths must agree bit for bit, the moment counterpart of
-`test_value_keyed_scalar_fast_path_matches_per_row`.
+inputs); with column parameters it runs per row. The two paths differ in *shape* and must agree in *value*: constant
+parameters make the whole expression a scalar column, length 1 on its own and broadcast wherever it meets a longer
+column, while column parameters give a length-n one. Gating the same closed form, they must agree on every row.
 
 A divergence (a parameter-order swap in the length-1 lit args, a non-bit-identical width recompute on the scalar path,
-or a length mismatch from a missing broadcast) must fail here.
+or a scalar path that stopped being a scalar) must fail here. `fast_path_context_test.py` pins the same equality in the
+contexts where the broadcast target is not the whole frame.
 """
 
 from __future__ import annotations
@@ -22,7 +23,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from tests._polars_compat import assert_series_equal
-from tests.property._specs import ALL_SPECS
+from tests.property._specs import ALL_SPECS, ULP_ABS_TOL, ULP_REL_TOL, ULP_TOLERANT_MOMENT_SPECS
 
 if TYPE_CHECKING:
     from tests.property._specs import DistSpec
@@ -43,8 +44,15 @@ def test_moment_scalar_fast_path_matches_per_row(spec: DistSpec, moment: str, da
     params = data.draw(spec.params)
     frame = pl.DataFrame({"_": range(_N_ROWS)})
 
-    fast = frame.select(r=getattr(spec.make(params), moment)())["r"]
-    per_row = frame.select(r=getattr(spec.make_columns(params), moment)())["r"]
+    fast = getattr(spec.make(params), moment)()
+    per_row = getattr(spec.make_columns(params), moment)()
 
-    assert_series_equal(fast, per_row, check_exact=True)
-    assert fast.len() == _N_ROWS  # the scalar fast path stays length-n (broadcast), not collapsed to 1
+    # The scalar path is a scalar column: length 1 on its own, whatever the frame height.
+    assert frame.select(r=fast).height == 1
+    # Selected beside the per-row column, polars broadcasts it, and then every row must agree.
+    both = frame.select(fast=fast, per_row=per_row)
+    assert both.height == _N_ROWS
+    exact = spec.name not in ULP_TOLERANT_MOMENT_SPECS
+    assert_series_equal(
+        both["fast"], both["per_row"], check_names=False, check_exact=exact, rel_tol=ULP_REL_TOL, abs_tol=ULP_ABS_TOL
+    )

--- a/tests/property/value_keyed_test.py
+++ b/tests/property/value_keyed_test.py
@@ -7,9 +7,10 @@ In Rust both plugins call the same named per-method body, so for any parameteris
 must agree bit for bit, including null propagation and ppf's null-outside-``[0, 1]`` contract. A
 divergence (e.g. a parameter-order swap in a scalar kwargs struct) must fail here.
 
-Distributions without a Rust value-keyed plugin (bernoulli, uniform) evaluate the same Polars
-expressions on both paths, so they pass trivially; they stay in the sweep to keep the contract
-uniform across ``ALL_SPECS``.
+Bit-equality holds wherever a single Rust body feeds both paths. ``bernoulli``, ``uniform`` and ``exponential``
+have no Rust value-keyed plugin: both evaluate the same Polars expression, and the scalar path does it on
+length-1 operands, so polars may fold it differently. Where that moves the last bit
+(``ULP_TOLERANT_VALUE_SPECS``) the comparison is 1 ULP; the rest stay exact.
 """
 
 from __future__ import annotations
@@ -23,7 +24,7 @@ from hypothesis import strategies as st
 
 from polars_stats.distributions._base import ContinuousDistribution, DiscreteDistribution
 from tests._polars_compat import assert_series_equal, linear_space
-from tests.property._specs import ALL_SPECS
+from tests.property._specs import ALL_SPECS, ULP_ABS_TOL, ULP_REL_TOL, ULP_TOLERANT_VALUE_SPECS
 
 if TYPE_CHECKING:
     from polars_stats.distributions._base import _UnivariateDistribution
@@ -74,7 +75,8 @@ def test_value_keyed_scalar_fast_path_matches_per_row(spec: DistSpec, data: st.D
         (quantiles, scalar.ppf(q), per_row.ppf(q)),
         (quantiles, scalar.isf(q), per_row.isf(q)),
     ]
+    exact = spec.name not in ULP_TOLERANT_VALUE_SPECS
     for frame, fast_expr, per_row_expr in cases:
         fast = frame.select(r=fast_expr)["r"]
         slow = frame.select(r=per_row_expr)["r"]
-        assert_series_equal(fast, slow, check_exact=True)
+        assert_series_equal(fast, slow, check_exact=exact, rel_tol=ULP_REL_TOL, abs_tol=ULP_ABS_TOL)


### PR DESCRIPTION
Polars broadcasts nothing into a plugin and `try_*_elementwise` truncates to its shortest input, so a length-1 parameter (`pl.{lit, first, max, ...}`) silently dropped every row past the first. Row-alignment now lives in Rust: `align_inputs` broadcasts every length-1 input up to the call's row count before any cast, or raises `ShapeMismatch`, and `_coerce` stops padding scalars with `pl.repeat` (which never covered user-written length-1 expressions anyway).

Breaking: an expression built only from constants is now a scalar column with polars' own semantics, so `df.select(Normal(0.0, 1.0).mean())` is one row rather than the frame height. Values are unchanged wherever any column-valued input is present.