### PR TITLE
feat: add the Geometric distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Each row is scored against its own `Normal(mu, sigma)`, in one vectorised pass, 
 The maths runs on [`statrs`](https://docs.rs/statrs), and `make audit` sweeps every method against
 an [`mpmath`](https://mpmath.org) oracle at 50 digits, including inputs many decades past where
 `scipy` itself saturates. For tail work on `Normal`, `LogNormal` and the closed-form distributions
-(`Uniform`, `Exponential`, `Bernoulli`), use `log_cdf` / `log_sf` rather than the linear pair, and
+(`Uniform`, `Exponential`, `Bernoulli`, `Geometric`), use `log_cdf` / `log_sf` rather than the linear pair, and
 `isf(q)` rather than `ppf(1 - q)`. `Beta` and `Binomial` inherit several documented `statrs`-side
 limits in this release: there the log methods underflow with the linear ones, and the extreme lower
 tail of `ppf` misbehaves. Every known limit is listed with a regime and a magnitude in

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -21,10 +21,10 @@ from pathlib import Path
 from typing import Annotated, get_args
 
 from cyclopts import App, Parameter
-from scipy.stats import bernoulli, beta, binom, expon, lognorm, norm, uniform
+from scipy.stats import bernoulli, beta, binom, expon, geom, lognorm, norm, uniform
 
 from benchmarks._harness import ALL_METHODS, Comparison, Method, OutputFormat, Sweep, emit, run_comparison
-from polars_stats import Bernoulli, Beta, Binomial, Exponential, LogNormal, Normal, Uniform
+from polars_stats import Bernoulli, Beta, Binomial, Exponential, Geometric, LogNormal, Normal, Uniform
 
 # `--rows 1 2 3` (multiple tokens per flag), not `--rows 1 --rows 2`; without this a list option takes
 # a single token and the rest leak onto the positional `distributions`.
@@ -41,6 +41,7 @@ REGISTRY: dict[str, Comparison] = {
     "beta": Comparison("beta", Beta(a=2.0, b=3.0), beta(a=2.0, b=3.0)),
     "bernoulli": Comparison("bernoulli", Bernoulli(p=0.3), bernoulli(0.3)),
     "binomial": Comparison("binomial", Binomial(n=10, p=0.3), binom(10, 0.3)),
+    "geometric": Comparison("geometric", Geometric(p=0.3), geom(0.3)),
 }
 
 app = App(name="bench", help="Benchmark polars_stats sampling against scipy.stats.")

--- a/docs/explanation/accuracy.md
+++ b/docs/explanation/accuracy.md
@@ -33,9 +33,10 @@ recorded in the report with its reason rather than dropped.
 
 `cdf` and `sf` return `0.0` once the true value drops below ~`1e-308`, which is a `float64` range
 limit and not something an algorithm can fix. For `Normal`, `LogNormal` and the closed-form
-distributions (`Uniform`, `Exponential`, `Bernoulli`), `log_cdf` and `log_sf` stay finite far past
-that and are the right methods for tail scoring. Likewise `isf(q)` rather than `ppf(1 - q)` on those
-five: forming the complement quantises the tail mass to `1.1e-16` absolute before any inverse runs.
+distributions (`Uniform`, `Exponential`, `Bernoulli`, `Geometric`), `log_cdf` and `log_sf` stay
+finite far past that and are the right methods for tail scoring. Likewise `isf(q)` rather than
+`ppf(1 - q)` on those six: forming the complement quantises the tail mass to `1.1e-16` absolute
+before any inverse runs.
 
 In this release that advice does **not** extend to `Beta` and `Binomial`. Their `log_cdf` / `log_sf`
 are the linear value's logarithm, so they return `-inf` at exactly the point where `cdf` / `sf`
@@ -50,8 +51,16 @@ magnitudes are in the inherited limits below.
 
 * **Discrete `ppf` / `isf` at a step boundary.** `Binomial.ppf` is a binary search resolved to the
   cdf's own precision, so a quantile within `1e-12` *relative* of a cdf step may return the
-  neighbouring support point. Parity with `scipy` is gated at integer equality rather than at a
-  float tolerance.
+  neighbouring support point. `Geometric.ppf` / `isf` decide the same tie in the log domain, testing
+  `k * log1p(-p)` against `log1p(-q)` rather than re-deriving `cdf(k)`. That is deliberate and it is
+  the more accurate rule: across 1997 probes sitting on and either side of exact step boundaries it
+  disagrees with exact rational arithmetic 357 times, against 490 for the alternative. The price is
+  that `ppf` and `cdf` are not exact mutual inverses there, and the miss goes both ways. At
+  `p = 0.1` with `q` one ulp above `cdf(10)`, `ppf(q)` is `10` where `11` is the answer; at
+  `p = 1e-8` with `q = sf(1)`, `isf(q)` is `2` where `1` is. Both are single support points, and in
+  both the `cdf` / `sf` value is itself exact, so it is the tie-break and nothing else. `scipy` made
+  the opposite trade (it tests against its own `cdf`, so it is self-consistent and less accurate).
+  Parity is gated at integer equality rather than at a float tolerance.
 * **A constant parameter and a column parameter can differ in the last bit.** `Uniform(-2.5, 7.5).cdf("x")`
   and `Uniform(pl.col("lo"), pl.col("hi")).cdf("x")` evaluate the same closed form, but polars folds the
   constant spelling over one row and the column spelling over `n`, and the two kernels do not round

--- a/docs/explanation/accuracy.md
+++ b/docs/explanation/accuracy.md
@@ -65,13 +65,22 @@ magnitudes are in the inherited limits below.
   and `Uniform(pl.col("lo"), pl.col("hi")).cdf("x")` evaluate the same closed form, but polars folds the
   constant spelling over one row and the column spelling over `n`, and the two kernels do not round
   identically. It reaches the methods evaluated as polars expressions rather than in Rust: `Uniform`'s
-  moments and value-keyed methods, and `Exponential`'s value-keyed methods. The difference is at or below
-  `1e-15` relative, roughly 4x a double's ULP. Everything backed by `statrs` runs the same Rust body either
-  way and stays bit-identical.
+  moments and value-keyed methods, `Exponential`'s value-keyed methods, and `Geometric.std` / `.entropy`.
+  The difference is at or below `1e-15` relative, roughly 4x a double's ULP. Everything backed by `statrs`
+  runs the same Rust body either way and stays bit-identical.
+
+    `Geometric`'s two are narrower than the rest: both divide by `p`, and only a `pl.repeat(p, n=pl.len())`
+    parameter moves the last bit, because polars keeps that spelling scalar-backed and divides by it with a
+    reciprocal multiply. A materialised `p` column matches the constant bit for bit.
 * **`float64` range, not algorithm.** Some quantities genuinely exceed the type: `LogNormal`'s
   variance overflows above `sigma ~ 18.8`, and `Exponential.pdf` lands in the subnormal range once
   `rate * x` passes ~708, where only one or two significant digits remain. `log_pdf` is exact well
   past that.
+* **`UInt64` range, for a discrete sample.** `Geometric.sample` draws a trial count, which averages
+  `1 / p`, so a small enough `p` puts the draw past `u64::MAX`, where it saturates. A single draw
+  does so with probability `exp(-u64::MAX * p)`: negligible at `p = 1e-18`, 16% at `1e-19` and 83%
+  at `1e-20`. `mean()` and the other moments are `Float64` and stay exact far past that. No other
+  sampler has a reachable limit: `Bernoulli` is `Boolean` and `Binomial`'s count is bounded by `n`.
 
 ### Inherited from `statrs` 0.19, tracked upstream
 

--- a/docs/explanation/accuracy.md
+++ b/docs/explanation/accuracy.md
@@ -59,10 +59,11 @@ magnitudes are in the inherited limits below.
   one support point: at `p = 1e-8` with `q = sf(1)`, `isf(q)` is `2` where `1` is the answer. On a
   step the two roundings decide the last bit, so which side a given quantile falls on is also the
   platform's `exp` and `log1p` and not the rule alone: at `p = 0.1` with `q` one ulp above `cdf(10)`,
-  `ppf(q)` is `10` on [Apple's libm](https://github.com/apple-oss-distributions/Libm) and `11` on
-  [glibc](https://www.gnu.org/software/libc/manual/html_node/Errors-in-Math-Functions.html), because
-  their `exp` puts `cdf(10)` itself an ulp apart, inside the few ulps of error a libm permits itself.
-  Only the one-support-point bound is portable, so it is the only thing pinned. `scipy`'s
+  `ppf(q)` is `10` on Apple's libm and `11` on glibc, because their `exp` puts `cdf(10)` itself an ulp
+  apart. Neither libm is [correctly rounded](https://core-math.gitlabpages.inria.fr/), and a last-bit
+  difference sits well inside
+  [the error glibc documents](https://www.gnu.org/software/libc/manual/html_node/Errors-in-Math-Functions.html)
+  for it. Only the one-support-point bound is portable, so it is the only thing pinned. `scipy`'s
   [`geom._ppf`](https://github.com/scipy/scipy/blob/main/scipy/stats/_discrete_distns.py) made the
   opposite trade (it tests against its own `_cdf`, so it is self-consistent and less accurate). Parity
   is gated at integer equality rather than at a float tolerance.

--- a/docs/explanation/accuracy.md
+++ b/docs/explanation/accuracy.md
@@ -55,12 +55,17 @@ magnitudes are in the inherited limits below.
   `k * log1p(-p)` against `log1p(-q)` rather than re-deriving `cdf(k)`. That is deliberate and it is
   the more accurate rule: across 1997 probes sitting on and either side of exact step boundaries it
   disagrees with exact rational arithmetic 357 times, against 490 for the alternative. The price is
-  that `ppf` and `cdf` are not exact mutual inverses there, and the miss goes both ways. At
-  `p = 0.1` with `q` one ulp above `cdf(10)`, `ppf(q)` is `10` where `11` is the answer; at
-  `p = 1e-8` with `q = sf(1)`, `isf(q)` is `2` where `1` is. Both are single support points, and in
-  both the `cdf` / `sf` value is itself exact, so it is the tie-break and nothing else. `scipy` made
-  the opposite trade (it tests against its own `cdf`, so it is self-consistent and less accurate).
-  Parity is gated at integer equality rather than at a float tolerance.
+  that `ppf` and `cdf` are not exact mutual inverses there, and the miss goes both ways, by at most
+  one support point: at `p = 1e-8` with `q = sf(1)`, `isf(q)` is `2` where `1` is the answer. On a
+  step the two roundings decide the last bit, so which side a given quantile falls on is also the
+  platform's `exp` and `log1p` and not the rule alone: at `p = 0.1` with `q` one ulp above `cdf(10)`,
+  `ppf(q)` is `10` on [Apple's libm](https://github.com/apple-oss-distributions/Libm) and `11` on
+  [glibc](https://www.gnu.org/software/libc/manual/html_node/Errors-in-Math-Functions.html), because
+  their `exp` puts `cdf(10)` itself an ulp apart, inside the few ulps of error a libm permits itself.
+  Only the one-support-point bound is portable, so it is the only thing pinned. `scipy`'s
+  [`geom._ppf`](https://github.com/scipy/scipy/blob/main/scipy/stats/_discrete_distns.py) made the
+  opposite trade (it tests against its own `_cdf`, so it is self-consistent and less accurate). Parity
+  is gated at integer equality rather than at a float tolerance.
 * **A constant parameter and a column parameter can differ in the last bit.** `Uniform(-2.5, 7.5).cdf("x")`
   and `Uniform(pl.col("lo"), pl.col("hi")).cdf("x")` evaluate the same closed form, but polars folds the
   constant spelling over one row and the column spelling over `n`, and the two kernels do not round
@@ -88,11 +93,13 @@ The defects below live in the `statrs` 0.19 routines this release binds. Each is
 upstream: filed reports are linked, and the remaining links are added here as each one is filed. Per
 the contract at the bottom of this page, a bullet comes out of this list when a fix lands.
 
-* **`Beta.ppf` / `isf` in the extreme lower tail.** The `statrs` inverse (AS 64) has an unguarded
-  Newton step and an unbounded step-halving loop, which costs three regimes. Below `q ~ 1e-165` it
-  **panics**, and a panic inside the plugin aborts the whole query, not just the row. For `q` in
-  roughly `[1e-150, 1e-60]` at some shapes below 1 it **does not return** in reasonable time (over
-  15 s for a *single* row at `(a, b) = (200, 2)`). And its convergence floor is absolute rather than
+* **`Beta.ppf` / `isf` in the extreme lower tail.** The `statrs` inverse
+  ([`inv_beta_reg`](https://github.com/statrs-dev/statrs/blob/v0.19.1/src/function/beta.rs#L269), an
+  implementation of [AS 64](https://www.jstor.org/stable/2346798)) has an unguarded Newton step and an
+  unbounded step-halving loop, which costs three regimes. Below `q ~ 1e-165` it **panics**, and a panic
+  inside the plugin aborts the whole query, not just the row. For `q` in roughly `[1e-150, 1e-60]` at
+  some shapes below 1 it **does not return** in reasonable time (over 15 s for a *single* row at
+  `(a, b) = (200, 2)`). And its convergence floor is absolute rather than
   relative, so results **saturate** to one constant across decades: `Beta(0.05, 0.05).ppf(q)` returns
   the same value from `q = 1e-40` all the way down to `1e-160`. `q >= ~1e-40` at ordinary shapes is
   well-behaved. `isf` composes `ppf(1 - q)`, so it shares all three regimes on top of the complement
@@ -105,11 +112,13 @@ the contract at the bottom of this page, a bullet comes out of this list when a 
   a log-space regularized incomplete beta, tracked upstream as
   [statrs PR #421](https://github.com/statrs-dev/statrs/pull/421).
 * **`Beta` and `Binomial` at very large shapes.** `cdf` / `sf` run `statrs`' regularized
-  incomplete-beta continued fraction, which stops at 141 terms. That cap is first exceeded somewhere
-  between shapes of `1e4` and `1e5`, after which the fraction truncates silently: `Beta(s, s).cdf(0.5)`
-  is exactly `0.5` by symmetry, and statrs returns `0.4912` at `s = 1e6`, `0.2129` at `1e7`, and
-  `-1.147` at `1e8`, a probability outside `[0, 1]`. The audited range covers shapes to `1e3`. Filed
-  upstream: [statrs#434](https://github.com/statrs-dev/statrs/issues/434).
+  incomplete-beta continued fraction
+  ([`beta_reg`](https://github.com/statrs-dev/statrs/blob/v0.19.1/src/function/beta.rs#L130)), which
+  stops at 141 terms. That cap is first exceeded somewhere between shapes of `1e4` and `1e5`, after
+  which the fraction truncates silently: `Beta(s, s).cdf(0.5)` is exactly `0.5` by symmetry, and statrs
+  returns `0.4912` at `s = 1e6`, `0.2129` at `1e7`, and `-1.147` at `1e8`, a probability outside
+  `[0, 1]`. The audited range covers shapes to `1e3`. Filed upstream:
+  [statrs#434](https://github.com/statrs-dev/statrs/issues/434).
 * **`LogNormal.pdf` underflows in a left-tail band.** It returns `0.0` across up to 49 decades where
   the density is finite and representable: `LogNormal(0, 5).pdf(1.38e-87)` is `0.0` against a true
   `2.11e-262`. `log_pdf` is exact there (`-602.55` at that point) and is the workaround.

--- a/docs/how-to/migrate-from-scipy.md
+++ b/docs/how-to/migrate-from-scipy.md
@@ -39,6 +39,7 @@ Some of these translations are not identities, so check this table rather than g
 | `beta(a, b)` | `Beta(a=a, b=b)` | same meaning |
 | `bernoulli(p)` | `Bernoulli(p=p)` | same meaning |
 | `binom(n, p)` | `Binomial(n=n, p=p)` | same meaning |
+| `geom(p)` | `Geometric(p=p)` | same meaning; `p = 0` raises here, `scipy` allows it |
 
 Two further differences apply everywhere:
 

--- a/docs/reference/discrete.md
+++ b/docs/reference/discrete.md
@@ -23,3 +23,7 @@ classes follow, alphabetically. The members listed under each class include thos
 ::: polars_stats.Binomial
     options:
       inherited_members: true
+
+::: polars_stats.Geometric
+    options:
+      inherited_members: true

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -21,6 +21,7 @@ For worked examples, see the [tutorial](../tutorial.md) and the [How-to guides](
 | `Uniform(min, max)` | continuous | `max > min` | `uniform(loc=min, scale=max - min)` |
 | `Bernoulli(p)` | discrete | `0 <= p <= 1` | `bernoulli(p)` |
 | `Binomial(n, p)` | discrete | `n >= 0`, `0 <= p <= 1` | `binom(n, p)` |
+| `Geometric(p)` | discrete | `0 < p <= 1` | `geom(p)` |
 
 Each class names its parameters after the distribution's conventional parameters. `Normal` and `LogNormal` default to
 `mu=0.0, sigma=1.0`; the others have no defaults. Parameter values are validated at evaluation, not at construction.

--- a/docs/reference/parameters-and-contracts.md
+++ b/docs/reference/parameters-and-contracts.md
@@ -80,6 +80,7 @@ may hold any count its dtype can, up to `UInt64`.
 | `Uniform(min, max)` | `max > min` | `max - min` finite |
 | `Bernoulli(p)` | `0 <= p <= 1` | |
 | `Binomial(n, p)` | `n >= 0`, `0 <= p <= 1` | `n` integral |
+| `Geometric(p)` | `0 < p <= 1` | `p = 0` rejected, unlike `Bernoulli` |
 
 A violation raises `ComputeError` and fails the whole evaluation. See
 [nulls, NaNs and errors](#nulls-nans-and-errors) below.
@@ -94,7 +95,7 @@ Element dtype is per distribution and is not normalised to `Float64`:
 | Distribution | Sample dtype |
 |---|---|
 | `Bernoulli` | `Boolean` |
-| `Binomial` | `UInt64` |
+| `Binomial`, `Geometric` | `UInt64` |
 | `Beta`, `Exponential`, `LogNormal`, `Normal`, `Uniform` | `Float64` |
 
 | Aspect | Behaviour |

--- a/polars_stats/__init__.py
+++ b/polars_stats/__init__.py
@@ -6,6 +6,7 @@ from polars_stats.distributions._bernoulli import Bernoulli
 from polars_stats.distributions._beta import Beta
 from polars_stats.distributions._binomial import Binomial
 from polars_stats.distributions._exponential import Exponential
+from polars_stats.distributions._geometric import Geometric
 from polars_stats.distributions._lognormal import LogNormal
 from polars_stats.distributions._normal import Normal
 from polars_stats.distributions._uniform import Uniform
@@ -17,6 +18,7 @@ __all__ = (
     "ContinuousDistribution",
     "DiscreteDistribution",
     "Exponential",
+    "Geometric",
     "LogNormal",
     "Normal",
     "Uniform",

--- a/polars_stats/distributions/_geometric.py
+++ b/polars_stats/distributions/_geometric.py
@@ -16,14 +16,14 @@ if TYPE_CHECKING:
     from polars_stats._typing import IntoExprColumn
 
 _LN_2 = math.log(2.0)
-"""`log(2)`, the constant in the `expm1` identity `_cdf` and `_log_cdf` are spelled through."""
+"""The constant in the `expm1` identity `Geometric._cdf` and `Geometric._log_cdf` are spelled through."""
 
 _CDF_DIRECT_COMPLEMENT_MAX = -20.0
 """Crossover of `Geometric._cdf`, in units of `log(sf)`.
 
 Below it `exp(log_tail)` is small enough that the direct `1 - exp(log_tail)` rounds no worse than the
-`sinh` identity and cannot round above `1`. The identity itself only breaks where `log_tail / 2`
-overflows `sinh`, past `log_tail ~ -1455`, far inside this branch.
+`sinh` identity and cannot round above `1`. The identity itself only breaks past `log_tail ~ -1455`,
+where `sinh` overflows, far inside this branch.
 """
 
 _LOG_CDF_LOG1P_MAX = -1.0
@@ -41,12 +41,12 @@ def _smallest_support_point(log_target: pl.Expr, log_failure: pl.Expr) -> pl.Exp
     ceiling, the one-ulp correction and the clip to the support floor are common. Every answer is a
     positive integer, so the ceiling is clipped up to ``1.0``, which is also where ``-0.0`` lands at
     the degenerate endpoint of either inverse. A ratio sitting an ulp above an exact integer
-    overshoots by one support point, so the candidate steps back down whenever ``k - 1`` already
-    satisfies the inequality, compared in the same log domain both sides entered through.
+    overshoots by one support point, so it steps back down whenever ``k - 1`` already satisfies the
+    inequality, compared in the same log domain both sides entered through.
     """
-    candidate = (log_target / log_failure).ceil()
-    stepped_down = pl.when((candidate - 1.0) * log_failure <= log_target).then(candidate - 1.0).otherwise(candidate)
-    return stepped_down.clip(1.0)
+    ceiling = (log_target / log_failure).ceil()
+    overshot = (ceiling - 1.0) * log_failure <= log_target
+    return pl.when(overshot).then(ceiling - 1.0).otherwise(ceiling).clip(1.0)
 
 
 class Geometric(DiscreteDistribution):
@@ -65,8 +65,9 @@ class Geometric(DiscreteDistribution):
     An invalid ``p`` (``p <= 0``, ``p > 1`` or ``NaN``) is not checked at construction; matching every
     other distribution, it raises ``InvalidOperation`` (a ``ComputeError``) when any method is
     evaluated. A null ``p`` propagates to null wherever the result depends on ``p``; the off-support
-    constants (``pmf(0) = 0``, ``sf(0) = 1``) do not, as in ``Bernoulli``. Samples are ``UInt64``
-    trial counts, so unlike ``Bernoulli`` the degenerate ``p = 0`` point mass is not representable.
+    constants (``pmf(0) = 0``, ``cdf(0) = 0``, ``sf(0) = 1``) do not, as in ``Bernoulli``. Samples are
+    ``UInt64`` trial counts, so unlike ``Bernoulli`` the degenerate ``p = 0`` point mass is not
+    representable.
     """
 
     _p: pl.Expr
@@ -82,116 +83,130 @@ class Geometric(DiscreteDistribution):
 
     @property
     def _checked_p(self) -> pl.Expr:
-        """``p`` validated in Rust to lie in ``(0, 1]`` (raises otherwise), as a length-n column.
+        """``p`` validated in Rust to lie in ``(0, 1]`` (raises otherwise), null when ``p`` is null.
 
-        Validated in Rust so the closed-form methods (moments and pmf/cdf/ppf) report an invalid ``p`` consistently
-        with ``sample`` rather than silently computing with a non-positive probability. Null propagates.
-
-        `_checked` validates once for a scalar ``p`` (length-1 input) and per-row for a column,
-        returning the raw ``p`` behind the validity gate either way (length-n on both paths).
+        Validated in Rust so the closed-form methods report an invalid ``p`` consistently with
+        ``sample`` rather than silently computing with a non-positive probability. `_checked`
+        validates once for a scalar ``p`` (length-1 input) and per-row for a column.
         """
         return self._checked("geometric_p", self._p)
 
+    @property
+    def _raw_p(self) -> pl.Expr:
+        """``p`` as ``Float64``, without the validating round trip: the operand every formula reads.
+
+        Free to name repeatedly, unlike `_checked_p`. The cast is the one `geometric_p` performs on
+        the way in, so a ``Float32`` parameter column still yields ``Float64`` results.
+        """
+        return self._p.cast(pl.Float64())
+
+    def _when_p_valid(self, formula: pl.Expr) -> pl.Expr:
+        """``formula``, read off `_raw_p`, behind a single validation of ``p``.
+
+        `_UnivariateDistribution._moment`'s gate, extended to the value-keyed formulas: every
+        Geometric formula but ``mean`` names ``p`` two to six times, and polars folds neither a
+        repeated subexpression nor a plugin call, so naming `_checked_p` inline would cross FFI once
+        per mention. Over a column ``p`` that is 10x one validation on ``ppf`` and 6x on ``entropy``.
+
+        The gate wraps the ``p``-dependent branch only, never a whole method: the off-support
+        constants in `_pmf`, `_cdf` and `_log_sf` do not depend on ``p`` and must survive a null one.
+        An invalid ``p`` still raises from either branch, since polars evaluates both.
+        """
+        return pl.when(self._checked_p.is_not_null()).then(formula)
+
+    def _log_tail(self, value: pl.Expr) -> pl.Expr:
+        """``floor(value) * log1p(-p)``, the log survival mass every tail method enters through.
+
+        ``log1p(-p)`` rather than the literal ``log(1 - p)``, which inherits the rounding of ``1 - p``
+        (a few parts in ``1e9`` at ``p = 1e-8``) and collapses to ``0.0`` below ``p ~ 1.1e-16``. See
+        docs/contributing.md, "Numerical stability".
+        """
+        return value.floor() * (-self._raw_p).log1p()
+
     def _pmf(self, value: pl.Expr) -> pl.Expr:
         """``(1 - p)**(k - 1) * p`` on the positive integers, ``0`` elsewhere."""
-        p = self._checked_p
+        p = self._raw_p
         k = value.floor()
-        is_support = (value >= 1) & (k == value)
-        return (
-            pl.when(is_support)
-            # `k = 1` short-circuits the power term, which is `0 * -inf = nan` at `p = 1`.
-            .then(pl.when(k == 1).then(p).otherwise(p * ((k - 1) * (-p).log1p()).exp()))
-            .otherwise(0.0)
-        )
+        # `k = 1` short-circuits the power term, which is `0 * -inf = nan` at `p = 1`.
+        mass = pl.when(k == 1).then(p).otherwise(p * ((k - 1) * (-p).log1p()).exp())
+        return pl.when((value >= 1) & (k == value)).then(self._when_p_valid(mass)).otherwise(0.0)
 
     def _log_pmf(self, value: pl.Expr) -> pl.Expr:
         """``(k - 1) * log1p(-p) + log(p)`` on the positive integers, ``-inf`` elsewhere.
 
         Overrides the base ``pmf().log()``, whose ``log(1 - p)`` collapses to ``0.0`` below
-        ``p ~ 1.1e-16``. See docs/contributing.md, "Numerical stability". ``k = 1`` reads ``log(p)``
-        directly, because ``(k - 1) * log1p(-p)`` is ``0 * -inf = nan`` at ``p = 1``.
+        ``p ~ 1.1e-16``. ``k = 1`` reads ``log(p)`` directly, because ``(k - 1) * log1p(-p)`` is
+        ``0 * -inf = nan`` at ``p = 1``.
         """
-        p = self._checked_p
+        p = self._raw_p
         k = value.floor()
-        is_support = (value >= 1) & (k == value)
-        return (
-            pl.when(is_support)
-            .then(pl.when(k == 1).then(p.log()).otherwise((k - 1) * (-p).log1p() + p.log()))
-            .otherwise(float("-inf"))
-        )
+        log_mass = pl.when(k == 1).then(p.log()).otherwise((k - 1) * (-p).log1p() + p.log())
+        return pl.when((value >= 1) & (k == value)).then(self._when_p_valid(log_mass)).otherwise(float("-inf"))
 
     def _cdf(self, value: pl.Expr) -> pl.Expr:
-        """``0`` below the support, else ``-expm1(k * log1p(-p))`` with ``k = floor(value)``.
+        """``0`` below the support, else ``-expm1(log_tail)``.
 
-        Entering through ``log1p(-p)`` keeps a small ``p`` exact, where the literal
-        ``1 - (1 - p)**k`` inherits the rounding of ``1 - p`` and of the subtraction against ``1``:
-        a few parts in ``1e9`` at ``p = 1e-8``. Polars has no ``expm1``, so it is spelled through the
-        identity ``expm1(t) = 2 exp(t / 2) sinh(t / 2)``, and read directly as ``1 - exp(t)`` past
-        `_CDF_DIRECT_COMPLEMENT_MAX`.
+        Polars has no ``expm1``, so it is spelled through the identity
+        ``expm1(t) = 2 exp(t / 2) sinh(t / 2)``, and read directly as ``1 - exp(t)`` past
+        `_CDF_DIRECT_COMPLEMENT_MAX`. The literal ``1 - (1 - p)**k`` would instead inherit the
+        rounding of both ``1 - p`` and the subtraction against ``1``.
         """
-        p = self._checked_p
-        log_tail = value.floor() * (-p).log1p()
+        log_tail = self._log_tail(value)
         half = log_tail / 2
-        return (
-            pl.when(value < 1)
-            .then(0.0)
-            .when(log_tail <= _CDF_DIRECT_COMPLEMENT_MAX)
+        complement = (
+            pl.when(log_tail <= _CDF_DIRECT_COMPLEMENT_MAX)
             .then(1.0 - log_tail.exp())
             .otherwise(-2.0 * half.exp() * half.sinh())
         )
+        return pl.when(value < 1).then(0.0).otherwise(self._when_p_valid(complement))
 
     def _log_cdf(self, value: pl.Expr) -> pl.Expr:
-        """``-inf`` below the support, else ``log(1 - exp(k * log1p(-p)))`` with ``k = floor(value)``.
+        """``-inf`` below the support, else ``log(1 - exp(log_tail))``.
 
         Two regimes, split at `_LOG_CDF_LOG1P_MAX` where the answer's own magnitude stops dwarfing
         the absolute granularity of the pieces. Below it ``log1p`` carries the difference from ``1``
         exactly; above it the `_cdf` pieces assemble on the log scale, each one large precisely where
         the answer is large, so their rounding stays relative.
         """
-        p = self._checked_p
-        log_tail = value.floor() * (-p).log1p()
+        log_tail = self._log_tail(value)
         half = log_tail / 2
-        return (
-            pl.when(value < 1)
-            .then(float("-inf"))
-            .when(log_tail <= _LOG_CDF_LOG1P_MAX)
+        log_complement = (
+            pl.when(log_tail <= _LOG_CDF_LOG1P_MAX)
             .then((-log_tail.exp()).log1p())
             .otherwise(_LN_2 + half + (-half.sinh()).log())
         )
+        return pl.when(value < 1).then(float("-inf")).otherwise(self._when_p_valid(log_complement))
 
     def _sf(self, value: pl.Expr) -> pl.Expr:
-        """``1`` below the support, else ``exp(floor(value) * log1p(-p))``.
+        """``exp(log_sf)``, which is exactly ``1`` below the support.
 
         Overrides the base ``1 - cdf``, which recomputes ``p`` as ``1 - (1 - p)`` and so quantises it
-        to the ``1.1e-16`` spacing of ``1.0``, reaching ``0.0`` below that. ``log1p(-p)`` also avoids
-        the rounding of the literal ``1 - p``, a few parts in ``1e9`` at ``p = 1e-8``.
+        to the ``1.1e-16`` spacing of ``1.0``, reaching ``0.0`` below that.
         """
-        p = self._checked_p
-        return pl.when(value < 1).then(1.0).otherwise((value.floor() * (-p).log1p()).exp())
+        return self._log_sf(value).exp()
 
     def _log_sf(self, value: pl.Expr) -> pl.Expr:
-        """``0`` below the support, else ``floor(value) * log1p(-p)``."""
-        p = self._checked_p
-        return pl.when(value < 1).then(0.0).otherwise(value.floor() * (-p).log1p())
+        """``0`` below the support, else `_log_tail`."""
+        return pl.when(value < 1).then(0.0).otherwise(self._when_p_valid(self._log_tail(value)))
 
     def _ppf(self, quantile: pl.Expr) -> pl.Expr:
         """Smallest ``k`` with ``cdf(k) >= quantile``: ``ceil(log1p(-q) / log1p(-p))``, clipped to the support floor.
 
-        Null for ``q`` outside ``[0, 1]``. Both sides go through ``log1p``: the literal
+        Null for ``q`` outside ``[0, 1]``. The numerator goes through ``log1p`` as well: the literal
         ``log(1 - q)`` collapses to ``0.0`` below ``q ~ 1.1e-16`` and answers ``0`` where the smallest
-        support point ``1`` is the only correct answer, and the denominator is the reason in
-        `_log_pmf`. The negation is written ``0.0 - q`` so an unsigned quantile column promotes to
-        ``Float64`` (polars rejects ``neg`` on an unsigned dtype).
+        support point ``1`` is the only correct answer. Its negation is written ``0.0 - q`` so an
+        unsigned quantile column promotes to ``Float64`` (polars rejects ``neg`` on an unsigned dtype).
 
         ``q = 1`` runs the ratio off to ``+inf``, the right answer for an unbounded support.
         ``p = 1`` short-circuits before `_smallest_support_point`, where the ratio would be
         ``-inf / -inf = nan`` and the whole mass sits on ``k = 1``.
         """
-        p = self._checked_p
+        p = self._raw_p
         support_point = _smallest_support_point((0.0 - quantile).log1p(), (-p).log1p())
+        answer = pl.when(p == 1).then(1.0).otherwise(support_point)
         return (
             pl.when(quantile.is_between(0, 1))
-            .then(pl.when(p == 1).then(1.0).otherwise(support_point))
+            .then(self._when_p_valid(answer))
             .otherwise(pl.lit(None, dtype=pl.Float64()))
         )
 
@@ -204,39 +219,39 @@ class Geometric(DiscreteDistribution):
         every survival quantile inverts to ``k = 1``, including ``q = 0``, where ``sf(1) = 0``
         already satisfies the inequality.
         """
-        p = self._checked_p
+        p = self._raw_p
         support_point = _smallest_support_point(quantile.log(), (-p).log1p())
+        answer = pl.when(p == 1).then(1.0).otherwise(support_point)
         return (
             pl.when(quantile.is_between(0, 1))
-            .then(pl.when(p == 1).then(1.0).otherwise(support_point))
+            .then(self._when_p_valid(answer))
             .otherwise(pl.lit(None, dtype=pl.Float64()))
         )
 
     def mean(self) -> pl.Expr:
-        """Expected value, ``1 / p``."""
+        """Expected value, ``1 / p``. The one formula naming ``p`` once, so it reads `_checked_p` directly."""
         return 1 / self._checked_p
 
     def variance(self) -> pl.Expr:
         """Variance, ``(1 - p) / p**2``."""
-        p = self._checked_p
-        return (1 - p) / p**2
+        p = self._raw_p
+        return self._when_p_valid((1 - p) / p**2)
 
     def std(self) -> pl.Expr:
         """Standard deviation, ``sqrt(1 - p) / p``.
 
-        Overrides the base-class ``variance().sqrt()``, which squares ``p`` and then unsquares
-        it: the round trip overflows about 150 decades before ``sqrt(1 - p) / p`` does.
+        Overrides the base-class ``variance().sqrt()``, which squares ``p`` and then unsquares it:
+        the round trip overflows about 150 decades before ``sqrt(1 - p) / p`` does.
         """
-        p = self._checked_p
-        return (1 - p).sqrt() / p
+        p = self._raw_p
+        return self._when_p_valid((1 - p).sqrt() / p)
 
     def entropy(self) -> pl.Expr:
         """Shannon entropy, ``(-(1 - p) * log1p(-p) - p * log(p)) / p``, with the ``0`` limit at ``p = 1``.
 
         Uses the convention ``0 * log 0 = 0`` so the degenerate ``p = 1`` point mass has entropy ``0``.
-        The first term goes through ``log1p`` for the reason in `_log_pmf`.
         """
-        p = self._checked_p
+        p = self._raw_p
         q = 1 - p
-
-        return pl.when(p == 1).then(0.0).otherwise((-q * (-p).log1p() - p * p.log()) / p)
+        shannon = pl.when(p == 1).then(0.0).otherwise((-q * (-p).log1p() - p * p.log()) / p)
+        return self._when_p_valid(shannon)

--- a/polars_stats/distributions/_geometric.py
+++ b/polars_stats/distributions/_geometric.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, ClassVar
+
+import polars as pl
+
+from polars_stats.distributions._base import (
+    DiscreteDistribution,
+    coerce_param,
+    scalar_float,
+    scalar_kwargs,
+)
+
+if TYPE_CHECKING:
+    from polars_stats._typing import IntoExprColumn
+
+# Past this log-tail depth the cdf complement `exp(x)` is small enough that `1 - exp(x)`
+# rounds no worse than the sinh identity, and cannot round above `1`.
+_CDF_DIRECT_TAIL = -20.0
+
+
+class Geometric(DiscreteDistribution):
+    """Geometric distribution: the number of trials up to and including the first success.
+
+    Equivalent to ``scipy.stats.geom(p)``. The support is the positive integers: a draw of ``k``
+    means trials ``1 .. k - 1`` failed and trial ``k`` succeeded, so ``pmf(1) = p`` and the mass
+    decays geometrically above it.
+
+    Arguments:
+        p: Success probability of each trial, with ``0 < p <= 1``. Either a Python ``float`` or an
+            ``IntoExprColumn`` (``pl.Expr``, ``pl.Series`` or column name ``str``) carrying one
+            probability per row.
+
+    An invalid ``p`` (``p <= 0``, ``p > 1`` or ``NaN``) is not checked at construction; matching every
+    other distribution, it raises ``InvalidOperation`` (a ``ComputeError``) when any method is
+    evaluated. A null ``p`` propagates to null. Samples are ``UInt64`` trial counts, so unlike
+    ``Bernoulli`` the degenerate ``p = 0`` point mass is not representable.
+    """
+
+    _p: pl.Expr
+    _plugin_prefix: ClassVar[str] = "geometric"
+
+    def __init__(self, p: float | IntoExprColumn) -> None:
+        self._p = coerce_param(p, name="p")
+        self._scalar_kwargs = scalar_kwargs(p=scalar_float(p))
+
+    @property
+    def _param_exprs(self) -> tuple[pl.Expr, ...]:
+        return (self._p,)
+
+    @property
+    def _checked_p(self) -> pl.Expr:
+        """``p`` validated in Rust to lie in ``(0, 1]`` (raises otherwise), as a length-n column.
+
+        Validated in Rust so the closed-form methods (moments and pmf/cdf/ppf) report an invalid ``p`` consistently
+        with ``sample`` rather than silently computing with a non-positive probability. Null propagates.
+
+        `_checked` validates once for a scalar ``p`` (length-1 input) and per-row for a column,
+        returning the raw ``p`` behind the validity gate either way (length-n on both paths).
+        """
+        return self._checked("geometric_p", self._p)
+
+    def _pmf(self, value: pl.Expr) -> pl.Expr:
+        """``(1 - p)**(k - 1) * p`` on the positive integers, ``0`` elsewhere."""
+        p = self._checked_p
+        is_support = (value >= 1) & (value.floor() == value)
+        return (
+            pl.when(is_support)
+            .then(
+                # `k = 1` short-circuits before the power term: `(k - 1) * log1p(-p)` degenerates to
+                # `0 * -inf = nan` at `p = 1`, where the mass is exactly `p`.
+                pl.when(value <= 1).then(p).otherwise(p * ((value.floor() - 1) * (-p).log1p()).exp())
+            )
+            .otherwise(0.0)
+        )
+
+    def _log_pmf(self, value: pl.Expr) -> pl.Expr:
+        """``(k - 1) * log1p(-p) + log(p)`` on the positive integers, ``-inf`` elsewhere.
+
+        Overrides the base ``pmf().log()``, whose ``log(1 - p)`` collapses to ``0.0`` below
+        ``p ~ 1.1e-16``. See docs/contributing.md, "Numerical stability". The ``k = 1`` case reads
+        ``log(p)`` directly because ``(k - 1) * log1p(-p)`` degenerates to ``0 * -inf = nan`` at
+        ``p = 1``, where the answer is exactly ``0``.
+        """
+        p = self._checked_p
+        is_support = (value >= 1) & (value.floor() == value)
+        return (
+            pl.when(is_support)
+            .then(pl.when(value.floor() == 1).then(p.log()).otherwise((value.floor() - 1) * (-p).log1p() + p.log()))
+            .otherwise(float("-inf"))
+        )
+
+    def _cdf(self, value: pl.Expr) -> pl.Expr:
+        """``0`` for ``value < 1``, else ``-expm1(floor(value) * log1p(-p))``.
+
+        The mass sits at ``p``-scale for small ``k``, so the naive ``1 - (1 - p)**floor(value)``
+        inherits the rounding of ``1 - p`` and of the subtraction against ``1`` -- a few parts in
+        ``1e9`` of relative error at ``p = 1e-8``, where the true answer is ``1e-8``. Entering
+        through ``log1p(-p)`` keeps the parameter exact; past ``x = -20`` the complement is read
+        directly as ``1 - exp(x)``, which cannot round above ``1``; the exponential itself is
+        evaluated through the identity ``expm1(x) = 2 exp(x/2) sinh(x/2)`` (polars has no
+        ``expm1``), whose only weak spot is ``x/2`` overflowing ``sinh`` below ``x ~ -1455`` --
+        far inside the direct-complement branch.
+        """
+        p = self._checked_p
+        x = value.floor() * (-p).log1p()
+        return (
+            pl.when(value < 1)
+            .then(0.0)
+            .when(x <= _CDF_DIRECT_TAIL)
+            .then(1.0 - x.exp())
+            .otherwise(-2.0 * (x / 2).exp() * (x / 2).sinh())
+        )
+
+    def _log_cdf(self, value: pl.Expr) -> pl.Expr:
+        """``-inf`` for ``value < 1``, else ``log(1 - exp(floor(value) * log1p(-p)))``.
+
+        Two regimes, split where the answer's own magnitude stops dwarfing the absolute granularity
+        of the pieces. Below ``x = -1`` the cdf sits within ``0.63`` of ``1``, and ``log1p(-exp(x))``
+        carries that difference exactly -- down through the ``cdf ~ 1 - 1e-16`` saturation zone,
+        where ``log(cdf)`` reads the tail mass rounded away against ``1`` and answers ``0``. Above
+        it, the answer assembles from the `_cdf` pieces on the log scale, ``log(2 exp(x/2)
+        sinh(x/2))``: every piece is huge precisely where the answer is huge, so their rounding
+        stays relative.
+        """
+        p = self._checked_p
+        x = value.floor() * (-p).log1p()
+        return (
+            pl.when(value < 1)
+            .then(float("-inf"))
+            .when(x <= -1.0)
+            .then((-x.exp()).log1p())
+            .otherwise(math.log(2.0) + x / 2 + (-(x / 2).sinh()).log())
+        )
+
+    def _sf(self, value: pl.Expr) -> pl.Expr:
+        """``1`` for ``value < 1``, ``exp(floor(value) * log1p(-p))`` for ``value >= 1``.
+
+        A closed form that stays accurate in the upper tail, unlike the base ``1 - cdf``, which
+        recomputes ``p`` as ``1 - (1 - p)`` and so quantises it to the ``1.1e-16`` spacing of ``1.0``,
+        reaching ``0.0`` below that. Entering through ``log1p(-p)`` also avoids the rounding of the
+        literal ``1 - p``, visible as a few parts in ``1e9`` of relative error at ``p = 1e-8``.
+        """
+        p = self._checked_p
+        return pl.when(value < 1).then(1.0).otherwise((value.floor() * (-p).log1p()).exp())
+
+    def _log_sf(self, value: pl.Expr) -> pl.Expr:
+        """``0`` for ``value < 1``, ``floor(value) * log1p(-p)`` for ``value >= 1``."""
+        p = self._checked_p
+        return pl.when(value < 1).then(0.0).otherwise(value.floor() * (-p).log1p())
+
+    def _ppf(self, quantile: pl.Expr) -> pl.Expr:
+        """Smallest ``k`` with ``cdf(k) >= quantile``: ``ceil(log1p(-q) / log1p(-p))``, clipped to the support floor.
+
+        Null for ``q`` outside ``[0, 1]``. Both sides go through ``log1p``: the naive
+        ``log(1 - q) / log(1 - p)`` collapses its numerator to ``0.0`` below ``q ~ 1.1e-16`` and
+        answers ``0`` where the smallest support point ``1`` is the only correct answer, while the
+        denominator side is the reason in ``_log_pmf``. The negation is written ``0.0 - q`` so an
+        unsigned quantile column promotes to ``Float64`` (polars rejects ``neg`` on an unsigned
+        dtype).
+
+        Every answer lives on the positive integers, so the ``ceil`` is clipped up to ``1.0``: at
+        ``q = 0`` the formula degenerates to ``-0.0``, and at ``p < 1, q = 1`` the ratio runs off to
+        ``+inf``. At ``p = 1`` the ratio is ``-inf / -inf = nan``, so that parameter degeneracy
+        short-circuits first: the whole mass sits on ``k = 1``.
+
+        The raw ceiling can overshoot by one support point when the ratio lands an ulp above an
+        exact integer -- the stored quantile then sits a hair below the cdf step it belongs to --
+        so the candidate is stepped back down whenever ``k - 1`` already satisfies its own defining
+        inequality, compared in the log domain both sides entered through.
+
+        The result stays a ``Float64`` support point rather than an integral dtype, matching the other
+        distributions' inverses and leaving the wrapper's ``NaN -> NaN`` contract representable.
+        """
+        p = self._checked_p
+        tail_log = (-p).log1p()
+        target_log = (0.0 - quantile).log1p()
+        candidate = (target_log / tail_log).ceil()
+        stepped = (
+            pl.when((candidate - 1.0) * tail_log <= target_log).then(candidate - 1.0).otherwise(candidate).clip(1.0)
+        )
+        return (
+            pl.when(quantile.is_between(0, 1))
+            .then(pl.when(p == 1).then(1.0).otherwise(stepped))
+            .otherwise(pl.lit(None, dtype=pl.Float64()))
+        )
+
+    def _isf(self, quantile: pl.Expr) -> pl.Expr:
+        """Smallest ``k`` with ``sf(k) <= quantile``: ``ceil(log(q) / log1p(-p))``, clipped to the support floor.
+
+        The exact inverse of `_sf`, entered against ``quantile`` itself rather than through the base
+        ``ppf(1 - quantile)``, whose complement throws the tail mass away before the inverse runs.
+        As in `_ppf`, every answer lives on the positive integers, so the ``ceil`` is clipped up to
+        ``1.0``: at ``q = 1`` the formula degenerates to ``-0.0``, and ``q = 0`` flows through it as
+        ``+inf``. At ``p = 1`` the ratio is ``nan`` or ``-inf / -inf``, so that parameter degeneracy
+        short-circuits first: every survival quantile inverts to the single mass point ``k = 1``,
+        including ``q = 0``, where ``sf(1) = 0`` already satisfies the inequality.
+
+        The same one-ulp overshoot as in `_ppf` applies -- an exact-integer ratio landing an ulp high
+        skips a support point -- so the candidate steps back down whenever ``k - 1`` already
+        satisfies ``sf(k - 1) <= q``, compared as ``(k - 1) * log1p(-p) <= log(q)``.
+        """
+        p = self._checked_p
+        tail_log = (-p).log1p()
+        target_log = quantile.log()
+        candidate = (target_log / tail_log).ceil()
+        stepped = (
+            pl.when((candidate - 1.0) * tail_log <= target_log).then(candidate - 1.0).otherwise(candidate).clip(1.0)
+        )
+        return (
+            pl.when(quantile.is_between(0, 1))
+            .then(pl.when(p == 1).then(1.0).otherwise(stepped))
+            .otherwise(pl.lit(None, dtype=pl.Float64()))
+        )
+
+    def mean(self) -> pl.Expr:
+        """Expected value, ``1 / p``."""
+        return 1 / self._checked_p
+
+    def variance(self) -> pl.Expr:
+        """Variance, ``(1 - p) / p**2``."""
+        return (1 - self._checked_p) / self._checked_p**2
+
+    def std(self) -> pl.Expr:
+        """Standard deviation, ``sqrt(1 - p) / p``.
+
+        Overrides the base-class ``variance().sqrt()``, which squares ``p`` and then unsquares
+        it: the round trip overflows about 150 decades before ``sqrt(1 - p) / p`` does.
+        """
+        return (1 - self._checked_p).sqrt() / self._checked_p
+
+    def entropy(self) -> pl.Expr:
+        """Shannon entropy, ``(-(1 - p) * log1p(-p) - p * log(p)) / p``, with the ``0`` limit at ``p = 1``.
+
+        Uses the convention ``0 * log 0 = 0`` so the degenerate ``p = 1`` point mass has entropy ``0``.
+        The first term goes through ``log1p`` for the reason in ``_log_pmf``.
+        """
+        p = self._checked_p
+        q = 1 - p
+
+        return pl.when(p == 1).then(0.0).otherwise((-q * (-p).log1p() - p * p.log()) / p)

--- a/polars_stats/distributions/_geometric.py
+++ b/polars_stats/distributions/_geometric.py
@@ -15,9 +15,38 @@ from polars_stats.distributions._base import (
 if TYPE_CHECKING:
     from polars_stats._typing import IntoExprColumn
 
-# Past this log-tail depth the cdf complement `exp(x)` is small enough that `1 - exp(x)`
-# rounds no worse than the sinh identity, and cannot round above `1`.
-_CDF_DIRECT_TAIL = -20.0
+_LN_2 = math.log(2.0)
+"""`log(2)`, the constant in the `expm1` identity `_cdf` and `_log_cdf` are spelled through."""
+
+_CDF_DIRECT_COMPLEMENT_MAX = -20.0
+"""Crossover of `Geometric._cdf`, in units of `log(sf)`.
+
+Below it `exp(log_tail)` is small enough that the direct `1 - exp(log_tail)` rounds no worse than the
+`sinh` identity and cannot round above `1`. The identity itself only breaks where `log_tail / 2`
+overflows `sinh`, past `log_tail ~ -1455`, far inside this branch.
+"""
+
+_LOG_CDF_LOG1P_MAX = -1.0
+"""Crossover of `Geometric._log_cdf`, in units of `log(sf)`.
+
+Below it the cdf sits within `0.63` of `1` and `log1p(-exp(log_tail))` carries that difference
+exactly, down through the `cdf ~ 1 - 1e-16` zone where `cdf().log()` reads the tail mass as `0`.
+"""
+
+
+def _smallest_support_point(log_target: pl.Expr, log_failure: pl.Expr) -> pl.Expr:
+    """Smallest ``k >= 1`` with ``k * log_failure <= log_target``, the shape both inverses share.
+
+    ``ppf`` and ``isf`` differ only in what they take the log of (``1 - q`` against ``q``); the
+    ceiling, the one-ulp correction and the clip to the support floor are common. Every answer is a
+    positive integer, so the ceiling is clipped up to ``1.0``, which is also where ``-0.0`` lands at
+    the degenerate endpoint of either inverse. A ratio sitting an ulp above an exact integer
+    overshoots by one support point, so the candidate steps back down whenever ``k - 1`` already
+    satisfies the inequality, compared in the same log domain both sides entered through.
+    """
+    candidate = (log_target / log_failure).ceil()
+    stepped_down = pl.when((candidate - 1.0) * log_failure <= log_target).then(candidate - 1.0).otherwise(candidate)
+    return stepped_down.clip(1.0)
 
 
 class Geometric(DiscreteDistribution):
@@ -25,7 +54,8 @@ class Geometric(DiscreteDistribution):
 
     Equivalent to ``scipy.stats.geom(p)``. The support is the positive integers: a draw of ``k``
     means trials ``1 .. k - 1`` failed and trial ``k`` succeeded, so ``pmf(1) = p`` and the mass
-    decays geometrically above it.
+    decays geometrically above it. Textbooks that count *failures before* the first success start the
+    support at ``0`` instead; that is a different parameterisation and not what this class computes.
 
     Arguments:
         p: Success probability of each trial, with ``0 < p <= 1``. Either a Python ``float`` or an
@@ -34,8 +64,9 @@ class Geometric(DiscreteDistribution):
 
     An invalid ``p`` (``p <= 0``, ``p > 1`` or ``NaN``) is not checked at construction; matching every
     other distribution, it raises ``InvalidOperation`` (a ``ComputeError``) when any method is
-    evaluated. A null ``p`` propagates to null. Samples are ``UInt64`` trial counts, so unlike
-    ``Bernoulli`` the degenerate ``p = 0`` point mass is not representable.
+    evaluated. A null ``p`` propagates to null wherever the result depends on ``p``; the off-support
+    constants (``pmf(0) = 0``, ``sf(0) = 1``) do not, as in ``Bernoulli``. Samples are ``UInt64``
+    trial counts, so unlike ``Bernoulli`` the degenerate ``p = 0`` point mass is not representable.
     """
 
     _p: pl.Expr
@@ -64,14 +95,12 @@ class Geometric(DiscreteDistribution):
     def _pmf(self, value: pl.Expr) -> pl.Expr:
         """``(1 - p)**(k - 1) * p`` on the positive integers, ``0`` elsewhere."""
         p = self._checked_p
-        is_support = (value >= 1) & (value.floor() == value)
+        k = value.floor()
+        is_support = (value >= 1) & (k == value)
         return (
             pl.when(is_support)
-            .then(
-                # `k = 1` short-circuits before the power term: `(k - 1) * log1p(-p)` degenerates to
-                # `0 * -inf = nan` at `p = 1`, where the mass is exactly `p`.
-                pl.when(value <= 1).then(p).otherwise(p * ((value.floor() - 1) * (-p).log1p()).exp())
-            )
+            # `k = 1` short-circuits the power term, which is `0 * -inf = nan` at `p = 1`.
+            .then(pl.when(k == 1).then(p).otherwise(p * ((k - 1) * (-p).log1p()).exp()))
             .otherwise(0.0)
         )
 
@@ -79,110 +108,90 @@ class Geometric(DiscreteDistribution):
         """``(k - 1) * log1p(-p) + log(p)`` on the positive integers, ``-inf`` elsewhere.
 
         Overrides the base ``pmf().log()``, whose ``log(1 - p)`` collapses to ``0.0`` below
-        ``p ~ 1.1e-16``. See docs/contributing.md, "Numerical stability". The ``k = 1`` case reads
-        ``log(p)`` directly because ``(k - 1) * log1p(-p)`` degenerates to ``0 * -inf = nan`` at
-        ``p = 1``, where the answer is exactly ``0``.
+        ``p ~ 1.1e-16``. See docs/contributing.md, "Numerical stability". ``k = 1`` reads ``log(p)``
+        directly, because ``(k - 1) * log1p(-p)`` is ``0 * -inf = nan`` at ``p = 1``.
         """
         p = self._checked_p
-        is_support = (value >= 1) & (value.floor() == value)
+        k = value.floor()
+        is_support = (value >= 1) & (k == value)
         return (
             pl.when(is_support)
-            .then(pl.when(value.floor() == 1).then(p.log()).otherwise((value.floor() - 1) * (-p).log1p() + p.log()))
+            .then(pl.when(k == 1).then(p.log()).otherwise((k - 1) * (-p).log1p() + p.log()))
             .otherwise(float("-inf"))
         )
 
     def _cdf(self, value: pl.Expr) -> pl.Expr:
-        """``0`` for ``value < 1``, else ``-expm1(floor(value) * log1p(-p))``.
+        """``0`` below the support, else ``-expm1(k * log1p(-p))`` with ``k = floor(value)``.
 
-        The mass sits at ``p``-scale for small ``k``, so the naive ``1 - (1 - p)**floor(value)``
-        inherits the rounding of ``1 - p`` and of the subtraction against ``1`` -- a few parts in
-        ``1e9`` of relative error at ``p = 1e-8``, where the true answer is ``1e-8``. Entering
-        through ``log1p(-p)`` keeps the parameter exact; past ``x = -20`` the complement is read
-        directly as ``1 - exp(x)``, which cannot round above ``1``; the exponential itself is
-        evaluated through the identity ``expm1(x) = 2 exp(x/2) sinh(x/2)`` (polars has no
-        ``expm1``), whose only weak spot is ``x/2`` overflowing ``sinh`` below ``x ~ -1455`` --
-        far inside the direct-complement branch.
+        Entering through ``log1p(-p)`` keeps a small ``p`` exact, where the literal
+        ``1 - (1 - p)**k`` inherits the rounding of ``1 - p`` and of the subtraction against ``1``:
+        a few parts in ``1e9`` at ``p = 1e-8``. Polars has no ``expm1``, so it is spelled through the
+        identity ``expm1(t) = 2 exp(t / 2) sinh(t / 2)``, and read directly as ``1 - exp(t)`` past
+        `_CDF_DIRECT_COMPLEMENT_MAX`.
         """
         p = self._checked_p
-        x = value.floor() * (-p).log1p()
+        log_tail = value.floor() * (-p).log1p()
+        half = log_tail / 2
         return (
             pl.when(value < 1)
             .then(0.0)
-            .when(x <= _CDF_DIRECT_TAIL)
-            .then(1.0 - x.exp())
-            .otherwise(-2.0 * (x / 2).exp() * (x / 2).sinh())
+            .when(log_tail <= _CDF_DIRECT_COMPLEMENT_MAX)
+            .then(1.0 - log_tail.exp())
+            .otherwise(-2.0 * half.exp() * half.sinh())
         )
 
     def _log_cdf(self, value: pl.Expr) -> pl.Expr:
-        """``-inf`` for ``value < 1``, else ``log(1 - exp(floor(value) * log1p(-p)))``.
+        """``-inf`` below the support, else ``log(1 - exp(k * log1p(-p)))`` with ``k = floor(value)``.
 
-        Two regimes, split where the answer's own magnitude stops dwarfing the absolute granularity
-        of the pieces. Below ``x = -1`` the cdf sits within ``0.63`` of ``1``, and ``log1p(-exp(x))``
-        carries that difference exactly -- down through the ``cdf ~ 1 - 1e-16`` saturation zone,
-        where ``log(cdf)`` reads the tail mass rounded away against ``1`` and answers ``0``. Above
-        it, the answer assembles from the `_cdf` pieces on the log scale, ``log(2 exp(x/2)
-        sinh(x/2))``: every piece is huge precisely where the answer is huge, so their rounding
-        stays relative.
+        Two regimes, split at `_LOG_CDF_LOG1P_MAX` where the answer's own magnitude stops dwarfing
+        the absolute granularity of the pieces. Below it ``log1p`` carries the difference from ``1``
+        exactly; above it the `_cdf` pieces assemble on the log scale, each one large precisely where
+        the answer is large, so their rounding stays relative.
         """
         p = self._checked_p
-        x = value.floor() * (-p).log1p()
+        log_tail = value.floor() * (-p).log1p()
+        half = log_tail / 2
         return (
             pl.when(value < 1)
             .then(float("-inf"))
-            .when(x <= -1.0)
-            .then((-x.exp()).log1p())
-            .otherwise(math.log(2.0) + x / 2 + (-(x / 2).sinh()).log())
+            .when(log_tail <= _LOG_CDF_LOG1P_MAX)
+            .then((-log_tail.exp()).log1p())
+            .otherwise(_LN_2 + half + (-half.sinh()).log())
         )
 
     def _sf(self, value: pl.Expr) -> pl.Expr:
-        """``1`` for ``value < 1``, ``exp(floor(value) * log1p(-p))`` for ``value >= 1``.
+        """``1`` below the support, else ``exp(floor(value) * log1p(-p))``.
 
-        A closed form that stays accurate in the upper tail, unlike the base ``1 - cdf``, which
-        recomputes ``p`` as ``1 - (1 - p)`` and so quantises it to the ``1.1e-16`` spacing of ``1.0``,
-        reaching ``0.0`` below that. Entering through ``log1p(-p)`` also avoids the rounding of the
-        literal ``1 - p``, visible as a few parts in ``1e9`` of relative error at ``p = 1e-8``.
+        Overrides the base ``1 - cdf``, which recomputes ``p`` as ``1 - (1 - p)`` and so quantises it
+        to the ``1.1e-16`` spacing of ``1.0``, reaching ``0.0`` below that. ``log1p(-p)`` also avoids
+        the rounding of the literal ``1 - p``, a few parts in ``1e9`` at ``p = 1e-8``.
         """
         p = self._checked_p
         return pl.when(value < 1).then(1.0).otherwise((value.floor() * (-p).log1p()).exp())
 
     def _log_sf(self, value: pl.Expr) -> pl.Expr:
-        """``0`` for ``value < 1``, ``floor(value) * log1p(-p)`` for ``value >= 1``."""
+        """``0`` below the support, else ``floor(value) * log1p(-p)``."""
         p = self._checked_p
         return pl.when(value < 1).then(0.0).otherwise(value.floor() * (-p).log1p())
 
     def _ppf(self, quantile: pl.Expr) -> pl.Expr:
         """Smallest ``k`` with ``cdf(k) >= quantile``: ``ceil(log1p(-q) / log1p(-p))``, clipped to the support floor.
 
-        Null for ``q`` outside ``[0, 1]``. Both sides go through ``log1p``: the naive
-        ``log(1 - q) / log(1 - p)`` collapses its numerator to ``0.0`` below ``q ~ 1.1e-16`` and
-        answers ``0`` where the smallest support point ``1`` is the only correct answer, while the
-        denominator side is the reason in ``_log_pmf``. The negation is written ``0.0 - q`` so an
-        unsigned quantile column promotes to ``Float64`` (polars rejects ``neg`` on an unsigned
-        dtype).
+        Null for ``q`` outside ``[0, 1]``. Both sides go through ``log1p``: the literal
+        ``log(1 - q)`` collapses to ``0.0`` below ``q ~ 1.1e-16`` and answers ``0`` where the smallest
+        support point ``1`` is the only correct answer, and the denominator is the reason in
+        `_log_pmf`. The negation is written ``0.0 - q`` so an unsigned quantile column promotes to
+        ``Float64`` (polars rejects ``neg`` on an unsigned dtype).
 
-        Every answer lives on the positive integers, so the ``ceil`` is clipped up to ``1.0``: at
-        ``q = 0`` the formula degenerates to ``-0.0``, and at ``p < 1, q = 1`` the ratio runs off to
-        ``+inf``. At ``p = 1`` the ratio is ``-inf / -inf = nan``, so that parameter degeneracy
-        short-circuits first: the whole mass sits on ``k = 1``.
-
-        The raw ceiling can overshoot by one support point when the ratio lands an ulp above an
-        exact integer -- the stored quantile then sits a hair below the cdf step it belongs to --
-        so the candidate is stepped back down whenever ``k - 1`` already satisfies its own defining
-        inequality, compared in the log domain both sides entered through.
-
-        The result stays a ``Float64`` support point rather than an integral dtype, matching the other
-        distributions' inverses and leaving the wrapper's ``NaN -> NaN`` contract representable.
+        ``q = 1`` runs the ratio off to ``+inf``, the right answer for an unbounded support.
+        ``p = 1`` short-circuits before `_smallest_support_point`, where the ratio would be
+        ``-inf / -inf = nan`` and the whole mass sits on ``k = 1``.
         """
         p = self._checked_p
-        tail_log = (-p).log1p()
-        target_log = (0.0 - quantile).log1p()
-        candidate = (target_log / tail_log).ceil()
-        stepped = (
-            pl.when((candidate - 1.0) * tail_log <= target_log).then(candidate - 1.0).otherwise(candidate).clip(1.0)
-        )
+        support_point = _smallest_support_point((0.0 - quantile).log1p(), (-p).log1p())
         return (
             pl.when(quantile.is_between(0, 1))
-            .then(pl.when(p == 1).then(1.0).otherwise(stepped))
+            .then(pl.when(p == 1).then(1.0).otherwise(support_point))
             .otherwise(pl.lit(None, dtype=pl.Float64()))
         )
 
@@ -191,26 +200,15 @@ class Geometric(DiscreteDistribution):
 
         The exact inverse of `_sf`, entered against ``quantile`` itself rather than through the base
         ``ppf(1 - quantile)``, whose complement throws the tail mass away before the inverse runs.
-        As in `_ppf`, every answer lives on the positive integers, so the ``ceil`` is clipped up to
-        ``1.0``: at ``q = 1`` the formula degenerates to ``-0.0``, and ``q = 0`` flows through it as
-        ``+inf``. At ``p = 1`` the ratio is ``nan`` or ``-inf / -inf``, so that parameter degeneracy
-        short-circuits first: every survival quantile inverts to the single mass point ``k = 1``,
-        including ``q = 0``, where ``sf(1) = 0`` already satisfies the inequality.
-
-        The same one-ulp overshoot as in `_ppf` applies -- an exact-integer ratio landing an ulp high
-        skips a support point -- so the candidate steps back down whenever ``k - 1`` already
-        satisfies ``sf(k - 1) <= q``, compared as ``(k - 1) * log1p(-p) <= log(q)``.
+        Here ``q = 1`` degenerates to ``-0.0`` and ``q = 0`` flows through as ``+inf``. At ``p = 1``
+        every survival quantile inverts to ``k = 1``, including ``q = 0``, where ``sf(1) = 0``
+        already satisfies the inequality.
         """
         p = self._checked_p
-        tail_log = (-p).log1p()
-        target_log = quantile.log()
-        candidate = (target_log / tail_log).ceil()
-        stepped = (
-            pl.when((candidate - 1.0) * tail_log <= target_log).then(candidate - 1.0).otherwise(candidate).clip(1.0)
-        )
+        support_point = _smallest_support_point(quantile.log(), (-p).log1p())
         return (
             pl.when(quantile.is_between(0, 1))
-            .then(pl.when(p == 1).then(1.0).otherwise(stepped))
+            .then(pl.when(p == 1).then(1.0).otherwise(support_point))
             .otherwise(pl.lit(None, dtype=pl.Float64()))
         )
 
@@ -220,7 +218,8 @@ class Geometric(DiscreteDistribution):
 
     def variance(self) -> pl.Expr:
         """Variance, ``(1 - p) / p**2``."""
-        return (1 - self._checked_p) / self._checked_p**2
+        p = self._checked_p
+        return (1 - p) / p**2
 
     def std(self) -> pl.Expr:
         """Standard deviation, ``sqrt(1 - p) / p``.
@@ -228,13 +227,14 @@ class Geometric(DiscreteDistribution):
         Overrides the base-class ``variance().sqrt()``, which squares ``p`` and then unsquares
         it: the round trip overflows about 150 decades before ``sqrt(1 - p) / p`` does.
         """
-        return (1 - self._checked_p).sqrt() / self._checked_p
+        p = self._checked_p
+        return (1 - p).sqrt() / p
 
     def entropy(self) -> pl.Expr:
         """Shannon entropy, ``(-(1 - p) * log1p(-p) - p * log(p)) / p``, with the ``0`` limit at ``p = 1``.
 
         Uses the convention ``0 * log 0 = 0`` so the degenerate ``p = 1`` point mass has entropy ``0``.
-        The first term goes through ``log1p`` for the reason in ``_log_pmf``.
+        The first term goes through ``log1p`` for the reason in `_log_pmf`.
         """
         p = self._checked_p
         q = 1 - p

--- a/src/distributions/geometric.rs
+++ b/src/distributions/geometric.rs
@@ -10,10 +10,8 @@ use crate::rng::{
     samples_u64_output, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
-/// Construct a `statrs::Geometric`, mapping the invalid-parameter case to a `ComputeError`.
-///
-/// `statrs::Geometric::new` rejects a `NaN` `p` or a `p` outside `(0, 1]`, so unlike `Bernoulli`
-/// the degenerate `p = 0` point mass is not representable.
+/// `statrs::Geometric::new` rejects `NaN` and any `p` outside `(0, 1]`, so unlike `Bernoulli` the
+/// degenerate `p = 0` point mass is not representable.
 fn build_dist(proba: f64) -> PolarsResult<Geometric> {
     Geometric::new(proba).map_err(|e| {
         PolarsError::InvalidOperation(format!("p must be in (0, 1], got {proba}: {e}").into())

--- a/src/distributions/geometric.rs
+++ b/src/distributions/geometric.rs
@@ -1,0 +1,123 @@
+#![allow(clippy::unused_unit)]
+use polars::prelude::*;
+use pyo3_polars::derive::polars_expr;
+use rand::distr::Distribution as RandDistribution;
+use statrs::distribution::Geometric;
+
+use crate::distributions::{align_inputs, validate_params_unary};
+use crate::rng::{
+    binary_param_rows, sample_by_index, sample_per_row_binary, samples_by_index, samples_per_row,
+    samples_u64_output, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
+};
+
+/// Construct a `statrs::Geometric`, mapping the invalid-parameter case to a `ComputeError`.
+///
+/// `statrs::Geometric::new` rejects a `NaN` `p` or a `p` outside `(0, 1]`, so unlike `Bernoulli`
+/// the degenerate `p = 0` point mass is not representable.
+fn build_dist(proba: f64) -> PolarsResult<Geometric> {
+    Geometric::new(proba).map_err(|e| {
+        PolarsError::InvalidOperation(format!("p must be in (0, 1], got {proba}: {e}").into())
+    })
+}
+
+/// Geometric's constant success probability, deserialised once per call.
+#[derive(serde::Deserialize)]
+struct GeometricParamsKwargs {
+    p: f64,
+}
+
+impl GeometricParamsKwargs {
+    fn build(&self) -> PolarsResult<Geometric> {
+        build_dist(self.p)
+    }
+}
+
+/// Element-wise validation of the success probability: returns `p` unchanged, raising
+/// `InvalidOperation` if `p` is outside `(0, 1]`. `null` propagates.
+///
+/// The closed-form Python methods derive from this so they report an invalid `p` consistently
+/// with `geometric_sample`, instead of silently computing with a non-positive probability.
+#[polars_expr(output_type=Float64)]
+fn geometric_p(inputs: &[Series]) -> PolarsResult<Series> {
+    let proba = inputs[0].cast(&DataType::Float64)?;
+
+    validate_params_unary(proba.f64()?, |proba| {
+        build_dist(proba)?;
+        Ok(proba)
+    })
+}
+
+/// One Geometric draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
+///
+/// Every Geometric sampler draws through here, per-row and fast path alike, so their bit-equality is
+/// structural rather than only sampled by `sample_test.py`.
+#[inline]
+fn draw(dist: &Geometric, rng: &mut impl rand::Rng) -> u64 {
+    RandDistribution::<u64>::sample(dist, rng)
+}
+
+/// Element-wise Geometric sampler over `(p, row_index)`, returning `UInt64`.
+///
+/// Per row, `null` propagates and an invalid `p` raises via [`build_dist`]. Seeding and
+/// chunk-invariance follow [`sample_per_row_binary`].
+#[polars_expr(output_type=UInt64)]
+fn geometric_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
+    let proba = inputs[0].cast(&DataType::Float64)?;
+    let index = inputs[1].cast(&DataType::UInt64)?;
+    let name = inputs[0].name().clone();
+
+    sample_per_row_binary(
+        name,
+        proba.f64()?,
+        index.u64()?,
+        kwargs.seed,
+        build_dist,
+        draw,
+    )
+}
+
+/// Constant-parameter fast path for [`geometric_sample`].
+#[polars_expr(output_type=UInt64)]
+fn geometric_sample_scalar(
+    inputs: &[Series],
+    kwargs: SampleScalarKwargs<GeometricParamsKwargs>,
+) -> PolarsResult<Series> {
+    let dist = kwargs.params.build()?;
+    let name = inputs[0].name().clone();
+
+    sample_by_index(name, &inputs[0], kwargs.seed, |rng| draw(&dist, rng))
+}
+
+/// Constant-parameter multi-draw fast path: the `samples` twin of [`geometric_sample_scalar`].
+///
+/// `size` consecutive draws from each row's stream, so `samples(size=1)` matches `sample` bit for
+/// bit and the distribution is built once per call. Returns `Array(UInt64, size)`.
+#[polars_expr(output_type_func_with_kwargs=samples_u64_output)]
+fn geometric_samples_scalar(
+    inputs: &[Series],
+    kwargs: SamplesScalarKwargs<GeometricParamsKwargs>,
+) -> PolarsResult<Series> {
+    let dist = kwargs.params.build()?;
+    let name = inputs[0].name().clone();
+
+    samples_by_index(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
+        draw(&dist, rng)
+    })
+}
+
+/// Element-wise multi-draw Geometric sampler: `size` draws per row in one call, the distribution
+/// built once per row. Returns `Array(UInt64, size)`.
+///
+/// Seeding and the null/error contract follow [`samples_per_row`] and [`geometric_sample`].
+#[polars_expr(output_type_func_with_kwargs=samples_u64_output)]
+fn geometric_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
+    let proba = inputs[0].cast(&DataType::Float64)?;
+    let index = inputs[1].cast(&DataType::UInt64)?;
+    let name = inputs[0].name().clone();
+
+    let rows = binary_param_rows(proba.f64()?, index.u64()?, build_dist);
+
+    samples_per_row(name, rows, kwargs.seed, kwargs.size, draw)
+}

--- a/src/distributions/geometric.rs
+++ b/src/distributions/geometric.rs
@@ -18,6 +18,15 @@ fn build_dist(proba: f64) -> PolarsResult<Geometric> {
     })
 }
 
+/// The samplers' per-row state: `ln(1 - p)`, the log base [`draw`]'s inverse transform divides by.
+///
+/// Validated through [`build_dist`], so an invalid `p` raises identically either way. Built once per
+/// row, not once per draw: the multi-draw and constant-parameter paths take many draws per state.
+fn build_sampler(proba: f64) -> PolarsResult<f64> {
+    build_dist(proba)?;
+    Ok((-proba).ln_1p())
+}
+
 /// Geometric's constant success probability, deserialised once per call.
 #[derive(serde::Deserialize)]
 struct GeometricParamsKwargs {
@@ -25,8 +34,8 @@ struct GeometricParamsKwargs {
 }
 
 impl GeometricParamsKwargs {
-    fn build(&self) -> PolarsResult<Geometric> {
-        build_dist(self.p)
+    fn build_sampler(&self) -> PolarsResult<f64> {
+        build_sampler(self.p)
     }
 }
 
@@ -49,14 +58,24 @@ fn geometric_p(inputs: &[Series]) -> PolarsResult<Series> {
 ///
 /// Every Geometric sampler draws through here, per-row and fast path alike, so their bit-equality is
 /// structural rather than only sampled by `sample_test.py`.
+///
+/// The inverse transform `ceil(ln u / ln(1 - p))` takes its log base from [`build_sampler`]'s
+/// `ln_1p`, not from `statrs`' `Distribution<u64>`, which forms the literal `1.0 - p`: that rounds
+/// to `1.0` at `p <= 2^-54`, so the base is `0.0`, the ratio `-inf`, and every draw below the
+/// threshold casts to `0` where the true draws are around `1 / p`.
+///
+/// `u` comes from `(0, 1]`, so `u = 1` gives a raw draw of `0`; `.max(1)` lifts it to the support
+/// floor, where that endpoint's mass belongs in the limit. At the other end the cast saturates once
+/// `-ln u` outgrows `u64::MAX * p`, from around `p ~ 2e-18`: a dtype limit, not an algorithm one.
 #[inline]
-fn draw(dist: &Geometric, rng: &mut impl rand::Rng) -> u64 {
-    RandDistribution::<u64>::sample(dist, rng)
+fn draw(log_failure: &f64, rng: &mut impl rand::Rng) -> u64 {
+    let uniform: f64 = RandDistribution::sample(&rand::distr::OpenClosed01, rng);
+    ((uniform.ln() / log_failure).ceil() as u64).max(1)
 }
 
 /// Element-wise Geometric sampler over `(p, row_index)`, returning `UInt64`.
 ///
-/// Per row, `null` propagates and an invalid `p` raises via [`build_dist`]. Seeding and
+/// Per row, `null` propagates and an invalid `p` raises via [`build_sampler`]. Seeding and
 /// chunk-invariance follow [`sample_per_row_binary`].
 #[polars_expr(output_type=UInt64)]
 fn geometric_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
@@ -70,7 +89,7 @@ fn geometric_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Ser
         proba.f64()?,
         index.u64()?,
         kwargs.seed,
-        build_dist,
+        build_sampler,
         draw,
     )
 }
@@ -81,31 +100,31 @@ fn geometric_sample_scalar(
     inputs: &[Series],
     kwargs: SampleScalarKwargs<GeometricParamsKwargs>,
 ) -> PolarsResult<Series> {
-    let dist = kwargs.params.build()?;
+    let log_failure = kwargs.params.build_sampler()?;
     let name = inputs[0].name().clone();
 
-    sample_by_index(name, &inputs[0], kwargs.seed, |rng| draw(&dist, rng))
+    sample_by_index(name, &inputs[0], kwargs.seed, |rng| draw(&log_failure, rng))
 }
 
 /// Constant-parameter multi-draw fast path: the `samples` twin of [`geometric_sample_scalar`].
 ///
 /// `size` consecutive draws from each row's stream, so `samples(size=1)` matches `sample` bit for
-/// bit and the distribution is built once per call. Returns `Array(UInt64, size)`.
+/// bit. Returns `Array(UInt64, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_u64_output)]
 fn geometric_samples_scalar(
     inputs: &[Series],
     kwargs: SamplesScalarKwargs<GeometricParamsKwargs>,
 ) -> PolarsResult<Series> {
-    let dist = kwargs.params.build()?;
+    let log_failure = kwargs.params.build_sampler()?;
     let name = inputs[0].name().clone();
 
     samples_by_index(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
-        draw(&dist, rng)
+        draw(&log_failure, rng)
     })
 }
 
-/// Element-wise multi-draw Geometric sampler: `size` draws per row in one call, the distribution
-/// built once per row. Returns `Array(UInt64, size)`.
+/// Element-wise multi-draw Geometric sampler: `size` draws per row in one call. Returns
+/// `Array(UInt64, size)`.
 ///
 /// Seeding and the null/error contract follow [`samples_per_row`] and [`geometric_sample`].
 #[polars_expr(output_type_func_with_kwargs=samples_u64_output)]
@@ -115,7 +134,7 @@ fn geometric_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<S
     let index = inputs[1].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
 
-    let rows = binary_param_rows(proba.f64()?, index.u64()?, build_dist);
+    let rows = binary_param_rows(proba.f64()?, index.u64()?, build_sampler);
 
     samples_per_row(name, rows, kwargs.seed, kwargs.size, draw)
 }

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -2,6 +2,7 @@ pub mod bernoulli;
 pub mod beta;
 pub mod binomial;
 pub mod exponential;
+pub mod geometric;
 pub mod lognormal;
 pub mod normal;
 pub mod uniform;

--- a/tests/distributions/geometric/cdf_test.py
+++ b/tests/distributions/geometric/cdf_test.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Geometric
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@pytest.mark.parametrize("p", [0.1, 0.3, 0.5, 0.8])
+@pytest.mark.parametrize(
+    ("value", "expected_fn"),
+    [
+        (0.99, lambda _p: 0.0),  # below the support
+        (-1.0, lambda _p: 0.0),
+        (1, lambda p: p),
+        (2, lambda p: 1 - (1 - p) ** 2),
+        (3, lambda p: 1 - (1 - p) ** 3),
+        (10, lambda p: 1 - (1 - p) ** 10),
+    ],
+)
+def test_cdf_scalar_p(
+    p: float,
+    value: float,
+    expected_fn: Callable[[float], float],
+    unit_frame: pl.DataFrame,
+) -> None:
+    result = unit_frame.select(v=Geometric(p=p).cdf(value)).item(0, "v")
+    assert result == pytest.approx(expected_fn(p))
+
+
+def test_cdf_column_value() -> None:
+    p = 0.3
+    df = pl.DataFrame({"v": [-1, 0, 1, 2]}, schema={"v": pl.Int64})
+    result = df.select(r=Geometric(p=p).cdf(pl.col("v")))["r"]
+    expected = pl.Series("r", [0.0, 0.0, p, 1 - (1 - p) ** 2], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_cdf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"v": [0, None, 2]}, schema={"v": pl.Int64})
+    result = df.select(r=Geometric(p=0.5).cdf(pl.col("v")))["r"]
+    expected = pl.Series("r", [0.0, None, 0.75], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_cdf_propagates_null_in_p(p_with_null: pl.DataFrame) -> None:
+    result = p_with_null.select(r=Geometric(p=pl.col("p")).cdf(2))["r"]
+    expected = pl.Series("r", [0.51, None, 0.96], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/geometric/conftest.py
+++ b/tests/distributions/geometric/conftest.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import polars as pl
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+SEED = 42
+DEFAULT_SIZE = 1000
+
+
+@pytest.fixture(scope="session")
+def seed() -> int:
+    return SEED
+
+
+@pytest.fixture(scope="session")
+def rng() -> np.random.Generator:
+    return np.random.default_rng(seed=SEED)
+
+
+@pytest.fixture
+def frame(rng: np.random.Generator) -> Callable[..., pl.DataFrame]:
+    def _make(size: int = DEFAULT_SIZE) -> pl.DataFrame:
+        return pl.DataFrame(
+            {
+                "k": list(range(size)),
+                "p1": rng.uniform(0.01, 0.99, size=size),
+                "p2": rng.uniform(0.01, 0.99, size=size),
+            },
+        )
+
+    return _make
+
+
+@pytest.fixture
+def unit_frame() -> pl.DataFrame:
+    """Single-row frame for evaluating scalar-output expressions."""
+    return pl.DataFrame({"_": [0]})
+
+
+@pytest.fixture
+def p_with_null() -> pl.DataFrame:
+    """A `p` column with a null in the middle row: (0.3, null, 0.8)."""
+    return pl.DataFrame({"p": [0.3, None, 0.8]}, schema={"p": pl.Float64})

--- a/tests/distributions/geometric/construct_test.py
+++ b/tests/distributions/geometric/construct_test.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import pytest
+
+from polars_stats import Geometric
+
+
+@pytest.mark.parametrize("bad_p", [None, True, False, 1, 0, [0.5, 0.5], (0.5,), {"p": 0.5}])
+def test_construct_invalid_type_raises(bad_p: object) -> None:
+    with pytest.raises(TypeError, match="p should be a float or IntoExprColumn"):
+        Geometric(p=bad_p)  # type: ignore[arg-type]

--- a/tests/distributions/geometric/degenerate_test.py
+++ b/tests/distributions/geometric/degenerate_test.py
@@ -1,0 +1,94 @@
+"""`p = 1`: the whole mass on `k = 1`, and the branch ordering that keeps `NaN` out of it.
+
+At `p = 1` the shared entry `log1p(-p)` is `-inf`, so `floor(value) * log1p(-p)` is `NaN` for every
+`value` in `[0, 1)` and `-inf` above it. Each of `_cdf`, `_log_cdf`, `_sf` and `_log_sf` answers its
+below-support constant *before* forming that product, and each inverse short-circuits on `p == 1`
+before dividing `-inf` by `-inf`. Nothing else pins that ordering: the scipy parity grid excludes
+`p = 1` (scipy's generic discrete `ppf`, `isf`, `median` and `entropy` do not answer there) and the
+per-method grids stop at `p = 0.8`, so a reordered `when` chain would leak `NaN` and still ship green.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+
+from polars_stats import Geometric
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_NEG_INF = float("-inf")
+
+# One row per (method, value) with the exact answer of the `p = 1` point mass.
+_VALUE_KEYED: dict[str, tuple[Callable[[Geometric, pl.Expr], pl.Expr], list[tuple[float, float]]]] = {
+    "pmf": (lambda g, v: g.pmf(v), [(-1.0, 0.0), (0.0, 0.0), (0.5, 0.0), (1.0, 1.0), (2.0, 0.0), (10.0, 0.0)]),
+    "log_pmf": (
+        lambda g, v: g.log_pmf(v),
+        [(-1.0, _NEG_INF), (0.0, _NEG_INF), (0.5, _NEG_INF), (1.0, 0.0), (2.0, _NEG_INF)],
+    ),
+    "cdf": (lambda g, v: g.cdf(v), [(-1.0, 0.0), (0.0, 0.0), (0.5, 0.0), (1.0, 1.0), (2.0, 1.0), (1e6, 1.0)]),
+    "log_cdf": (
+        lambda g, v: g.log_cdf(v),
+        [(-1.0, _NEG_INF), (0.0, _NEG_INF), (0.5, _NEG_INF), (1.0, 0.0), (2.0, 0.0), (1e6, 0.0)],
+    ),
+    "sf": (lambda g, v: g.sf(v), [(-1.0, 1.0), (0.0, 1.0), (0.5, 1.0), (1.0, 0.0), (2.0, 0.0), (1e6, 0.0)]),
+    "log_sf": (
+        lambda g, v: g.log_sf(v),
+        [(-1.0, 0.0), (0.0, 0.0), (0.5, 0.0), (1.0, _NEG_INF), (2.0, _NEG_INF), (1e6, _NEG_INF)],
+    ),
+}
+
+
+@pytest.mark.parametrize(("expr_fn", "cases"), _VALUE_KEYED.values(), ids=list(_VALUE_KEYED))
+def test_value_keyed_method_at_p_one(
+    expr_fn: Callable[[Geometric, pl.Expr], pl.Expr],
+    cases: list[tuple[float, float]],
+    unit_frame: pl.DataFrame,
+) -> None:
+    """Exact, and never `NaN`: `0 * -inf` must not reach the result on either side of the support."""
+    for value, expected in cases:
+        got = unit_frame.select(r=expr_fn(Geometric(p=1.0), pl.lit(value)))["r"].item()
+        assert not math.isnan(got), f"{value} -> NaN"
+        assert got == expected, f"{value} -> {got}, want {expected}"
+
+
+@pytest.mark.parametrize(("expr_fn", "cases"), _VALUE_KEYED.values(), ids=list(_VALUE_KEYED))
+def test_value_keyed_method_at_p_one_from_a_column(
+    expr_fn: Callable[[Geometric, pl.Expr], pl.Expr],
+    cases: list[tuple[float, float]],
+) -> None:
+    """The per-row path answers identically: `p = 1` is a value, not a constant-folding artefact."""
+    frame = pl.DataFrame({"p": [1.0] * len(cases), "v": [v for v, _ in cases]})
+    got = frame.select(r=expr_fn(Geometric(p=pl.col("p")), pl.col("v")))["r"].to_list()
+    assert got == [e for _, e in cases]
+
+
+@pytest.mark.parametrize("quantile", [0.0, 1e-300, 0.25, 0.5, 0.75, 1.0])
+def test_both_inverses_collapse_to_the_mass_point(quantile: float, unit_frame: pl.DataFrame) -> None:
+    """Every quantile inverts to `k = 1`, including the endpoints where the ratio would be `NaN`."""
+    frame = unit_frame.select(ppf=Geometric(p=1.0).ppf(quantile), isf=Geometric(p=1.0).isf(quantile))
+    assert frame.item(0, "ppf") == 1.0
+    assert frame.item(0, "isf") == 1.0
+
+
+def test_moments_at_p_one(unit_frame: pl.DataFrame) -> None:
+    """A point mass at `k = 1`: mean `1`, no spread, and entropy `0` by the `0 log 0 = 0` convention."""
+    g = Geometric(p=1.0)
+    got = unit_frame.select(mean=g.mean(), variance=g.variance(), std=g.std(), median=g.median(), entropy=g.entropy())
+    assert got.item(0, "mean") == 1.0
+    assert got.item(0, "variance") == 0.0
+    assert got.item(0, "std") == 0.0
+    assert got.item(0, "median") == 1.0
+    assert got.item(0, "entropy") == 0.0
+
+
+def test_sample_at_p_one_is_always_the_mass_point() -> None:
+    """Every trial succeeds, so every draw is `1`."""
+    frame = pl.DataFrame({"_": range(64)})
+    drawn = frame.select(r=Geometric(p=1.0).sample(seed=7))["r"]
+    assert drawn.dtype == pl.UInt64
+    assert drawn.unique().to_list() == [1]

--- a/tests/distributions/geometric/entropy_test.py
+++ b/tests/distributions/geometric/entropy_test.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Geometric
+
+
+@pytest.mark.parametrize("p", [0.1, 0.3, 0.5, 0.7, 0.9])
+def test_entropy_interior(p: float, unit_frame: pl.DataFrame) -> None:
+    q = 1 - p
+    result = unit_frame.select(v=Geometric(p=p).entropy()).item(0, "v")
+    expected = (-q * math.log(q) - p * math.log(p)) / p
+    assert result == pytest.approx(expected)
+
+
+def test_entropy_degenerate_endpoint_is_zero(unit_frame: pl.DataFrame) -> None:
+    # 0 * log 0 = 0 convention: the degenerate point mass at p = 1 has zero entropy.
+    result = unit_frame.select(v=Geometric(p=1.0).entropy()).item(0, "v")
+    assert result == 0.0
+
+
+def test_entropy_at_half_equals_two_log_two(unit_frame: pl.DataFrame) -> None:
+    half = unit_frame.select(v=Geometric(p=0.5).entropy()).item(0, "v")
+    assert half == pytest.approx(2 * math.log(2))
+
+
+@pytest.mark.parametrize("p", [0.1, 0.3, 0.7])
+def test_entropy_grows_as_p_shrinks(p: float, unit_frame: pl.DataFrame) -> None:
+    # The geometric distribution spreads out as success becomes rarer.
+    smaller = unit_frame.select(v=Geometric(p=p / 2).entropy()).item(0, "v")
+    larger = unit_frame.select(v=Geometric(p=p).entropy()).item(0, "v")
+    assert smaller > larger
+
+
+def test_entropy_propagates_null_in_p() -> None:
+    # Includes the degenerate endpoint on purpose: its entropy is 0 by convention,
+    # so this also guards the "0 * log 0 = 0" branch in the null-propagation path.
+    df = pl.DataFrame({"p": [0.5, None, 1.0]}, schema={"p": pl.Float64})
+    result = df.select(v=Geometric(p=pl.col("p")).entropy())["v"]
+    expected = pl.Series("v", [2 * math.log(2), None, 0.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/geometric/isf_test.py
+++ b/tests/distributions/geometric/isf_test.py
@@ -45,6 +45,24 @@ def test_isf_deep_tail_keeps_full_precision(unit_frame: pl.DataFrame) -> None:
     assert got == expected
 
 
+def test_isf_overshoots_by_one_at_an_exact_step_boundary(unit_frame: pl.DataFrame) -> None:
+    """At `q = sf(1)` the answer is `2`, where `sf(1) <= q` already makes `1` the definition's answer.
+
+    The `ppf` twin of this lands on the *other* side of its boundary, which is the shape of the
+    caveat: at a representable step the log-domain tie-break can miss in either direction. `sf(1)`
+    is exact here (`1 - 1e-8` is representable), so nothing but the tie-break is in play. One ulp
+    above the boundary the answer is `1` as expected, so the miss is one-sided in `q`, not a shifted
+    support. Pinned, not fixed; see the reasoning on the `ppf` twin and in
+    docs/explanation/accuracy.md, "Discrete `ppf` / `isf` at a step boundary".
+    """
+    p, support_floor, next_point = 1e-8, 1.0, 2.0
+    sf_at_floor = unit_frame.select(v=Geometric(p=p).sf(support_floor)).item(0, "v")
+
+    assert unit_frame.select(v=Geometric(p=p).isf(sf_at_floor)).item(0, "v") == next_point
+    assert unit_frame.select(v=Geometric(p=p).isf(math.nextafter(sf_at_floor, 0.0))).item(0, "v") == next_point
+    assert unit_frame.select(v=Geometric(p=p).isf(math.nextafter(sf_at_floor, 1.0))).item(0, "v") == support_floor
+
+
 @pytest.mark.parametrize("quantile", [-0.1, 1.5])
 def test_isf_out_of_range_quantile_is_null(quantile: float, unit_frame: pl.DataFrame) -> None:
     result = unit_frame.select(v=Geometric(p=0.3).isf(quantile)).item(0, "v")

--- a/tests/distributions/geometric/isf_test.py
+++ b/tests/distributions/geometric/isf_test.py
@@ -48,12 +48,12 @@ def test_isf_deep_tail_keeps_full_precision(unit_frame: pl.DataFrame) -> None:
 def test_isf_overshoots_by_one_at_an_exact_step_boundary(unit_frame: pl.DataFrame) -> None:
     """At `q = sf(1)` the answer is `2`, where `sf(1) <= q` already makes `1` the definition's answer.
 
-    The `ppf` twin of this lands on the *other* side of its boundary, which is the shape of the
-    caveat: at a representable step the log-domain tie-break can miss in either direction. `sf(1)`
-    is exact here (`1 - 1e-8` is representable), so nothing but the tie-break is in play. One ulp
-    above the boundary the answer is `1` as expected, so the miss is one-sided in `q`, not a shifted
-    support. Pinned, not fixed; see the reasoning on the `ppf` twin and in
-    docs/explanation/accuracy.md, "Discrete `ppf` / `isf` at a step boundary".
+    The direction is pinnable here, unlike on the `ppf` twin. `sf(1)` sits so close to `1` that the
+    `log` back out of it is quantised to the spacing of `1.0`, which is `1e-8` *relative* at this
+    `p`: the ratio misses the integer by `5e-9` rather than by a last bit, so every libm agrees on
+    which side it falls. One ulp above the boundary the answer is `1` as expected, so the miss is
+    one-sided in `q`, not a shifted support. Pinned, not fixed; see the reasoning on the `ppf` twin
+    and in docs/explanation/accuracy.md, "Discrete `ppf` / `isf` at a step boundary".
     """
     p, support_floor, next_point = 1e-8, 1.0, 2.0
     sf_at_floor = unit_frame.select(v=Geometric(p=p).sf(support_floor)).item(0, "v")

--- a/tests/distributions/geometric/isf_test.py
+++ b/tests/distributions/geometric/isf_test.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Geometric
+
+
+@pytest.mark.parametrize(
+    ("p", "quantile", "expected"),
+    [
+        (0.3, 1.0, 1.0),  # smallest support point, mapped explicitly at the degenerate endpoint
+        (0.3, 0.71, 1.0),  # sf(1) = 0.7 <= 0.71
+        (0.3, 0.69, 2.0),  # sf(1) = 0.7 > 0.69
+        (0.3, 0.5, 2.0),
+        (0.5, 0.5, 1.0),
+        (0.5, 0.25, 2.0),
+        (0.3, 0.0, float("inf")),
+        (1.0, 0.5, 1.0),  # point mass at k = 1: every quantile inverts to it
+        (1.0, 1e-300, 1.0),
+        (1.0, 0.0, 1.0),  # sf(1) = 0 already satisfies the inequality at the mass point
+    ],
+)
+def test_isf_scalar(p: float, quantile: float, expected: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Geometric(p=p).isf(quantile)).item(0, "v")
+    assert result == expected
+
+
+def test_isf_inverts_sf(unit_frame: pl.DataFrame) -> None:
+    for p, q in [(0.1, 1e-4), (0.3, 1e-8), (0.7, 0.9)]:
+        k = unit_frame.select(v=Geometric(p=p).isf(q)).item(0, "v")
+        assert unit_frame.select(v=Geometric(p=p).sf(k)).item(0, "v") <= q
+        assert unit_frame.select(v=Geometric(p=p).sf(k - 1)).item(0, "v") > q
+
+
+def test_isf_deep_tail_keeps_full_precision(unit_frame: pl.DataFrame) -> None:
+    # The base ppf(1 - q) quantises the tail mass to the spacing of 1.0 before the inverse
+    # runs; entering against q itself must resolve q down past the underflow threshold.
+    p, q = 0.5, 1e-300
+    expected = math.ceil(math.log(q) / math.log1p(-p))
+    got = unit_frame.select(v=Geometric(p=p).isf(q)).item(0, "v")
+    assert got == expected
+
+
+@pytest.mark.parametrize("quantile", [-0.1, 1.5])
+def test_isf_out_of_range_quantile_is_null(quantile: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Geometric(p=0.3).isf(quantile)).item(0, "v")
+    assert result is None
+
+
+def test_isf_propagates_nan_in_quantile(unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Geometric(p=0.3).isf(float("nan"))).item(0, "v")
+    assert math.isnan(result)
+
+
+def test_isf_propagates_null_in_quantile() -> None:
+    df = pl.DataFrame({"q": [0.1, None, 0.9]}, schema={"q": pl.Float64})
+    result = df.select(v=Geometric(p=0.3).isf(pl.col("q")))["v"]
+    expected = pl.Series("v", [7.0, None, 1.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_isf_propagates_null_in_p(p_with_null: pl.DataFrame) -> None:
+    result = p_with_null.select(v=Geometric(p=pl.col("p")).isf(0.5))["v"]
+    expected = pl.Series("v", [2.0, None, 1.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/geometric/log_cdf_test.py
+++ b/tests/distributions/geometric/log_cdf_test.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Geometric
+
+
+@pytest.mark.parametrize("p", [0.1, 0.25, 0.5, 0.75])
+@pytest.mark.parametrize("value", [1, 2, 10])
+def test_log_cdf_is_log_of_cdf(p: float, value: int, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Geometric(p=p).log_cdf(value)).item(0, "v")
+    expected = math.log(1 - (1 - p) ** value)
+    assert result == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("value", [-1, 0, 0.5])
+def test_log_cdf_below_support_is_negative_inf(value: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Geometric(p=0.3).log_cdf(value)).item(0, "v")
+    assert result == float("-inf")
+
+
+def test_log_cdf_tiny_p_keeps_full_precision(unit_frame: pl.DataFrame) -> None:
+    # The cdf sits a hair below 1 for tiny p, so its linear log collapses to 0.0;
+    # entering through log1p(-p) keeps the whole regime: here log_cdf reads log(k * p).
+    result = unit_frame.select(v=Geometric(p=1e-17).log_cdf(1000)).item(0, "v")
+    assert result == pytest.approx(math.log(1000 * 1e-17), rel=1e-12)
+
+
+@pytest.mark.parametrize("value", [100, 10_000, 1_000_000])
+def test_log_cdf_deep_tail_does_not_underflow(value: int, unit_frame: pl.DataFrame) -> None:
+    # cdf = 1 - (1-p)^k rounds to exactly 1.0 long before here, so a naive log would answer 0.
+    p = 0.001
+    result = unit_frame.select(v=Geometric(p=p).log_cdf(value)).item(0, "v")
+    assert result == pytest.approx(math.log1p(-math.exp(value * math.log1p(-p))))
+
+
+def test_log_cdf_propagates_null_in_p(p_with_null: pl.DataFrame) -> None:
+    result = p_with_null.select(r=Geometric(p=pl.col("p")).log_cdf(2))["r"]
+    expected = pl.Series("r", [math.log(1 - (1 - 0.3) ** 2), None, math.log(1 - (1 - 0.8) ** 2)], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/geometric/log_pmf_test.py
+++ b/tests/distributions/geometric/log_pmf_test.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Geometric
+
+
+@pytest.mark.parametrize("p", [0.1, 0.25, 0.5, 0.75, 1.0])
+@pytest.mark.parametrize("value", [1, 2, 5, 20])
+def test_log_pmf_is_log_of_pmf(p: float, value: int, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Geometric(p=p).log_pmf(value)).item(0, "v")
+    mass = (1 - p) ** (value - 1) * p
+    expected = math.log(mass) if mass > 0 else float("-inf")
+    assert result == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("value", [-1, 0, 0.5, 2.5])
+def test_log_pmf_off_support_is_negative_inf(value: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Geometric(p=0.3).log_pmf(value)).item(0, "v")
+    assert result == float("-inf")
+
+
+def test_log_pmf_tiny_p_keeps_full_precision(unit_frame: pl.DataFrame) -> None:
+    # log(1 - p) collapses to 0.0 for tiny p; log1p(-p) keeps it, so the whole
+    # small-p regime must not come back as -inf through the base pmf().log().
+    result = unit_frame.select(v=Geometric(p=1e-17).log_pmf(1000)).item(0, "v")
+    assert result == pytest.approx(math.log(1e-17))
+
+
+def test_log_pmf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"v": [0, None, 1]}, schema={"v": pl.Int64})
+    result = df.select(r=Geometric(p=0.3).log_pmf(pl.col("v")))["r"]
+    expected = pl.Series("r", [float("-inf"), None, math.log(0.3)], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_log_pmf_propagates_null_in_p(p_with_null: pl.DataFrame) -> None:
+    result = p_with_null.select(r=Geometric(p=pl.col("p")).log_pmf(1))["r"]
+    expected = pl.Series("r", [math.log(0.3), None, math.log(0.8)], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/geometric/log_sf_test.py
+++ b/tests/distributions/geometric/log_sf_test.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Geometric
+
+
+@pytest.mark.parametrize("p", [0.1, 0.25, 0.5, 0.75])
+@pytest.mark.parametrize("value", [1, 2, 10])
+def test_log_sf_is_log_of_sf(p: float, value: int, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Geometric(p=p).log_sf(value)).item(0, "v")
+    expected = (value) * math.log1p(-p)
+    assert result == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("value", [-1, 0, 0.5])
+def test_log_sf_below_support_is_zero(value: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Geometric(p=0.3).log_sf(value)).item(0, "v")
+    assert result == 0.0
+
+
+@pytest.mark.parametrize("k", [10_000, 100_000, 1_000_000])
+def test_log_sf_deep_tail_does_not_underflow(k: int, unit_frame: pl.DataFrame) -> None:
+    # sf = (1-p)^k underflows to exactly 0.0 around k ~ 70_000 for p = 0.001,
+    # so the base sf().log() would answer -inf where this still has digits.
+    p = 0.001
+    result = unit_frame.select(v=Geometric(p=p).log_sf(k)).item(0, "v")
+    assert result == pytest.approx(k * math.log1p(-p))
+
+
+def test_log_sf_propagates_null_in_p(p_with_null: pl.DataFrame) -> None:
+    result = p_with_null.select(r=Geometric(p=pl.col("p")).log_sf(2))["r"]
+    expected = pl.Series("r", [2 * math.log1p(-0.3), None, 2 * math.log1p(-0.8)], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/geometric/mean_test.py
+++ b/tests/distributions/geometric/mean_test.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Geometric
+
+
+@pytest.mark.parametrize(
+    ("p", "expected"),
+    [(0.25, 4.0), (0.3, 10 / 3), (0.5, 2.0), (1.0, 1.0)],
+)
+def test_mean(p: float, expected: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Geometric(p=p).mean()).item(0, "v")
+    assert result == pytest.approx(expected)
+
+
+def test_mean_propagates_null_in_p(p_with_null: pl.DataFrame) -> None:
+    result = p_with_null.select(v=Geometric(p=pl.col("p")).mean())["v"]
+    expected = pl.Series("v", [1 / 0.3, None, 1 / 0.8], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/geometric/median_test.py
+++ b/tests/distributions/geometric/median_test.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Geometric
+
+
+@pytest.mark.parametrize(("p", "expected"), [(0.2, 4.0), (0.3, 2.0), (0.5, 1.0), (0.9, 1.0)])
+def test_median(p: float, expected: float, unit_frame: pl.DataFrame) -> None:
+    # median = ppf(0.5): the smallest k whose cdf reaches one half.
+    result = unit_frame.select(v=Geometric(p=p).median()).item(0, "v")
+    assert result == expected
+
+
+def test_median_propagates_null_in_p(p_with_null: pl.DataFrame) -> None:
+    result = p_with_null.select(v=Geometric(p=pl.col("p")).median())["v"]
+    expected = pl.Series("v", [2.0, None, 1.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/geometric/null_param_test.py
+++ b/tests/distributions/geometric/null_param_test.py
@@ -1,0 +1,66 @@
+"""A null `p` nulls every answer that depends on it, and only those.
+
+`pmf(0) = 0`, `cdf(0) = 0` and `sf(0) = 1` are off-support constants with no `p` in them, so they
+survive a null one; the class docstring promises it and `Bernoulli` behaves the same way.
+
+It is a placement contract on a single gate. Every closed-form method reads `p` through one
+validating round trip (`Geometric._when_p_valid`) rather than naming the validated `p` inline, and
+widening that gate from the `p`-dependent branch to the whole method would null these constants and
+still leave the suite green: the per-method null tests all evaluate on the support.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from polars_stats import Geometric
+
+_NEG_INF = float("-inf")
+
+# (id, expr builder, expected) for the answers that hold with no `p` at all.
+_OFF_SUPPORT: list[tuple[str, str, float, float]] = [
+    ("pmf", "pmf", -1.0, 0.0),
+    ("pmf", "pmf", 0.0, 0.0),
+    ("pmf", "pmf", 0.5, 0.0),
+    ("log_pmf", "log_pmf", 0.0, _NEG_INF),
+    ("cdf", "cdf", 0.0, 0.0),
+    ("log_cdf", "log_cdf", 0.0, _NEG_INF),
+    ("sf", "sf", 0.0, 1.0),
+    ("log_sf", "log_sf", 0.0, 0.0),
+]
+
+_ON_SUPPORT = ["pmf", "log_pmf", "cdf", "log_cdf", "sf", "log_sf"]
+
+_PARAMETER_ONLY = ["mean", "variance", "std", "median", "entropy"]
+
+
+@pytest.mark.parametrize(
+    ("method", "value", "expected"),
+    [(m, v, e) for _, m, v, e in _OFF_SUPPORT],
+    ids=[f"{name}({value})" for name, _, value, _ in _OFF_SUPPORT],
+)
+def test_off_support_constant_survives_a_null_p(method: str, value: float, expected: float) -> None:
+    frame = pl.DataFrame({"p": [None]}, schema={"p": pl.Float64})
+    result = frame.select(r=getattr(Geometric(p=pl.col("p")), method)(value))["r"].item()
+    assert result == expected
+
+
+@pytest.mark.parametrize("method", _ON_SUPPORT)
+def test_on_support_value_nulls_under_a_null_p(method: str) -> None:
+    frame = pl.DataFrame({"p": [None]}, schema={"p": pl.Float64})
+    assert frame.select(r=getattr(Geometric(p=pl.col("p")), method)(1.0))["r"].item() is None
+
+
+@pytest.mark.parametrize("method", _PARAMETER_ONLY)
+def test_moment_nulls_under_a_null_p(method: str) -> None:
+    frame = pl.DataFrame({"p": [None]}, schema={"p": pl.Float64})
+    assert frame.select(r=getattr(Geometric(p=pl.col("p")), method)())["r"].item() is None
+
+
+@pytest.mark.parametrize("method", ["ppf", "isf"])
+@pytest.mark.parametrize("quantile", [0.5, 2.0])
+def test_inverse_nulls_under_a_null_p(method: str, quantile: float) -> None:
+    """Null inside `[0, 1]` because the answer needs `p`, and null outside it by the domain contract."""
+    frame = pl.DataFrame({"p": [None]}, schema={"p": pl.Float64})
+    assert frame.select(r=getattr(Geometric(p=pl.col("p")), method)(quantile))["r"].item() is None

--- a/tests/distributions/geometric/pmf_test.py
+++ b/tests/distributions/geometric/pmf_test.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Geometric
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@pytest.mark.parametrize("p", [0.1, 0.25, 0.5, 0.75, 1.0])
+@pytest.mark.parametrize(
+    ("value", "expected_fn"),
+    [
+        (1, lambda p: p),
+        (2, lambda p: (1 - p) * p),
+        (3, lambda p: (1 - p) ** 2 * p),
+        (10, lambda p: (1 - p) ** 9 * p),
+        (0, lambda _p: 0.0),  # below the support: the first trial is trial 1
+        (-1, lambda _p: 0.0),
+        (2.5, lambda _p: 0.0),  # non-integer support points
+    ],
+)
+def test_pmf_scalar_p(
+    p: float,
+    value: float,
+    expected_fn: Callable[[float], float],
+    unit_frame: pl.DataFrame,
+) -> None:
+    result = unit_frame.select(v=Geometric(p=p).pmf(value)).item(0, "v")
+    assert result == pytest.approx(expected_fn(p))
+
+
+def test_pmf_column_p() -> None:
+    probs = [0.1, 0.4, 0.6, 0.9]
+    df = pl.DataFrame({"p": probs})
+    pmf_at_1 = df.select(v=Geometric(p=pl.col("p")).pmf(1))["v"]
+    pmf_at_2 = df.select(v=Geometric(p=pl.col("p")).pmf(2))["v"]
+    assert_series_equal(pmf_at_1, pl.Series("v", probs, dtype=pl.Float64))
+    assert_series_equal(pmf_at_2, pl.Series("v", [(1 - x) * x for x in probs], dtype=pl.Float64))
+
+
+def test_pmf_column_value() -> None:
+    p = 0.3
+    df = pl.DataFrame({"v": [-1, 0, 1, 2]}, schema={"v": pl.Int64})
+    result = df.select(r=Geometric(p=p).pmf(pl.col("v")))["r"]
+    expected = pl.Series("r", [0.0, 0.0, p, (1 - p) * p], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_pmf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"v": [0, None, 1]}, schema={"v": pl.Int64})
+    result = df.select(r=Geometric(p=0.3).pmf(pl.col("v")))["r"]
+    expected = pl.Series("r", [0.0, None, 0.3], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_pmf_propagates_null_in_p(p_with_null: pl.DataFrame) -> None:
+    result = p_with_null.select(r=Geometric(p=pl.col("p")).pmf(1))["r"]
+    expected = pl.Series("r", [0.3, None, 0.8], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/geometric/ppf_test.py
+++ b/tests/distributions/geometric/ppf_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from fractions import Fraction
 
 import polars as pl
 import pytest
@@ -41,23 +42,43 @@ def test_ppf_matches_closed_form_for_small_p(unit_frame: pl.DataFrame) -> None:
     assert got == expected
 
 
-def test_ppf_undershoots_by_one_at_an_exact_step_boundary(unit_frame: pl.DataFrame) -> None:
-    """One ulp above `cdf(10)` the answer stays `10`, where the definition asks for `11`.
+def _smallest_support_point_exact(p: float, quantile: float) -> int:
+    """Smallest `k >= 1` with `cdf(k) >= quantile`, evaluated without rounding.
 
-    `cdf(10)` is exact here (`1 - 0.9**10` is representable), so this is the tie-break alone: the
-    step-down test compares `k * log1p(-p)` against `log1p(-q)`, and at a representable step those
-    two roundings can fall either side of the answer. Pinned, not fixed. Re-deciding the tie against
-    `cdf(k)` would get this point right and cost accuracy overall (1997 boundary probes: 357
-    disagreements with exact arithmetic against 490). scipy answers `10` here too. See
-    docs/explanation/accuracy.md, "Discrete `ppf` / `isf` at a step boundary", and the `isf` twin,
-    which lands on the other side.
+    `1 - (1 - p)**k >= q` over `Fraction`s, so this is the definition itself rather than a second
+    floating-point implementation of it to compare against.
     """
-    p, step = 0.1, 10.0
-    cdf_at_step = unit_frame.select(v=Geometric(p=p).cdf(step)).item(0, "v")
-    quantile = math.nextafter(cdf_at_step, 1.0)
+    failure, target = 1 - Fraction(p), Fraction(quantile)
+    k, tail = 1, failure
+    while 1 - tail < target:
+        k += 1
+        tail *= failure
+    return k
 
-    assert unit_frame.select(v=Geometric(p=p).ppf(quantile)).item(0, "v") == step
-    assert cdf_at_step < quantile
+
+@pytest.mark.parametrize(("p", "step"), [(0.1, 10), (0.3, 4), (0.5, 20), (0.05, 13)])
+@pytest.mark.parametrize("offset", [-1, 0, 1])
+def test_ppf_at_an_exact_step_boundary_can_miss_by_one(
+    p: float, step: int, offset: int, unit_frame: pl.DataFrame
+) -> None:
+    """On a step the answer is the definition's support point or a neighbour, and no further.
+
+    The tie-break compares `k * log1p(-p)` against `log1p(-q)` rather than re-deriving `cdf(k)`.
+    That is deliberate and the more accurate rule (1997 boundary probes: 357 disagreements with
+    exact arithmetic against 490 for the alternative), and the price is that `ppf` and `cdf` are not
+    exact mutual inverses on a step: the two roundings decide the last bit there. Which side they
+    fall on is the platform's `exp` and `log1p`, not the rule, so only the bound is portable and
+    only the bound is pinned. At `p = 0.1` one ulp above `cdf(10)`, Apple's libm answers `10` and
+    glibc `11`, because their `exp` puts `cdf(10)` itself an ulp apart. Away from a step the answer
+    is exact, as the scalar cases above and the `isf` twin, whose probe amplifies a round trip well
+    past a last bit, pin. See docs/explanation/accuracy.md, "Discrete `ppf` / `isf` at a step
+    boundary".
+    """
+    cdf_at_step = unit_frame.select(v=Geometric(p=p).cdf(float(step))).item(0, "v")
+    quantile = cdf_at_step if offset == 0 else math.nextafter(cdf_at_step, float(offset > 0))
+
+    got = unit_frame.select(v=Geometric(p=p).ppf(quantile)).item(0, "v")
+    assert abs(got - _smallest_support_point_exact(p, quantile)) <= 1
 
 
 @pytest.mark.parametrize("quantile", [-0.1, 1.5])

--- a/tests/distributions/geometric/ppf_test.py
+++ b/tests/distributions/geometric/ppf_test.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Geometric
+
+
+@pytest.mark.parametrize(
+    ("p", "quantile", "expected"),
+    [
+        (0.3, 0.0, 1.0),  # smallest support point, mapped explicitly at the degenerate endpoint
+        (0.3, 1e-300, 1.0),  # every representable q > 0 is >= cdf(1)
+        (0.3, 0.29, 1.0),  # 0.29 <= cdf(1) = 0.3
+        (0.3, 0.31, 2.0),  # boundary crossed between k=1 and k=2
+        (0.3, 0.5, 2.0),
+        (0.3, 0.51, 3.0),  # fl(0.51) > cdf(2) = 0.51: the stored quantile already crosses k = 2
+        (0.5, 0.75, 2.0),  # exact power-of-two boundary: cdf(2) = 0.75 lands on the quantile bit-for-bit
+        (0.3, 0.52, 3.0),
+        (0.3, 1.0, float("inf")),  # unbounded support: only the limit answers q = 1
+        (0.5, 0.5, 1.0),
+        (1.0, 0.5, 1.0),
+        (1.0, 0.0, 1.0),
+        (1.0, 1.0, 1.0),
+    ],
+)
+def test_ppf_scalar(p: float, quantile: float, expected: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Geometric(p=p).ppf(quantile)).item(0, "v")
+    assert result == expected
+
+
+def test_ppf_matches_closed_form_for_small_p(unit_frame: pl.DataFrame) -> None:
+    # Interior-quantile check in a regime where a naive log(1 - q) / log(1 - p) loses
+    # digits on both sides.
+    p, q = 1e-13, 1e-11
+    expected = math.ceil(math.log1p(-q) / math.log1p(-p))
+    got = unit_frame.select(v=Geometric(p=p).ppf(q)).item(0, "v")
+    assert got == expected
+
+
+@pytest.mark.parametrize("quantile", [-0.1, 1.5])
+def test_ppf_out_of_range_quantile_is_null(quantile: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Geometric(p=0.3).ppf(quantile)).item(0, "v")
+    assert result is None
+
+
+def test_ppf_propagates_nan_in_quantile(unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Geometric(p=0.3).ppf(float("nan"))).item(0, "v")
+    assert math.isnan(result)
+
+
+def test_ppf_propagates_null_in_quantile() -> None:
+    df = pl.DataFrame({"q": [0.1, None, 0.9]}, schema={"q": pl.Float64})
+    result = df.select(v=Geometric(p=0.3).ppf(pl.col("q")))["v"]
+    expected = pl.Series("v", [1.0, None, 7.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_ppf_propagates_null_in_p(p_with_null: pl.DataFrame) -> None:
+    result = p_with_null.select(v=Geometric(p=pl.col("p")).ppf(0.5))["v"]
+    expected = pl.Series("v", [2.0, None, 1.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/geometric/ppf_test.py
+++ b/tests/distributions/geometric/ppf_test.py
@@ -41,6 +41,25 @@ def test_ppf_matches_closed_form_for_small_p(unit_frame: pl.DataFrame) -> None:
     assert got == expected
 
 
+def test_ppf_undershoots_by_one_at_an_exact_step_boundary(unit_frame: pl.DataFrame) -> None:
+    """One ulp above `cdf(10)` the answer stays `10`, where the definition asks for `11`.
+
+    `cdf(10)` is exact here (`1 - 0.9**10` is representable), so this is the tie-break alone: the
+    step-down test compares `k * log1p(-p)` against `log1p(-q)`, and at a representable step those
+    two roundings can fall either side of the answer. Pinned, not fixed. Re-deciding the tie against
+    `cdf(k)` would get this point right and cost accuracy overall (1997 boundary probes: 357
+    disagreements with exact arithmetic against 490). scipy answers `10` here too. See
+    docs/explanation/accuracy.md, "Discrete `ppf` / `isf` at a step boundary", and the `isf` twin,
+    which lands on the other side.
+    """
+    p, step = 0.1, 10.0
+    cdf_at_step = unit_frame.select(v=Geometric(p=p).cdf(step)).item(0, "v")
+    quantile = math.nextafter(cdf_at_step, 1.0)
+
+    assert unit_frame.select(v=Geometric(p=p).ppf(quantile)).item(0, "v") == step
+    assert cdf_at_step < quantile
+
+
 @pytest.mark.parametrize("quantile", [-0.1, 1.5])
 def test_ppf_out_of_range_quantile_is_null(quantile: float, unit_frame: pl.DataFrame) -> None:
     result = unit_frame.select(v=Geometric(p=0.3).ppf(quantile)).item(0, "v")

--- a/tests/distributions/geometric/sample_test.py
+++ b/tests/distributions/geometric/sample_test.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal, assert_series_not_equal
+
+from polars_stats import Geometric
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@pytest.mark.parametrize("size", [0, 100, 1_000])
+def test_sample_basic_properties(
+    size: int,
+    frame: Callable[..., pl.DataFrame],
+    seed: int,
+) -> None:
+    result = frame(size=size).lazy().with_columns(geometric=Geometric(p=0.3).sample(seed=seed))
+    assert result.collect_schema()["geometric"] == pl.UInt64
+    assert result.collect().height == size
+
+
+@pytest.mark.parametrize("p", [0.1, 0.3, 0.8, pl.col("p1"), pl.col("p2")])
+def test_sample_seed_reproducible(
+    p: float | pl.Expr,
+    frame: Callable[..., pl.DataFrame],
+    seed: int,
+) -> None:
+    dframe = frame()
+    s1 = dframe.with_columns(k=Geometric(p=p).sample(seed=seed))["k"]
+    s2 = dframe.with_columns(k=Geometric(p=p).sample(seed=seed))["k"]
+    assert_series_equal(s1, s2)
+
+
+@pytest.mark.parametrize("p", [0.1, 0.3, 0.8, pl.col("p1"), pl.col("p2")])
+def test_sample_different_seeds_differ(
+    p: float | pl.Expr,
+    frame: Callable[..., pl.DataFrame],
+    seed: int,
+) -> None:
+    dframe = frame()
+    s1 = dframe.with_columns(k=Geometric(p=p).sample(seed=123))["k"]
+    s2 = dframe.with_columns(k=Geometric(p=p).sample(seed=seed))["k"]
+    assert_series_not_equal(s1, s2)
+
+
+@pytest.mark.parametrize("p", [0.05, 0.3, 0.8])
+def test_sample_support_is_the_positive_integers(p: float, frame: Callable[..., pl.DataFrame]) -> None:
+    result = frame().with_columns(k=Geometric(p=p).sample(seed=7))
+    assert (result["k"] >= 1).all()
+
+
+def test_sample_extreme_p_is_always_one(frame: Callable[..., pl.DataFrame]) -> None:
+    result = frame().with_columns(k=Geometric(p=1.0).sample(seed=7))
+    assert (result["k"] == 1).all()
+
+
+@pytest.mark.parametrize("p", [0.05, 0.3, 0.5, 0.8])
+def test_sample_mean_close_to_inverse_p_for_large_n(p: float, frame: Callable[..., pl.DataFrame]) -> None:
+    n = 100_000
+    tolerance = 0.01 * (1 / p)
+    result = frame(n).with_columns(k=Geometric(p=p).sample(seed=123))
+    observed = result["k"].mean()
+    assert isinstance(observed, float)
+    assert abs(observed - 1 / p) < tolerance
+
+
+def test_sample_null_p_row_is_null(seed: int) -> None:
+    dframe = pl.DataFrame({"p": [0.5, None, 0.5]}, schema={"p": pl.Float64})
+    result = dframe.select(k=Geometric(p=pl.col("p")).sample(seed=seed))["k"]
+    assert result[0] is not None
+    assert result[1] is None

--- a/tests/distributions/geometric/sample_test.py
+++ b/tests/distributions/geometric/sample_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -56,6 +57,110 @@ def test_sample_support_is_the_positive_integers(p: float, frame: Callable[..., 
 def test_sample_extreme_p_is_always_one(frame: Callable[..., pl.DataFrame]) -> None:
     result = frame().with_columns(k=Geometric(p=1.0).sample(seed=7))
     assert (result["k"] == 1).all()
+
+
+# `1.0 - p` rounds to exactly `1.0` at or below this, which is what made a `1.0 - p` log base
+# collapse and every draw land outside the support. The draw enters through `log1p(-p)` instead.
+_ONE_MINUS_P_ROUNDS_TO_ONE = 2.0**-54
+
+
+@pytest.mark.parametrize("p", [1e-8, 1e-16, _ONE_MINUS_P_ROUNDS_TO_ONE, 1e-17, 1e-19])
+def test_sample_support_holds_below_the_one_minus_p_threshold(p: float, frame: Callable[..., pl.DataFrame]) -> None:
+    """A small `p` is a valid parameterisation, so its draws must still be positive integers.
+
+    The regime at and below `2 ** -54` is the one a `1.0 - p` log base cannot express: the base is
+    exactly `1.0`, its log is `0.0`, and every draw saturates to `0`, below the support, while
+    `mean()` correctly reports `1 / p`. Nothing above `p = 0.05` reaches it.
+    """
+    result = frame().with_columns(k=Geometric(p=p).sample(seed=7))
+    assert (result["k"] >= 1).all()
+
+
+@pytest.mark.parametrize("p", [1e-8, 1e-12, 1e-17])
+def test_sample_mean_tracks_inverse_p_into_the_small_p_regime(p: float, frame: Callable[..., pl.DataFrame]) -> None:
+    """Being inside the support is not enough: the draws must have the right scale.
+
+    Clamping a broken draw up to the support floor would satisfy the support test above while
+    answering `1` where the mean is `1e17`, so this pins the distribution rather than its range.
+    """
+    n = 100_000
+    result = frame(n).with_columns(k=Geometric(p=p).sample(seed=123))
+    observed = result["k"].cast(pl.Float64).mean()
+    assert isinstance(observed, float)
+    assert observed == pytest.approx(1 / p, rel=0.02)
+
+
+def test_sample_saturates_where_the_trial_count_outgrows_uint64(frame: Callable[..., pl.DataFrame]) -> None:
+    """A small enough `p` puts the trial count past `u64::MAX`, where the draw saturates.
+
+    A dtype limit rather than an algorithm one, and the one place a draw is deliberately not the
+    inverse transform's answer. A single draw saturates with probability `exp(-u64::MAX * p)`, which
+    is why this uses a `p` where that is indistinguishable from 1 rather than one near the onset
+    (about 16% of draws at `p = 1e-19`). Pinned so it stays a known boundary.
+    """
+    result = frame().with_columns(k=Geometric(p=1e-300).sample(seed=7))
+    assert (result["k"] == 2**64 - 1).all()
+
+
+# The largest trial count `UInt64` holds, and the value a saturating cast pins a draw to.
+_U64_MAX = 2**64 - 1
+
+# Below this `p` the generator's smallest `u` (about `2 ** -53`) can already reach `u64::MAX`, so
+# saturation becomes possible at all: `exp(-u64::MAX * p) >= 2 ** -53` from here down.
+_SATURATION_ONSET = 2e-18
+
+
+@pytest.mark.parametrize("p", [1e-19, 1e-20])
+def test_sample_saturated_fraction_matches_the_documented_probability(
+    p: float, frame: Callable[..., pl.DataFrame]
+) -> None:
+    """Through the onset band a draw saturates with probability `exp(-u64::MAX * p)`, not all or nothing.
+
+    That probability is what docs/explanation/accuracy.md quotes, and `p = 1e-300` above only pins
+    the end where it is indistinguishable from `1`. Between `_SATURATION_ONSET` and `p = 1e-20` the
+    fraction climbs from `0` to 83%, so a change to the cast, to the clamp, or to the uniform's
+    distribution would move a boundary neither of the all-or-nothing tests can see.
+    """
+    n = 200_000
+    result = frame(n).with_columns(k=Geometric(p=p).sample(seed=5))
+    saturated = (result["k"] == _U64_MAX).sum() / n
+    assert saturated == pytest.approx(math.exp(-_U64_MAX * p), rel=0.02)
+
+
+@pytest.mark.parametrize("p", [1e-17, 10 * _SATURATION_ONSET])
+def test_sample_never_saturates_above_the_onset(p: float, frame: Callable[..., pl.DataFrame]) -> None:
+    """Above `_SATURATION_ONSET` no `u` the generator can produce reaches `u64::MAX`.
+
+    The other side of the band: `exp(-u64::MAX * p)` drops below the smallest `u`, so saturation
+    stops being reachable rather than merely rare. Pins the onset from above, where a wrongly
+    documented threshold would otherwise leave a silently biased regime looking safe.
+    """
+    result = frame(50_000).with_columns(k=Geometric(p=p).sample(seed=5))
+    assert (result["k"] < _U64_MAX).all()
+
+
+@pytest.mark.parametrize("p", [1e-8, _ONE_MINUS_P_ROUNDS_TO_ONE, 1e-17, 1e-19])
+def test_sample_fast_path_matches_per_row_in_the_small_p_regime(p: float) -> None:
+    """Both sampler paths draw identically where the property suite cannot look.
+
+    `tests/property/_specs.py` floors the geometric `p` at 0.05 so its finite-support sum stays
+    tractable, which is why `test_sample_scalar_fast_path_matches_per_row` held while every draw
+    below `2 ** -54` was `0`: the two paths were equally wrong. Agreement is only worth something
+    alongside the value tests above, and only in the regime that broke.
+    """
+    frame = pl.DataFrame({"p": [p] * 500})
+    fast = frame.with_columns(k=Geometric(p=p).sample(seed=11))["k"]
+    per_row = frame.with_columns(k=Geometric(p=pl.col("p")).sample(seed=11))["k"]
+    assert_series_equal(fast, per_row)
+
+
+@pytest.mark.parametrize("p", [1e-8, _ONE_MINUS_P_ROUNDS_TO_ONE, 1e-19])
+def test_samples_fast_path_matches_per_row_in_the_small_p_regime(p: float) -> None:
+    """The multi-draw twin of the above: one built state per row, `size` draws off it."""
+    frame = pl.DataFrame({"p": [p] * 200})
+    fast = frame.with_columns(k=Geometric(p=p).samples(size=4, seed=11))["k"]
+    per_row = frame.with_columns(k=Geometric(p=pl.col("p")).samples(size=4, seed=11))["k"]
+    assert_series_equal(fast, per_row)
 
 
 @pytest.mark.parametrize("p", [0.05, 0.3, 0.5, 0.8])

--- a/tests/distributions/geometric/samples_test.py
+++ b/tests/distributions/geometric/samples_test.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Geometric
+from tests._polars_compat import arr_explode
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@pytest.mark.parametrize("size", [1, 4, 16])
+def test_samples_shape_and_dtype(
+    size: int,
+    frame: Callable[..., pl.DataFrame],
+    seed: int,
+) -> None:
+    n = 32
+    result = frame(size=n).select(s=Geometric(p=0.5).samples(size=size, seed=seed))
+    assert result.height == n
+    assert result.schema["s"] == pl.Array(pl.UInt64, size)
+
+
+def test_samples_seed_reproducible(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    dframe = frame(size=128)
+    s1 = dframe.select(s=Geometric(p=0.4).samples(size=8, seed=seed))["s"]
+    s2 = dframe.select(s=Geometric(p=0.4).samples(size=8, seed=seed))["s"]
+    assert_series_equal(s1, s2)
+
+
+def test_samples_columns_are_not_all_equal(
+    frame: Callable[..., pl.DataFrame],
+    seed: int,
+) -> None:
+    # Regression: the same seed must derive distinct sub-seeds so the `size`
+    # columns are independent draws, not `size` copies of the same draw.
+    size = 8
+    dframe = frame(size=512)
+    result = dframe.select(s=Geometric(p=0.5).samples(size=size, seed=seed))["s"]
+    columns = [result.arr.get(i) for i in range(size)]
+    distinct = {tuple(c.to_list()) for c in columns}
+    assert len(distinct) == size  # 8 truly independent draws -> 8 distinct rasters
+
+
+def test_samples_mean_close_to_inverse_p_for_large_total(
+    frame: Callable[..., pl.DataFrame],
+    seed: int,
+) -> None:
+    n, size, p = 4_000, 16, 0.3
+    tolerance = 0.01 * (1 / p)
+    result = arr_explode(frame(n).select(s=Geometric(p=p).samples(size=size, seed=seed))["s"])
+    mean = cast("float", result.mean())
+    assert abs(mean - 1 / p) < tolerance
+
+
+@pytest.mark.parametrize("bad_size", [0, -1])
+def test_samples_rejects_non_positive_size(bad_size: int) -> None:
+    with pytest.raises(ValueError, match="size must be a positive integer"):
+        Geometric(p=0.5).samples(size=bad_size, seed=0)
+
+
+def test_samples_null_p_row_is_null_array(seed: int) -> None:
+    # When `p` is null on a row, the entire array for that row must be null,
+    # not an array of inner-null elements (which would still be a non-null array).
+    size = 4
+    dframe = pl.DataFrame({"p": [0.5, None, 0.5]}, schema={"p": pl.Float64})
+    result = dframe.select(s=Geometric(p=pl.col("p")).samples(size=size, seed=seed))["s"]
+    assert result.dtype == pl.Array(pl.UInt64, size)
+    assert_series_equal(result.is_null(), pl.Series("s", [False, True, False]))

--- a/tests/distributions/geometric/sf_test.py
+++ b/tests/distributions/geometric/sf_test.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Geometric
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@pytest.mark.parametrize("p", [0.1, 0.3, 0.5, 0.8])
+@pytest.mark.parametrize(
+    ("value", "expected_fn"),
+    [
+        (0.99, lambda _p: 1.0),  # below the support
+        (-1.0, lambda _p: 1.0),
+        (1, lambda p: 1 - p),
+        (2, lambda p: (1 - p) ** 2),
+        (10, lambda p: (1 - p) ** 10),
+    ],
+)
+def test_sf_scalar_p(
+    p: float,
+    value: float,
+    expected_fn: Callable[[float], float],
+    unit_frame: pl.DataFrame,
+) -> None:
+    result = unit_frame.select(v=Geometric(p=p).sf(value)).item(0, "v")
+    assert result == pytest.approx(expected_fn(p))
+
+
+def test_sf_column_value() -> None:
+    p = 0.3
+    df = pl.DataFrame({"v": [-1, 0, 1, 2]}, schema={"v": pl.Int64})
+    result = df.select(r=Geometric(p=p).sf(pl.col("v")))["r"]
+    expected = pl.Series("r", [1.0, 1.0, 1 - p, (1 - p) ** 2], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_sf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"v": [0, None, 2]}, schema={"v": pl.Int64})
+    result = df.select(r=Geometric(p=0.5).sf(pl.col("v")))["r"]
+    expected = pl.Series("r", [1.0, None, 0.25], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_sf_propagates_null_in_p(p_with_null: pl.DataFrame) -> None:
+    result = p_with_null.select(r=Geometric(p=pl.col("p")).sf(2))["r"]
+    expected = pl.Series("r", [(1 - 0.3) ** 2, None, (1 - 0.8) ** 2], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/geometric/std_test.py
+++ b/tests/distributions/geometric/std_test.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Geometric
+
+
+@pytest.mark.parametrize("p", [0.25, 0.5, 0.75])
+def test_std_is_sqrt_of_variance(p: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Geometric(p=p).std()).item(0, "v")
+    variance = unit_frame.select(v=Geometric(p=p).variance()).item(0, "v")
+    assert result == pytest.approx(math.sqrt(variance))
+
+
+def test_std_does_not_overflow_where_the_variance_route_saturates(unit_frame: pl.DataFrame) -> None:
+    # std = sqrt((1-p)/p^2) squares p first: below p ~ 1e-154 the square underflows to 0 and the
+    # base-class route returns inf where sqrt(1-p)/p is still finite (~1e200 here).
+    p = 1e-200
+    result = unit_frame.select(v=Geometric(p=p).std()).item(0, "v")
+    assert result == pytest.approx(math.sqrt(1 - p) / p)
+
+
+def test_std_propagates_null_in_p(p_with_null: pl.DataFrame) -> None:
+    result = p_with_null.select(v=Geometric(p=pl.col("p")).std())["v"]
+    expected = pl.Series(
+        "v",
+        [math.sqrt(1 - 0.3) / 0.3, None, math.sqrt(1 - 0.8) / 0.8],
+        dtype=pl.Float64,
+    )
+    assert_series_equal(result, expected)

--- a/tests/distributions/geometric/validation_test.py
+++ b/tests/distributions/geometric/validation_test.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+
+from polars_stats import Geometric
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Every public method must report an out-of-range `p` as a ComputeError, not silently compute.
+# The support is `0 < p <= 1`, so unlike Bernoulli the degenerate `p = 0` is invalid too. The
+# deterministic methods all derive from the Rust-validated `_checked_p`; the samplers validate in
+# their own plugin.
+_METHODS: dict[str, Callable[[Geometric], pl.Expr]] = {
+    "pmf": lambda g: g.pmf(pl.col("k")),
+    "log_pmf": lambda g: g.log_pmf(pl.col("k")),
+    "cdf": lambda g: g.cdf(pl.col("k")),
+    "log_cdf": lambda g: g.log_cdf(pl.col("k")),
+    "sf": lambda g: g.sf(pl.col("k")),
+    "log_sf": lambda g: g.log_sf(pl.col("k")),
+    "ppf": lambda g: g.ppf(pl.col("q")),
+    "isf": lambda g: g.isf(pl.col("q")),
+    "mean": lambda g: g.mean(),
+    "variance": lambda g: g.variance(),
+    "std": lambda g: g.std(),
+    "median": lambda g: g.median(),
+    "entropy": lambda g: g.entropy(),
+    "sample": lambda g: g.sample(seed=0),
+    "samples": lambda g: g.samples(size=4, seed=0),
+}
+
+
+@pytest.mark.parametrize("bad_p", [1.5, 0.0])
+@pytest.mark.parametrize("expr_fn", _METHODS.values(), ids=list(_METHODS))
+def test_method_raises_on_out_of_range_p_column(bad_p: float, expr_fn: Callable[[Geometric], pl.Expr]) -> None:
+    df = pl.DataFrame({"p": [0.5, bad_p], "k": [1, 1], "q": [0.5, 0.5]})
+    g = Geometric(p=pl.col("p"))
+    with pytest.raises(pl.exceptions.ComputeError, match="p must be in"):
+        df.select(r=expr_fn(g))
+
+
+@pytest.mark.parametrize("bad_p", [1.5, 0.0])
+@pytest.mark.parametrize("expr_fn", _METHODS.values(), ids=list(_METHODS))
+def test_method_raises_on_out_of_range_p_scalar(bad_p: float, expr_fn: Callable[[Geometric], pl.Expr]) -> None:
+    df = pl.DataFrame({"k": [1], "q": [0.5]})
+    g = Geometric(p=bad_p)
+    with pytest.raises(pl.exceptions.ComputeError, match="p must be in"):
+        df.select(r=expr_fn(g))

--- a/tests/distributions/geometric/variance_test.py
+++ b/tests/distributions/geometric/variance_test.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import Geometric
+
+
+@pytest.mark.parametrize(
+    ("p", "expected"),
+    [(0.25, 12.0), (0.5, 2.0), (0.75, 4 / 9)],
+)
+def test_variance(p: float, expected: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=Geometric(p=p).variance()).item(0, "v")
+    assert result == pytest.approx(expected)
+
+
+def test_variance_propagates_null_in_p(p_with_null: pl.DataFrame) -> None:
+    result = p_with_null.select(v=Geometric(p=pl.col("p")).variance())["v"]
+    expected = pl.Series("v", [(1 - 0.3) / 0.3**2, None, (1 - 0.8) / 0.8**2], dtype=pl.Float64)
+    assert_series_equal(result, expected)

--- a/tests/distributions/moment_fast_path_test.py
+++ b/tests/distributions/moment_fast_path_test.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
-from polars_stats import Bernoulli, Beta, Binomial, LogNormal, Normal, Uniform
+from polars_stats import Bernoulli, Beta, Binomial, Geometric, LogNormal, Normal, Uniform
 from tests._polars_compat import assert_series_equal
 
 if TYPE_CHECKING:
@@ -66,6 +66,11 @@ _CASES: dict[str, tuple[_UnivariateDistribution, _UnivariateDistribution, bool]]
     "bernoulli p=1.5": (Bernoulli(1.5), Bernoulli(_col(1.5)), True),
     "bernoulli p=-0.1": (Bernoulli(-0.1), Bernoulli(_col(-0.1)), True),
     "bernoulli p=nan": (Bernoulli(_NAN), Bernoulli(_col(_NAN)), True),
+    # The geometric support excludes the `p = 0` point mass its Bernoulli counterpart accepts.
+    "geometric p=0": (Geometric(0.0), Geometric(_col(0.0)), True),
+    "geometric p=-0.1": (Geometric(-0.1), Geometric(_col(-0.1)), True),
+    "geometric p=1.5": (Geometric(1.5), Geometric(_col(1.5)), True),
+    "geometric p=nan": (Geometric(_NAN), Geometric(_col(_NAN)), True),
     "binomial p=1.5": (Binomial(5, 1.5), Binomial(_col(5, pl.Int64()), _col(1.5)), True),
     "binomial p=nan": (Binomial(5, _NAN), Binomial(_col(5, pl.Int64()), _col(_NAN)), True),
     "beta a=0": (Beta(0.0, 1.0), Beta(_col(0.0), _col(1.0)), True),
@@ -141,6 +146,7 @@ def test_moment_fast_path_on_empty_frame_is_a_scalar() -> None:
 _DEGENERATE: dict[str, tuple[_UnivariateDistribution, _UnivariateDistribution, float]] = {
     "bernoulli p=0 entropy": (Bernoulli(0.0), Bernoulli(_col(0.0)), 0.0),
     "bernoulli p=1 entropy": (Bernoulli(1.0), Bernoulli(_col(1.0)), 0.0),
+    "geometric p=1 entropy": (Geometric(1.0), Geometric(_col(1.0)), 0.0),
     "binomial p=0 entropy": (Binomial(5, 0.0), Binomial(_col(5, pl.Int64()), _col(0.0)), 0.0),
     "binomial p=1 entropy": (Binomial(5, 1.0), Binomial(_col(5, pl.Int64()), _col(1.0)), 0.0),
     "binomial n=0 entropy": (Binomial(0, 0.5), Binomial(_col(0, pl.Int64()), _col(0.5)), 0.0),

--- a/tests/distributions/output_name_test.py
+++ b/tests/distributions/output_name_test.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
-from polars_stats import Bernoulli, Beta, Binomial, Exponential, LogNormal, Normal, Uniform
+from polars_stats import Bernoulli, Beta, Binomial, Exponential, Geometric, LogNormal, Normal, Uniform
 
 if TYPE_CHECKING:
     from polars_stats.distributions._base import _UnivariateDistribution
@@ -32,6 +32,7 @@ _FRAME = pl.DataFrame({"p": [0.5, 0.5], "mu": [0.0, 0.0], "n": [5, 5]})
 _SCALAR_PARAMS: dict[str, _UnivariateDistribution] = {
     "bernoulli": Bernoulli(p=0.5),
     "binomial": Binomial(n=5, p=0.5),
+    "geometric": Geometric(p=0.5),
     "normal": Normal(mu=0.0, sigma=1.0),
     "lognormal": LogNormal(mu=0.0, sigma=1.0),
     "uniform": Uniform(min=0.0, max=1.0),
@@ -43,6 +44,7 @@ _SCALAR_PARAMS: dict[str, _UnivariateDistribution] = {
 _COLUMN_PARAMS: dict[str, tuple[_UnivariateDistribution, str]] = {
     "bernoulli": (Bernoulli(p=pl.col("p")), "p"),
     "binomial": (Binomial(n=pl.col("n"), p=0.5), "n"),
+    "geometric": (Geometric(p=pl.col("p")), "p"),
     "normal": (Normal(mu=pl.col("mu"), sigma=1.0), "mu"),
     "lognormal": (LogNormal(mu=pl.col("mu"), sigma=1.0), "mu"),
     "uniform": (Uniform(min=pl.col("mu"), max=1.0), "mu"),
@@ -107,6 +109,7 @@ _VALIDATOR_FRAME = pl.DataFrame(
 _VALIDATOR_EXPRS: dict[str, tuple[pl.Expr, str]] = {
     "bernoulli_proba": (Bernoulli(p=pl.col("p"))._checked_p, "p"),
     "exponential_rate": (Exponential(rate=pl.col("rate"))._checked_rate, "rate"),
+    "geometric_p": (Geometric(p=pl.col("p"))._checked_p, "p"),
     "uniform_range": (Uniform(min=pl.col("lo"), max=pl.col("hi")).range, "lo"),
     "normal_sigma": (Normal(mu=pl.col("mu"), sigma=pl.col("sigma"))._checked_params, "mu"),
     "lognormal_sigma": (LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma"))._checked_params, "mu"),

--- a/tests/distributions/std_representable_range_test.py
+++ b/tests/distributions/std_representable_range_test.py
@@ -55,7 +55,8 @@ def test_uniform_std_is_the_span_over_root_twelve(span: float) -> None:
 
 
 # `p` is a probability, so only the underflow half of `_EXTREME_SCALES` is reachable here: `p ** 2`
-# underflows below ~1.49e-162 while `sqrt(1 - p) / p` stays finite to ~5e-324.
+# underflows below ~1.49e-162 while `sqrt(1 - p) / p` stays finite down to ~5.6e-309, where `1 / p`
+# itself overflows.
 _EXTREME_PROBABILITIES = [s for s in _EXTREME_SCALES if s < 1.0]
 
 

--- a/tests/distributions/std_representable_range_test.py
+++ b/tests/distributions/std_representable_range_test.py
@@ -23,10 +23,10 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
-from polars_stats import Exponential, LogNormal, Normal, Uniform
+from polars_stats import Exponential, Geometric, LogNormal, Normal, Uniform
 
 if TYPE_CHECKING:
-    from polars_stats.distributions._base import ContinuousDistribution
+    from polars_stats.distributions._base import _UnivariateDistribution
 
 # One parameter per decade band that the squaring round trip destroys: `x ** 2` overflows above
 # ~1.34e154 and underflows below ~1.49e-162, while `x` itself is representable to 1.8e308 / 5e-324.
@@ -54,6 +54,19 @@ def test_uniform_std_is_the_span_over_root_twelve(span: float) -> None:
     assert got == pytest.approx(span / math.sqrt(12.0), rel=1e-15, abs=0.0)
 
 
+# `p` is a probability, so only the underflow half of `_EXTREME_SCALES` is reachable here: `p ** 2`
+# underflows below ~1.49e-162 while `sqrt(1 - p) / p` stays finite to ~5e-324.
+_EXTREME_PROBABILITIES = [s for s in _EXTREME_SCALES if s < 1.0]
+
+
+@pytest.mark.parametrize("p", _EXTREME_PROBABILITIES, ids=lambda p: f"p={p:.0e}")
+def test_geometric_std_is_sqrt_one_minus_p_over_p(p: float) -> None:
+    """`Geometric(p).std()` is `sqrt(1 - p) / p` where the squared-variance route returns `inf`."""
+    got = pl.DataFrame({"z": [0.0]}).select(r=Geometric(p=p).std())["r"].item()
+    assert math.isfinite(got)
+    assert got == pytest.approx(math.sqrt(1 - p) / p, rel=1e-15, abs=0.0)
+
+
 @pytest.mark.parametrize("sigma", [1.0, 18.0, 20.0, 26.0], ids=lambda s: f"sigma={s}")
 def test_lognormal_std_outlives_its_variance(sigma: float) -> None:
     """`LogNormal.std()` stays finite past `sigma ~ 18.8`, where the variance genuinely overflows.
@@ -74,11 +87,12 @@ def test_lognormal_std_outlives_its_variance(sigma: float) -> None:
         (Normal(mu=0.0, sigma=2.0), 2.0),
         (Exponential(rate=4.0), 0.25),
         (Uniform(min=-3.0, max=7.0), 10.0 / math.sqrt(12.0)),
+        (Geometric(p=0.25), math.sqrt(0.75) / 0.25),
     ],
-    ids=["normal", "exponential", "uniform"],
+    ids=["normal", "exponential", "uniform", "geometric"],
 )
 def test_std_squared_still_agrees_with_variance_in_the_ordinary_range(
-    dist: ContinuousDistribution, expected: float
+    dist: _UnivariateDistribution, expected: float
 ) -> None:
     """The overrides must not drift from `variance()` where both are representable."""
     frame = pl.DataFrame({"z": [0.0]})

--- a/tests/distributions/value_arg_str_test.py
+++ b/tests/distributions/value_arg_str_test.py
@@ -14,7 +14,7 @@ import polars as pl
 import pytest
 from polars.testing import assert_series_equal
 
-from polars_stats import Bernoulli, Beta, Binomial, Exponential, LogNormal, Normal, Uniform
+from polars_stats import Bernoulli, Beta, Binomial, Exponential, Geometric, LogNormal, Normal, Uniform
 from polars_stats.distributions._base import ContinuousDistribution
 
 if TYPE_CHECKING:
@@ -27,6 +27,7 @@ DISTRIBUTIONS: list[tuple[_UnivariateDistribution, str]] = [
     (Uniform(min="lo", max="hi"), "Uniform"),
     (Bernoulli(p="p"), "Bernoulli"),
     (Binomial(n="n", p="p"), "Binomial"),
+    (Geometric(p="p"), "Geometric"),
     (Exponential(rate="p"), "Exponential"),  # `p` is positive on every row, a valid rate
     (Beta(a="p", b="sigma"), "Beta"),  # both columns are positive on every row, valid shapes
 ]

--- a/tests/property/_specs.py
+++ b/tests/property/_specs.py
@@ -260,8 +260,15 @@ DISCRETE_SPECS = [s for s in ALL_SPECS if not s.continuous]
 ULP_TOLERANT_VALUE_SPECS = frozenset({"uniform", "exponential"})
 """Specs whose value-keyed methods compare to `ULP_REL_TOL` instead of bit-exactly."""
 
-ULP_TOLERANT_MOMENT_SPECS = frozenset({"uniform"})
-"""Specs whose moments compare to `ULP_REL_TOL` instead of bit-exactly."""
+ULP_TOLERANT_MOMENT_SPECS = frozenset({"uniform", "geometric"})
+"""Specs whose moments compare to `ULP_REL_TOL` instead of bit-exactly.
+
+`geometric` is here for `std` and `entropy` only, and for a narrower reason than `uniform`: both
+divide by the parameter itself, and `_col`'s `pl.repeat` keeps `p` in polars' scalar-backed
+representation, whose division kernel is a reciprocal multiply rather than an exactly-rounded divide.
+A materialised `p` column and a `pl.lit(pl.Series(...))` one both stay bit-exact against the fast
+path (0 divergences over 300 random `p`); only the `pl.repeat` spelling moves the last bit.
+"""
 
 ULP_REL_TOL = 1e-15
 """~4x a double's ULP."""

--- a/tests/property/_specs.py
+++ b/tests/property/_specs.py
@@ -132,20 +132,19 @@ _BINOMIAL = DistSpec(
 )
 
 
-def _geometric_tail_k(p: float) -> int:
+def _geometric_support_limit(p: float) -> int:
     """Smallest `k` whose tail mass `(1 - p)**k` falls below `1e-15`.
 
-    The geometric support is infinite, so its finite-support sum truncates where the missing tail
-    sits far below the suite's mass tolerance. At the degenerate `p = 1` the whole mass sits on
-    `k = 1`."""
+    The geometric support is infinite, so the suite truncates it where the missing tail sits far
+    below its mass tolerance. At the degenerate `p = 1` the whole mass sits on `k = 1`."""
     return 1 if p >= 1.0 else ceil(log(1e-15) / log1p(-p))
 
 
 _GEOMETRIC = DistSpec(
     name="geometric",
     continuous=False,
-    # `p` spans `(0, 1]`: unlike Bernoulli there is no `p = 0` point mass, "never succeeds" has no
-    # moments and statrs rejects it.
+    # `p` spans `(0, 1]`: unlike Bernoulli there is no `p = 0` point mass, since "never succeeds"
+    # has no moments and statrs rejects it.
     params=st.tuples(_finite(0.05, 1.0)),
     make=lambda p: Geometric(p=p[0]),
     make_columns=lambda p: Geometric(p=_col(p[0])),
@@ -154,8 +153,8 @@ _GEOMETRIC = DistSpec(
     make_series=lambda p: Geometric(p=_series(p[0])),
     example=(0.3,),
     density=lambda d, c: d.pmf(c),
-    eval_range=lambda p: (-1.0, float(_geometric_tail_k(p[0]) + 1)),
-    support=lambda p: [float(k) for k in range(1, _geometric_tail_k(p[0]) + 1)],
+    eval_range=lambda p: (-1.0, float(_geometric_support_limit(p[0]) + 1)),
+    support=lambda p: [float(k) for k in range(1, _geometric_support_limit(p[0]) + 1)],
 )
 
 _NORMAL = DistSpec(

--- a/tests/property/_specs.py
+++ b/tests/property/_specs.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from math import exp
+from math import ceil, exp, log, log1p
 from typing import TYPE_CHECKING, Any
 
 import polars as pl
 from hypothesis import strategies as st
 
-from polars_stats import Bernoulli, Beta, Binomial, Exponential, LogNormal, Normal, Uniform
+from polars_stats import Bernoulli, Beta, Binomial, Exponential, Geometric, LogNormal, Normal, Uniform
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -131,6 +131,33 @@ _BINOMIAL = DistSpec(
     support=lambda p: [float(k) for k in range(int(p[0]) + 1)],
 )
 
+
+def _geometric_tail_k(p: float) -> int:
+    """Smallest `k` whose tail mass `(1 - p)**k` falls below `1e-15`.
+
+    The geometric support is infinite, so its finite-support sum truncates where the missing tail
+    sits far below the suite's mass tolerance. At the degenerate `p = 1` the whole mass sits on
+    `k = 1`."""
+    return 1 if p >= 1.0 else ceil(log(1e-15) / log1p(-p))
+
+
+_GEOMETRIC = DistSpec(
+    name="geometric",
+    continuous=False,
+    # `p` spans `(0, 1]`: unlike Bernoulli there is no `p = 0` point mass, "never succeeds" has no
+    # moments and statrs rejects it.
+    params=st.tuples(_finite(0.05, 1.0)),
+    make=lambda p: Geometric(p=p[0]),
+    make_columns=lambda p: Geometric(p=_col(p[0])),
+    make_masked=lambda p, m: Geometric(p=pl.when(~m).then(_col(p[0]))),
+    make_literals=lambda p: Geometric(p=_lit(p[0])),
+    make_series=lambda p: Geometric(p=_series(p[0])),
+    example=(0.3,),
+    density=lambda d, c: d.pmf(c),
+    eval_range=lambda p: (-1.0, float(_geometric_tail_k(p[0]) + 1)),
+    support=lambda p: [float(k) for k in range(1, _geometric_tail_k(p[0]) + 1)],
+)
+
 _NORMAL = DistSpec(
     name="normal",
     continuous=True,
@@ -222,7 +249,7 @@ _BETA = DistSpec(
     integration_bounds=lambda _: (0.0, 1.0),
 )
 
-ALL_SPECS = [_BERNOULLI, _BINOMIAL, _NORMAL, _UNIFORM, _LOGNORMAL, _EXPONENTIAL, _BETA]
+ALL_SPECS = [_BERNOULLI, _BINOMIAL, _GEOMETRIC, _NORMAL, _UNIFORM, _LOGNORMAL, _EXPONENTIAL, _BETA]
 CONTINUOUS_SPECS = [s for s in ALL_SPECS if s.continuous]
 DISCRETE_SPECS = [s for s in ALL_SPECS if not s.continuous]
 

--- a/tests/property/value_keyed_test.py
+++ b/tests/property/value_keyed_test.py
@@ -7,8 +7,8 @@ In Rust both plugins call the same named per-method body, so for any parameteris
 must agree bit for bit, including null propagation and ppf's null-outside-``[0, 1]`` contract. A
 divergence (e.g. a parameter-order swap in a scalar kwargs struct) must fail here.
 
-Bit-equality holds wherever a single Rust body feeds both paths. ``bernoulli``, ``uniform`` and ``exponential``
-have no Rust value-keyed plugin: both evaluate the same Polars expression, and the scalar path does it on
+Bit-equality holds wherever a single Rust body feeds both paths. ``bernoulli``, ``uniform``, ``exponential`` and
+``geometric`` have no Rust value-keyed plugin: both evaluate the same Polars expression, and the scalar path does it on
 length-1 operands, so polars may fold it differently. Where that moves the last bit
 (``ULP_TOLERANT_VALUE_SPECS``) the comparison is 1 ULP; the rest stay exact.
 """

--- a/tests/scipy_parity/geometric_test.py
+++ b/tests/scipy_parity/geometric_test.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+from scipy.stats import geom as scipy_geom
+
+from polars_stats import Geometric
+from tests._polars_compat import assert_series_equal
+from tests.scipy_parity._harness import Case, assert_case_matches_scipy
+
+# Parameter and evaluation grids for the parity sweep. Owned by this test category and independent
+# of the per-method functional tests under `tests/distributions/geometric`.
+# The support is `0 < p <= 1`; scipy accepts `p = 0` (degenerate answers) but this crate rejects it,
+# so the grid holds only valid parameters. `p = 1` is excluded because scipy's generic discrete
+# entropy does not answer there (see the divergence note below).
+_PS = [0.05, 0.1, 0.25, 0.5, 0.75, 0.9]
+# Interior quantiles only: scipy's discrete ppf/isf return the below-support sentinel -1 at the
+# exact endpoints q in {0, 1}, which this support-clamped ppf/isf does not reproduce.
+_QUANTILES = [0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95]
+# Spans below the support, several integer points, a non-integer, and well into the upper tail.
+_VALUE_GRID = [-1.0, 0.0, 1.0, 2.0, 3.7, 10.0, 50.0]
+
+
+_CASES: list[Case[Geometric]] = [
+    Case("pmf", "value", lambda g, c: g.pmf(c), "pmf"),
+    Case("log_pmf", "value", lambda g, c: g.log_pmf(c), "logpmf"),
+    Case("cdf", "value", lambda g, c: g.cdf(c), "cdf"),
+    Case("log_cdf", "value", lambda g, c: g.log_cdf(c), "logcdf"),
+    Case("sf", "value", lambda g, c: g.sf(c), "sf"),
+    Case("log_sf", "value", lambda g, c: g.log_sf(c), "logsf"),
+    Case("ppf", "quantile", lambda g, c: g.ppf(c), "ppf"),
+    Case("isf", "quantile", lambda g, c: g.isf(c), "isf"),
+    Case("mean", "scalar", lambda g, _: g.mean(), "mean"),
+    Case("variance", "scalar", lambda g, _: g.variance(), "var"),
+    Case("std", "scalar", lambda g, _: g.std(), "std"),
+    Case("median", "scalar", lambda g, _: g.median(), "median"),
+    Case("entropy", "scalar", lambda g, _: g.entropy(), "entropy"),
+]
+
+
+@pytest.mark.parametrize("p", _PS, ids=[f"p={p}" for p in _PS])
+@pytest.mark.parametrize("case", _CASES, ids=lambda c: c.name)
+def test_method_matches_scipy(case: Case[Geometric], p: float) -> None:
+    """Every closed-form method matches `scipy.stats.geom(p)` across `_PS` x grids.
+
+    Table-driven: adding a method is one row in `_CASES`. `ppf`/`isf` use interior quantiles only,
+    since scipy's discrete inverse returns the below-support sentinel -1 at `q` in `{0, 1}`, which
+    the support-clamped inverses here do not reproduce. Method-specific behaviour (support handling,
+    null propagation) is asserted in the per-method test files.
+    """
+    assert_case_matches_scipy(
+        case,
+        dist=Geometric(p),
+        scipy_frozen=scipy_geom(p),
+        value_grid=_VALUE_GRID,
+        quantiles=_QUANTILES,
+    )
+
+
+# Regressions from `make audit`, in a regime `_QUANTILES` / `_VALUE_GRID` above never reach.
+
+
+def test_log_sf_deep_tail_beyond_the_linear_underflow() -> None:
+    """`log_sf` keeps digits where `(1 - p)**k` underflows to exactly `0.0`.
+
+    At `p = 0.001`, the linear sf hits `0.0` around `k ~ 70_000`; a naive `log(sf)` would answer
+    `-inf` from there on. The closed form stays exact, so this compares against it directly rather
+    than against scipy, which is not a trustworthy oracle past its own saturation.
+    """
+    p = 0.001
+    for k in [100_000, 1_000_000]:
+        got = pl.DataFrame({"k": [float(k)]}).select(r=Geometric(p).log_sf(pl.col("k")))["r"].item()
+        assert got == pytest.approx(k * math.log1p(-p))
+
+
+def test_ppf_resolves_quantiles_far_below_one_half() -> None:
+    """`ppf` matches scipy for quantiles where a collapsed `log(1 - q)` would answer `1`."""
+    for p, q in [(0.5, 1e-16), (0.001, 1e-13), (0.9, 1e-20)]:
+        got = pl.DataFrame({"q": [q]}).select(r=Geometric(p).ppf(pl.col("q")))["r"].item()
+        assert got == float(scipy_geom.ppf(q, p))
+
+
+def test_isf_deep_tail_keeps_full_precision() -> None:
+    """`isf` enters against `q` itself, so it resolves far past the `1 - q` quantisation.
+
+    Asserted against the exact closed form only: scipy's discrete inverse goes through
+    `ppf(1 - q)`, whose complement saturates here (`log1p(0)` divides by zero and scipy answers
+    `inf`), so it is not a usable oracle in this regime — which is the defect this override exists
+    to avoid.
+    """
+    p = 0.5
+    q = 1e-300
+    expected = math.ceil(math.log(q) / math.log1p(-p))
+    got = pl.DataFrame({"q": [q]}).select(r=Geometric(p).isf(pl.col("q")))["r"].item()
+    assert got == float(expected)
+
+
+def test_memorylessness_of_sf() -> None:
+    """`sf(k + j) = sf(k) * sf(j)`, the identity that names the distribution memoryless.
+
+    Holds only up to float rounding of the shared product; asserted to the default tolerance.
+    """
+    p = 0.3
+    df = pl.DataFrame({"k": [1.0, 5.0, 10.0], "j": [3.0, 7.0, 25.0]})
+    sf_kj = df.select(r=Geometric(p).sf(pl.col("k") + pl.col("j")))["r"]
+    sf_k_times_j = df.select(r=Geometric(p).sf(pl.col("k")) * Geometric(p).sf(pl.col("j")))["r"]
+    assert_series_equal(sf_kj, sf_k_times_j, check_names=False)
+
+
+# NOTE: Deliberate divergences from scipy, recorded here rather than rediscovered as surprises.
+#
+# * Endpoints of the inverse: scipy's discrete `ppf(0)` returns its below-support sentinel `-1`,
+#   while the smallest support point here (`k = 1`) is the only meaningful answer; `ppf(1)` is `inf`
+#   on both sides. Interior-quantile parity covers everything else.
+# * `p = 0`: scipy accepts it and returns degenerate values; this crate raises, as the geometric
+#   law degenerates to "never succeeds" and has no finite moments.
+# * `entropy` at `p = 1`: this crate answers `0.0` by the `0 * log 0 = 0` convention; scipy's
+#   generic discrete entropy does not answer there.
+# * Deep-tail `isf`: scipy quantises the tail mass through `ppf(1 - q)` and saturates (`inf`) for
+#   `q` below roughly 1e-16; this crate inverts against `q` directly and stays finite (asserted
+#   above against the exact closed form, since scipy cannot referee there).

--- a/tests/scipy_parity/geometric_test.py
+++ b/tests/scipy_parity/geometric_test.py
@@ -75,6 +75,24 @@ def test_log_sf_deep_tail_beyond_the_linear_underflow() -> None:
         assert got == pytest.approx(k * math.log1p(-p))
 
 
+@pytest.mark.parametrize("p", [0.001, 0.5])
+def test_linear_tail_underflows_where_the_log_tail_stays_exact(p: float) -> None:
+    """Past `ln(2**-1074) / log1p(-p)` the linear `sf` is exactly `0.0` and only `log_sf` has digits.
+
+    `0.0` is the correctly rounded `sf` there, which is what leaves `log_sf` as the only method that
+    can answer. `tools/accuracy_audit.py::geometric_points` straddles the same crossing; this pins it
+    in CI, which does not run the audit.
+    """
+    log_failure = math.log1p(-p)
+    k_underflow = math.ceil(math.log(5e-324) / log_failure)
+    for k, expect_zero in [(k_underflow // 2, False), (4 * k_underflow, True)]:
+        got = pl.DataFrame({"k": [float(k)]}).select(
+            sf=Geometric(p).sf(pl.col("k")), log_sf=Geometric(p).log_sf(pl.col("k"))
+        )
+        assert (got["sf"].item() == 0.0) is expect_zero
+        assert got["log_sf"].item() == pytest.approx(k * log_failure)
+
+
 def test_ppf_resolves_quantiles_far_below_one_half() -> None:
     """`ppf` matches scipy for quantiles where a collapsed `log(1 - q)` would answer `1`."""
     for p, q in [(0.5, 1e-16), (0.001, 1e-13), (0.9, 1e-20)]:

--- a/tools/accuracy_audit.py
+++ b/tools/accuracy_audit.py
@@ -716,8 +716,8 @@ def geometric_entropy(params: Params, _x: float) -> mp.mpf:
 def geometric_points(params: Params, rng: random.Random, count: int) -> list[Point]:
     """The first few support points and their gaps, plus random support integers across the bulk."""
     points: list[Point] = [(v, "danger") for v in (-1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0)]
-    hi = int(min(max(50.0, 50.0 / params[0]), 2_000_000))
-    points.extend((float(rng.randint(1, hi)), "random") for _ in range(count))
+    max_probe = int(min(max(50.0, 50.0 / params[0]), 2_000_000))
+    points.extend((float(rng.randint(1, max_probe)), "random") for _ in range(count))
     return points
 
 

--- a/tools/accuracy_audit.py
+++ b/tools/accuracy_audit.py
@@ -713,9 +713,25 @@ def geometric_entropy(params: Params, _x: float) -> mp.mpf:
     return -(q * mp.log(q) + p * mp.log(p)) / p
 
 
+LOG_SMALLEST_SUBNORMAL = float(mp.log(SMALLEST_SUBNORMAL))
+"""`ln(2**-1074)`, about -744.4: the point `k * log1p(-p)` crosses on its way to a zero linear tail."""
+
+
 def geometric_points(params: Params, rng: random.Random, count: int) -> list[Point]:
-    """The first few support points and their gaps, plus random support integers across the bulk."""
+    """The first few support points and their gaps, random support integers, and the deep tail.
+
+    `k_underflow = ln(2**-1074) / log1p(-p)` is where `(1 - p)**k` reaches `0.0` and only the log
+    methods can still answer. Probing on both sides of it is the whole point of auditing a geometric
+    tail: below it every method is finite, above it `sf` / `cdf` are expected to read `UNDERFLOW`
+    while `log_sf` / `log_cdf` must stay `OK`. The random probes are capped well short of that at a
+    small `p` (`50 / p` is 5e9 at `p = 1e-8`), so without these the sweep never gets there.
+    """
     points: list[Point] = [(v, "danger") for v in (-1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0)]
+    # `p = 1` puts the whole mass on `k = 1`: the tail is exactly zero from `k = 2`, `log1p(-p)` has
+    # no value, and there is no underflow point to straddle.
+    if params[0] < 1.0:
+        underflow = LOG_SMALLEST_SUBNORMAL / math.log1p(-params[0])
+        points.extend((float(math.ceil(underflow * fraction)), "danger") for fraction in (0.5, 1.0, 4.0))
     max_probe = int(min(max(50.0, 50.0 / params[0]), 2_000_000))
     points.extend((float(rng.randint(1, max_probe)), "random") for _ in range(count))
     return points

--- a/tools/accuracy_audit.py
+++ b/tools/accuracy_audit.py
@@ -54,7 +54,7 @@ from typing import TYPE_CHECKING, Literal, cast
 import mpmath as mp
 import polars as pl
 
-from polars_stats import Bernoulli, Beta, Binomial, Exponential, LogNormal, Normal, Uniform
+from polars_stats import Bernoulli, Beta, Binomial, Exponential, Geometric, LogNormal, Normal, Uniform
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -630,6 +630,97 @@ def binomial_entropy(params: Params, _x: float) -> mp.mpf:
     return total
 
 
+# Geometric oracles.
+
+
+def geometric_pmf(params: Params, x: float) -> mp.mpf:
+    """`p (1 - p)**(k - 1)` on the positive integers, `0` off them."""
+    p = mp.mpf(params[0])
+    if x < 1 or not x.is_integer():
+        return mp.mpf(0)
+    k = int(x)
+    return p * (1 - p) ** (k - 1)
+
+
+def geometric_log_pmf(params: Params, x: float) -> mp.mpf:
+    """`ln` of [`geometric_pmf`], taken at oracle precision."""
+    return ln(geometric_pmf(params, x))
+
+
+def geometric_cdf(params: Params, x: float) -> mp.mpf:
+    """`1 - (1 - p)**floor(x)` from the support floor up, `0` below it."""
+    p = mp.mpf(params[0])
+    if x < 1:
+        return mp.mpf(0)
+    k = math.floor(x)
+    return mp.mpf(1) - (1 - p) ** k
+
+
+def geometric_sf(params: Params, x: float) -> mp.mpf:
+    """`(1 - p)**floor(x)`, the memoryless tail above the floor of `x`."""
+    p = mp.mpf(params[0])
+    if x < 1:
+        return mp.mpf(1)
+    k = math.floor(x)
+    return (1 - p) ** k
+
+
+def _geometric_search_limit(params: Params) -> int:
+    """Support point past which the tail mass `(1 - p)**k` has sunk below `1e-320`.
+
+    Bounds the discrete inverse searches ([`smallest_satisfying`] wants a finite bracket): the
+    smallest probed quantile is `1e-300`, so a bracket this deep always contains the answer while
+    staying inside float64's exact-integer range for every audited `p`.
+    """
+    p = params[0]
+    if p >= 1.0:
+        return 1
+    return max(2, math.ceil(math.log(1e-320) / math.log1p(-p)))
+
+
+def geometric_ppf(params: Params, q: float) -> mp.mpf:
+    """Smallest support point with `cdf(k) >= q`, by exact binary search over the oracle cdf."""
+    if q <= 0:
+        return mp.mpf(1)
+    if q >= 1:
+        # Below the degenerate `p = 1` point mass no finite `k` accumulates all the mass; at it,
+        # every quantile inverts to the support floor.
+        return mp.mpf(1) if params[0] >= 1.0 else mp.inf
+    target = mp.mpf(q)
+    limit = _geometric_search_limit(params)
+    return smallest_satisfying(limit, lambda k: geometric_cdf(params, float(k)) >= target)
+
+
+def geometric_isf(params: Params, q: float) -> mp.mpf:
+    """Smallest support point with `sf(k) <= q`, the exact inverse survival function."""
+    if q >= 1:
+        return mp.mpf(1)
+    if q <= 0:
+        # At the `p = 1` point mass `sf(1) = 0` already satisfies the inequality; below it the tail
+        # never reaches zero.
+        return mp.mpf(1) if params[0] >= 1.0 else mp.inf
+    target = mp.mpf(q)
+    limit = _geometric_search_limit(params)
+    return smallest_satisfying(limit, lambda k: geometric_sf(params, float(k)) <= target)
+
+
+def geometric_entropy(params: Params, _x: float) -> mp.mpf:
+    """`(-p ln p - (1 - p) ln(1 - p)) / p`, the elementary closed form."""
+    p = mp.mpf(params[0])
+    if p == 1:
+        return mp.mpf(0)
+    q = 1 - p
+    return -(q * mp.log(q) + p * mp.log(p)) / p
+
+
+def geometric_points(params: Params, rng: random.Random, count: int) -> list[Point]:
+    """The first few support points and their gaps, plus random support integers across the bulk."""
+    points: list[Point] = [(v, "danger") for v in (-1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0)]
+    hi = int(min(max(50.0, 50.0 / params[0]), 2_000_000))
+    points.extend((float(rng.randint(1, hi)), "random") for _ in range(count))
+    return points
+
+
 # Shared moment oracles, lifted into the standard signature.
 
 
@@ -1139,6 +1230,43 @@ def build_registry() -> tuple[DistributionSpec, ...]:
                         SPECIAL_RTOL,
                     ),
                     MethodSpec("entropy", binomial_entropy, DISCRETE_LOG_RTOL, max_first_param=1000.0),
+                ),
+            ),
+        ),
+        DistributionSpec(
+            name="Geometric",
+            build=lambda p: Geometric(p=p[0]),
+            param_names=("p",),
+            param_dtypes=(pl.Float64(),),
+            # `0.5` makes every power-of-two quantile boundary (`q = 0.75` against `p = 0.5`) land
+            # exactly at oracle precision, which is where a discrete inverse most wants to slip an
+            # off-by-one; `1e-8` is the smallest audited `p` because smaller values push the inverse
+            # search bracket past float64's exact-integer range.
+            params=(
+                (0.3,),
+                (0.5,),
+                (0.9,),
+                (0.999,),
+                (0.001,),
+                (1e-8,),
+                (1 - 1e-12,),
+                (1.0,),
+            ),
+            methods=(
+                MethodSpec("pmf", geometric_pmf, CLOSED_FORM_RTOL, geometric_points),
+                MethodSpec("log_pmf", geometric_log_pmf, LOG_RTOL, geometric_points),
+                MethodSpec("cdf", geometric_cdf, CLOSED_FORM_RTOL, geometric_points),
+                MethodSpec("log_cdf", log_pair(geometric_cdf, geometric_sf), LOG_RTOL, geometric_points),
+                MethodSpec("sf", geometric_sf, CLOSED_FORM_RTOL, geometric_points),
+                MethodSpec("log_sf", log_pair(geometric_sf, geometric_cdf), LOG_RTOL, geometric_points),
+                MethodSpec("ppf", geometric_ppf, DISCRETE_PPF_RTOL, quantile_points),
+                MethodSpec("isf", geometric_isf, DISCRETE_PPF_RTOL, survival_points),
+                *moments(
+                    constant(lambda p: 1 / mp.mpf(p[0])),
+                    constant(lambda p: (1 - mp.mpf(p[0])) / mp.mpf(p[0]) ** 2),
+                    at_median(geometric_ppf),
+                    geometric_entropy,
+                    CLOSED_FORM_RTOL,
                 ),
             ),
         ),


### PR DESCRIPTION
## Summary

Adds `Geometric(p)` — the number of trials up to and including the first success, support `k >= 1`, parameter `p in (0, 1]`, equivalent to `scipy.stats.geom(p)` — following the Bernoulli template for discrete distributions.

- Rust + statrs back the sampler (UInt64 draws) and a `geometric_p` validator plugin; unlike Bernoulli, `p = 0` has no point mass here and is rejected.
- Every other method is a pure-Polars closed form with the usual log1p discipline (`_log_pmf`, `_log_sf`, and both inverses enter through `log1p(-p)`; the naive `log(1 - p)` collapses below `p ~ 1.1e-16`).
- `std` overrides the base `variance().sqrt()` route, which overflows ~150 decades early.

## Numerical-stability decisions worth review

- **cdf/sf** are computed as functions of `x = floor(value) * log1p(-p)`, so neither inherits the rounding of a literal `(1 - p)` (a few parts in 1e9 relative error at `p = 1e-8`). polars has no `expm1`, so the cdf evaluates it through the identity `expm1(x) = 2 exp(x/2) sinh(x/2)`, switching to a direct complement `1 - exp(x)` past `x = -20` — that branch structurally cannot round above 1.
- **log_cdf** splits at `x = -1`: below, `log1p(-exp(x))` carries the difference exactly down into the `cdf ~ 1 - 1e-16` saturation zone where `log(cdf)` reads 0; above, the sinh pieces on the log scale keep rounding relative to the answer's own magnitude.
- **ppf/isf** step their `ceil` candidate back down whenever `k - 1` already satisfies its defining inequality compared in the log domain, absorbing one-ulp overshoot when the ratio lands just above an exact integer. Both inverses short-circuit to `k = 1` at the degenerate `p = 1` point mass (the raw ratio is nan there), as does entropy (convention `0 * log 0 = 0`).

## Known divergences from scipy

Documented inline in the parity tests: ppf(0) answers the support floor 1 rather than scipy's -1 sentinel; isf deep-tail answers follow the exact closed form where scipy saturates to inf behind a divide-by-zero warning; entropy(1) = 0 by convention.

## Validation

- New tests: tests/distributions/geometric/ (19 files) + tests/scipy_parity/geometric_test.py, plus entries in all shared registries (property specs incl. hypothesis strategies, moment fast path, output name, value arg str). Full suite: **3547 passed**, coverage 99.54%.
- tools/accuracy_audit.py gained mpmath oracles at 50 digits (mass/cdf/sf/log pairs, discrete inverses via exact binary search, closed-form moments/entropy) across 8 parameter regimes: **4208 probes, 0 non-OK**.
- make lint / typing / benchmark all green; benchmark registry entry included.
