### PR TITLE
fix!: a null Uniform bound nulls the density instead of reporting zero

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,9 @@ Two things `make test` alone will not catch:
 
 * **The strict docs build**, after any `docs/` edit: `uv run --group docs zensical build --strict`.
 
-Fast loop after a Rust change: `make install-release && uv run pytest tests/distributions/bernoulli/ -x`. Bernoulli
-exercises the whole pipeline. Run `prek` through `make lint`, and do not pass `--no-verify` unless asked.
+Fast loop after a Rust change: `make install-release && uv run pytest --no-cov tests/distributions/bernoulli/ -x`.
+Bernoulli exercises the whole pipeline, and `--no-cov` keeps the 95% floor from failing a deliberately partial run.
+Run `prek` through `make lint`, and do not pass `--no-verify` unless asked.
 
 ## Non-negotiables
 

--- a/polars_stats/distributions/_uniform.py
+++ b/polars_stats/distributions/_uniform.py
@@ -64,14 +64,35 @@ class Uniform(ContinuousDistribution):
         return self._checked("uniform_range", self._max - self._min)
 
     def _pdf(self, value: pl.Expr) -> pl.Expr:
-        """``1 / (max - min)`` on ``[min, max]``, ``0`` outside."""
+        """``1 / (max - min)`` on ``[min, max]``, ``0`` outside, null where a bound is null.
+
+        The null branch is explicit because ``is_between`` yields null on a null bound, and a bare
+        ``when(in_range).then(...).otherwise(0.0)`` would take the ``otherwise``, reporting a confident
+        "outside the support" for a row whose support is unknown. ``_cdf`` and ``_sf`` need no such
+        branch, because their ``otherwise`` is the arithmetic and nulls on its own.
+        """
         in_range = value.is_between(self._min, self._max, closed="both")
-        return pl.when(in_range).then(1 / self.range).otherwise(0.0)
+        return (
+            pl.when(in_range.is_null())
+            .then(pl.lit(None, dtype=pl.Float64))
+            .when(in_range)
+            .then(1 / self.range)
+            .otherwise(0.0)
+        )
 
     def _log_pdf(self, value: pl.Expr) -> pl.Expr:
-        """``-log(max - min)`` on the support, ``-inf`` outside."""
+        """``-log(max - min)`` on the support, ``-inf`` outside, null where a bound is null.
+
+        Same null branch as ``_pdf``, for the same reason.
+        """
         in_range = value.is_between(self._min, self._max, closed="both")
-        return pl.when(in_range).then(-self.range.log()).otherwise(float("-inf"))
+        return (
+            pl.when(in_range.is_null())
+            .then(pl.lit(None, dtype=pl.Float64))
+            .when(in_range)
+            .then(-self.range.log())
+            .otherwise(float("-inf"))
+        )
 
     def _cdf(self, value: pl.Expr) -> pl.Expr:
         """``(value - min) / (max - min)`` clamped to ``[0, 1]``."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,12 @@ docs = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = [
-  "--import-mode=importlib",
+  # `--cov` must not be last. It takes an *optional* value, so a path passed on the command line is
+  # swallowed as that value and `testpaths` takes over, covering the whole suite instead of the path
+  # asked for. A flag after it keeps the next token starting with `-`, which the parser will not
+  # consume, leaving the value unset so the sources stay the ones under `[tool.coverage.run]`.
   "--cov",
+  "--import-mode=importlib",
 ]
 filterwarnings = [
   "error",

--- a/tests/_polars_compat.py
+++ b/tests/_polars_compat.py
@@ -1,10 +1,10 @@
 """Compatibility shims for ``polars`` across supported polars versions.
 
-Polars renamed the tolerance keyword arguments of `assert_frame_equal` and `assert_series_equal` from
-``rtol``/``atol`` to ``rel_tol``/``abs_tol`` in v1.32.3.
-This project supports ``polars>=1.15.0``, so the test suite has to run against both spellings.
+Polars renamed the tolerance keyword arguments of `assert_series_equal` from ``rtol``/``atol`` to
+``rel_tol``/``abs_tol`` in v1.32.3. This project supports ``polars>=1.15.0``, so the test suite has to run
+against both spellings.
 
-These wrappers expose the *latest* signature (``rel_tol``/``abs_tol``) explicitly, by remapping the two tolerance
+The wrapper exposes the *latest* signature (``rel_tol``/``abs_tol``) explicitly, by remapping the two tolerance
 arguments to whatever the installed polars version actually accepts; every other argument has a stable name and is
 forwarded untouched.
 
@@ -22,16 +22,14 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 from packaging.version import Version
-from polars.testing import assert_frame_equal as _assert_frame_equal
 from polars.testing import assert_series_equal as _assert_series_equal
 
 if TYPE_CHECKING:
-    from polars import DataFrame, LazyFrame, Series
+    from polars import Series
 
 __all__ = (
     "PARTITIONED_BROADCAST_AVAILABLE",
     "arr_explode",
-    "assert_frame_equal",
     "assert_series_equal",
     "linear_space",
 )
@@ -68,9 +66,7 @@ def arr_explode(series: Series) -> Series:
     plain `explode` on older supported polars, which has no kwarg and no warning. Every call site
     explodes an `Array` column, whose rows are never empty, so the two paths return identical output.
     """
-    if _EXPLODE_HAS_EMPTY_AS_NULL:
-        return series.arr.explode(empty_as_null=False)
-    return series.arr.explode()
+    return series.arr.explode(empty_as_null=False) if _EXPLODE_HAS_EMPTY_AS_NULL else series.arr.explode()
 
 
 def linear_space(start: float, end: float, num_samples: int) -> Series:
@@ -85,35 +81,6 @@ def linear_space(start: float, end: float, num_samples: int) -> Series:
         raise ValueError(msg)
     step = (end - start) / (num_samples - 1)
     return pl.int_range(0, num_samples, eager=True).cast(pl.Float64) * step + start
-
-
-def assert_frame_equal(  # noqa: PLR0913
-    left: DataFrame | LazyFrame,
-    right: DataFrame | LazyFrame,
-    *,
-    check_row_order: bool = True,
-    check_column_order: bool = True,
-    check_dtypes: bool = True,
-    check_exact: bool = False,
-    rel_tol: float = 1e-05,
-    abs_tol: float = 1e-08,
-    categorical_as_str: bool = False,
-) -> None:
-    """Version-agnostic `polars.testing.assert_frame_equal`.
-
-    Mirrors the latest polars signature. ``rel_tol``/``abs_tol`` are remapped to the
-    spelling the installed polars version supports.
-    """
-    _assert_frame_equal(
-        left,
-        right,
-        check_row_order=check_row_order,
-        check_column_order=check_column_order,
-        check_dtypes=check_dtypes,
-        check_exact=check_exact,
-        categorical_as_str=categorical_as_str,
-        **{_REL_NAME: rel_tol, _ABS_NAME: abs_tol},
-    )
 
 
 def assert_series_equal(  # noqa: PLR0913

--- a/tests/distributions/base_defaults_test.py
+++ b/tests/distributions/base_defaults_test.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, ClassVar
+
+import polars as pl
+import pytest
+
+from polars_stats.distributions._base import ContinuousDistribution, DiscreteDistribution
+
+if TYPE_CHECKING:
+    from polars_stats.distributions._base import _UnivariateDistribution
+
+# Every shipped distribution overrides `_sf`, `_log_pdf` and `_log_pmf` with a form that keeps
+# precision in a tail, so the composing defaults have no caller in the library. They are still what a
+# new distribution inherits until it needs the accurate form.
+
+_MEDIAN_QUANTILE = 0.5
+
+
+class _UnitUniform(ContinuousDistribution):
+    """`Uniform(0, 1)` in plain Polars, implementing the abstract hooks and nothing else."""
+
+    _plugin_prefix: ClassVar[str] = "test_unit_uniform"
+
+    def __init__(self) -> None:
+        self._scalar_kwargs = None
+
+    @property
+    def _param_exprs(self) -> tuple[pl.Expr, ...]:
+        return ()
+
+    def _pdf(self, value: pl.Expr) -> pl.Expr:
+        return pl.when(value.is_between(0.0, 1.0)).then(1.0).otherwise(0.0)
+
+    def _cdf(self, value: pl.Expr) -> pl.Expr:
+        return value.clip(0.0, 1.0)
+
+    def _ppf(self, quantile: pl.Expr) -> pl.Expr:
+        return quantile
+
+    def mean(self) -> pl.Expr:
+        return pl.lit(0.5)
+
+    def variance(self) -> pl.Expr:
+        return pl.lit(1 / 12)
+
+    def entropy(self) -> pl.Expr:
+        return pl.lit(0.0)
+
+
+class _FairCoin(DiscreteDistribution):
+    """`Bernoulli(0.5)` in plain Polars, implementing the abstract hooks and nothing else."""
+
+    _plugin_prefix: ClassVar[str] = "test_fair_coin"
+
+    def __init__(self) -> None:
+        self._scalar_kwargs = None
+
+    @property
+    def _param_exprs(self) -> tuple[pl.Expr, ...]:
+        return ()
+
+    def _pmf(self, value: pl.Expr) -> pl.Expr:
+        return pl.when(value.is_in([0.0, 1.0])).then(0.5).otherwise(0.0)
+
+    def _cdf(self, value: pl.Expr) -> pl.Expr:
+        return pl.when(value < 0).then(0.0).when(value < 1).then(0.5).otherwise(1.0)
+
+    def _ppf(self, quantile: pl.Expr) -> pl.Expr:
+        return (quantile > _MEDIAN_QUANTILE).cast(pl.Float64)
+
+    def mean(self) -> pl.Expr:
+        return pl.lit(0.5)
+
+    def variance(self) -> pl.Expr:
+        return pl.lit(0.25)
+
+    def entropy(self) -> pl.Expr:
+        return pl.lit(math.log(2.0))
+
+
+@dataclass(frozen=True)
+class _Toy:
+    """One minimal distribution and what to evaluate it on.
+
+    Arguments:
+        dist: The instance.
+        density: `"pdf"` or `"pmf"`. The density methods live on the family subclass, so a test
+            written across both families reaches them by name.
+        grid: Evaluation points spanning the support and both sides outside it.
+        quantile: An interior quantile, away from the median so `ppf` and `isf` disagree.
+        moments: Expected value of every parameter-free method, at that quantile for the inverses.
+    """
+
+    dist: _UnivariateDistribution
+    density: str
+    grid: list[float]
+    quantile: float
+    moments: dict[str, float]
+
+
+_TOYS = {
+    "continuous": _Toy(
+        dist=_UnitUniform(),
+        density="pdf",
+        grid=[-0.5, 0.0, 0.25, 0.5, 0.75, 1.0, 1.5],
+        quantile=0.25,
+        moments={
+            "ppf": 0.25,
+            "isf": 0.75,
+            "mean": 0.5,
+            "variance": 1 / 12,
+            "std": math.sqrt(1 / 12),
+            "median": 0.5,
+            "entropy": 0.0,
+        },
+    ),
+    "discrete": _Toy(
+        dist=_FairCoin(),
+        density="pmf",
+        grid=[-1.0, 0.0, 0.5, 1.0, 2.0],
+        quantile=0.75,
+        moments={
+            "ppf": 1.0,
+            "isf": 0.0,
+            "mean": 0.5,
+            "variance": 0.25,
+            "std": 0.5,
+            "median": 0.0,
+            "entropy": math.log(2.0),
+        },
+    ),
+}
+
+pytestmark = pytest.mark.parametrize("toy", _TOYS.values(), ids=list(_TOYS))
+
+
+def test_the_default_sf_is_the_complement_of_cdf(toy: _Toy) -> None:
+    got = pl.DataFrame({"x": toy.grid}).select(cdf=toy.dist.cdf(pl.col("x")), sf=toy.dist.sf(pl.col("x")))
+
+    assert (got["cdf"] + got["sf"]).to_list() == [1.0] * len(toy.grid)
+
+
+def test_the_default_sf_keeps_the_null_and_nan_contract(toy: _Toy) -> None:
+    # `sf` wraps the hook in `propagate_null_and_nan`, so the default inherits the contract. Only the
+    # null and `NaN` rows are asserted here; the value is the test above.
+    frame = pl.DataFrame({"x": [toy.quantile, None, float("nan")]}, schema={"x": pl.Float64})
+
+    got = frame.select(r=toy.dist.sf(pl.col("x")))["r"].to_list()
+
+    assert got[0] is not None
+    assert got[1] is None
+    assert math.isnan(got[2])
+
+
+def test_the_default_log_density_is_the_log_of_the_density(toy: _Toy) -> None:
+    got = pl.DataFrame({"x": toy.grid}).select(
+        direct=getattr(toy.dist, f"log_{toy.density}")(pl.col("x")),
+        composed=getattr(toy.dist, toy.density)(pl.col("x")),
+    )
+
+    for direct, composed in zip(got["direct"], got["composed"], strict=True):
+        assert direct == (math.log(composed) if composed > 0 else -math.inf)
+
+
+def test_the_minimal_surface_is_coherent(toy: _Toy) -> None:
+    # The remaining defaults a distribution inherits for free: `_isf` as `ppf(1 - q)`, `std` as
+    # `sqrt(variance)`, `median` as `ppf(0.5)`.
+    dist = toy.dist
+    got = pl.DataFrame({"q": [toy.quantile]}).select(
+        ppf=dist.ppf(pl.col("q")),
+        isf=dist.isf(pl.col("q")),
+        mean=dist.mean(),
+        variance=dist.variance(),
+        std=dist.std(),
+        median=dist.median(),
+        entropy=dist.entropy(),
+    )
+
+    assert got.row(0, named=True) == pytest.approx(toy.moments)
+    # No parameter crosses FFI, which is why the samplers are out of reach for these two classes.
+    assert dist._param_exprs == ()

--- a/tests/distributions/row_index_test.py
+++ b/tests/distributions/row_index_test.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from polars_stats.distributions import _base
+from polars_stats.distributions._base import row_index_expr
+
+# `row_index_expr` has two implementations of one idea, chosen by `_LITERAL_LEN_IN_AGG`. From polars
+# 1.35 a literal's length can be asked for inside a partition context; below it the frame-free lengths
+# are resolved eagerly instead. Only one runs on any installed polars, so the gate is parametrised and
+# every case asserts the same index on both arms, which is the agreement the gate assumes.
+
+_FRAME = pl.DataFrame({"x": [1.0, 2.0, 3.0]})
+_FRAME_INDEX = [0, 1, 2]
+_SERIES_ROWS = 8
+_SERIES_INDEX = list(range(_SERIES_ROWS))
+
+
+def _series_param() -> pl.Expr:
+    return pl.lit(pl.Series([0.5] * _SERIES_ROWS))
+
+
+# A bare column always has the frame's height and a length-1 input never sets the row count, so both
+# leave the index at the frame's own length; a longer parameter sets it. `pl.col("x") * 2` is a
+# candidate that is not a bare column and whose length needs a frame, which is what the eager arm
+# defers to `.len()`.
+_CASES: dict[str, tuple[tuple[pl.Expr, ...], list[int]]] = {
+    "bare column": ((pl.col("x"),), _FRAME_INDEX),
+    "length-1 literal": ((pl.lit(1.0),), _FRAME_INDEX),
+    "series longer than the frame": ((_series_param(),), _SERIES_INDEX),
+    "frame-dependent beside a series": ((pl.col("x") * 2, _series_param()), _SERIES_INDEX),
+}
+
+_GATE_ARMS = {"literal-len-in-agg": True, "eager-lengths": False}
+
+
+@pytest.mark.parametrize("literal_len_in_agg", _GATE_ARMS.values(), ids=list(_GATE_ARMS))
+@pytest.mark.parametrize(("params", "expected"), _CASES.values(), ids=list(_CASES))
+def test_row_index_follows_the_calls_row_count(
+    params: tuple[pl.Expr, ...],
+    expected: list[int],
+    *,
+    literal_len_in_agg: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_base, "_LITERAL_LEN_IN_AGG", literal_len_in_agg)
+
+    assert _FRAME.select(r=row_index_expr(params))["r"].to_list() == expected
+
+
+_LENGTHS: dict[str, tuple[pl.Expr, int | None]] = {
+    "length-1 literal": (pl.lit(1.0), 1),
+    "series literal": (_series_param(), _SERIES_ROWS),
+    "frame-dependent expr": (pl.col("x") * 2, None),
+}
+
+
+@pytest.mark.parametrize(("param", "expected"), _LENGTHS.values(), ids=list(_LENGTHS))
+def test_frame_free_length_reports_only_what_it_can_resolve(param: pl.Expr, expected: int | None) -> None:
+    assert _base._frame_free_length(param) == expected

--- a/tests/distributions/uniform/null_params_test.py
+++ b/tests/distributions/uniform/null_params_test.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+
+from polars_stats import Uniform
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Every method must propagate a null bound to a null result. The value-keyed methods are evaluated at
+# an on-support point, where both bounds enter the formula, so the null flows through whichever one is
+# missing. The points where only one bound decides the answer are covered below.
+_METHODS: dict[str, Callable[[Uniform], pl.Expr]] = {
+    "pdf": lambda u: u.pdf(pl.lit(0.5)),
+    "log_pdf": lambda u: u.log_pdf(pl.lit(0.5)),
+    "cdf": lambda u: u.cdf(pl.lit(0.5)),
+    "log_cdf": lambda u: u.log_cdf(pl.lit(0.5)),
+    "sf": lambda u: u.sf(pl.lit(0.5)),
+    "log_sf": lambda u: u.log_sf(pl.lit(0.5)),
+    "ppf": lambda u: u.ppf(pl.lit(0.5)),
+    "isf": lambda u: u.isf(pl.lit(0.5)),
+    "mean": lambda u: u.mean(),
+    "variance": lambda u: u.variance(),
+    "std": lambda u: u.std(),
+    "median": lambda u: u.median(),
+    "entropy": lambda u: u.entropy(),
+    "sample": lambda u: u.sample(seed=0),
+    "samples": lambda u: u.samples(size=2, seed=0),
+}
+
+
+def _column_bounds() -> Uniform:
+    return Uniform(min=pl.col("lo"), max=pl.col("hi"))
+
+
+@pytest.mark.parametrize("expr_fn", _METHODS.values(), ids=list(_METHODS))
+def test_method_propagates_null_in_min(expr_fn: Callable[[Uniform], pl.Expr]) -> None:
+    df = pl.DataFrame({"lo": [0.0, None, 0.0], "hi": [1.0, 1.0, 1.0]}, schema={"lo": pl.Float64, "hi": pl.Float64})
+    result = df.select(r=expr_fn(_column_bounds()))["r"]
+    assert result.is_null().to_list() == [False, True, False]
+
+
+@pytest.mark.parametrize("expr_fn", _METHODS.values(), ids=list(_METHODS))
+def test_method_propagates_null_in_max(expr_fn: Callable[[Uniform], pl.Expr]) -> None:
+    # `max` is the *second* plugin input, so a guard written against the first only would pass the
+    # test above and fail here.
+    df = pl.DataFrame({"lo": [0.0, 0.0, 0.0], "hi": [1.0, None, 1.0]}, schema={"lo": pl.Float64, "hi": pl.Float64})
+    result = df.select(r=expr_fn(_column_bounds()))["r"]
+    assert result.is_null().to_list() == [False, True, False]
+
+
+def test_density_nulls_where_the_null_bound_decides_the_support() -> None:
+    # `is_between` yields null on a null bound and `pl.when(null)` takes the `otherwise`, so without an
+    # explicit null branch the density reports a confident `0.0` (`-inf` for the log) for a row whose
+    # support is unknown. `cdf` and `sf` need no such branch, because their `otherwise` is the
+    # arithmetic and nulls on its own.
+    df = pl.DataFrame({"lo": [0.0, None], "hi": [1.0, 1.0]}, schema={"lo": pl.Float64, "hi": pl.Float64})
+    dist = _column_bounds()
+
+    on_support = df.select(pdf=dist.pdf(pl.lit(0.5)), log_pdf=dist.log_pdf(pl.lit(0.5)))
+    below = df.select(pdf=dist.pdf(pl.lit(-1.0)), log_pdf=dist.log_pdf(pl.lit(-1.0)))
+
+    assert on_support["pdf"].to_list() == [1.0, None]
+    assert on_support["log_pdf"].to_list() == [0.0, None]
+    assert below["pdf"].to_list() == [0.0, None]
+    assert below["log_pdf"].to_list() == [float("-inf"), None]
+
+
+def test_density_stays_confident_when_the_known_bound_settles_it() -> None:
+    # A null bound does not null the row where the *other* bound already places the point outside the
+    # support. `is_between` is `False` there rather than null (Kleene `False & null` is `False`), and
+    # the density is `0` for every admissible value of the missing bound, so a guard that nulled these
+    # rows would be too blunt.
+    schema = {"lo": pl.Float64, "hi": pl.Float64}
+    null_min = pl.DataFrame({"lo": [None], "hi": [1.0]}, schema=schema)
+    null_max = pl.DataFrame({"lo": [0.0], "hi": [None]}, schema=schema)
+    dist = _column_bounds()
+
+    above_known_max = null_min.select(pdf=dist.pdf(pl.lit(2.0)), log_pdf=dist.log_pdf(pl.lit(2.0)))
+    below_known_min = null_max.select(pdf=dist.pdf(pl.lit(-1.0)), log_pdf=dist.log_pdf(pl.lit(-1.0)))
+
+    for got in (above_known_max, below_known_min):
+        assert got["pdf"].to_list() == [0.0]
+        assert got["log_pdf"].to_list() == [float("-inf")]

--- a/tests/property/fast_path_context_test.py
+++ b/tests/property/fast_path_context_test.py
@@ -88,7 +88,7 @@ def _assert_matches_across_contexts(
 
     # The two partition contexts, on the polars versions that get them right (see
     # `PARTITIONED_BROADCAST_AVAILABLE`). `select` and the streaming engine still run below that floor.
-    if PARTITIONED_BROADCAST_AVAILABLE:
+    if PARTITIONED_BROADCAST_AVAILABLE:  # pragma: no branch  # false only on CI's test-oldest job
         # `over`: polars broadcasts a scalar to each (uneven) partition's length, then scatters back.
         assert_series_equal(
             frame.select(r=fast.over("g"))["r"],
@@ -111,7 +111,7 @@ def _assert_matches_across_contexts(
         )
 
     # streaming engine: the source is split across morsels; non-positional exprs must be invariant.
-    if _STREAMING_AVAILABLE:
+    if _STREAMING_AVAILABLE:  # pragma: no branch  # false only on CI's test-oldest job
         lazy = frame.lazy().select(fast=fast, slow=slow).collect(engine="streaming")
         assert_series_equal(
             lazy["fast"], lazy["slow"], check_names=False, check_exact=exact, rel_tol=ULP_REL_TOL, abs_tol=ULP_ABS_TOL


### PR DESCRIPTION
`Uniform.{_pdf, _log_pdf}` branch on `is_between`, which yields null when either bound is null, and `pl.when(null)` takes the otherwise, so a row with a null min or max got a confident 0.0/-inf (respectively) rather than null, contradicting both the class docstring and the contract. An explicit null branch fixes it