### PR TITLE
feat: add the DiscreteUniform distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ Each row is scored against its own `Normal(mu, sigma)`, in one vectorised pass, 
 The maths runs on [`statrs`](https://docs.rs/statrs), and `make audit` sweeps every method against
 an [`mpmath`](https://mpmath.org) oracle at 50 digits, including inputs many decades past where
 `scipy` itself saturates. For tail work on `Normal`, `LogNormal` and the closed-form distributions
-(`Uniform`, `Exponential`, `Bernoulli`, `Geometric`), use `log_cdf` / `log_sf` rather than the linear pair, and
-`isf(q)` rather than `ppf(1 - q)`. `Beta` and `Binomial` inherit several documented `statrs`-side
+(`Uniform`, `Exponential`, `Bernoulli`, `Geometric`, `DiscreteUniform`), use `log_cdf` / `log_sf` rather than the
+linear pair, and `isf(q)` rather than `ppf(1 - q)`. `Beta` and `Binomial` inherit several documented `statrs`-side
 limits in this release: there the log methods underflow with the linear ones, and the extreme lower
 tail of `ppf` misbehaves. Every known limit is listed with a regime and a magnitude in
 [Numerical accuracy](https://fbruzzesi.github.io/polars-stats/explanation/accuracy/).

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -21,10 +21,10 @@ from pathlib import Path
 from typing import Annotated, get_args
 
 from cyclopts import App, Parameter
-from scipy.stats import bernoulli, beta, binom, expon, geom, lognorm, norm, uniform
+from scipy.stats import bernoulli, beta, binom, expon, geom, lognorm, norm, randint, uniform
 
 from benchmarks._harness import ALL_METHODS, Comparison, Method, OutputFormat, Sweep, emit, run_comparison
-from polars_stats import Bernoulli, Beta, Binomial, Exponential, Geometric, LogNormal, Normal, Uniform
+from polars_stats import Bernoulli, Beta, Binomial, DiscreteUniform, Exponential, Geometric, LogNormal, Normal, Uniform
 
 # `--rows 1 2 3` (multiple tokens per flag), not `--rows 1 --rows 2`; without this a list option takes
 # a single token and the rest leak onto the positional `distributions`.
@@ -41,6 +41,7 @@ REGISTRY: dict[str, Comparison] = {
     "beta": Comparison("beta", Beta(a=2.0, b=3.0), beta(a=2.0, b=3.0)),
     "bernoulli": Comparison("bernoulli", Bernoulli(p=0.3), bernoulli(0.3)),
     "binomial": Comparison("binomial", Binomial(n=10, p=0.3), binom(10, 0.3)),
+    "discrete_uniform": Comparison("discrete_uniform", DiscreteUniform(min=-2, max=9), randint(low=-2, high=10)),
     "geometric": Comparison("geometric", Geometric(p=0.3), geom(0.3)),
 }
 

--- a/docs/explanation/accuracy.md
+++ b/docs/explanation/accuracy.md
@@ -74,11 +74,12 @@ magnitudes are in the inherited limits below.
     one, so there `cdf(ppf(q)) < q`. Outside that window both inverses agree with exact rational
     arithmetic, checked on `N = 6, 8, 15, 101` and `1000`. **On** an exactly representable edge the
     two contracts diverge, and this library inverts its own `sf` rather than the exact rational:
-    `isf(sf(x)) == x` holds for 5/6, 15/15 and 98/101 support points on `(1,6)`, `(-5,9)` and
-    `(0,100)`, against 2/6, 7/15 and 58/101 under the rational rule. The misses land where the
-    survival quotient and `isf`'s upward-only correction round to opposite sides of a step; a probe
-    below would recover three of the four, at the price of moving off the shared closed form, and
-    the portable bound stays one support point either way.
+    `isf` probes both neighbours of its candidate and keeps the smallest point whose survival
+    quotient still satisfies the quantile, so `isf(sf(x)) == x` holds for 5/6, 15/15 and 101/101
+    support points on `(1,6)`, `(-5,9)` and `(0,100)`, against 2/6, 7/15 and 58/101 under the
+    rational rule. The one remaining miss is `sf`'s, not the inverse's: its reciprocal multiply
+    lands an ulp below the exact `k / N`, so the point it came from genuinely no longer satisfies
+    the survival contract at that quantile, and the portable bound stays one support point.
 * **A `float` evaluation point cannot address a support narrower than one float step.**
   At `2**62` one float step is 1024 wide, so all 11 points of `{min, ..., min + 10}` denote the same
   `float64`. `cdf`, `sf` and their logs then answer for the whole support at once, because `value >= max`

--- a/docs/explanation/accuracy.md
+++ b/docs/explanation/accuracy.md
@@ -68,14 +68,17 @@ magnitudes are in the inherited limits below.
   opposite trade (it tests against its own `_cdf`, so it is self-consistent and less accurate). Parity
   is gated at integer equality rather than at a float tolerance.
 
-    `DiscreteUniform.ppf` / `isf` are closed forms rather than searches, so they are exact off the
-    step edges: a quantile displaced by half an ulp from any `k / N` inverts to the same support point
-    exact rational arithmetic gives, on `N = 6, 8, 15, 101` and `1000`. **On** an exactly representable
-    edge the two contracts diverge, and this library inverts its own `sf` rather than the exact
-    rational: `isf(sf(x)) == x` holds for 5/6, 15/15 and 98/101 support points on `(1,6)`, `(-5,9)`
-    and `(0,100)`, against 2/6, 7/15 and 58/101 under the rational rule. The four misses are the ones
-    where `_sf`'s reciprocal multiply lands an ulp below the exact `k / N`, so no choice of inverse
-    recovers them.
+    `DiscreteUniform.ppf` / `isf` are closed forms rather than searches, and `ppf` carries scipy's
+    own rounding, bit for bit: in a one-ulp quantile window above each cdf step edge, `q * N` rounds
+    down across the integer boundary and the answer sits one support point below the exact rational
+    one, so there `cdf(ppf(q)) < q`. Outside that window both inverses agree with exact rational
+    arithmetic, checked on `N = 6, 8, 15, 101` and `1000`. **On** an exactly representable edge the
+    two contracts diverge, and this library inverts its own `sf` rather than the exact rational:
+    `isf(sf(x)) == x` holds for 5/6, 15/15 and 98/101 support points on `(1,6)`, `(-5,9)` and
+    `(0,100)`, against 2/6, 7/15 and 58/101 under the rational rule. The misses land where the
+    survival quotient and `isf`'s upward-only correction round to opposite sides of a step; a probe
+    below would recover three of the four, at the price of moving off the shared closed form, and
+    the portable bound stays one support point either way.
 * **A `float` evaluation point cannot address a support narrower than one float step.**
   At `2**62` one float step is 1024 wide, so all 11 points of `{min, ..., min + 10}` denote the same
   `float64`. `cdf`, `sf` and their logs then answer for the whole support at once, because `value >= max`

--- a/docs/explanation/accuracy.md
+++ b/docs/explanation/accuracy.md
@@ -33,10 +33,10 @@ recorded in the report with its reason rather than dropped.
 
 `cdf` and `sf` return `0.0` once the true value drops below ~`1e-308`, which is a `float64` range
 limit and not something an algorithm can fix. For `Normal`, `LogNormal` and the closed-form
-distributions (`Uniform`, `Exponential`, `Bernoulli`, `Geometric`), `log_cdf` and `log_sf` stay
-finite far past that and are the right methods for tail scoring. Likewise `isf(q)` rather than
-`ppf(1 - q)` on those six: forming the complement quantises the tail mass to `1.1e-16` absolute
-before any inverse runs.
+distributions (`Uniform`, `Exponential`, `Bernoulli`, `Geometric`, `DiscreteUniform`), `log_cdf` and
+`log_sf` stay finite far past that and are the right methods for tail scoring. Likewise `isf(q)`
+rather than `ppf(1 - q)` on those seven: forming the complement quantises the tail mass to `1.1e-16`
+absolute before any inverse runs.
 
 In this release that advice does **not** extend to `Beta` and `Binomial`. Their `log_cdf` / `log_sf`
 are the linear value's logarithm, so they return `-inf` at exactly the point where `cdf` / `sf`
@@ -67,6 +67,38 @@ magnitudes are in the inherited limits below.
   [`geom._ppf`](https://github.com/scipy/scipy/blob/main/scipy/stats/_discrete_distns.py) made the
   opposite trade (it tests against its own `_cdf`, so it is self-consistent and less accurate). Parity
   is gated at integer equality rather than at a float tolerance.
+
+    `DiscreteUniform.ppf` / `isf` are closed forms rather than searches, so they are exact off the
+    step edges: a quantile displaced by half an ulp from any `k / N` inverts to the same support point
+    exact rational arithmetic gives, on `N = 6, 8, 15, 101` and `1000`. **On** an exactly representable
+    edge the two contracts diverge, and this library inverts its own `sf` rather than the exact
+    rational: `isf(sf(x)) == x` holds for 5/6, 15/15 and 98/101 support points on `(1,6)`, `(-5,9)`
+    and `(0,100)`, against 2/6, 7/15 and 58/101 under the rational rule. The four misses are the ones
+    where `_sf`'s reciprocal multiply lands an ulp below the exact `k / N`, so no choice of inverse
+    recovers them.
+* **A `float` evaluation point cannot address a support narrower than one float step.**
+  At `2**62` one float step is 1024 wide, so all 11 points of `{min, ..., min + 10}` denote the same
+  `float64`. `cdf`, `sf` and their logs then answer for the whole support at once, because `value >= max`
+  is true for each of them; `pmf` / `log_pmf` test membership rather than a count, so they are
+  unaffected. Passing the point as a Python `int` keeps the arithmetic exact, since the count is
+  subtracted in `Int64` inside the support: `cdf(min + 5)` on `DiscreteUniform(2**62, 2**62 + 10)`
+  is `6/11` from an `int` and `1.0` from the equal `float`. It applies to any support whose width is
+  below `2**-52` of its magnitude.
+* **`DiscreteUniform.ppf` / `isf` return fewer distinct points than such a support has.** The same
+  regime on the *output* side, and there is no `int` spelling to escape to: the candidate is formed as
+  `min + ceil(q * N) - 1` in `Float64`, where `min + 1 - 1` is not `min` above `2**53`.
+  `DiscreteUniform(2**60, 2**60 + 4).ppf(q)` answers `min` for every `q`, and
+  `DiscreteUniform(2**53 + 2, 2**53 + 12)` resolves 3 of its 11 points. Both inverses are exact for
+  bounds inside `±2**53`, which is where a support that a `float64` quantile can address at all lives.
+* **A moment can be correctly rounded and still land outside the support.** `mean` and `median` form
+  the midpoint as `min + (max - min) // 2` in `Int64` and round once, so they are exact for bounds
+  inside `±2**53` and within one ulp everywhere else. Summing the two bounds in `Float64` instead
+  would round each before they cancel, which costs up to `1.2e-13` relative for bounds straddling
+  zero. For a support narrower than one float step near the `Int64` extremes the midpoint can still
+  sit up to half a step outside `[min, max]` when compared in exact integers: it does so for about
+  99% of random supports of width `< 20` drawn from `[2**62, 2**63)`, because the bounds themselves
+  are not representable there. It never happens for a support wider than one float step, nor anywhere
+  inside `±2**53`.
 * **A constant parameter and a column parameter can differ in the last bit.** `Uniform(-2.5, 7.5).cdf("x")`
   and `Uniform(pl.col("lo"), pl.col("hi")).cdf("x")` evaluate the same closed form, but polars folds the
   constant spelling over one row and the column spelling over `n`, and the two kernels do not round

--- a/docs/how-to/migrate-from-scipy.md
+++ b/docs/how-to/migrate-from-scipy.md
@@ -40,6 +40,7 @@ Some of these translations are not identities, so check this table rather than g
 | `bernoulli(p)` | `Bernoulli(p=p)` | same meaning |
 | `binom(n, p)` | `Binomial(n=n, p=p)` | same meaning |
 | `geom(p)` | `Geometric(p=p)` | same meaning; `p = 0` raises here, `scipy` allows it |
+| `randint(low=min, high=max + 1)` | `DiscreteUniform(min=min, max=max)` | **`high` is exclusive, `max` is inclusive**: pass `max = high - 1` |
 
 Two further differences apply everywhere:
 
@@ -135,6 +136,8 @@ Polars defaults to `ddof=1`.
 | Return type | NumPy array | `pl.Expr` |
 | Randomness | `random_state` / global NumPy state | per-call `seed` only, no global state |
 | Accuracy | reference implementation | matched to `1e-12` absolute in the parity suite, relaxed to `1e-9` / `1e-6` for erf-based and search-based `ppf` methods |
+| `DiscreteUniform.median()` | `randint.median()` is `ppf(0.5)`, a support point | the midpoint `(min + max) / 2`, which for an even support size is not a support point |
+| Discrete `ppf(0)` / `isf(1)` | the below-support sentinel `low - 1` | clamped to the support, so `ppf(0)` is `min` and `isf(1)` is `min` |
 
 ## What has no equivalent
 

--- a/docs/reference/discrete.md
+++ b/docs/reference/discrete.md
@@ -24,6 +24,10 @@ classes follow, alphabetically. The members listed under each class include thos
     options:
       inherited_members: true
 
+::: polars_stats.DiscreteUniform
+    options:
+      inherited_members: true
+
 ::: polars_stats.Geometric
     options:
       inherited_members: true

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -21,6 +21,7 @@ For worked examples, see the [tutorial](../tutorial.md) and the [How-to guides](
 | `Uniform(min, max)` | continuous | `max > min` | `uniform(loc=min, scale=max - min)` |
 | `Bernoulli(p)` | discrete | `0 <= p <= 1` | `bernoulli(p)` |
 | `Binomial(n, p)` | discrete | `n >= 0`, `0 <= p <= 1` | `binom(n, p)` |
+| `DiscreteUniform(min, max)` | discrete | `min <= max`, both inclusive | `randint(low=min, high=max + 1)` |
 | `Geometric(p)` | discrete | `0 < p <= 1` | `geom(p)` |
 
 Each class names its parameters after the distribution's conventional parameters. `Normal` and `LogNormal` default to

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -21,7 +21,7 @@ For worked examples, see the [tutorial](../tutorial.md) and the [How-to guides](
 | `Uniform(min, max)` | continuous | `max > min` | `uniform(loc=min, scale=max - min)` |
 | `Bernoulli(p)` | discrete | `0 <= p <= 1` | `bernoulli(p)` |
 | `Binomial(n, p)` | discrete | `n >= 0`, `0 <= p <= 1` | `binom(n, p)` |
-| `DiscreteUniform(min, max)` | discrete | `min <= max`, both inclusive | `randint(low=min, high=max + 1)` |
+| `DiscreteUniform(min, max)` | discrete | `min <= max`, both inclusive | `randint(low=min, high=max + 1)`; **`max` is inclusive** |
 | `Geometric(p)` | discrete | `0 < p <= 1` | `geom(p)` |
 
 Each class names its parameters after the distribution's conventional parameters. `Normal` and `LogNormal` default to

--- a/docs/reference/parameters-and-contracts.md
+++ b/docs/reference/parameters-and-contracts.md
@@ -9,8 +9,8 @@ the lookup table; the how-to guides show what to do about it.
 
 ## Accepted inputs
 
-Constructor parameters and value-keyed method arguments follow the same coercion rules, with two differences: a float
-parameter rejects an `int`, an integer bound rejects a `float`, and a method argument accepts either.
+Constructor parameters and value-keyed method arguments follow the same coercion rules, with one asymmetry: a float
+parameter rejects an `int` and an integer bound rejects a `float`, while a method argument accepts either.
 
 The bounds of `Uniform` and `DiscreteUniform` sit on opposite sides of the float rule despite sharing the names `min`
 and `max`.

--- a/docs/reference/parameters-and-contracts.md
+++ b/docs/reference/parameters-and-contracts.md
@@ -9,18 +9,21 @@ the lookup table; the how-to guides show what to do about it.
 
 ## Accepted inputs
 
-Constructor parameters and value-keyed method arguments follow the same coercion rules, with one difference: a float
-parameter rejects an `int`, while a method argument accepts either.
+Constructor parameters and value-keyed method arguments follow the same coercion rules, with two differences: a float
+parameter rejects an `int`, an integer bound rejects a `float`, and a method argument accepts either.
 
-| Input | Float parameter (`mu`, `sigma`, `p`, `rate`, `a`, `b`, `min`, `max`) | Count parameter (`n`) | Method argument (`x`, `q`) |
-|---|---|---|---|
-| `float` | accepted | `TypeError` | accepted |
-| `int` | `TypeError` | accepted (`0` to `2**63 - 1`) | accepted |
-| `bool` | `TypeError` | `TypeError` | `TypeError` |
-| `str` | read as `pl.col(name)` | read as `pl.col(name)` | read as `pl.col(name)` |
-| `pl.Expr` | passed through | passed through | passed through |
-| `pl.Series` | wrapped as `pl.lit(series)` | wrapped as `pl.lit(series)` | wrapped as `pl.lit(series)` |
-| anything else | `TypeError` | `TypeError` | `TypeError` |
+The bounds of `Uniform` and `DiscreteUniform` sit on opposite sides of the float rule despite sharing the names `min`
+and `max`.
+
+| Input | Float parameter (`mu`, `sigma`, `p`, `rate`, `a`, `b`, `Uniform`'s `min` / `max`) | Count parameter (`n`) | Integer bound (`DiscreteUniform`'s `min` / `max`) | Method argument (`x`, `q`) |
+|---|---|---|---|---|
+| `float` | accepted | `TypeError` | `TypeError` | accepted |
+| `int` | `TypeError` | accepted (`0` to `2**63 - 1`) | accepted (any `Int64`) | accepted |
+| `bool` | `TypeError` | `TypeError` | `TypeError` | `TypeError` |
+| `str` | read as `pl.col(name)` | read as `pl.col(name)` | read as `pl.col(name)` | read as `pl.col(name)` |
+| `pl.Expr` | passed through | passed through | passed through | passed through |
+| `pl.Series` | wrapped as `pl.lit(series)` | wrapped as `pl.lit(series)` | wrapped as `pl.lit(series)` | wrapped as `pl.lit(series)` |
+| anything else | `TypeError` | `TypeError` | `TypeError` | `TypeError` |
 
 A `str` is always a column reference, never a literal value. A Python scalar becomes `pl.lit(value)`, a length-1
 scalar column that the Rust plugin broadcasts to the call's row count
@@ -58,10 +61,11 @@ A length-1 *expression* is accepted wherever a column is and broadcasts rather t
     distribution expression itself inside `over()` or `agg()` that is affected.
 
 Numeric columns of any width are cast to `Float64` at evaluation, so an integer column works wherever a float is
-expected. The count parameter `n` is the exception: its column must already hold integers, of any width up to
-`UInt64`, because casting a float one would silently truncate a fractional count. The rule is judged on the
-dtype, so a float `n` column raises even when every value in it is null; a `Null`-dtype column propagates nulls
-like any other parameter. A non-numeric column raises at
+expected. The integer parameters are the exception: the count `n` and `DiscreteUniform`'s bounds must already hold
+integers, of any integer dtype, because casting a float one would silently truncate. `n` widens to `UInt64` and the
+bounds to `Int64`, so a `UInt64` bound *value* above `i64::MAX` raises rather than wrapping. The rule is judged on the
+dtype, so a float column raises even when every value in it is null; a `Null`-dtype column
+propagates nulls like any other parameter. A non-numeric column raises at
 evaluation: Polars fails the query with `InvalidOperationError` rather than returning nulls.
 
 ## Parameter validity
@@ -80,6 +84,7 @@ may hold any count its dtype can, up to `UInt64`.
 | `Uniform(min, max)` | `max > min` | `max - min` finite |
 | `Bernoulli(p)` | `0 <= p <= 1` | |
 | `Binomial(n, p)` | `n >= 0`, `0 <= p <= 1` | `n` integral |
+| `DiscreteUniform(min, max)` | `min <= max`, both inclusive | `max - min + 1` fits `Int64` |
 | `Geometric(p)` | `0 < p <= 1` | `p = 0` rejected, unlike `Bernoulli` |
 
 A violation raises `ComputeError` and fails the whole evaluation. See
@@ -102,6 +107,7 @@ Element dtype is per distribution and is not normalised to `Float64`:
 |---|---|
 | `Bernoulli` | `Boolean` |
 | `Binomial`, `Geometric` | `UInt64` |
+| `DiscreteUniform` | `Int64` |
 | `Beta`, `Exponential`, `LogNormal`, `Normal`, `Uniform` | `Float64` |
 
 | Aspect | Behaviour |

--- a/polars_stats/__init__.py
+++ b/polars_stats/__init__.py
@@ -5,6 +5,7 @@ from polars_stats.distributions._base import ContinuousDistribution, DiscreteDis
 from polars_stats.distributions._bernoulli import Bernoulli
 from polars_stats.distributions._beta import Beta
 from polars_stats.distributions._binomial import Binomial
+from polars_stats.distributions._discrete_uniform import DiscreteUniform
 from polars_stats.distributions._exponential import Exponential
 from polars_stats.distributions._geometric import Geometric
 from polars_stats.distributions._lognormal import LogNormal
@@ -17,6 +18,7 @@ __all__ = (
     "Binomial",
     "ContinuousDistribution",
     "DiscreteDistribution",
+    "DiscreteUniform",
     "Exponential",
     "Geometric",
     "LogNormal",

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -165,11 +165,16 @@ def coerce_int(value: int | IntoExprColumn, *, name: str) -> pl.Expr:
     """Coerce a signed integer parameter (e.g. discrete uniform bounds) into a `pl.Expr`.
 
     The signed counterpart of `coerce_n`: accepts a Python `int` or an `IntoExprColumn` (a `bool`
-    raises on type, as everywhere), coerces the literal to an `Int64` column, and judges no *value*
-    at construction — negatives are legitimate bounds, so validity is left to evaluation like every
-    other parameter. A scalar outside `Int64` range is refused by polars when the plugin reads it,
-    consistent with a column of the same values. See `_coerce` for the coercion rules.
+    raises on type, as everywhere) and coerces the literal to an `Int64` column. Negatives are
+    legitimate bounds, so no *value* is judged here beyond representability: an `int` outside `Int64`
+    raises `ValueError` at construction, matching `coerce_n`, because polars would otherwise refuse
+    the literal with a message naming only `u64`, `i64` and a column called `literal`. A column keeps
+    its dtype until Rust widens it, which requires an integer dtype and every value inside `Int64`.
+    See `_coerce` for the coercion rules.
     """
+    if (bound := scalar_int(value)) is not None and not -(2**63) <= bound <= _MAX_WIRE_INT:
+        msg = f"{name} must be in [{-(2**63)}, {_MAX_WIRE_INT}] as a Python int, got {bound}: pass a column instead"
+        raise ValueError(msg)
     return _coerce(value, name=name, scalar_label="an int", scalar_types=int, dtype=pl.Int64())
 
 
@@ -498,6 +503,23 @@ class _UnivariateDistribution(ABC):
             return register_plugin(plugin_name, self._param_exprs)
         validated_once = register_plugin(plugin_name, self._scalar_lit_args())
         return pl.when(validated_once.is_not_null()).then(validated)
+
+    def _checked_plugin_output(self, plugin_name: str, *length_from: pl.Expr) -> pl.Expr:
+        """A parameter-validating plugin call whose **own output** is the answer, on both routings.
+
+        Same scalar-vs-column branch as `_checked`, and the difference is why both exist: `_checked`
+        returns a Python-recomputed expression on the scalar path, which is right when the quantity is
+        incidental and wrong when the two routings must agree bit for bit, because polars folds a
+        literal expression with a different kernel than the length-n columns of the per-row branch.
+        Here both branches return what the plugin computed.
+
+        `length_from` exprs are appended after the parameters and never reach the closure; they set the
+        call's row count, since `align_inputs` takes it from the one input whose length is not 1.
+        Passing none leaves a constant parameterisation at length 1; passing a column-valued expr makes
+        the validator run per row. Each call is one validator pass, so callers name it once.
+        """
+        args = self._param_exprs if self._scalar_kwargs is None else self._scalar_lit_args()
+        return register_plugin(plugin_name, [*args, *length_from])
 
     def _param_plugin(self, function_name: str) -> pl.Expr:
         """Register a parameter-keyed Rust plugin call `f(*params)` for a moment with no closed form.

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -157,6 +157,18 @@ def coerce_n(value: int | IntoExprColumn, *, name: str = "n") -> pl.Expr:
     return _coerce(value, name=name, scalar_label="an int", scalar_types=int, dtype=pl.UInt64())
 
 
+def coerce_int(value: int | IntoExprColumn, *, name: str) -> pl.Expr:
+    """Coerce a signed integer parameter (e.g. discrete uniform bounds) into a `pl.Expr`.
+
+    The signed counterpart of `coerce_n`: accepts a Python `int` or an `IntoExprColumn` (a `bool`
+    raises on type, as everywhere), coerces the literal to an `Int64` column, and judges no *value*
+    at construction — negatives are legitimate bounds, so validity is left to evaluation like every
+    other parameter. A scalar outside `Int64` range is refused by polars when the plugin reads it,
+    consistent with a column of the same values. See `_coerce` for the coercion rules.
+    """
+    return _coerce(value, name=name, scalar_label="an int", scalar_types=int, dtype=pl.Int64())
+
+
 def scalar_float(value: float | IntoExprColumn) -> float | None:
     """Return `value` as a `float` if it is a plain numeric scalar, else `None`.
 

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -381,7 +381,7 @@ class _UnivariateDistribution(ABC):
         """Draw one random variate per row.
 
         Returns a column with one variate per input row, in the distribution's element dtype
-        (`Float64`, `UInt64` or `Boolean`). Output length follows the surrounding context (frame length
+        (`Float64`, `Int64`, `UInt64` or `Boolean`). Output length follows the surrounding context (frame length
         under `select` / `with_columns`, partition length under `over` / `group_by`), and each row's draw
         is derived from a per-row sub-seed mixed from `seed` and the row's position, so the result is
         independent of Polars chunking and thread scheduling.

--- a/polars_stats/distributions/_discrete_uniform.py
+++ b/polars_stats/distributions/_discrete_uniform.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
+import polars as pl
+
+from polars_stats.distributions._base import (
+    ROW_INDEX_EXPR,
+    DiscreteDistribution,
+    coerce_int,
+    register_plugin,
+    scalar_int,
+    scalar_kwargs,
+)
+
+if TYPE_CHECKING:
+    from polars_stats._typing import IntoExprColumn
+
+_INV_12 = 1 / 12
+"""The correctly rounded ``1 / 12``, multiplied rather than divided against so the constant-parameter
+and per-row kernels cannot disagree in the last bit (see `n`)."""
+
+
+class DiscreteUniform(DiscreteDistribution):
+    """Discrete uniform distribution over the integers ``{min, ..., max}``, **both bounds inclusive**.
+
+    Equivalent to ``scipy.stats.randint(low=min, high=max + 1)``. The ``max`` argument is
+    **inclusive**, unlike scipy's exclusive ``high``: the support is ``{min, ..., max}`` and
+    ``cdf(max) == 1``. This is the single most common trap when porting scipy code.
+
+    Arguments:
+        min: Inclusive lower bound, an integer. Either a Python ``int`` or an ``IntoExprColumn``
+            (``pl.Expr``, ``pl.Series`` or column name ``str``) carrying one bound per row.
+        max: Inclusive upper bound, with ``max >= min`` (``min == max`` is a one-point mass). Same
+            accepted types as ``min``.
+
+    An invalid parameterisation (``max < min``, or a width ``max - min + 1`` that overflows
+    ``Int64``) is not checked at construction; matching every other distribution, it raises
+    ``InvalidOperation`` (a ``ComputeError``) when any method is evaluated. Null bounds propagate
+    to null.
+    """
+
+    _min: pl.Expr
+    _max: pl.Expr
+    _plugin_prefix: ClassVar[str] = "discreteuniform"
+
+    def __init__(self, min: int | IntoExprColumn, max: int | IntoExprColumn) -> None:  # noqa: A002
+        self._min = coerce_int(min, name="min")
+        self._max = coerce_int(max, name="max")
+        self._scalar_kwargs = scalar_kwargs(min=scalar_int(min), max=scalar_int(max))
+
+    @property
+    def _param_exprs(self) -> tuple[pl.Expr, ...]:
+        return (self._min, self._max)
+
+    @property
+    def n(self) -> pl.Expr:
+        """Support count ``N = max - min + 1``, computed by the Rust range validator as ``Float64``.
+
+        Every closed-form method divides by this, so the validator is what makes them raise on an
+        invalid parameterisation (``max < min``, an overflowing width) consistently with the sampler;
+        null bounds propagate. Both the constant-parameter and the per-row routing consume the
+        validator's own output rather than a Polars-recomputed fallback: with literals, folding
+        ``max - min + 1`` into a constant lets the engine turn those divisions into reciprocal
+        multiplies, which drifts the scalar path a few ulps from the per-row kernel and breaks
+        fast-path bit-equality on exactly the methods this distribution exists to provide.
+        """
+        if self._scalar_kwargs is None:
+            return register_plugin("discreteuniform_range", self._param_exprs)
+        return register_plugin("discreteuniform_range", self._scalar_lit_args())
+
+    @property
+    def _checked_params(self) -> pl.Expr:
+        """The validated support count; see `n`."""
+        return self.n
+
+    @property
+    def _inv_n(self) -> pl.Expr:
+        """``1 / n``, read off the validator once so every consumer multiplies by the same rounded reciprocal.
+
+        Dividing by ``n`` directly is not bit-stable across the two parameter routings: polars
+        divides a column by a broadcast scalar through a different code path than column by column,
+        and the two disagree in the last bit. Multiplying by a single materialised ``1 / n`` removes
+        the fork -- every method below performs the very same multiplication on both paths.
+        """
+        return 1 / self.n
+
+    def _on_support(self, value: pl.Expr) -> pl.Expr:
+        """Whether ``value`` is an integer inside ``[min, max]``, where the mass sits."""
+        return (value >= self._min) & (value <= self._max) & (value.floor() == value)
+
+    def _pmf(self, value: pl.Expr) -> pl.Expr:
+        """``1 / N`` on the integer support, ``0`` off it, ``null`` for null bounds.
+
+        The second ``when`` arm is load bearing: ``on_support`` reads the bounds, so a null bound
+        makes its condition -- not its result -- null, and an unmatched ``when`` arm would silently
+        route a null-bounds row into the ``0.0`` off-support answer. Re-checking ``n``'s nullness
+        turns those rows back into nulls, on both engines.
+        """
+        return (
+            pl.when(self._on_support(value))
+            .then(self._inv_n)
+            .when(self.n.is_not_null())
+            .then(0.0)
+            .otherwise(pl.lit(None, dtype=pl.Float64()))
+        )
+
+    def _sf(self, value: pl.Expr) -> pl.Expr:
+        """``(max - floor(value)) * (1 / N)`` inside the support, ``1`` below ``min``, ``0`` from ``max`` up.
+
+        A direct count of the support points above ``value``, mirroring `_cdf`. Overrides the base
+        ``1 - cdf``, whose subtraction absorbs the whole tail once the cdf rounds towards ``1`` --
+        a few parts in ``1e11`` of relative error at ``N ~ 1e6``, where the true sf is ``1 / N``.
+
+        The whole chain sits behind a ``n.is_not_null()`` gate: the ``1.0`` below-support branch reads
+        only ``min``, so without the gate a null ``max`` would answer ``1.0`` instead of propagating.
+        """
+        return (
+            pl.when(self.n.is_not_null())
+            .then(
+                pl.when(value < self._min)
+                .then(1.0)
+                .when(value >= self._max)
+                .then(0.0)
+                .otherwise((self._max.cast(pl.Float64()) - value.floor()) * self._inv_n)
+            )
+            .otherwise(pl.lit(None, dtype=pl.Float64()))
+        )
+
+    def _log_pmf(self, value: pl.Expr) -> pl.Expr:
+        """``-log(N)`` on the integer support, ``-inf`` off it, ``null`` for null bounds.
+
+        Overrides the base ``pmf().log()`` only to skip the pointless division: the mass is exactly
+        ``1 / N``, so its log reads straight off the count. The extra ``when`` arm preserves null
+        bounds for the reason in `_pmf`.
+        """
+        return (
+            pl.when(self._on_support(value))
+            .then(-self.n.log())
+            .when(self.n.is_not_null())
+            .then(float("-inf"))
+            .otherwise(pl.lit(None, dtype=pl.Float64()))
+        )
+
+    def _cdf(self, value: pl.Expr) -> pl.Expr:
+        """``(floor(value) - min + 1) * (1 / N)`` clamped to ``[0, 1]``.
+
+        The floor counts the support points at or below ``value``; clamping covers everything below
+        ``min`` (a non-positive numerator) and above ``max`` (a numerator past ``N``), so
+        ``cdf(max) == 1`` exactly -- the inclusive upper bound is the visible difference from scipy's
+        exclusive one. The count enters through `_inv_n`; see that property for why this is a
+        multiplication rather than a division.
+        """
+        return ((value.floor() - self._min + 1) * self._inv_n).clip(0.0, 1.0)
+
+    def _ppf(self, quantile: pl.Expr) -> pl.Expr:
+        """``min + ceil(quantile * N) - 1``, corrected and clamped; null outside ``[0, 1]``.
+
+        The closed form matches scipy's ``randint.ppf`` -- not just the ceiling formula but its
+        correction step, which probes ``k - 1`` (clamped into the support) and keeps it whenever its
+        cdf already reaches ``quantile``. That probe is what settles the step-boundary cases: an
+        ulp of noise in ``quantile * N`` around an exact integer would otherwise skip a support
+        point, and matching scipy means resolving them the same way rather than hoping the grids
+        miss them.
+
+        The count enters through `n_rowwise` -- validated at the frame's full height, not broadcast
+        from a length-1 value. The correction's ``>=`` has no slack, so it needs the honestly
+        rounded quotient of a column-by-column division: polars rewrites a division by a broadcast
+        scalar as a reciprocal multiply, whose last bit lands on either side of the step depending
+        on the engine.
+        """
+        if self._scalar_kwargs is None:
+            n_rowwise = register_plugin("discreteuniform_range_rowwise", [*self._param_exprs, ROW_INDEX_EXPR])
+        else:
+            n_rowwise = register_plugin("discreteuniform_range_rowwise", [*self._scalar_lit_args(), ROW_INDEX_EXPR])
+        lo = self._min.cast(pl.Float64())
+        hi = self._max.cast(pl.Float64())
+        candidate = lo + (quantile * n_rowwise).ceil() - 1.0
+        stepped = (candidate - 1.0).clip(lo, hi)
+        return (
+            pl.when(quantile.is_between(0, 1))
+            .then(
+                pl.when((stepped.floor() - self._min + 1) / n_rowwise >= quantile)
+                .then(stepped)
+                .otherwise(candidate)
+                .clip(lo, hi)
+            )
+            .otherwise(pl.lit(None, dtype=pl.Float64()))
+        )
+
+    def _isf(self, quantile: pl.Expr) -> pl.Expr:
+        """``max - floor(quantile * N)``, clamped to the support; null outside ``[0, 1]``.
+
+        Entered against ``quantile`` itself, not the base ``ppf(1 - quantile)``: the complement
+        rounds before the inverse runs, and on this distribution that flips whole support points --
+        the survival steps sit at multiples of ``1 / N``, exactly where ``1 - q`` has spent its
+        precision. In real arithmetic this is the same function (smallest ``k`` with
+        ``(max - k) / N <= q``), and at ``q = 0`` it reads ``max`` directly, where ``sf(max) = 0``
+        already satisfies the inequality.
+        """
+        lo = self._min.cast(pl.Float64())
+        hi = self._max.cast(pl.Float64())
+        return (
+            pl.when(quantile.is_between(0, 1))
+            .then((hi - (quantile * self.n).floor()).clip(lo, hi))
+            .otherwise(pl.lit(None, dtype=pl.Float64()))
+        )
+
+    def mean(self) -> pl.Expr:
+        """Expected value, ``(min + max) / 2``."""
+        return self._moment((self._min + self._max) / 2)
+
+    def variance(self) -> pl.Expr:
+        """Variance, ``(N**2 - 1) / 12``."""
+        return self._moment((self.n**2 - 1) * _INV_12)
+
+    def median(self) -> pl.Expr:
+        """Median, ``(min + max) / 2``.
+
+        Overrides the base ``ppf(0.5)``, which would answer a support point: for even ``N`` the
+        midpoint falls between two of them, and it is the midpoint scipy reports too.
+        """
+        return self._moment((self._min + self._max) / 2)
+
+    def entropy(self) -> pl.Expr:
+        """Shannon entropy in nats, ``log(N)``.
+
+        statrs implements no entropy for this distribution, but every outcome carries mass ``1 / N``,
+        so the support sum collapses to the elementary form and lives here rather than in Rust.
+        """
+        return self._moment(self.n.log())

--- a/polars_stats/distributions/_discrete_uniform.py
+++ b/polars_stats/distributions/_discrete_uniform.py
@@ -35,14 +35,22 @@ class DiscreteUniform(DiscreteDistribution):
     rather than answering its below-support sentinel ``min - 1``.
 
     Arguments:
-        min: Inclusive lower bound, an integer. Either a Python ``int`` or an ``IntoExprColumn``
-            (``pl.Expr``, ``pl.Series`` or column name ``str``) carrying one bound per row.
-        max: Inclusive upper bound, with ``max >= min`` (``min == max`` is a one-point mass). Same
-            accepted types as ``min``.
+        min: Inclusive lower bound, an integer anywhere in ``Int64``: ``[-2**63, 2**63 - 1]``.
+            Either a Python ``int`` (rejected at construction outside that range) or an
+            ``IntoExprColumn`` (``pl.Expr``, ``pl.Series`` or column name ``str``) carrying one
+            bound per row; a column may be any integer dtype, judged by its values fitting
+            ``Int64``.
+        max: Inclusive upper bound, with ``max >= min`` (``min == max`` is a one-point mass) and
+            the width ``max - min + 1`` fitting ``Int64``. Same accepted types and range as
+            ``min``.
 
     An invalid parameterisation (``max < min``, or a width ``max - min + 1`` overflowing ``Int64``)
     is not checked at construction; as everywhere, it raises ``InvalidOperation`` (a
     ``ComputeError``) when a method is evaluated. Null bounds propagate to null.
+
+    The closed forms run in Rust (``src/distributions/discrete_uniform.rs``), one plugin pass per
+    method, where an integer evaluation point keeps exact integer arithmetic; the numeric notes
+    (endpoint contract, ``log1p`` cut-over, inverse correction) live on the Rust bodies.
     """
 
     _min: pl.Expr
@@ -62,9 +70,10 @@ class DiscreteUniform(DiscreteDistribution):
     def support_size(self) -> pl.Expr:
         """Support count ``N = max - min + 1``, as ``Float64``.
 
-        Validated in Rust so every closed form raises on an invalid parameterisation (``max < min``,
-        an overflowing width) consistently with the sampler; null bounds propagate. Above ``2**53``
-        the count itself is rounded. Each mention is one validator pass over the bounds.
+        Validated in Rust so every moment raises on an invalid parameterisation (``max < min``, an
+        overflowing width) consistently with the value-keyed methods and the sampler; null bounds
+        propagate. Above ``2**53`` the count itself is rounded. Each mention is one validator pass
+        over the bounds.
         """
         return self._checked_plugin_output("discreteuniform_range")
 
@@ -74,28 +83,8 @@ class DiscreteUniform(DiscreteDistribution):
         return self.support_size
 
     @property
-    def _point_mass(self) -> pl.Expr:
-        """``1 / support_size``, the mass on each support point.
-
-        Read off the validator once so every consumer multiplies the same reciprocal: polars divides
-        a column by a broadcast scalar through a different code path than column by column, and the
-        two disagree in the last bit. Costs one or two ulp against an exact quotient.
-        """
-        return 1 / self.support_size
-
-    @property
-    def _min_f64(self) -> pl.Expr:
-        """``min`` as ``Float64``, the operand the inverses clip against."""
-        return self._min.cast(pl.Float64())
-
-    @property
-    def _max_f64(self) -> pl.Expr:
-        """``max`` as ``Float64``, the operand the inverses clip against."""
-        return self._max.cast(pl.Float64())
-
-    @property
     def _min_i64(self) -> pl.Expr:
-        """``min`` widened to ``Int64``, the dtype the closed forms' integer arithmetic assumes.
+        """``min`` widened to ``Int64``, the dtype `_midpoint`'s integer arithmetic assumes.
 
         A bound column keeps its own dtype until Rust widens it, so arithmetic on the raw bound runs
         in that dtype and wraps once the support outgrows it (``Int8`` bounds ``(-100, 100)``).
@@ -121,182 +110,42 @@ class DiscreteUniform(DiscreteDistribution):
         width = self._max_i64 - self._min_i64
         return (self._min_i64 + width // 2).cast(pl.Float64()) + (width % 2) * 0.5
 
-    def _is_on_support(self, value: pl.Expr) -> pl.Expr:
-        """Whether ``value`` is an integer inside ``[min, max]``, where the mass sits."""
-        return (value >= self._min) & (value <= self._max) & (value.floor() == value)
-
-    def _points_at_or_below(self, value: pl.Expr) -> pl.Expr:
-        """``k``, the number of support points at or below ``value``.
-
-        The bound is widened via `_min_i64` so an integer ``value`` subtracts in ``Int64``, exact
-        over the ``[1, N - 1]`` range every caller reads; a float ``value`` promotes to ``Float64``.
-        Rows outside the support do evaluate it and may wrap; their branch discards the result.
-        """
-        return value.floor() - self._min_i64 + 1
-
     def _pmf(self, value: pl.Expr) -> pl.Expr:
-        """``1 / N`` on the integer support, ``0`` off it, ``null`` for null bounds.
-
-        The null branch is explicit because `_is_on_support` reads the bounds, so a null bound makes
-        its condition null rather than false, and a bare ``otherwise(0.0)`` would report a confident
-        "off the support" for a row whose support is unknown.
-        """
-        return (
-            pl.when(self._is_on_support(value))
-            .then(self._point_mass)
-            .when(self.support_size.is_not_null())
-            .then(0.0)
-            .otherwise(pl.lit(None, dtype=pl.Float64()))
-        )
+        """``1 / N`` on the integer support, ``0`` off it."""
+        return self._value_plugin("discreteuniform_pmf", value)
 
     def _log_pmf(self, value: pl.Expr) -> pl.Expr:
-        """``-log(N)`` on the integer support, ``-inf`` off it, ``null`` for null bounds.
-
-        Overrides the base ``pmf().log()`` to skip the division: the mass is exactly ``1 / N``, so its
-        log reads straight off the count. Same null branch as `_pmf`.
-        """
-        return (
-            pl.when(self._is_on_support(value))
-            .then(-self.support_size.log())
-            .when(self.support_size.is_not_null())
-            .then(float("-inf"))
-            .otherwise(pl.lit(None, dtype=pl.Float64()))
-        )
+        """``-log(N)`` on the integer support, ``-inf`` off it: the log reads straight off the count."""
+        return self._value_plugin("discreteuniform_ln_pmf", value)
 
     def _cdf(self, value: pl.Expr) -> pl.Expr:
-        """``k * (1 / N)`` inside the support, ``0`` below ``min``, ``1`` from ``max`` up.
-
-        The explicit endpoints make ``cdf(max) == 1`` an answer rather than the limit of a clamp,
-        which is the visible difference from scipy's exclusive upper bound: ``N * (1 / N)`` is not
-        ``1.0`` for 483 of the first 4000 support counts. They also keep `_points_at_or_below` inside
-        the support, where its subtraction is exact.
-        """
-        return (
-            pl.when(self.support_size.is_not_null())
-            .then(
-                pl.when(value < self._min)
-                .then(0.0)
-                .when(value >= self._max)
-                .then(1.0)
-                .otherwise(self._points_at_or_below(value) * self._point_mass)
-            )
-            .otherwise(pl.lit(None, dtype=pl.Float64()))
-        )
+        """``k / N`` inside the support, with explicit endpoints so ``cdf(max) == 1`` exactly."""
+        return self._value_plugin("discreteuniform_cdf", value)
 
     def _sf(self, value: pl.Expr) -> pl.Expr:
-        """``(max - floor(value)) * (1 / N)`` inside the support, ``1`` below ``min``, ``0`` from ``max`` up.
-
-        A direct count of the support points above ``value``, mirroring `_cdf`. Overrides the base
-        ``1 - cdf``, whose subtraction absorbs the whole tail once the cdf rounds towards ``1``. The
-        chain sits behind a null gate because the ``1.0`` branch reads only ``min``.
-        """
-        return (
-            pl.when(self.support_size.is_not_null())
-            .then(
-                pl.when(value < self._min)
-                .then(1.0)
-                .when(value >= self._max)
-                .then(0.0)
-                .otherwise((self._max_i64 - value.floor()) * self._point_mass)
-            )
-            .otherwise(pl.lit(None, dtype=pl.Float64()))
-        )
+        """A direct count of the points above ``value``, not ``1 - cdf``, which absorbs the tail."""
+        return self._value_plugin("discreteuniform_sf", value)
 
     def _log_cdf(self, value: pl.Expr) -> pl.Expr:
-        """``log(k / N)``, through ``log1p`` of the survival ratio once the cdf passes one half.
-
-        Overrides the base ``cdf().log()``, whose relative error one support point below the top grows
-        with ``N``: ``8.7e-16`` at ``N = 1e3`` but ``2.8e-08`` at ``N = 1e9``. Same branch
-        `Uniform._log_cdf` takes. The null gate is there for the reason in `_sf`.
-        """
-        count = self._points_at_or_below(value)
-        return (
-            pl.when(self.support_size.is_not_null())
-            .then(
-                pl.when(value < self._min)
-                .then(float("-inf"))
-                .when(value >= self._max)
-                .then(0.0)
-                .when(count * 2.0 > self.support_size)
-                .then((-((self.support_size - count) * self._point_mass)).log1p())
-                .otherwise((count * self._point_mass).log())
-            )
-            .otherwise(pl.lit(None, dtype=pl.Float64()))
-        )
+        """``log(k / N)``, through ``log1p`` of the survival ratio once the cdf passes one half."""
+        return self._value_plugin("discreteuniform_ln_cdf", value)
 
     def _log_sf(self, value: pl.Expr) -> pl.Expr:
-        """The mirror of `_log_cdf`: the near-certain side is the lower one, so ``log1p`` sits there.
-
-        ``0`` below ``min`` and ``-inf`` at or above ``max``, and the same null gate.
-        """
-        count = self._points_at_or_below(value)
-        return (
-            pl.when(self.support_size.is_not_null())
-            .then(
-                pl.when(value < self._min)
-                .then(0.0)
-                .when(value >= self._max)
-                .then(float("-inf"))
-                .when(count * 2.0 > self.support_size)
-                .then(((self.support_size - count) * self._point_mass).log())
-                .otherwise((-(count * self._point_mass)).log1p())
-            )
-            .otherwise(pl.lit(None, dtype=pl.Float64()))
-        )
+        """The mirror of `_log_cdf`: the near-certain side is the lower one, so ``log1p`` sits there."""
+        return self._value_plugin("discreteuniform_ln_sf", value)
 
     def _ppf(self, quantile: pl.Expr) -> pl.Expr:
-        """``min + ceil(quantile * N) - 1``, corrected and clamped; null outside ``[0, 1]``.
-
-        Matches scipy's ``randint.ppf`` including its correction step, which probes the point below and
-        keeps it whenever that point's cdf already reaches ``quantile``, settling the step boundaries
-        where an ulp of noise in ``quantile * N`` would skip a support point. The probe's ``>=`` has no
-        slack, so it reads an honestly rounded column-by-column quotient; that is why the validator
-        takes ``quantile`` as a `_checked_plugin_output` length input, which makes it run per row.
-
-        Both inverses lose support points above ``2**53``; see docs/explanation/accuracy.md.
-        """
-        support_size_per_row = self._checked_plugin_output("discreteuniform_range", quantile)
-        min_f64, max_f64 = self._min_f64, self._max_f64
-        candidate = min_f64 + (quantile * support_size_per_row).ceil() - 1.0
-        point_below = (candidate - 1.0).clip(min_f64, max_f64)
-        return (
-            pl.when(quantile.is_between(0, 1))
-            .then(
-                pl.when(self._points_at_or_below(point_below) / support_size_per_row >= quantile)
-                .then(point_below)
-                .otherwise(candidate)
-                .clip(min_f64, max_f64)
-            )
-            .otherwise(pl.lit(None, dtype=pl.Float64()))
-        )
+        """``min + ceil(quantile * N) - 1``, corrected at the step boundaries as scipy's ``randint.ppf`` is."""
+        return self._value_plugin("discreteuniform_ppf", quantile)
 
     def _isf(self, quantile: pl.Expr) -> pl.Expr:
-        """``max - floor(quantile * N)``, corrected and clamped; null outside ``[0, 1]``.
+        """The smallest support point whose survival mass is at most ``quantile``.
 
-        The smallest support point whose survival mass is at most ``quantile``. Entered against
-        ``quantile`` itself rather than the base ``ppf(1 - quantile)``: the complement rounds before the
-        inverse runs, and the survival steps sit at multiples of ``1 / N``, exactly where ``1 - q`` has
-        spent its precision.
-
-        The correction mirrors `_ppf`'s but probes the neighbour **above**: a product that rounds
-        high floors one too high, and the probe pulls it back. A product can also round low, at a
-        quantile sitting exactly on an honest step quotient ``(max - x) / N``; that side stays
-        uncorrected and answers one point above the smallest admissible one, within the one-point
-        bound in docs/explanation/accuracy.md.
+        Entered against ``quantile`` itself rather than the base ``ppf(1 - quantile)``: the
+        complement rounds before the inverse runs, and the survival steps sit at multiples of
+        ``1 / N``, exactly where ``1 - q`` has spent its precision.
         """
-        support_size_per_row = self._checked_plugin_output("discreteuniform_range", quantile)
-        min_f64, max_f64 = self._min_f64, self._max_f64
-        candidate = max_f64 - (quantile * support_size_per_row).floor()
-        return (
-            pl.when(quantile.is_between(0, 1))
-            .then(
-                pl.when((max_f64 - candidate) / support_size_per_row <= quantile)
-                .then(candidate)
-                .otherwise(candidate + 1.0)
-                .clip(min_f64, max_f64)
-            )
-            .otherwise(pl.lit(None, dtype=pl.Float64()))
-        )
+        return self._value_plugin("discreteuniform_isf", quantile)
 
     def mean(self) -> pl.Expr:
         """Expected value, ``(min + max) / 2``. See `_midpoint` for how the sum avoids overflowing."""

--- a/polars_stats/distributions/_discrete_uniform.py
+++ b/polars_stats/distributions/_discrete_uniform.py
@@ -5,10 +5,8 @@ from typing import TYPE_CHECKING, ClassVar
 import polars as pl
 
 from polars_stats.distributions._base import (
-    ROW_INDEX_EXPR,
     DiscreteDistribution,
     coerce_int,
-    register_plugin,
     scalar_int,
     scalar_kwargs,
 )
@@ -16,9 +14,13 @@ from polars_stats.distributions._base import (
 if TYPE_CHECKING:
     from polars_stats._typing import IntoExprColumn
 
-_INV_12 = 1 / 12
-"""The correctly rounded ``1 / 12``, multiplied rather than divided against so the constant-parameter
-and per-row kernels cannot disagree in the last bit (see `n`)."""
+_ONE_TWELFTH = 1 / 12
+"""The correctly rounded ``1 / 12``.
+
+Multiplied by rather than divided against: polars spells ``column / 12`` as an honest division up to
+eight rows and as a reciprocal multiply above, so dividing would make ``variance`` row-count
+dependent. Costs a third of an ulp against a correctly rounded quotient.
+"""
 
 
 class DiscreteUniform(DiscreteDistribution):
@@ -26,7 +28,11 @@ class DiscreteUniform(DiscreteDistribution):
 
     Equivalent to ``scipy.stats.randint(low=min, high=max + 1)``. The ``max`` argument is
     **inclusive**, unlike scipy's exclusive ``high``: the support is ``{min, ..., max}`` and
-    ``cdf(max) == 1``. This is the single most common trap when porting scipy code.
+    ``cdf(max) == 1``.
+
+    Two further divergences from scipy: ``median`` is the midpoint ``(min + max) / 2``, not the
+    support point scipy's ``ppf(0.5)`` reports, and ``ppf(0)`` / ``isf(1)`` clamp to the support
+    rather than answering its below-support sentinel ``min - 1``.
 
     Arguments:
         min: Inclusive lower bound, an integer. Either a Python ``int`` or an ``IntoExprColumn``
@@ -34,10 +40,9 @@ class DiscreteUniform(DiscreteDistribution):
         max: Inclusive upper bound, with ``max >= min`` (``min == max`` is a one-point mass). Same
             accepted types as ``min``.
 
-    An invalid parameterisation (``max < min``, or a width ``max - min + 1`` that overflows
-    ``Int64``) is not checked at construction; matching every other distribution, it raises
-    ``InvalidOperation`` (a ``ComputeError``) when any method is evaluated. Null bounds propagate
-    to null.
+    An invalid parameterisation (``max < min``, or a width ``max - min + 1`` overflowing ``Int64``)
+    is not checked at construction; as everywhere, it raises ``InvalidOperation`` (a
+    ``ComputeError``) when a method is evaluated. Null bounds propagate to null.
     """
 
     _min: pl.Expr
@@ -54,54 +59,111 @@ class DiscreteUniform(DiscreteDistribution):
         return (self._min, self._max)
 
     @property
-    def n(self) -> pl.Expr:
-        """Support count ``N = max - min + 1``, computed by the Rust range validator as ``Float64``.
+    def support_size(self) -> pl.Expr:
+        """Support count ``N = max - min + 1``, as ``Float64``.
 
-        Every closed-form method divides by this, so the validator is what makes them raise on an
-        invalid parameterisation (``max < min``, an overflowing width) consistently with the sampler;
-        null bounds propagate. Both the constant-parameter and the per-row routing consume the
-        validator's own output rather than a Polars-recomputed fallback: with literals, folding
-        ``max - min + 1`` into a constant lets the engine turn those divisions into reciprocal
-        multiplies, which drifts the scalar path a few ulps from the per-row kernel and breaks
-        fast-path bit-equality on exactly the methods this distribution exists to provide.
+        Validated in Rust so every closed form raises on an invalid parameterisation (``max < min``,
+        an overflowing width) consistently with the sampler; null bounds propagate. Above ``2**53``
+        the count itself is rounded. Each mention is one validator pass over the bounds.
         """
-        if self._scalar_kwargs is None:
-            return register_plugin("discreteuniform_range", self._param_exprs)
-        return register_plugin("discreteuniform_range", self._scalar_lit_args())
+        return self._checked_plugin_output("discreteuniform_range")
 
     @property
     def _checked_params(self) -> pl.Expr:
-        """The validated support count; see `n`."""
-        return self.n
+        """The validated support count; see `support_size`."""
+        return self.support_size
 
     @property
-    def _inv_n(self) -> pl.Expr:
-        """``1 / n``, read off the validator once so every consumer multiplies by the same rounded reciprocal.
+    def _point_mass(self) -> pl.Expr:
+        """``1 / support_size``, the mass on each support point.
 
-        Dividing by ``n`` directly is not bit-stable across the two parameter routings: polars
-        divides a column by a broadcast scalar through a different code path than column by column,
-        and the two disagree in the last bit. Multiplying by a single materialised ``1 / n`` removes
-        the fork -- every method below performs the very same multiplication on both paths.
+        Read off the validator once so every consumer multiplies the same reciprocal: polars divides
+        a column by a broadcast scalar through a different code path than column by column, and the
+        two disagree in the last bit. Costs one or two ulp against an exact quotient.
         """
-        return 1 / self.n
+        return 1 / self.support_size
 
-    def _on_support(self, value: pl.Expr) -> pl.Expr:
+    @property
+    def _min_f64(self) -> pl.Expr:
+        """``min`` as ``Float64``, the operand the inverses clip against."""
+        return self._min.cast(pl.Float64())
+
+    @property
+    def _max_f64(self) -> pl.Expr:
+        """``max`` as ``Float64``, the operand the inverses clip against."""
+        return self._max.cast(pl.Float64())
+
+    @property
+    def _midpoint(self) -> pl.Expr:
+        """``(min + max) / 2``, formed as ``min + (max - min) // 2`` to stay in ``Int64``.
+
+        ``min + max`` overflows well inside the range the validator accepts, and casting each bound to
+        ``Float64`` first rounds both before they cancel (``1.2e-13`` relative for bounds straddling
+        zero). The width is exact in ``Int64`` and ``min + width // 2`` lies in ``[min, max]``, so the
+        cast is the only rounding.
+        """
+        width = self._max - self._min
+        return (self._min + width // 2).cast(pl.Float64()) + (width % 2) * 0.5
+
+    def _is_on_support(self, value: pl.Expr) -> pl.Expr:
         """Whether ``value`` is an integer inside ``[min, max]``, where the mass sits."""
         return (value >= self._min) & (value <= self._max) & (value.floor() == value)
+
+    def _points_at_or_below(self, value: pl.Expr) -> pl.Expr:
+        """``k``, the number of support points at or below ``value``.
+
+        Only ever read where ``k`` lies in ``[1, N - 1]``, which is what keeps the subtraction in
+        ``Int64`` where it is exact. Rows outside the support do evaluate it and may wrap; their
+        branch discards the result.
+        """
+        return value.floor() - self._min + 1
 
     def _pmf(self, value: pl.Expr) -> pl.Expr:
         """``1 / N`` on the integer support, ``0`` off it, ``null`` for null bounds.
 
-        The second ``when`` arm is load bearing: ``on_support`` reads the bounds, so a null bound
-        makes its condition -- not its result -- null, and an unmatched ``when`` arm would silently
-        route a null-bounds row into the ``0.0`` off-support answer. Re-checking ``n``'s nullness
-        turns those rows back into nulls, on both engines.
+        The null branch is explicit because `_is_on_support` reads the bounds, so a null bound makes
+        its condition null rather than false, and a bare ``otherwise(0.0)`` would report a confident
+        "off the support" for a row whose support is unknown.
         """
         return (
-            pl.when(self._on_support(value))
-            .then(self._inv_n)
-            .when(self.n.is_not_null())
+            pl.when(self._is_on_support(value))
+            .then(self._point_mass)
+            .when(self.support_size.is_not_null())
             .then(0.0)
+            .otherwise(pl.lit(None, dtype=pl.Float64()))
+        )
+
+    def _log_pmf(self, value: pl.Expr) -> pl.Expr:
+        """``-log(N)`` on the integer support, ``-inf`` off it, ``null`` for null bounds.
+
+        Overrides the base ``pmf().log()`` to skip the division: the mass is exactly ``1 / N``, so its
+        log reads straight off the count. Same null branch as `_pmf`.
+        """
+        return (
+            pl.when(self._is_on_support(value))
+            .then(-self.support_size.log())
+            .when(self.support_size.is_not_null())
+            .then(float("-inf"))
+            .otherwise(pl.lit(None, dtype=pl.Float64()))
+        )
+
+    def _cdf(self, value: pl.Expr) -> pl.Expr:
+        """``k * (1 / N)`` inside the support, ``0`` below ``min``, ``1`` from ``max`` up.
+
+        The explicit endpoints make ``cdf(max) == 1`` an answer rather than the limit of a clamp,
+        which is the visible difference from scipy's exclusive upper bound: ``N * (1 / N)`` is not
+        ``1.0`` for 483 of the first 4000 support counts. They also keep `_points_at_or_below` inside
+        the support, where its subtraction is exact.
+        """
+        return (
+            pl.when(self.support_size.is_not_null())
+            .then(
+                pl.when(value < self._min)
+                .then(0.0)
+                .when(value >= self._max)
+                .then(1.0)
+                .otherwise(self._points_at_or_below(value) * self._point_mass)
+            )
             .otherwise(pl.lit(None, dtype=pl.Float64()))
         )
 
@@ -109,123 +171,130 @@ class DiscreteUniform(DiscreteDistribution):
         """``(max - floor(value)) * (1 / N)`` inside the support, ``1`` below ``min``, ``0`` from ``max`` up.
 
         A direct count of the support points above ``value``, mirroring `_cdf`. Overrides the base
-        ``1 - cdf``, whose subtraction absorbs the whole tail once the cdf rounds towards ``1`` --
-        a few parts in ``1e11`` of relative error at ``N ~ 1e6``, where the true sf is ``1 / N``.
-
-        The whole chain sits behind a ``n.is_not_null()`` gate: the ``1.0`` below-support branch reads
-        only ``min``, so without the gate a null ``max`` would answer ``1.0`` instead of propagating.
+        ``1 - cdf``, whose subtraction absorbs the whole tail once the cdf rounds towards ``1``. The
+        chain sits behind a null gate because the ``1.0`` branch reads only ``min``.
         """
         return (
-            pl.when(self.n.is_not_null())
+            pl.when(self.support_size.is_not_null())
             .then(
                 pl.when(value < self._min)
                 .then(1.0)
                 .when(value >= self._max)
                 .then(0.0)
-                .otherwise((self._max.cast(pl.Float64()) - value.floor()) * self._inv_n)
+                .otherwise((self._max - value.floor()) * self._point_mass)
             )
             .otherwise(pl.lit(None, dtype=pl.Float64()))
         )
 
-    def _log_pmf(self, value: pl.Expr) -> pl.Expr:
-        """``-log(N)`` on the integer support, ``-inf`` off it, ``null`` for null bounds.
+    def _log_cdf(self, value: pl.Expr) -> pl.Expr:
+        """``log(k / N)``, through ``log1p`` of the survival ratio once the cdf passes one half.
 
-        Overrides the base ``pmf().log()`` only to skip the pointless division: the mass is exactly
-        ``1 / N``, so its log reads straight off the count. The extra ``when`` arm preserves null
-        bounds for the reason in `_pmf`.
+        Overrides the base ``cdf().log()``, whose relative error one support point below the top grows
+        with ``N``: ``8.7e-16`` at ``N = 1e3`` but ``2.8e-08`` at ``N = 1e9``. Same branch
+        `Uniform._log_cdf` takes. The null gate is there for the reason in `_sf`.
         """
+        count = self._points_at_or_below(value)
         return (
-            pl.when(self._on_support(value))
-            .then(-self.n.log())
-            .when(self.n.is_not_null())
-            .then(float("-inf"))
+            pl.when(self.support_size.is_not_null())
+            .then(
+                pl.when(value < self._min)
+                .then(float("-inf"))
+                .when(value >= self._max)
+                .then(0.0)
+                .when(count * 2.0 > self.support_size)
+                .then((-((self.support_size - count) * self._point_mass)).log1p())
+                .otherwise((count * self._point_mass).log())
+            )
             .otherwise(pl.lit(None, dtype=pl.Float64()))
         )
 
-    def _cdf(self, value: pl.Expr) -> pl.Expr:
-        """``(floor(value) - min + 1) * (1 / N)`` clamped to ``[0, 1]``.
+    def _log_sf(self, value: pl.Expr) -> pl.Expr:
+        """The mirror of `_log_cdf`: the near-certain side is the lower one, so ``log1p`` sits there.
 
-        The floor counts the support points at or below ``value``; clamping covers everything below
-        ``min`` (a non-positive numerator) and above ``max`` (a numerator past ``N``), so
-        ``cdf(max) == 1`` exactly -- the inclusive upper bound is the visible difference from scipy's
-        exclusive one. The count enters through `_inv_n`; see that property for why this is a
-        multiplication rather than a division.
+        ``0`` below ``min`` and ``-inf`` at or above ``max``, and the same null gate.
         """
-        return ((value.floor() - self._min + 1) * self._inv_n).clip(0.0, 1.0)
+        count = self._points_at_or_below(value)
+        return (
+            pl.when(self.support_size.is_not_null())
+            .then(
+                pl.when(value < self._min)
+                .then(0.0)
+                .when(value >= self._max)
+                .then(float("-inf"))
+                .when(count * 2.0 > self.support_size)
+                .then(((self.support_size - count) * self._point_mass).log())
+                .otherwise((-(count * self._point_mass)).log1p())
+            )
+            .otherwise(pl.lit(None, dtype=pl.Float64()))
+        )
 
     def _ppf(self, quantile: pl.Expr) -> pl.Expr:
         """``min + ceil(quantile * N) - 1``, corrected and clamped; null outside ``[0, 1]``.
 
-        The closed form matches scipy's ``randint.ppf`` -- not just the ceiling formula but its
-        correction step, which probes ``k - 1`` (clamped into the support) and keeps it whenever its
-        cdf already reaches ``quantile``. That probe is what settles the step-boundary cases: an
-        ulp of noise in ``quantile * N`` around an exact integer would otherwise skip a support
-        point, and matching scipy means resolving them the same way rather than hoping the grids
-        miss them.
+        Matches scipy's ``randint.ppf`` including its correction step, which probes the point below and
+        keeps it whenever that point's cdf already reaches ``quantile``, settling the step boundaries
+        where an ulp of noise in ``quantile * N`` would skip a support point. The probe's ``>=`` has no
+        slack, so it reads an honestly rounded column-by-column quotient; that is why the validator
+        takes ``quantile`` as a `_checked_plugin_output` length input, which makes it run per row.
 
-        The count enters through `n_rowwise` -- validated at the frame's full height, not broadcast
-        from a length-1 value. The correction's ``>=`` has no slack, so it needs the honestly
-        rounded quotient of a column-by-column division: polars rewrites a division by a broadcast
-        scalar as a reciprocal multiply, whose last bit lands on either side of the step depending
-        on the engine.
+        Both inverses lose support points above ``2**53``; see docs/explanation/accuracy.md.
         """
-        if self._scalar_kwargs is None:
-            n_rowwise = register_plugin("discreteuniform_range_rowwise", [*self._param_exprs, ROW_INDEX_EXPR])
-        else:
-            n_rowwise = register_plugin("discreteuniform_range_rowwise", [*self._scalar_lit_args(), ROW_INDEX_EXPR])
-        lo = self._min.cast(pl.Float64())
-        hi = self._max.cast(pl.Float64())
-        candidate = lo + (quantile * n_rowwise).ceil() - 1.0
-        stepped = (candidate - 1.0).clip(lo, hi)
+        support_size_per_row = self._checked_plugin_output("discreteuniform_range", quantile)
+        min_f64, max_f64 = self._min_f64, self._max_f64
+        candidate = min_f64 + (quantile * support_size_per_row).ceil() - 1.0
+        point_below = (candidate - 1.0).clip(min_f64, max_f64)
         return (
             pl.when(quantile.is_between(0, 1))
             .then(
-                pl.when((stepped.floor() - self._min + 1) / n_rowwise >= quantile)
-                .then(stepped)
+                pl.when(self._points_at_or_below(point_below) / support_size_per_row >= quantile)
+                .then(point_below)
                 .otherwise(candidate)
-                .clip(lo, hi)
+                .clip(min_f64, max_f64)
             )
             .otherwise(pl.lit(None, dtype=pl.Float64()))
         )
 
     def _isf(self, quantile: pl.Expr) -> pl.Expr:
-        """``max - floor(quantile * N)``, clamped to the support; null outside ``[0, 1]``.
+        """``max - floor(quantile * N)``, corrected and clamped; null outside ``[0, 1]``.
 
-        Entered against ``quantile`` itself, not the base ``ppf(1 - quantile)``: the complement
-        rounds before the inverse runs, and on this distribution that flips whole support points --
-        the survival steps sit at multiples of ``1 / N``, exactly where ``1 - q`` has spent its
-        precision. In real arithmetic this is the same function (smallest ``k`` with
-        ``(max - k) / N <= q``), and at ``q = 0`` it reads ``max`` directly, where ``sf(max) = 0``
-        already satisfies the inequality.
+        The smallest support point whose survival mass is at most ``quantile``. Entered against
+        ``quantile`` itself rather than the base ``ppf(1 - quantile)``: the complement rounds before the
+        inverse runs, and the survival steps sit at multiples of ``1 / N``, exactly where ``1 - q`` has
+        spent its precision.
+
+        The correction mirrors `_ppf`'s but probes the neighbour **above**, the only direction it can
+        need: a rounded ``quantile * N`` can only floor one too high.
         """
-        lo = self._min.cast(pl.Float64())
-        hi = self._max.cast(pl.Float64())
+        support_size_per_row = self._checked_plugin_output("discreteuniform_range", quantile)
+        min_f64, max_f64 = self._min_f64, self._max_f64
+        candidate = max_f64 - (quantile * support_size_per_row).floor()
         return (
             pl.when(quantile.is_between(0, 1))
-            .then((hi - (quantile * self.n).floor()).clip(lo, hi))
+            .then(
+                pl.when((max_f64 - candidate) / support_size_per_row <= quantile)
+                .then(candidate)
+                .otherwise(candidate + 1.0)
+                .clip(min_f64, max_f64)
+            )
             .otherwise(pl.lit(None, dtype=pl.Float64()))
         )
 
     def mean(self) -> pl.Expr:
-        """Expected value, ``(min + max) / 2``."""
-        return self._moment((self._min + self._max) / 2)
+        """Expected value, ``(min + max) / 2``. See `_midpoint` for how the sum avoids overflowing."""
+        return self._moment(self._midpoint)
 
     def variance(self) -> pl.Expr:
         """Variance, ``(N**2 - 1) / 12``."""
-        return self._moment((self.n**2 - 1) * _INV_12)
+        return (self.support_size**2 - 1) * _ONE_TWELFTH
 
     def median(self) -> pl.Expr:
-        """Median, ``(min + max) / 2``.
+        """Median, the midpoint ``(min + max) / 2``, which for an even support size is not a support point.
 
-        Overrides the base ``ppf(0.5)``, which would answer a support point: for even ``N`` the
-        midpoint falls between two of them, and it is the midpoint scipy reports too.
+        Overrides the base ``ppf(0.5)``, and **diverges from scipy**, which reports that support point:
+        ``scipy.stats.randint(low=1, high=7).median()`` is ``3.0`` against this crate's ``3.5``.
         """
-        return self._moment((self._min + self._max) / 2)
+        return self._moment(self._midpoint)
 
     def entropy(self) -> pl.Expr:
-        """Shannon entropy in nats, ``log(N)``.
-
-        statrs implements no entropy for this distribution, but every outcome carries mass ``1 / N``,
-        so the support sum collapses to the elementary form and lives here rather than in Rust.
-        """
-        return self._moment(self.n.log())
+        """Shannon entropy in nats, ``log(N)``."""
+        return self.support_size.log()

--- a/polars_stats/distributions/_discrete_uniform.py
+++ b/polars_stats/distributions/_discrete_uniform.py
@@ -94,6 +94,22 @@ class DiscreteUniform(DiscreteDistribution):
         return self._max.cast(pl.Float64())
 
     @property
+    def _min_i64(self) -> pl.Expr:
+        """``min`` widened to ``Int64``, the dtype the closed forms' integer arithmetic assumes.
+
+        A bound column keeps its own dtype until Rust widens it, so arithmetic on the raw bound runs
+        in that dtype and wraps once the support outgrows it (``Int8`` bounds ``(-100, 100)``).
+        Non-strict, so an out-of-range ``UInt64`` value nulls here and stays the validator's error
+        to report.
+        """
+        return self._min.cast(pl.Int64(), strict=False)
+
+    @property
+    def _max_i64(self) -> pl.Expr:
+        """``max`` widened to ``Int64``; see `_min_i64`."""
+        return self._max.cast(pl.Int64(), strict=False)
+
+    @property
     def _midpoint(self) -> pl.Expr:
         """``(min + max) / 2``, formed as ``min + (max - min) // 2`` to stay in ``Int64``.
 
@@ -102,8 +118,8 @@ class DiscreteUniform(DiscreteDistribution):
         zero). The width is exact in ``Int64`` and ``min + width // 2`` lies in ``[min, max]``, so the
         cast is the only rounding.
         """
-        width = self._max - self._min
-        return (self._min + width // 2).cast(pl.Float64()) + (width % 2) * 0.5
+        width = self._max_i64 - self._min_i64
+        return (self._min_i64 + width // 2).cast(pl.Float64()) + (width % 2) * 0.5
 
     def _is_on_support(self, value: pl.Expr) -> pl.Expr:
         """Whether ``value`` is an integer inside ``[min, max]``, where the mass sits."""
@@ -112,11 +128,11 @@ class DiscreteUniform(DiscreteDistribution):
     def _points_at_or_below(self, value: pl.Expr) -> pl.Expr:
         """``k``, the number of support points at or below ``value``.
 
-        Only ever read where ``k`` lies in ``[1, N - 1]``, which is what keeps the subtraction in
-        ``Int64`` where it is exact. Rows outside the support do evaluate it and may wrap; their
-        branch discards the result.
+        The bound is widened via `_min_i64` so an integer ``value`` subtracts in ``Int64``, exact
+        over the ``[1, N - 1]`` range every caller reads; a float ``value`` promotes to ``Float64``.
+        Rows outside the support do evaluate it and may wrap; their branch discards the result.
         """
-        return value.floor() - self._min + 1
+        return value.floor() - self._min_i64 + 1
 
     def _pmf(self, value: pl.Expr) -> pl.Expr:
         """``1 / N`` on the integer support, ``0`` off it, ``null`` for null bounds.
@@ -181,7 +197,7 @@ class DiscreteUniform(DiscreteDistribution):
                 .then(1.0)
                 .when(value >= self._max)
                 .then(0.0)
-                .otherwise((self._max - value.floor()) * self._point_mass)
+                .otherwise((self._max_i64 - value.floor()) * self._point_mass)
             )
             .otherwise(pl.lit(None, dtype=pl.Float64()))
         )
@@ -262,8 +278,11 @@ class DiscreteUniform(DiscreteDistribution):
         inverse runs, and the survival steps sit at multiples of ``1 / N``, exactly where ``1 - q`` has
         spent its precision.
 
-        The correction mirrors `_ppf`'s but probes the neighbour **above**, the only direction it can
-        need: a rounded ``quantile * N`` can only floor one too high.
+        The correction mirrors `_ppf`'s but probes the neighbour **above**: a product that rounds
+        high floors one too high, and the probe pulls it back. A product can also round low, at a
+        quantile sitting exactly on an honest step quotient ``(max - x) / N``; that side stays
+        uncorrected and answers one point above the smallest admissible one, within the one-point
+        bound in docs/explanation/accuracy.md.
         """
         support_size_per_row = self._checked_plugin_output("discreteuniform_range", quantile)
         min_f64, max_f64 = self._min_f64, self._max_f64
@@ -291,7 +310,7 @@ class DiscreteUniform(DiscreteDistribution):
         """Median, the midpoint ``(min + max) / 2``, which for an even support size is not a support point.
 
         Overrides the base ``ppf(0.5)``, and **diverges from scipy**, which reports that support point:
-        ``scipy.stats.randint(low=1, high=7).median()`` is ``3.0`` against this crate's ``3.5``.
+        ``scipy.stats.randint(low=1, high=7).median()`` is ``3.0`` against this library's ``3.5``.
         """
         return self._moment(self._midpoint)
 

--- a/src/distributions/discrete_uniform.rs
+++ b/src/distributions/discrete_uniform.rs
@@ -1,0 +1,191 @@
+#![allow(clippy::unused_unit)]
+use polars::prelude::*;
+use pyo3_polars::derive::polars_expr;
+use rand::distr::Distribution;
+use statrs::distribution::DiscreteUniform;
+
+use crate::distributions::{align_inputs, validate_params_binary};
+use crate::rng::{
+    sample_by_index, sample_per_row_ternary, samples_by_index, samples_i64_output, samples_per_row,
+    ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
+};
+
+/// Construct a `statrs::DiscreteUniform`, mapping an invalid parameterisation to `InvalidOperation`.
+///
+/// `statrs` only rejects `max < min` (`min == max` is the legitimate one-point mass), so the one
+/// extra guard here is the support count: `max - min + 1` overflows `i64` for a span wider than
+/// `i64::MAX - 1`, and every closed form divides by that count. The width is computed in `i128`
+/// so the check itself cannot wrap.
+fn build_dist(min: i64, max: i64) -> PolarsResult<DiscreteUniform> {
+    let n = max as i128 - min as i128 + 1;
+    if n > i64::MAX as i128 {
+        return Err(PolarsError::InvalidOperation(
+            format!("support width max - min + 1 must fit in i64, got min={min}, max={max}").into(),
+        ));
+    }
+    DiscreteUniform::new(min, max).map_err(|e| {
+        PolarsError::InvalidOperation(
+            format!("max must be greater than or equal to min, got min={min}, max={max}: {e}")
+                .into(),
+        )
+    })
+}
+
+/// Widen a bound column to the `Int64` both distribution types take.
+///
+/// The signed counterpart of binomial's `coerce_n`: a float dtype is refused rather than cast
+/// (a bare cast would silently truncate `2.7` to `2`), and the strict cast to `Int64` is what
+/// reports values outside the range. A `Null`-dtype column widens to all-null so null-in-null-out
+/// holds; the dtype gate stays column-level, so a *float* column is refused even when every value
+/// in it is null.
+fn coerce_bound(bound: &Series) -> PolarsResult<Int64Chunked> {
+    let dtype = bound.dtype();
+    if dtype == &DataType::Null {
+        return Ok(bound.cast(&DataType::Int64)?.i64()?.clone());
+    }
+    if !dtype.is_integer() {
+        let msg = format!(
+            "bounds must be integer columns, got {dtype}: cast it explicitly, e.g. \
+             `pl.col(\"max\").cast(pl.Int64)`. The bounds are inclusive integers, so casting it \
+             here would silently truncate a fractional value"
+        );
+        return Err(PolarsError::InvalidOperation(msg.into()));
+    }
+    let cast = bound.strict_cast(&DataType::Int64).map_err(|e| {
+        PolarsError::InvalidOperation(
+            format!("bounds must be integers that fit in i64: {e}").into(),
+        )
+    })?;
+    Ok(cast.i64()?.clone())
+}
+
+/// DiscreteUniform's constant bounds, deserialised once per call.
+#[derive(serde::Deserialize)]
+struct DiscreteUniformParamsKwargs {
+    min: i64,
+    max: i64,
+}
+
+impl DiscreteUniformParamsKwargs {
+    fn build(&self) -> PolarsResult<DiscreteUniform> {
+        build_dist(self.min, self.max)
+    }
+}
+
+/// Element-wise validation of the `(min, max)` parameterisation: returns the support count
+/// `N = max - min + 1` as `Float64`, raising if `max < min` or the width overflows `i64`.
+/// `null` propagates.
+///
+/// Every closed-form Python method divides by this count, so routing it through Rust is what lets
+/// them report an invalid parameterisation consistently with `discreteuniform_sample`, instead of
+/// silently dividing by zero or a negative.
+#[polars_expr(output_type=Float64)]
+fn discreteuniform_range(inputs: &[Series]) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
+    let min = coerce_bound(&inputs[0])?;
+    let max = coerce_bound(&inputs[1])?;
+
+    validate_params_binary(&min, &max, |lo, hi| {
+        build_dist(lo, hi)?;
+        Ok((hi as i128 - lo as i128 + 1) as f64)
+    })
+}
+
+/// Row-aligned counterpart of [`discreteuniform_range`]: the third input is the row index, whose
+/// height [`align_inputs`] broadcasts the bounds up to, so the output is one count per row.
+///
+/// Exists for `_ppf`, whose step-boundary correction divides by the count and compares against the
+/// quantile with no slack: a length-1 count makes polars see a broadcast-scalar division, which the
+/// in-memory engine evaluates as a reciprocal multiply -- one ulp away from the true division, and
+/// exactly at the steps that flips the comparison to the wrong side of a support point. Dividing
+/// column by column keeps every engine on the honestly-rounded quotient.
+#[polars_expr(output_type=Float64)]
+fn discreteuniform_range_rowwise(inputs: &[Series]) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
+    let min = coerce_bound(&inputs[0])?;
+    let max = coerce_bound(&inputs[1])?;
+
+    validate_params_binary(&min, &max, |lo, hi| {
+        build_dist(lo, hi)?;
+        Ok((hi as i128 - lo as i128 + 1) as f64)
+    })
+}
+
+/// One DiscreteUniform draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
+///
+/// Every sampler draws through here, per-row and fast path alike, so their bit-equality is
+/// structural rather than only sampled by `sample_test.py`.
+#[inline]
+fn draw(dist: &DiscreteUniform, rng: &mut impl rand::Rng) -> i64 {
+    <DiscreteUniform as Distribution<i64>>::sample(dist, rng)
+}
+
+/// Element-wise DiscreteUniform sampler over `(min, max, row_index)`, returning `Int64`.
+///
+/// Per row, `null` propagates and an invalid parameterisation raises via [`build_dist`]. Seeding
+/// and chunk-invariance follow [`sample_per_row_ternary`].
+#[polars_expr(output_type=Int64)]
+fn discreteuniform_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
+    let min = coerce_bound(&inputs[0])?;
+    let max = coerce_bound(&inputs[1])?;
+    let index = inputs[2].cast(&DataType::UInt64)?;
+    let name = inputs[0].name().clone();
+
+    sample_per_row_ternary(
+        name,
+        &min,
+        &max,
+        index.u64()?,
+        kwargs.seed,
+        build_dist,
+        draw,
+    )
+}
+
+/// Constant-parameter fast path for [`discreteuniform_sample`].
+#[polars_expr(output_type=Int64)]
+fn discreteuniform_sample_scalar(
+    inputs: &[Series],
+    kwargs: SampleScalarKwargs<DiscreteUniformParamsKwargs>,
+) -> PolarsResult<Series> {
+    let dist = kwargs.params.build()?;
+    let name = inputs[0].name().clone();
+
+    sample_by_index(name, &inputs[0], kwargs.seed, |rng| draw(&dist, rng))
+}
+
+/// Constant-parameter multi-draw fast path: the `samples` twin of
+/// [`discreteuniform_sample_scalar`].
+///
+/// `size` consecutive draws from each row's stream, so `samples(size=1)` matches `sample` bit for
+/// bit and the distribution is built once per call. Returns `Array(Int64, size)`.
+#[polars_expr(output_type_func_with_kwargs=samples_i64_output)]
+fn discreteuniform_samples_scalar(
+    inputs: &[Series],
+    kwargs: SamplesScalarKwargs<DiscreteUniformParamsKwargs>,
+) -> PolarsResult<Series> {
+    let dist = kwargs.params.build()?;
+    let name = inputs[0].name().clone();
+
+    samples_by_index(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
+        draw(&dist, rng)
+    })
+}
+
+/// Element-wise multi-draw DiscreteUniform sampler: `size` draws per row in one call, the
+/// distribution built once per row. Returns `Array(Int64, size)`.
+///
+/// Seeding and the null/error contract follow [`samples_per_row`] and [`discreteuniform_sample`].
+#[polars_expr(output_type_func_with_kwargs=samples_i64_output)]
+fn discreteuniform_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
+    let min = coerce_bound(&inputs[0])?;
+    let max = coerce_bound(&inputs[1])?;
+    let index = inputs[2].cast(&DataType::UInt64)?;
+    let name = inputs[0].name().clone();
+
+    let rows = ternary_param_rows(&min, &max, index.u64()?, build_dist);
+
+    samples_per_row(name, rows, kwargs.seed, kwargs.size, draw)
+}

--- a/src/distributions/discrete_uniform.rs
+++ b/src/distributions/discrete_uniform.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::unused_unit)]
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution;
@@ -79,28 +78,15 @@ impl DiscreteUniformParamsKwargs {
 /// Every closed-form Python method divides by this count, so routing it through Rust is what lets
 /// them report an invalid parameterisation consistently with `discreteuniform_sample`, instead of
 /// silently dividing by zero or a negative.
+///
+/// Callers that need one count *per row* rather than a broadcast scalar append a third input, whose
+/// height [`align_inputs`] broadcasts the bounds up to; the closure never reads it. `_ppf` and `_isf`
+/// need that, because their step-boundary correction divides by the count and compares against the
+/// quantile with no slack: a length-1 count makes polars see a broadcast-scalar division, which the
+/// in-memory engine evaluates as a reciprocal multiply, one ulp from the true division and exactly at
+/// the steps where that flips the comparison to the wrong side of a support point.
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_range(inputs: &[Series]) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let min = coerce_bound(&inputs[0])?;
-    let max = coerce_bound(&inputs[1])?;
-
-    validate_params_binary(&min, &max, |lo, hi| {
-        build_dist(lo, hi)?;
-        Ok((hi as i128 - lo as i128 + 1) as f64)
-    })
-}
-
-/// Row-aligned counterpart of [`discreteuniform_range`]: the third input is the row index, whose
-/// height [`align_inputs`] broadcasts the bounds up to, so the output is one count per row.
-///
-/// Exists for `_ppf`, whose step-boundary correction divides by the count and compares against the
-/// quantile with no slack: a length-1 count makes polars see a broadcast-scalar division, which the
-/// in-memory engine evaluates as a reciprocal multiply -- one ulp away from the true division, and
-/// exactly at the steps that flips the comparison to the wrong side of a support point. Dividing
-/// column by column keeps every engine on the honestly-rounded quotient.
-#[polars_expr(output_type=Float64)]
-fn discreteuniform_range_rowwise(inputs: &[Series]) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
     let min = coerce_bound(&inputs[0])?;
     let max = coerce_bound(&inputs[1])?;

--- a/src/distributions/discrete_uniform.rs
+++ b/src/distributions/discrete_uniform.rs
@@ -1,9 +1,12 @@
+use polars::prelude::arity::{try_ternary_elementwise, unary_elementwise};
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution;
 use statrs::distribution::DiscreteUniform;
 
-use crate::distributions::{align_inputs, validate_params_binary};
+use crate::distributions::{
+    align_inputs, validate_params_binary, value_keyed_per_row, value_keyed_scalar,
+};
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_i64_output, samples_per_row,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
@@ -69,6 +72,461 @@ impl DiscreteUniformParamsKwargs {
     fn build(&self) -> PolarsResult<DiscreteUniform> {
         build_dist(self.min, self.max)
     }
+
+    /// Constant-parameter twin of the per-row [`du_value_keyed`], sharing its `<method>_point`
+    /// bodies: validate and size the support once per call, then map `f` over the evaluation-point
+    /// column in its own arithmetic (see [`coerce_points`]).
+    fn value_keyed<F>(&self, value: &Series, f: F) -> PolarsResult<Series>
+    where
+        F: Fn(&Support, Point) -> Option<f64>,
+    {
+        let support = build_support(self.min, self.max)?;
+        let name = value.name().clone();
+        let ca: Float64Chunked = match coerce_points(value)? {
+            Points::Float(v) => unary_elementwise(&v, |opt| {
+                opt.and_then(|v| {
+                    if v.is_nan() {
+                        Some(f64::NAN)
+                    } else {
+                        f(&support, Point::Float(v))
+                    }
+                })
+            }),
+            Points::Int(v) => unary_elementwise(&v, |opt| {
+                opt.and_then(|v| f(&support, Point::Int(v.into())))
+            }),
+            Points::Wide(v) => unary_elementwise(&v, |opt| {
+                opt.and_then(|v| f(&support, Point::Int(v.into())))
+            }),
+        };
+        Ok(ca.with_name(name).into_series())
+    }
+}
+
+/// The validated support, with the count precomputed: the state every closed-form body reads.
+///
+/// `n` is `(max - min + 1) as f64`, computed in `i128` exactly as [`discreteuniform_range`]
+/// returns it, so the Rust bodies and the Python moments read the same rounded count.
+struct Support {
+    min: i64,
+    max: i64,
+    n: f64,
+}
+
+/// Validate `(min, max)` via [`build_dist`] and size the support once.
+fn build_support(min: i64, max: i64) -> PolarsResult<Support> {
+    build_dist(min, max)?;
+    let n = (max as i128 - min as i128 + 1) as f64;
+    Ok(Support { min, max, n })
+}
+
+/// An evaluation point in its own arithmetic: `f64` for float columns, exact `i128` for integer
+/// columns. The integer side is what keeps an `int` spelling exact on supports a `Float64` cannot
+/// address (documented in docs/explanation/accuracy.md), and `i128` is wide enough that a `UInt64`
+/// point above `i64::MAX` still compares exactly instead of wrapping.
+///
+/// [`Point`], [`Placement`] and [`coerce_points`] stay private to this file on purpose:
+/// DiscreteUniform is their only consumer today. Geometric is the one remaining catalogue entry
+/// with closed forms over an integer support, so hoist the trio into `mod.rs` when its port makes
+/// it a second consumer, not before.
+#[derive(Clone, Copy)]
+enum Point {
+    Float(f64),
+    Int(i128),
+}
+
+/// Where a point sits relative to the support, with the two counts the closed forms read.
+///
+/// The float side compares and counts against `Float64`-cast bounds, mirroring how polars promotes
+/// a mixed `Float64`/`Int64` operation; the integer side stays exact. The mirror is a snapshot,
+/// not a dependency: the promotion rule is frozen here, so a future polars change to its supertype
+/// rules moves nothing in this file. `count` and `tail` are only read where the branches keep them
+/// in `[1, N - 1]`; elsewhere they are computed but discarded.
+struct Placement {
+    below: bool,
+    at_or_above_max: bool,
+    on_support: bool,
+    /// `floor(value) - min + 1`, the support points at or below the point, as `Float64`.
+    count: f64,
+    /// `max - floor(value)`, the support points strictly above the point, as `Float64`.
+    tail: f64,
+}
+
+fn place(s: &Support, point: Point) -> Placement {
+    match point {
+        Point::Int(v) => {
+            let (lo, hi) = (i128::from(s.min), i128::from(s.max));
+            Placement {
+                below: v < lo,
+                at_or_above_max: v >= hi,
+                on_support: v >= lo && v <= hi,
+                count: (v - lo + 1) as f64,
+                tail: (hi - v) as f64,
+            }
+        },
+        Point::Float(v) => {
+            let (lo, hi) = (s.min as f64, s.max as f64);
+            Placement {
+                below: v < lo,
+                at_or_above_max: v >= hi,
+                on_support: v >= lo && v <= hi && v.floor() == v,
+                count: v.floor() - lo + 1.0,
+                tail: hi - v.floor(),
+            }
+        },
+    }
+}
+
+// Per-method bodies, shared by the per-row plugins and their `*_scalar` twins. The drivers
+// short-circuit a `NaN` float point to `NaN` before these run, matching `value_keyed_scalar`.
+
+/// `1 / N` on the integer support, `0` off it.
+fn pmf_point(s: &Support, point: Point) -> Option<f64> {
+    let pos = place(s, point);
+    Some(if pos.on_support { 1.0 / s.n } else { 0.0 })
+}
+
+/// `-ln(N)` on the integer support, `-inf` off it: the mass is exactly `1 / N`, so its log reads
+/// straight off the count instead of a rounded quotient.
+fn ln_pmf_point(s: &Support, point: Point) -> Option<f64> {
+    let pos = place(s, point);
+    Some(if pos.on_support {
+        -s.n.ln()
+    } else {
+        f64::NEG_INFINITY
+    })
+}
+
+/// `count * (1 / N)` inside the support, `0` below `min`, `1` from `max` up.
+///
+/// The explicit endpoints make `cdf(max) == 1` an answer rather than the limit of a clamp:
+/// `N * (1 / N)` is not `1.0` for 483 of the first 4000 support counts.
+fn cdf_point(s: &Support, point: Point) -> Option<f64> {
+    let pos = place(s, point);
+    Some(if pos.below {
+        0.0
+    } else if pos.at_or_above_max {
+        1.0
+    } else {
+        pos.count * (1.0 / s.n)
+    })
+}
+
+/// `tail * (1 / N)` inside the support, `1` below `min`, `0` from `max` up: a direct count of the
+/// points above the value, not `1 - cdf`, whose subtraction absorbs the tail once the cdf rounds
+/// towards `1`.
+fn sf_point(s: &Support, point: Point) -> Option<f64> {
+    let pos = place(s, point);
+    Some(if pos.below {
+        1.0
+    } else if pos.at_or_above_max {
+        0.0
+    } else {
+        pos.tail * (1.0 / s.n)
+    })
+}
+
+/// `ln(count / N)`, through `ln_1p` of the survival ratio once the cdf passes one half: the naive
+/// log's relative error one point below the top grows with `N` (`8.7e-16` at `N = 1e3` but
+/// `2.8e-08` at `N = 1e9`).
+fn ln_cdf_point(s: &Support, point: Point) -> Option<f64> {
+    let pos = place(s, point);
+    Some(if pos.below {
+        f64::NEG_INFINITY
+    } else if pos.at_or_above_max {
+        0.0
+    } else if pos.count * 2.0 > s.n {
+        (-((s.n - pos.count) * (1.0 / s.n))).ln_1p()
+    } else {
+        (pos.count * (1.0 / s.n)).ln()
+    })
+}
+
+/// The mirror of [`ln_cdf_point`]: the near-certain side is the lower one, so `ln_1p` sits there.
+fn ln_sf_point(s: &Support, point: Point) -> Option<f64> {
+    let pos = place(s, point);
+    Some(if pos.below {
+        0.0
+    } else if pos.at_or_above_max {
+        f64::NEG_INFINITY
+    } else if pos.count * 2.0 > s.n {
+        ((s.n - pos.count) * (1.0 / s.n)).ln()
+    } else {
+        (-(pos.count * (1.0 / s.n))).ln_1p()
+    })
+}
+
+/// `min + ceil(q * N) - 1`, corrected and clamped; `None` (null) outside `[0, 1]`.
+///
+/// Matches scipy's `randint.ppf` including its correction step, which probes the point below and
+/// keeps it whenever that point's cdf already reaches `q`, settling the step boundaries where an
+/// ulp of noise in `q * N` would skip a support point. Both inverses lose support points above
+/// `2**53`; see docs/explanation/accuracy.md.
+fn ppf_value(s: &Support, q: f64) -> Option<f64> {
+    if !(0.0..=1.0).contains(&q) {
+        return None;
+    }
+    let (lo, hi) = (s.min as f64, s.max as f64);
+    let candidate = lo + (q * s.n).ceil() - 1.0;
+    let point_below = (candidate - 1.0).clamp(lo, hi);
+    let count_below = point_below.floor() - lo + 1.0;
+    let chosen = if count_below / s.n >= q {
+        point_below
+    } else {
+        candidate
+    };
+    Some(chosen.clamp(lo, hi))
+}
+
+/// The smallest support point whose survival mass is at most `q`, from `max - floor(q * N)`
+/// corrected on both sides and clamped; `None` (null) outside `[0, 1]`.
+///
+/// Entered against `q` itself rather than `ppf(1 - q)`: the complement rounds before the inverse
+/// runs, and the survival steps sit at multiples of `1 / N`, exactly where `1 - q` has spent its
+/// precision. A rounded `q * N` can floor one point off in either direction, so the correction
+/// probes both neighbours and keeps the smallest one whose survival mass `(max - x) / N` is still
+/// at most `q`.
+fn isf_value(s: &Support, q: f64) -> Option<f64> {
+    if !(0.0..=1.0).contains(&q) {
+        return None;
+    }
+    let (lo, hi) = (s.min as f64, s.max as f64);
+    let candidate = hi - (q * s.n).floor();
+    let point_below = candidate - 1.0;
+    let chosen = if (hi - point_below) / s.n <= q {
+        point_below
+    } else if (hi - candidate) / s.n <= q {
+        candidate
+    } else {
+        candidate + 1.0
+    };
+    Some(chosen.clamp(lo, hi))
+}
+
+/// The evaluation-point column in the arithmetic its dtype earns: floats (and an all-null `Null`
+/// column) run the `Float64` path, integer dtypes stay exact. `UInt64` keeps its own accessor so a
+/// value above `i64::MAX` reaches [`Point::Int`] via `i128` instead of failing a cast; every other
+/// integer dtype fits `Int64`. A non-numeric column is refused, as polars itself refuses it in the
+/// expression forms.
+enum Points {
+    Float(Float64Chunked),
+    Int(Int64Chunked),
+    Wide(UInt64Chunked),
+}
+
+fn coerce_points(value: &Series) -> PolarsResult<Points> {
+    let dtype = value.dtype();
+    if dtype.is_float() || dtype == &DataType::Null {
+        return Ok(Points::Float(
+            value.cast(&DataType::Float64)?.f64()?.clone(),
+        ));
+    }
+    if dtype == &DataType::UInt64 {
+        return Ok(Points::Wide(value.u64()?.clone()));
+    }
+    if dtype.is_integer() {
+        return Ok(Points::Int(value.cast(&DataType::Int64)?.i64()?.clone()));
+    }
+    Err(PolarsError::InvalidOperation(
+        format!("value must be a numeric column, got {dtype}").into(),
+    ))
+}
+
+/// Apply a closed-form `f(support, point)` element-wise over `(value, min, max)`; shared by the
+/// six value-keyed plugins with an integer-exact path. Null and `NaN` contracts follow
+/// [`value_keyed_per_row`]: any null input nulls the row without building, an invalid
+/// parameterisation raises via [`build_support`] even on a `NaN` row.
+fn du_value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
+where
+    F: Fn(&Support, Point) -> Option<f64>,
+{
+    let inputs = align_inputs(inputs)?;
+    let name = inputs[0].name().clone();
+    let min = coerce_bound(&inputs[1])?;
+    let max = coerce_bound(&inputs[2])?;
+
+    let ca: Float64Chunked = match coerce_points(&inputs[0])? {
+        Points::Float(v) => try_ternary_elementwise(&v, &min, &max, |v, lo, hi| {
+            per_row(v.map(Point::Float), lo, hi, &f)
+        })?,
+        Points::Int(v) => try_ternary_elementwise(&v, &min, &max, |v, lo, hi| {
+            per_row(v.map(|v| Point::Int(v.into())), lo, hi, &f)
+        })?,
+        Points::Wide(v) => try_ternary_elementwise(&v, &min, &max, |v, lo, hi| {
+            per_row(v.map(|v| Point::Int(v.into())), lo, hi, &f)
+        })?,
+    };
+    Ok(ca.with_name(name).into_series())
+}
+
+/// One row of [`du_value_keyed`]: build before the `NaN` short-circuit, so an invalid
+/// parameterisation still raises on a `NaN` row, exactly as [`value_keyed_per_row`] orders it.
+#[inline]
+fn per_row<F>(
+    point: Option<Point>,
+    min: Option<i64>,
+    max: Option<i64>,
+    f: &F,
+) -> PolarsResult<Option<f64>>
+where
+    F: Fn(&Support, Point) -> Option<f64>,
+{
+    match (point, min, max) {
+        (Some(point), Some(min), Some(max)) => {
+            let support = build_support(min, max)?;
+            Ok(match point {
+                Point::Float(v) if v.is_nan() => Some(f64::NAN),
+                _ => f(&support, point),
+            })
+        },
+        _ => Ok(None),
+    }
+}
+
+/// Element-wise pmf: `1 / N` on the integer support, `0` off it, `NaN` for a `NaN` value.
+/// See [`du_value_keyed`] for the null/error contract.
+#[polars_expr(output_type=Float64)]
+fn discreteuniform_pmf(inputs: &[Series]) -> PolarsResult<Series> {
+    du_value_keyed(inputs, pmf_point)
+}
+
+/// Element-wise log-pmf: `-ln(N)` on the integer support, `-inf` off it.
+#[polars_expr(output_type=Float64)]
+fn discreteuniform_ln_pmf(inputs: &[Series]) -> PolarsResult<Series> {
+    du_value_keyed(inputs, ln_pmf_point)
+}
+
+/// Element-wise cdf `P(X <= floor(value))`; see [`cdf_point`] for the endpoint contract.
+#[polars_expr(output_type=Float64)]
+fn discreteuniform_cdf(inputs: &[Series]) -> PolarsResult<Series> {
+    du_value_keyed(inputs, cdf_point)
+}
+
+/// Element-wise survival function `P(X > floor(value))`; see [`sf_point`].
+#[polars_expr(output_type=Float64)]
+fn discreteuniform_sf(inputs: &[Series]) -> PolarsResult<Series> {
+    du_value_keyed(inputs, sf_point)
+}
+
+/// Element-wise log-cdf, `ln_1p`-stable near the top of the support; see [`ln_cdf_point`].
+#[polars_expr(output_type=Float64)]
+fn discreteuniform_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
+    du_value_keyed(inputs, ln_cdf_point)
+}
+
+/// Element-wise log-sf, `ln_1p`-stable near the bottom of the support; see [`ln_sf_point`].
+#[polars_expr(output_type=Float64)]
+fn discreteuniform_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
+    du_value_keyed(inputs, ln_sf_point)
+}
+
+/// Element-wise ppf (inverse cdf), returning the integer support point as `f64`.
+/// See [`ppf_value`] for the correction and endpoint contract.
+#[polars_expr(output_type=Float64)]
+fn discreteuniform_ppf(inputs: &[Series]) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
+    let value = inputs[0].cast(&DataType::Float64)?;
+    let min = coerce_bound(&inputs[1])?;
+    let max = coerce_bound(&inputs[2])?;
+    value_keyed_per_row(
+        value.f64()?,
+        &min,
+        &max,
+        inputs[0].name().clone(),
+        build_support,
+        ppf_value,
+    )
+}
+
+/// Element-wise inverse survival function; see [`isf_value`] for the two-sided correction.
+#[polars_expr(output_type=Float64)]
+fn discreteuniform_isf(inputs: &[Series]) -> PolarsResult<Series> {
+    let inputs = align_inputs(inputs)?;
+    let value = inputs[0].cast(&DataType::Float64)?;
+    let min = coerce_bound(&inputs[1])?;
+    let max = coerce_bound(&inputs[2])?;
+    value_keyed_per_row(
+        value.f64()?,
+        &min,
+        &max,
+        inputs[0].name().clone(),
+        build_support,
+        isf_value,
+    )
+}
+
+/// Constant-parameter fast path for [`discreteuniform_pmf`].
+#[polars_expr(output_type=Float64)]
+fn discreteuniform_pmf_scalar(
+    inputs: &[Series],
+    kwargs: DiscreteUniformParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], pmf_point)
+}
+
+/// Constant-parameter fast path for [`discreteuniform_ln_pmf`].
+#[polars_expr(output_type=Float64)]
+fn discreteuniform_ln_pmf_scalar(
+    inputs: &[Series],
+    kwargs: DiscreteUniformParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], ln_pmf_point)
+}
+
+/// Constant-parameter fast path for [`discreteuniform_cdf`].
+#[polars_expr(output_type=Float64)]
+fn discreteuniform_cdf_scalar(
+    inputs: &[Series],
+    kwargs: DiscreteUniformParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], cdf_point)
+}
+
+/// Constant-parameter fast path for [`discreteuniform_sf`].
+#[polars_expr(output_type=Float64)]
+fn discreteuniform_sf_scalar(
+    inputs: &[Series],
+    kwargs: DiscreteUniformParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], sf_point)
+}
+
+/// Constant-parameter fast path for [`discreteuniform_ln_cdf`].
+#[polars_expr(output_type=Float64)]
+fn discreteuniform_ln_cdf_scalar(
+    inputs: &[Series],
+    kwargs: DiscreteUniformParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], ln_cdf_point)
+}
+
+/// Constant-parameter fast path for [`discreteuniform_ln_sf`].
+#[polars_expr(output_type=Float64)]
+fn discreteuniform_ln_sf_scalar(
+    inputs: &[Series],
+    kwargs: DiscreteUniformParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], ln_sf_point)
+}
+
+/// Constant-parameter fast path for [`discreteuniform_ppf`].
+#[polars_expr(output_type=Float64)]
+fn discreteuniform_ppf_scalar(
+    inputs: &[Series],
+    kwargs: DiscreteUniformParamsKwargs,
+) -> PolarsResult<Series> {
+    let support = build_support(kwargs.min, kwargs.max)?;
+    value_keyed_scalar(&inputs[0], |q| ppf_value(&support, q))
+}
+
+/// Constant-parameter fast path for [`discreteuniform_isf`].
+#[polars_expr(output_type=Float64)]
+fn discreteuniform_isf_scalar(
+    inputs: &[Series],
+    kwargs: DiscreteUniformParamsKwargs,
+) -> PolarsResult<Series> {
+    let support = build_support(kwargs.min, kwargs.max)?;
+    value_keyed_scalar(&inputs[0], |q| isf_value(&support, q))
 }
 
 /// Element-wise validation of the `(min, max)` parameterisation: returns the support count

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -1,6 +1,7 @@
 pub mod bernoulli;
 pub mod beta;
 pub mod binomial;
+pub mod discrete_uniform;
 pub mod exponential;
 pub mod geometric;
 pub mod lognormal;

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -150,6 +150,10 @@ impl DrawValue for u64 {
     type Data = UInt64Type;
 }
 
+impl DrawValue for i64 {
+    type Data = Int64Type;
+}
+
 impl DrawValue for bool {
     type Data = BooleanType;
 }
@@ -498,6 +502,11 @@ pub(crate) fn samples_f64_output(fields: &[Field], kwargs: SamplesKwargs) -> Pol
 /// Output dtype of an integer-valued multi-draw plugin: `Array(UInt64, size)`.
 pub(crate) fn samples_u64_output(fields: &[Field], kwargs: SamplesKwargs) -> PolarsResult<Field> {
     samples_output(fields, kwargs.size, DataType::UInt64)
+}
+
+/// Output dtype of a signed-integer-valued multi-draw plugin: `Array(Int64, size)`.
+pub(crate) fn samples_i64_output(fields: &[Field], kwargs: SamplesKwargs) -> PolarsResult<Field> {
+    samples_output(fields, kwargs.size, DataType::Int64)
 }
 
 /// Output dtype of a boolean-valued multi-draw plugin: `Array(Boolean, size)`.

--- a/tests/distributions/discrete_uniform/cdf_test.py
+++ b/tests/distributions/discrete_uniform/cdf_test.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import DiscreteUniform
+
+
+@pytest.mark.parametrize(
+    ("lo", "hi", "value", "expected"),
+    [
+        (1, 6, 0.5, 0.0),  # below the support
+        (1, 6, 1.0, 1 / 6),
+        (1, 6, 3.7, 3 / 6),  # non-integers accumulate to floor(value)
+        (1, 6, 6.0, 1.0),
+        (1, 6, 6.5, 1.0),
+        (-3, 2, -3.0, 1 / 6),
+        (-3, 2, -4.0, 0.0),
+        (3, 3, 3.0, 1.0),  # the point mass: cdf(max) == cdf(min) == 1
+    ],
+)
+def test_cdf_scalar(lo: int, hi: int, value: float, expected: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).cdf(value)).item(0, "v")
+    assert result == pytest.approx(expected)
+
+
+def test_cdf_max_is_exactly_one() -> None:
+    # The visible difference from scipy's exclusive upper bound: `cdf(max)` is exactly 1, where
+    # scipy's `randint.cdf(max)` answers `(max - low + 1) / (high - low) < 1`.
+    for lo, hi in [(1, 6), (-5, 9), (0, 100)]:
+        got = pl.DataFrame({"x": [float(hi)]}).select(r=DiscreteUniform(min=lo, max=hi).cdf("x"))["r"][0]
+        assert got == 1.0
+
+
+def test_cdf_column_value() -> None:
+    df = pl.DataFrame({"x": [0.5, 2.0, 6.0, 9.0]})
+    result = df.select(r=DiscreteUniform(min=1, max=6).cdf(pl.col("x")))["r"]
+    expected = pl.Series("r", [0.0, 2 / 6, 1.0, 1.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_cdf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"x": [2.0, None]}, schema={"x": pl.Float64})
+    result = df.select(r=DiscreteUniform(min=1, max=6).cdf(pl.col("x")))["r"]
+    assert_series_equal(result, pl.Series("r", [2 / 6, None], dtype=pl.Float64))
+
+
+def test_cdf_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
+    result = bounds_with_null.select(r=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).cdf(2.0))["r"]
+    assert_series_equal(result, pl.Series("r", [2 / 6, None, None], dtype=pl.Float64))

--- a/tests/distributions/discrete_uniform/cdf_test.py
+++ b/tests/distributions/discrete_uniform/cdf_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from fractions import Fraction
+
 import polars as pl
 import pytest
 from polars.testing import assert_series_equal
@@ -25,12 +27,24 @@ def test_cdf_scalar(lo: int, hi: int, value: float, expected: float, unit_frame:
     assert result == pytest.approx(expected)
 
 
-def test_cdf_max_is_exactly_one() -> None:
-    # The visible difference from scipy's exclusive upper bound: `cdf(max)` is exactly 1, where
-    # scipy's `randint.cdf(max)` answers `(max - low + 1) / (high - low) < 1`.
-    for lo, hi in [(1, 6), (-5, 9), (0, 100)]:
-        got = pl.DataFrame({"x": [float(hi)]}).select(r=DiscreteUniform(min=lo, max=hi).cdf("x"))["r"][0]
-        assert got == 1.0
+# `N = 49, 98, 103, 107` are the first four support counts where `N * (1 / N) != 1.0`, so these pairs
+# fail if `cdf(max)` is a clamped product rather than the explicit `1.0` branch.
+@pytest.mark.parametrize(("lo", "hi"), [(1, 6), (-5, 9), (0, 100), (3, 3), (0, 48), (0, 97), (0, 102), (0, 106)])
+def test_cdf_max_is_exactly_one(lo: int, hi: int) -> None:
+    """`cdf(max)` is exactly 1, the visible difference from scipy's exclusive upper bound."""
+    got = pl.DataFrame({"x": [float(hi)]}).select(r=DiscreteUniform(min=lo, max=hi).cdf("x"))["r"][0]
+    assert got == 1.0
+
+
+def test_cdf_max_is_exactly_one_for_every_support_count_up_to_4000() -> None:
+    """The column-routed sweep behind the curated pairs, covering all 483 counts that lose the product."""
+    counts = range(1, 4001)
+    df = pl.DataFrame(
+        {"lo": [0] * len(counts), "hi": [c - 1 for c in counts], "x": [float(c - 1) for c in counts]},
+        schema_overrides={"lo": pl.Int64, "hi": pl.Int64},
+    )
+    result = df.select(r=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).cdf("x"))["r"]
+    assert_series_equal(result, pl.Series("r", [1.0] * len(counts), dtype=pl.Float64))
 
 
 def test_cdf_column_value() -> None:
@@ -49,3 +63,25 @@ def test_cdf_propagates_null_in_value() -> None:
 def test_cdf_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
     result = bounds_with_null.select(r=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).cdf(2.0))["r"]
     assert_series_equal(result, pl.Series("r", [2 / 6, None, None], dtype=pl.Float64))
+
+
+def test_cdf_saturates_to_one_for_an_int_value_past_int64_half(unit_frame: pl.DataFrame) -> None:
+    """The `value >= max` branch discards a wrapped count, so the `int` and `float` spellings agree."""
+    d = DiscreteUniform(min=0, max=10)
+    point = 2**63 - 1
+    from_int = unit_frame.select(v=d.cdf(point)).item(0, "v")
+    from_float = unit_frame.select(v=d.cdf(float(point))).item(0, "v")
+    assert from_int == 1.0
+    assert from_int == from_float
+
+
+@pytest.mark.parametrize("offset", [0, 1, 5, 9, 10])
+def test_cdf_is_exact_for_an_int_value_in_a_narrow_support_past_the_float_grid(
+    offset: int, unit_frame: pl.DataFrame
+) -> None:
+    """An `int` evaluation point resolves every support point where a `Float64` one cannot."""
+    lo = 2**62
+    hi = lo + 10
+    n = hi - lo + 1
+    result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).cdf(lo + offset)).item(0, "v")
+    assert result == pytest.approx(float(Fraction(offset + 1, n)), rel=1e-15)

--- a/tests/distributions/discrete_uniform/conftest.py
+++ b/tests/distributions/discrete_uniform/conftest.py
@@ -20,11 +20,7 @@ def seed() -> int:
 
 @pytest.fixture
 def frame() -> Callable[..., pl.DataFrame]:
-    """Factory for a frame with per-row bounds `lo <= hi` for column-valued sampling.
-
-    Seeds a fresh generator on every call, so the data is reproducible regardless of test execution
-    order, selection (`-k`) or sharding, rather than depending on a shared session-scoped stream.
-    """
+    """Frame factory with per-row bounds `lo <= hi`; a fresh generator per call keeps it order-independent."""
 
     def _make(size: int = DEFAULT_SIZE) -> pl.DataFrame:
         local_rng = np.random.default_rng(seed=SEED)

--- a/tests/distributions/discrete_uniform/conftest.py
+++ b/tests/distributions/discrete_uniform/conftest.py
@@ -18,26 +18,18 @@ def seed() -> int:
     return SEED
 
 
-@pytest.fixture(scope="session")
-def rng() -> np.random.Generator:
-    return np.random.default_rng(seed=SEED)
-
-
 @pytest.fixture
-def frame(rng: np.random.Generator) -> Callable[..., pl.DataFrame]:
+def frame() -> Callable[..., pl.DataFrame]:
+    """Factory for a frame with per-row bounds `lo <= hi` for column-valued sampling.
+
+    Seeds a fresh generator on every call, so the data is reproducible regardless of test execution
+    order, selection (`-k`) or sharding, rather than depending on a shared session-scoped stream.
+    """
+
     def _make(size: int = DEFAULT_SIZE) -> pl.DataFrame:
-        lo = rng.integers(-20, 10, size=size)
-        hi = lo + rng.integers(0, 30, size=size)
-        return pl.DataFrame(
-            {
-                "lo": lo,
-                "hi": hi,
-                # Evaluation points spanning below `min`, inside the support (integers and not),
-                # and above `max`.
-                "x": rng.uniform(-25.0, 45.0, size=size),
-                "q": rng.uniform(0.0, 1.0, size=size),
-            },
-        )
+        local_rng = np.random.default_rng(seed=SEED)
+        lo = local_rng.integers(-20, 10, size=size)
+        return pl.DataFrame({"lo": lo, "hi": lo + local_rng.integers(0, 30, size=size)})
 
     return _make
 

--- a/tests/distributions/discrete_uniform/conftest.py
+++ b/tests/distributions/discrete_uniform/conftest.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import polars as pl
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+SEED = 42
+DEFAULT_SIZE = 1000
+
+
+@pytest.fixture(scope="session")
+def seed() -> int:
+    return SEED
+
+
+@pytest.fixture(scope="session")
+def rng() -> np.random.Generator:
+    return np.random.default_rng(seed=SEED)
+
+
+@pytest.fixture
+def frame(rng: np.random.Generator) -> Callable[..., pl.DataFrame]:
+    def _make(size: int = DEFAULT_SIZE) -> pl.DataFrame:
+        lo = rng.integers(-20, 10, size=size)
+        hi = lo + rng.integers(0, 30, size=size)
+        return pl.DataFrame(
+            {
+                "lo": lo,
+                "hi": hi,
+                # Evaluation points spanning below `min`, inside the support (integers and not),
+                # and above `max`.
+                "x": rng.uniform(-25.0, 45.0, size=size),
+                "q": rng.uniform(0.0, 1.0, size=size),
+            },
+        )
+
+    return _make
+
+
+@pytest.fixture
+def unit_frame() -> pl.DataFrame:
+    """Single-row frame for evaluating scalar-output expressions."""
+    return pl.DataFrame({"_": [0]})
+
+
+@pytest.fixture
+def bounds_with_null() -> pl.DataFrame:
+    """Bounds columns with a null in the middle row."""
+    return pl.DataFrame(
+        {"lo": [1, None, 3], "hi": [6, 8, None]},
+        schema={"lo": pl.Int64, "hi": pl.Int64},
+    )

--- a/tests/distributions/discrete_uniform/construct_test.py
+++ b/tests/distributions/discrete_uniform/construct_test.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from polars_stats import DiscreteUniform
+
+
+@pytest.mark.parametrize("bad_bound", [None, True, False, 1.5, [1, 2], (1,), {"max": 5}])
+@pytest.mark.parametrize("name", ["min", "max"])
+def test_construct_invalid_type_raises(name: str, bad_bound: object) -> None:
+    kwargs: dict[str, object] = {"min": 0, "max": 5}
+    kwargs[name] = bad_bound
+    with pytest.raises(TypeError, match=f"{name} should be an int or IntoExprColumn"):
+        DiscreteUniform(**kwargs)  # type: ignore[arg-type]
+
+
+def test_construct_negative_and_large_bounds_are_accepted() -> None:
+    # Signed bounds are the point of this distribution: validity is judged at evaluation, never at
+    # construction, so a negative or huge bound constructs fine.
+    DiscreteUniform(min=-10, max=-2)
+    DiscreteUniform(min=-(2**62), max=2**62)

--- a/tests/distributions/discrete_uniform/construct_test.py
+++ b/tests/distributions/discrete_uniform/construct_test.py
@@ -19,3 +19,13 @@ def test_construct_negative_and_large_bounds_are_accepted() -> None:
     # construction, so a negative or huge bound constructs fine.
     DiscreteUniform(min=-10, max=-2)
     DiscreteUniform(min=-(2**62), max=2**62)
+    DiscreteUniform(min=-(2**63), max=2**63 - 1)
+
+
+@pytest.mark.parametrize(("name", "bound"), [("max", 2**63), ("min", -(2**63) - 1)])
+def test_construct_bound_outside_int64_raises_at_construction(name: str, bound: int) -> None:
+    """A bound polars cannot hold as an `Int64` literal is refused when the literal is built."""
+    kwargs: dict[str, int] = {"min": 0, "max": 5}
+    kwargs[name] = bound
+    with pytest.raises(ValueError, match=f"{name} must be in "):
+        DiscreteUniform(**kwargs)

--- a/tests/distributions/discrete_uniform/entropy_test.py
+++ b/tests/distributions/discrete_uniform/entropy_test.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+
+from polars_stats import DiscreteUniform
+
+
+@pytest.mark.parametrize(
+    ("lo", "hi", "expected"),
+    [(1, 6, math.log(6)), (3, 3, 0.0), (-5, 9, math.log(15)), (0, 999, math.log(1000))],
+)
+def test_entropy(lo: int, hi: int, expected: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).entropy()).item(0, "v")
+    assert result == pytest.approx(expected)
+
+
+def test_entropy_of_the_point_mass_is_zero() -> None:
+    got = pl.DataFrame({"_": [0]}).select(v=DiscreteUniform(min=3, max=3).entropy())["v"][0]
+    assert got == 0.0
+
+
+def test_entropy_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
+    result = bounds_with_null.select(v=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).entropy())["v"]
+    assert result[0] == pytest.approx(math.log(6))
+    assert result[1] is None

--- a/tests/distributions/discrete_uniform/entropy_test.py
+++ b/tests/distributions/discrete_uniform/entropy_test.py
@@ -10,6 +10,7 @@ from polars_stats import DiscreteUniform
 
 @pytest.mark.parametrize(
     ("lo", "hi", "expected"),
+    # The point mass carries all of it, so its entropy collapses to log(1) = 0.
     [(1, 6, math.log(6)), (3, 3, 0.0), (-5, 9, math.log(15)), (0, 999, math.log(1000))],
 )
 def test_entropy(lo: int, hi: int, expected: float, unit_frame: pl.DataFrame) -> None:
@@ -17,12 +18,8 @@ def test_entropy(lo: int, hi: int, expected: float, unit_frame: pl.DataFrame) ->
     assert result == pytest.approx(expected)
 
 
-def test_entropy_of_the_point_mass_is_zero() -> None:
-    got = pl.DataFrame({"_": [0]}).select(v=DiscreteUniform(min=3, max=3).entropy())["v"][0]
-    assert got == 0.0
-
-
 def test_entropy_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
     result = bounds_with_null.select(v=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).entropy())["v"]
     assert result[0] == pytest.approx(math.log(6))
     assert result[1] is None
+    assert result[2] is None

--- a/tests/distributions/discrete_uniform/isf_test.py
+++ b/tests/distributions/discrete_uniform/isf_test.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+from scipy.stats import randint as scipy_randint
+
+from polars_stats import DiscreteUniform
+
+
+@pytest.mark.parametrize(
+    ("lo", "hi", "quantile", "expected"),
+    [
+        (1, 6, 1.0, 1.0),  # every survival mass is <= 1; the smallest point wins
+        (1, 6, 0.9, 1.0),
+        (1, 6, 5 / 6, 1.0),  # sf(min) = 5/6 sits exactly on this step
+        (1, 6, 0.8, 2.0),
+        (1, 6, 0.5, 3.0),
+        (1, 6, 1 / 6, 5.0),  # sf(5) = 1/6
+        (1, 6, 1e-300, 6.0),  # only sf(max) = 0 satisfies it
+        (1, 6, 0.0, 6.0),  # sf(max) = 0 already satisfies the inequality at the top point
+        (-3, 2, 0.5, -1.0),  # sf(-1) = 1/2 sits exactly on this step
+        (3, 3, 0.5, 3.0),
+    ],
+)
+def test_isf_scalar(lo: int, hi: int, quantile: float, expected: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).isf(quantile)).item(0, "v")
+    assert result == expected
+
+
+@pytest.mark.parametrize("lo_hi", [(1, 6), (-5, 9), (0, 100)])
+def test_isf_matches_scipy(lo_hi: tuple[int, int]) -> None:
+    """Exact parity with `scipy.stats.randint.isf` at mid-step quantiles.
+
+    Quantiles sit halfway between cdf steps, where every correct implementation has half a step of
+    slack and must agree; exactly-at-step quantiles are decided by each implementation's own float
+    path instead, and scipy's accumulates its cdf table by repeated addition so its edges drift.
+    Endpoints are excluded too: scipy's generic inverse answers its below-support sentinel
+    `low - 1` at exactly q = 1, where this implementation clamps to the support.
+    """
+    lo, hi = lo_hi[0], lo_hi[1]
+    n = hi - lo + 1
+    quantiles = [(k + 0.5) / n for k in range(n)]
+    df = pl.DataFrame({"q": quantiles})
+    got = df.select(r=DiscreteUniform(min=lo, max=hi).isf("q"))["r"]
+    expected = [scipy_randint.isf(q, low=lo, high=hi + 1) for q in quantiles]
+    assert got.to_list() == expected
+
+
+@pytest.mark.parametrize("quantile", [-0.1, 1.5])
+def test_isf_out_of_range_quantile_is_null(quantile: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=DiscreteUniform(min=1, max=6).isf(quantile)).item(0, "v")
+    assert result is None
+
+
+def test_isf_propagates_nan_in_quantile(unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=DiscreteUniform(min=1, max=6).isf(float("nan"))).item(0, "v")
+    assert math.isnan(result)
+
+
+def test_isf_propagates_null_in_quantile() -> None:
+    df = pl.DataFrame({"q": [0.1, None, 0.9]}, schema={"q": pl.Float64})
+    result = df.select(v=DiscreteUniform(min=1, max=6).isf(pl.col("q")))["v"]
+    assert_series_equal(result, pl.Series("v", [6.0, None, 1.0], dtype=pl.Float64))

--- a/tests/distributions/discrete_uniform/isf_test.py
+++ b/tests/distributions/discrete_uniform/isf_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from fractions import Fraction
 
 import polars as pl
 import pytest
@@ -30,17 +31,11 @@ def test_isf_scalar(lo: int, hi: int, quantile: float, expected: float, unit_fra
     assert result == expected
 
 
-@pytest.mark.parametrize("lo_hi", [(1, 6), (-5, 9), (0, 100)])
-def test_isf_matches_scipy(lo_hi: tuple[int, int]) -> None:
-    """Exact parity with `scipy.stats.randint.isf` at mid-step quantiles.
-
-    Quantiles sit halfway between cdf steps, where every correct implementation has half a step of
-    slack and must agree; exactly-at-step quantiles are decided by each implementation's own float
-    path instead, and scipy's accumulates its cdf table by repeated addition so its edges drift.
-    Endpoints are excluded too: scipy's generic inverse answers its below-support sentinel
-    `low - 1` at exactly q = 1, where this implementation clamps to the support.
-    """
-    lo, hi = lo_hi[0], lo_hi[1]
+# Endpoints stay out: scipy's generic inverse answers its below-support sentinel `low - 1` at exactly
+# q = 1, where this implementation clamps to the support.
+@pytest.mark.parametrize(("lo", "hi"), [(1, 6), (-5, 9), (0, 100)])
+def test_isf_matches_scipy(lo: int, hi: int) -> None:
+    """Parity with `scipy.stats.randint.isf` at mid-step quantiles, where both have half a step of slack."""
     n = hi - lo + 1
     quantiles = [(k + 0.5) / n for k in range(n)]
     df = pl.DataFrame({"q": quantiles})
@@ -64,3 +59,35 @@ def test_isf_propagates_null_in_quantile() -> None:
     df = pl.DataFrame({"q": [0.1, None, 0.9]}, schema={"q": pl.Float64})
     result = df.select(v=DiscreteUniform(min=1, max=6).isf(pl.col("q")))["v"]
     assert_series_equal(result, pl.Series("v", [6.0, None, 1.0], dtype=pl.Float64))
+
+
+# The grid displaces every step edge by half an ulp, where the rational answer is unambiguous and a
+# bare `floor` of the rounded product loses a support point. The exactly representable edges are
+# excluded deliberately: there `q` is the nearest float to `k / N` rather than `k / N` itself, so the
+# rational contract and inverting this library's own `sf` disagree (see docs/explanation/accuracy.md).
+@pytest.mark.parametrize(("lo", "hi"), [(1, 6), (0, 7), (-5, 9), (0, 100), (0, 999)])
+def test_isf_matches_the_exact_closed_form_off_the_representable_edges(lo: int, hi: int) -> None:
+    """Exact agreement with rational `max - floor(q * N)` on both sides of every step."""
+    n = hi - lo + 1
+    edges = [k / n for k in range(1, n)]
+    quantiles = sorted({e - 2**-53 for e in edges} | {e + 2**-53 for e in edges})
+    got = pl.DataFrame({"q": quantiles}).select(r=DiscreteUniform(min=lo, max=hi).isf("q"))["r"]
+    expected = [float(min(max(hi - math.floor(Fraction(q) * n), lo), hi)) for q in quantiles]
+    assert_series_equal(got, pl.Series("r", expected, dtype=pl.Float64))
+
+
+@pytest.mark.parametrize(("lo", "hi"), [(1, 6), (0, 7), (-5, 9), (0, 100), (-20, -10), (3, 3), (0, 999)])
+def test_isf_round_trips_every_support_point_to_within_one_step(lo: int, hi: int) -> None:
+    """`isf(sf(x))` is `x`, or the one point above it where `_sf`'s reciprocal multiply rounds low.
+
+    The one-point bound is what is portable: `_sf` multiplies by a rounded `1 / N` while `_isf` probes
+    with an honest division, so at an exactly representable step edge the two disagree by one point.
+    Asserting only `sf(isf(q)) <= q` would be vacuous, since `sf(max) == 0` satisfies it for every `q`.
+    """
+    d = DiscreteUniform(min=lo, max=hi)
+    points = pl.DataFrame({"x": [float(p) for p in range(lo, hi + 1)]})
+    round_trip = points.select(x=pl.col("x"), rt=d.isf(d.sf("x")))
+    assert round_trip.select(((pl.col("rt") == pl.col("x")) | (pl.col("rt") == pl.col("x") + 1)).all()).item()
+    # And the survival contract itself, which the bound above does not imply.
+    quantiles = points.select(q=d.sf("x"))
+    assert quantiles.select((d.sf(d.isf("q")) <= pl.col("q")).all()).item()

--- a/tests/distributions/discrete_uniform/isf_test.py
+++ b/tests/distributions/discrete_uniform/isf_test.py
@@ -78,16 +78,11 @@ def test_isf_matches_the_exact_closed_form_off_the_representable_edges(lo: int, 
 
 @pytest.mark.parametrize(("lo", "hi"), [(1, 6), (0, 7), (-5, 9), (0, 100), (-20, -10), (3, 3), (0, 999)])
 def test_isf_round_trips_every_support_point_to_within_one_step(lo: int, hi: int) -> None:
-    """`isf(sf(x))` is `x`, or the one point above it where `_sf`'s reciprocal multiply rounds low.
-
-    The one-point bound is what is portable: `_sf` multiplies by a rounded `1 / N` while `_isf` probes
-    with an honest division, so at an exactly representable step edge the two disagree by one point.
-    Asserting only `sf(isf(q)) <= q` would be vacuous, since `sf(max) == 0` satisfies it for every `q`.
-    """
+    """`isf(sf(x))` is `x` or the point above it, where `_sf`'s rounded `1 / N` and the probe's division disagree."""
     d = DiscreteUniform(min=lo, max=hi)
     points = pl.DataFrame({"x": [float(p) for p in range(lo, hi + 1)]})
     round_trip = points.select(x=pl.col("x"), rt=d.isf(d.sf("x")))
     assert round_trip.select(((pl.col("rt") == pl.col("x")) | (pl.col("rt") == pl.col("x") + 1)).all()).item()
-    # And the survival contract itself, which the bound above does not imply.
+    # The survival contract too; alone it is vacuous, since `sf(max) == 0` satisfies it for every `q`.
     quantiles = points.select(q=d.sf("x"))
     assert quantiles.select((d.sf(d.isf("q")) <= pl.col("q")).all()).item()

--- a/tests/distributions/discrete_uniform/log_cdf_test.py
+++ b/tests/distributions/discrete_uniform/log_cdf_test.py
@@ -23,15 +23,24 @@ def test_log_cdf_scalar(lo: int, hi: int, value: float, expected: float, unit_fr
     assert result == expected
 
 
-def test_log_cdf_saturation_zone_reads_the_tail() -> None:
-    # One support point short of the top, log_cdf must read log((N-1)/N), not the 0 a naive
-    # `cdf().log()` gives once the cdf rounds to 1.
-    lo, hi = 0, 10_000
+@pytest.mark.parametrize("n", [10_001, 10**5, 10**7, 10**9])
+def test_log_cdf_saturation_zone_reads_the_tail(n: int) -> None:
+    """One point below the top, `log_cdf` reads `log1p(-1/N)`, not `log` of a ratio rounded to 1."""
+    lo, hi = 0, n - 1
     got = pl.DataFrame({"x": [float(hi - 1)]}).select(r=DiscreteUniform(min=lo, max=hi).log_cdf("x"))["r"][0]
-    assert got == pytest.approx(math.log((hi - lo) / (hi - lo + 1)), rel=1e-12)
+    assert got == pytest.approx(math.log1p(-1.0 / n), rel=1e-15)
 
 
 def test_log_cdf_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
     result = bounds_with_null.select(r=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).log_cdf(2.0))["r"]
     assert result[0] == pytest.approx(math.log(2 / 6))
     assert result[1] is None
+    assert result[2] is None
+
+
+def test_log_cdf_saturates_to_zero_for_an_int_value_past_int64_half(unit_frame: pl.DataFrame) -> None:
+    """`log_cdf` reads `0.0` from the `value >= max` branch for both the `int` and the `float` spelling."""
+    d = DiscreteUniform(min=0, max=10)
+    point = 2**63 - 1
+    assert unit_frame.select(v=d.log_cdf(point)).item(0, "v") == 0.0
+    assert unit_frame.select(v=d.log_cdf(float(point))).item(0, "v") == 0.0

--- a/tests/distributions/discrete_uniform/log_cdf_test.py
+++ b/tests/distributions/discrete_uniform/log_cdf_test.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+
+from polars_stats import DiscreteUniform
+
+
+@pytest.mark.parametrize(
+    ("lo", "hi", "value", "expected"),
+    [
+        (1, 6, 0.5, float("-inf")),  # below the support: cdf == 0 exactly
+        (1, 6, 1.0, math.log(1 / 6)),
+        (1, 6, 6.0, 0.0),  # at the inclusive max the whole mass has accumulated
+        (1, 6, 9.9, 0.0),
+        (-3, 2, -4.5, float("-inf")),
+    ],
+)
+def test_log_cdf_scalar(lo: int, hi: int, value: float, expected: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).log_cdf(value)).item(0, "v")
+    assert result == expected
+
+
+def test_log_cdf_saturation_zone_reads_the_tail() -> None:
+    # One support point short of the top, log_cdf must read log((N-1)/N), not the 0 a naive
+    # `cdf().log()` gives once the cdf rounds to 1.
+    lo, hi = 0, 10_000
+    got = pl.DataFrame({"x": [float(hi - 1)]}).select(r=DiscreteUniform(min=lo, max=hi).log_cdf("x"))["r"][0]
+    assert got == pytest.approx(math.log((hi - lo) / (hi - lo + 1)), rel=1e-12)
+
+
+def test_log_cdf_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
+    result = bounds_with_null.select(r=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).log_cdf(2.0))["r"]
+    assert result[0] == pytest.approx(math.log(2 / 6))
+    assert result[1] is None

--- a/tests/distributions/discrete_uniform/log_pmf_test.py
+++ b/tests/distributions/discrete_uniform/log_pmf_test.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import DiscreteUniform
+
+
+@pytest.mark.parametrize(
+    ("lo", "hi", "value", "expected"),
+    [
+        (1, 6, 1.0, math.log(1 / 6)),
+        (1, 6, 6.0, math.log(1 / 6)),
+        (1, 6, 0.0, float("-inf")),  # off-support answers are exactly -inf, not log of a rounded 0
+        (1, 6, 7.0, float("-inf")),
+        (1, 6, 2.5, float("-inf")),
+        (3, 3, 3.0, 0.0),  # the point mass carries all of it: log(1)
+    ],
+)
+def test_log_pmf_scalar(lo: int, hi: int, value: float, expected: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).log_pmf(value)).item(0, "v")
+    assert result == expected
+
+
+def test_log_pmf_off_support_is_negative_inf() -> None:
+    df = pl.DataFrame({"x": [-1.0, 0.5, 99.0]})
+    result = df.select(r=DiscreteUniform(min=1, max=6).log_pmf(pl.col("x")))["r"]
+    assert_series_equal(result, pl.Series("r", [float("-inf")] * 3, dtype=pl.Float64))
+
+
+def test_log_pmf_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
+    result = bounds_with_null.select(r=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).log_pmf(2.0))["r"]
+    assert result[0] == pytest.approx(math.log(1 / 6))
+    assert result[1] is None
+    assert result[2] is None
+
+
+def test_log_pmf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"x": [1.0, None]}, schema={"x": pl.Float64})
+    result = df.select(r=DiscreteUniform(min=1, max=6).log_pmf(pl.col("x")))["r"]
+    assert result[0] == pytest.approx(math.log(1 / 6))
+    assert result[1] is None

--- a/tests/distributions/discrete_uniform/log_sf_test.py
+++ b/tests/distributions/discrete_uniform/log_sf_test.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+
+from polars_stats import DiscreteUniform
+
+
+@pytest.mark.parametrize(
+    ("lo", "hi", "value", "expected"),
+    [
+        (1, 6, 0.5, 0.0),  # below the support: sf == 1, log == 0
+        (1, 6, 1.0, math.log(5 / 6)),
+        (1, 6, 6.0, float("-inf")),  # zero mass above the inclusive max
+        (1, 6, 9.0, float("-inf")),
+        (-3, 2, -4.5, 0.0),
+    ],
+)
+def test_log_sf_scalar(lo: int, hi: int, value: float, expected: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).log_sf(value)).item(0, "v")
+    assert result == pytest.approx(expected)
+
+
+def test_log_sf_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
+    result = bounds_with_null.select(r=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).log_sf(2.0))["r"]
+    assert result[0] == pytest.approx(math.log(4 / 6))
+    assert result[1] is None

--- a/tests/distributions/discrete_uniform/log_sf_test.py
+++ b/tests/distributions/discrete_uniform/log_sf_test.py
@@ -27,3 +27,12 @@ def test_log_sf_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> Non
     result = bounds_with_null.select(r=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).log_sf(2.0))["r"]
     assert result[0] == pytest.approx(math.log(4 / 6))
     assert result[1] is None
+    assert result[2] is None
+
+
+@pytest.mark.parametrize("n", [10_001, 10**5, 10**7, 10**9])
+def test_log_sf_saturation_zone_reads_the_tail(n: int) -> None:
+    """The `log_cdf` mirror: at `min` the survival mass is `1 - 1/N`, whose log needs `log1p`."""
+    lo, hi = 0, n - 1
+    got = pl.DataFrame({"x": [float(lo)]}).select(r=DiscreteUniform(min=lo, max=hi).log_sf("x"))["r"][0]
+    assert got == pytest.approx(math.log1p(-1.0 / n), rel=1e-15)

--- a/tests/distributions/discrete_uniform/mean_test.py
+++ b/tests/distributions/discrete_uniform/mean_test.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import DiscreteUniform
+
+
+@pytest.mark.parametrize(
+    ("lo", "hi", "expected"),
+    [(1, 6, 3.5), (-3, 2, -0.5), (3, 3, 3.0), (0, 7, 3.5)],
+)
+def test_mean(lo: int, hi: int, expected: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).mean()).item(0, "v")
+    assert result == pytest.approx(expected)
+
+
+def test_mean_can_be_a_half_integer() -> None:
+    # For even N the midpoint falls between two support points; that is the answer, not a point.
+    lo, hi = 1, 6
+    got = pl.DataFrame({"_": [0]}).select(v=DiscreteUniform(min=lo, max=hi).mean())["v"][0]
+    assert got == (lo + hi) / 2
+
+
+def test_mean_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
+    result = bounds_with_null.select(v=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).mean())["v"]
+    assert_series_equal(result, pl.Series("v", [3.5, None, None], dtype=pl.Float64))

--- a/tests/distributions/discrete_uniform/mean_test.py
+++ b/tests/distributions/discrete_uniform/mean_test.py
@@ -26,14 +26,10 @@ def test_mean_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
 
 @pytest.mark.parametrize(("lo", "hi"), [(2**62, 2**62 + 10), (2**62, 2**63 - 1)])
 def test_mean_does_not_wrap_near_the_int64_ceiling(lo: int, hi: int, unit_frame: pl.DataFrame) -> None:
-    """`min + max` overflows `Int64` well inside the range the validator accepts.
-
-    Oracled by exact rational arithmetic rounded once, not the same sum spelled differently. A wrapped
-    sum misses `[min, max]` by `9.2e18`, though containment is not a general invariant: for a support
-    narrower than one float step the correctly rounded midpoint can sit half a step outside it.
-    """
+    """`min + max` overflows `Int64` well inside the validated range; the oracle is the exact midpoint rounded once."""
     result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).mean()).item(0, "v")
     assert result == float(Fraction(lo + hi, 2))
+    # Containment holds for these pairs; it is not a general invariant for supports narrower than a float step.
     assert lo <= result <= hi
 
 
@@ -46,12 +42,9 @@ def test_mean_does_not_wrap_near_the_int64_ceiling(lo: int, hi: int, unit_frame:
     ],
 )
 def test_mean_is_exact_for_bounds_straddling_zero(lo: int, hi: int, unit_frame: pl.DataFrame) -> None:
-    """Summing the bounds in `Float64` rounds both before they cancel; the `Int64` midpoint does not.
-
-    The exact midpoint is representable for each of these pairs, so anything but equality is the
-    cancellation defect rather than an unavoidable rounding.
-    """
+    """Summing the bounds in `Float64` rounds both before they cancel; the `Int64` midpoint does not."""
     exact = Fraction(lo + hi, 2)
+    # Each midpoint is representable, so any inequality below is the cancellation defect, not rounding.
     assert Fraction(float(exact)) == exact
     result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).mean()).item(0, "v")
     assert result == float(exact)

--- a/tests/distributions/discrete_uniform/mean_test.py
+++ b/tests/distributions/discrete_uniform/mean_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from fractions import Fraction
+
 import polars as pl
 import pytest
 from polars.testing import assert_series_equal
@@ -9,6 +11,7 @@ from polars_stats import DiscreteUniform
 
 @pytest.mark.parametrize(
     ("lo", "hi", "expected"),
+    # For even N the midpoint falls between two support points; that is the answer, not a point.
     [(1, 6, 3.5), (-3, 2, -0.5), (3, 3, 3.0), (0, 7, 3.5)],
 )
 def test_mean(lo: int, hi: int, expected: float, unit_frame: pl.DataFrame) -> None:
@@ -16,13 +19,39 @@ def test_mean(lo: int, hi: int, expected: float, unit_frame: pl.DataFrame) -> No
     assert result == pytest.approx(expected)
 
 
-def test_mean_can_be_a_half_integer() -> None:
-    # For even N the midpoint falls between two support points; that is the answer, not a point.
-    lo, hi = 1, 6
-    got = pl.DataFrame({"_": [0]}).select(v=DiscreteUniform(min=lo, max=hi).mean())["v"][0]
-    assert got == (lo + hi) / 2
-
-
 def test_mean_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
     result = bounds_with_null.select(v=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).mean())["v"]
     assert_series_equal(result, pl.Series("v", [3.5, None, None], dtype=pl.Float64))
+
+
+@pytest.mark.parametrize(("lo", "hi"), [(2**62, 2**62 + 10), (2**62, 2**63 - 1)])
+def test_mean_does_not_wrap_near_the_int64_ceiling(lo: int, hi: int, unit_frame: pl.DataFrame) -> None:
+    """`min + max` overflows `Int64` well inside the range the validator accepts.
+
+    Oracled by exact rational arithmetic rounded once, not the same sum spelled differently. A wrapped
+    sum misses `[min, max]` by `9.2e18`, though containment is not a general invariant: for a support
+    narrower than one float step the correctly rounded midpoint can sit half a step outside it.
+    """
+    result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).mean()).item(0, "v")
+    assert result == float(Fraction(lo + hi, 2))
+    assert lo <= result <= hi
+
+
+@pytest.mark.parametrize(
+    ("lo", "hi"),
+    [
+        (-4409513171799557951, 4409659924503471479),
+        (-(2**61), 2**61 + 1),
+        (-(2**62) + 3, 2**62 - 7),
+    ],
+)
+def test_mean_is_exact_for_bounds_straddling_zero(lo: int, hi: int, unit_frame: pl.DataFrame) -> None:
+    """Summing the bounds in `Float64` rounds both before they cancel; the `Int64` midpoint does not.
+
+    The exact midpoint is representable for each of these pairs, so anything but equality is the
+    cancellation defect rather than an unavoidable rounding.
+    """
+    exact = Fraction(lo + hi, 2)
+    assert Fraction(float(exact)) == exact
+    result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).mean()).item(0, "v")
+    assert result == float(exact)

--- a/tests/distributions/discrete_uniform/median_test.py
+++ b/tests/distributions/discrete_uniform/median_test.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import DiscreteUniform
+
+
+@pytest.mark.parametrize(
+    ("lo", "hi", "expected"),
+    [
+        (1, 6, 3.5),  # the midpoint, which for even N is not a support point
+        (-3, 2, -0.5),
+        (3, 3, 3.0),
+        (1, 8, 4.5),
+        (0, 7, 3.5),
+    ],
+)
+def test_median(lo: int, hi: int, expected: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).median()).item(0, "v")
+    assert result == expected
+
+
+def test_median_is_the_midpoint_not_ppf_half() -> None:
+    # scipy's `randint.median` is `ppf(0.5)` and lands on a support point; this crate reports the
+    # midpoint per the issue's convention, a documented divergence from scipy.
+    lo, hi = 1, 6
+    got = pl.DataFrame({"_": [0]}).select(v=DiscreteUniform(min=lo, max=hi).median())["v"][0]
+    ppf = pl.DataFrame({"_": [0]}).select(v=DiscreteUniform(min=lo, max=hi).ppf(0.5))["v"][0]
+    assert got == (lo + hi) / 2
+    assert ppf == lo + math.ceil(0.5 * (hi - lo + 1)) - 1
+
+
+def test_median_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
+    result = bounds_with_null.select(v=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).median())["v"]
+    assert_series_equal(result, pl.Series("v", [3.5, None, None], dtype=pl.Float64))

--- a/tests/distributions/discrete_uniform/median_test.py
+++ b/tests/distributions/discrete_uniform/median_test.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import math
+from fractions import Fraction
 
 import polars as pl
 import pytest
@@ -24,16 +24,25 @@ def test_median(lo: int, hi: int, expected: float, unit_frame: pl.DataFrame) -> 
     assert result == expected
 
 
-def test_median_is_the_midpoint_not_ppf_half() -> None:
-    # scipy's `randint.median` is `ppf(0.5)` and lands on a support point; this crate reports the
-    # midpoint per the issue's convention, a documented divergence from scipy.
-    lo, hi = 1, 6
-    got = pl.DataFrame({"_": [0]}).select(v=DiscreteUniform(min=lo, max=hi).median())["v"][0]
-    ppf = pl.DataFrame({"_": [0]}).select(v=DiscreteUniform(min=lo, max=hi).ppf(0.5))["v"][0]
-    assert got == (lo + hi) / 2
-    assert ppf == lo + math.ceil(0.5 * (hi - lo + 1)) - 1
+# scipy's `randint.median` is `ppf(0.5)` and lands on a support point; this crate reports the
+# midpoint, a documented divergence from scipy.
+@pytest.mark.parametrize(("lo", "hi", "midpoint", "ppf_half"), [(1, 6, 3.5, 3.0), (1, 8, 4.5, 4.0)])
+def test_median_is_the_midpoint_not_ppf_half(
+    lo: int, hi: int, midpoint: float, ppf_half: float, unit_frame: pl.DataFrame
+) -> None:
+    d = DiscreteUniform(min=lo, max=hi)
+    result = unit_frame.select(median=d.median(), ppf=d.ppf(0.5))
+    assert result["median"][0] == midpoint
+    assert result["ppf"][0] == ppf_half
 
 
 def test_median_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
     result = bounds_with_null.select(v=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).median())["v"]
     assert_series_equal(result, pl.Series("v", [3.5, None, None], dtype=pl.Float64))
+
+
+@pytest.mark.parametrize(("lo", "hi"), [(2**62, 2**62 + 10), (2**62, 2**63 - 1), (-(2**61), 2**61 + 1)])
+def test_median_does_not_wrap_near_the_int64_ceiling(lo: int, hi: int, unit_frame: pl.DataFrame) -> None:
+    """The same `(min + max) / 2` wrap as `mean`, which `median` computes independently."""
+    result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).median()).item(0, "v")
+    assert result == float(Fraction(lo + hi, 2))

--- a/tests/distributions/discrete_uniform/pmf_test.py
+++ b/tests/distributions/discrete_uniform/pmf_test.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import DiscreteUniform
+
+
+@pytest.mark.parametrize(
+    ("lo", "hi", "value", "expected"),
+    [
+        (1, 6, 1.0, 1 / 6),  # the lower bound is on the support
+        (1, 6, 3.0, 1 / 6),
+        (1, 6, 6.0, 1 / 6),  # so is the upper one: both bounds inclusive
+        (1, 6, 0.0, 0.0),  # below
+        (1, 6, 7.0, 0.0),  # above
+        (1, 6, 2.5, 0.0),  # non-integers carry no mass
+        (-3, 2, -3.0, 1 / 6),
+        (3, 3, 3.0, 1.0),  # the min == max point mass
+    ],
+)
+def test_pmf_scalar(lo: int, hi: int, value: float, expected: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).pmf(value)).item(0, "v")
+    assert result == pytest.approx(expected)
+
+
+def test_pmf_column_value() -> None:
+    lo, hi = 1, 6
+    df = pl.DataFrame({"x": [0.5, 1.0, 4.0, 6.0, 9.0]})
+    result = df.select(r=DiscreteUniform(min=lo, max=hi).pmf(pl.col("x")))["r"]
+    expected = pl.Series("r", [0.0] + [1 / 6] * 3 + [0.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_pmf_propagates_null_in_value() -> None:
+    df = pl.DataFrame({"x": [1.0, None, 6.0]}, schema={"x": pl.Float64})
+    result = df.select(r=DiscreteUniform(min=1, max=6).pmf(pl.col("x")))["r"]
+    assert_series_equal(result, pl.Series("r", [1 / 6, None, 1 / 6], dtype=pl.Float64))
+
+
+def test_pmf_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
+    # The one fully-valid row is (1, 6): mass 1/6. A null in either bound nulls the row.
+    result = bounds_with_null.select(r=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).pmf(2.0))["r"]
+    assert_series_equal(result, pl.Series("r", [1 / 6, None, None], dtype=pl.Float64))

--- a/tests/distributions/discrete_uniform/ppf_test.py
+++ b/tests/distributions/discrete_uniform/ppf_test.py
@@ -5,7 +5,6 @@ import math
 import polars as pl
 import pytest
 from polars.testing import assert_series_equal
-from scipy.stats import randint as scipy_randint
 
 from polars_stats import DiscreteUniform
 
@@ -28,30 +27,10 @@ from polars_stats import DiscreteUniform
     ],
 )
 def test_ppf_scalar(lo: int, hi: int, quantile: float, expected: float, unit_frame: pl.DataFrame) -> None:
+    # Integer equality, not the discrete tolerance band: the closed form matches scipy's own formula,
+    # so there is no search slack to absorb.
     result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).ppf(quantile)).item(0, "v")
-    # Held to integer equality rather than the discrete tolerance band: the closed form matches
-    # scipy's own formula, so there is no search slack to absorb.
     assert result == expected
-
-
-@pytest.mark.parametrize("lo_hi", [(1, 6), (-5, 9), (0, 100)])
-def test_ppf_matches_scipy_at_step_boundaries(lo_hi: tuple[int, int]) -> None:
-    """Exact parity with `scipy.stats.randint.ppf`, which shares this closed form.
-
-    The grid walks every interior cdf step edge of a support plus half-ulp perturbations of them,
-    where a one-sided rounding difference would show up as an off-by-one; scipy resolves those
-    through the same candidate-correction this ppf replicates. The exact endpoints stay out: at
-    q <= 0 / q >= 1 scipy answers its below-support sentinel `low - 1`, this implementation clamps
-    to the support.
-    """
-    lo, hi = lo_hi[0], lo_hi[1]
-    n = hi - lo + 1
-    edges = [k / n for k in range(1, n)]
-    quantiles = sorted(set(edges + [e - 2**-53 for e in edges] + [e + 2**-53 for e in edges]))
-    df = pl.DataFrame({"q": quantiles})
-    got = df.select(r=DiscreteUniform(min=lo, max=hi).ppf("q"))["r"]
-    expected = [scipy_randint.ppf(q, low=lo, high=hi + 1) for q in quantiles]
-    assert got.to_list() == expected
 
 
 @pytest.mark.parametrize("quantile", [-0.1, 1.5])
@@ -74,3 +53,14 @@ def test_ppf_propagates_null_in_quantile() -> None:
 def test_ppf_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
     result = bounds_with_null.select(v=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).ppf(0.5))["v"]
     assert_series_equal(result, pl.Series("v", [3.0, None, None], dtype=pl.Float64))
+
+
+def test_ppf_of_a_constant_parameterisation_is_a_scalar_expression() -> None:
+    """A scalar quantile against constant bounds is one value, not one per frame row."""
+    df = pl.DataFrame({"g": [0, 0, 1, 1, 1]})
+    grouped = df.group_by("g").agg(r=DiscreteUniform(min=0, max=5).ppf(0.5))
+    assert grouped.schema["r"] == pl.Float64
+
+    scalar = df.select(r=DiscreteUniform(min=0, max=5).ppf(0.5))
+    assert scalar.height == 1
+    assert_series_equal(scalar["r"], pl.Series("r", [2.0], dtype=pl.Float64))

--- a/tests/distributions/discrete_uniform/ppf_test.py
+++ b/tests/distributions/discrete_uniform/ppf_test.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+from scipy.stats import randint as scipy_randint
+
+from polars_stats import DiscreteUniform
+
+
+@pytest.mark.parametrize(
+    ("lo", "hi", "quantile", "expected"),
+    [
+        (1, 6, 0.0, 1.0),  # smallest support point, lifted from the formula's `min - 1` by the clamp
+        (1, 6, 1e-300, 1.0),  # any representable q > 0 is >= cdf(min)
+        (1, 6, 1 / 6, 1.0),  # exactly on the first cdf step
+        (1, 6, 0.2, 2.0),
+        (1, 6, 0.5, 3.0),
+        (1, 6, 1 / 6 + 1e-12, 2.0),  # just past a step
+        (1, 6, 5 / 6, 5.0),
+        (1, 6, 1.0 - 1e-300, 6.0),
+        (1, 6, 1.0, 6.0),  # the inclusive max answers q = 1
+        (-3, 2, 0.5, -1.0),  # cdf(-1) = 3/6 sits exactly on this step
+        (3, 3, 0.5, 3.0),  # the point mass inverts to itself
+        (3, 3, 0.0, 3.0),
+    ],
+)
+def test_ppf_scalar(lo: int, hi: int, quantile: float, expected: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).ppf(quantile)).item(0, "v")
+    # Held to integer equality rather than the discrete tolerance band: the closed form matches
+    # scipy's own formula, so there is no search slack to absorb.
+    assert result == expected
+
+
+@pytest.mark.parametrize("lo_hi", [(1, 6), (-5, 9), (0, 100)])
+def test_ppf_matches_scipy_at_step_boundaries(lo_hi: tuple[int, int]) -> None:
+    """Exact parity with `scipy.stats.randint.ppf`, which shares this closed form.
+
+    The grid walks every interior cdf step edge of a support plus half-ulp perturbations of them,
+    where a one-sided rounding difference would show up as an off-by-one; scipy resolves those
+    through the same candidate-correction this ppf replicates. The exact endpoints stay out: at
+    q <= 0 / q >= 1 scipy answers its below-support sentinel `low - 1`, this implementation clamps
+    to the support.
+    """
+    lo, hi = lo_hi[0], lo_hi[1]
+    n = hi - lo + 1
+    edges = [k / n for k in range(1, n)]
+    quantiles = sorted(set(edges + [e - 2**-53 for e in edges] + [e + 2**-53 for e in edges]))
+    df = pl.DataFrame({"q": quantiles})
+    got = df.select(r=DiscreteUniform(min=lo, max=hi).ppf("q"))["r"]
+    expected = [scipy_randint.ppf(q, low=lo, high=hi + 1) for q in quantiles]
+    assert got.to_list() == expected
+
+
+@pytest.mark.parametrize("quantile", [-0.1, 1.5])
+def test_ppf_out_of_range_quantile_is_null(quantile: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=DiscreteUniform(min=1, max=6).ppf(quantile)).item(0, "v")
+    assert result is None
+
+
+def test_ppf_propagates_nan_in_quantile(unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=DiscreteUniform(min=1, max=6).ppf(float("nan"))).item(0, "v")
+    assert math.isnan(result)
+
+
+def test_ppf_propagates_null_in_quantile() -> None:
+    df = pl.DataFrame({"q": [0.1, None, 0.9]}, schema={"q": pl.Float64})
+    result = df.select(v=DiscreteUniform(min=1, max=6).ppf(pl.col("q")))["v"]
+    assert_series_equal(result, pl.Series("v", [1.0, None, 6.0], dtype=pl.Float64))
+
+
+def test_ppf_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
+    result = bounds_with_null.select(v=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).ppf(0.5))["v"]
+    assert_series_equal(result, pl.Series("v", [3.0, None, None], dtype=pl.Float64))

--- a/tests/distributions/discrete_uniform/sample_test.py
+++ b/tests/distributions/discrete_uniform/sample_test.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal, assert_series_not_equal
+
+from polars_stats import DiscreteUniform
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@pytest.mark.parametrize("size", [0, 100, 1_000])
+def test_sample_basic_properties(
+    size: int,
+    frame: Callable[..., pl.DataFrame],
+    seed: int,
+) -> None:
+    result = frame(size=size).lazy().with_columns(du=DiscreteUniform(min=1, max=6).sample(seed=seed))
+    assert result.collect_schema()["du"] == pl.Int64
+    assert result.collect().height == size
+
+
+@pytest.mark.parametrize("bounds", [(1, 6), (-5, 9), (pl.col("lo"), pl.col("hi"))])
+def test_sample_seed_reproducible(
+    bounds: tuple[int | pl.Expr, int | pl.Expr],
+    frame: Callable[..., pl.DataFrame],
+    seed: int,
+) -> None:
+    dframe = frame()
+    s1 = dframe.with_columns(k=DiscreteUniform(min=bounds[0], max=bounds[1]).sample(seed=seed))["k"]
+    s2 = dframe.with_columns(k=DiscreteUniform(min=bounds[0], max=bounds[1]).sample(seed=seed))["k"]
+    assert_series_equal(s1, s2)
+
+
+def test_sample_different_seeds_differ(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    dframe = frame(size=128)
+    s1 = dframe.with_columns(k=DiscreteUniform(min=1, max=6).sample(seed=123))["k"]
+    s2 = dframe.with_columns(k=DiscreteUniform(min=1, max=6).sample(seed=seed))["k"]
+    assert_series_not_equal(s1, s2)
+
+
+def test_sample_support_is_the_inclusive_range(frame: Callable[..., pl.DataFrame]) -> None:
+    lo, hi = 3, 8
+    result = frame().with_columns(k=DiscreteUniform(min=lo, max=hi).sample(seed=7))
+    assert ((result["k"] >= lo) & (result["k"] <= hi)).all()
+    # A wide enough sweep should see both inclusive bounds themselves.
+    wide = frame(10_000).with_columns(k=DiscreteUniform(min=lo, max=hi).sample(seed=7))
+    assert set(wide["k"].unique()) == set(range(lo, hi + 1))
+
+
+def test_sample_point_mass_is_always_the_single_point(frame: Callable[..., pl.DataFrame]) -> None:
+    point = 4
+    result = frame().with_columns(k=DiscreteUniform(min=point, max=point).sample(seed=7))
+    assert (result["k"] == point).all()
+
+
+def test_sample_scalar_fast_path_matches_per_row() -> None:
+    # The constant-parameter fast path and the per-row plugin must agree bit for bit for the same
+    # parameterisation: one routes through kwargs, the other through columns.
+    n = 512
+    df = pl.DataFrame({"lo": [2] * n, "hi": [11] * n})
+    scalar = df.select(k=DiscreteUniform(min=2, max=11).sample(seed=9))["k"]
+    per_row = df.select(k=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).sample(seed=9))["k"]
+    assert_series_equal(scalar, per_row)
+
+
+def test_sample_mean_close_to_midpoint_for_large_n(frame: Callable[..., pl.DataFrame]) -> None:
+    n = 100_000
+    result = frame(n).with_columns(k=DiscreteUniform(min=1, max=6).sample(seed=123))
+    observed = result["k"].mean()
+    assert isinstance(observed, float)
+    assert abs(observed - 3.5) < 0.01 * 5
+
+
+def test_sample_null_bound_row_is_null(seed: int) -> None:
+    dframe = pl.DataFrame({"lo": [1, None, 1], "hi": [6, 6, 6]}, schema={"lo": pl.Int64, "hi": pl.Int64})
+    result = dframe.select(k=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).sample(seed=seed))["k"]
+    assert result[0] is not None
+    assert result[1] is None

--- a/tests/distributions/discrete_uniform/sample_test.py
+++ b/tests/distributions/discrete_uniform/sample_test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy as np
 import polars as pl
 import pytest
 from polars.testing import assert_series_equal, assert_series_not_equal
@@ -73,6 +74,33 @@ def test_sample_mean_close_to_midpoint_for_large_n(frame: Callable[..., pl.DataF
     observed = result["k"].mean()
     assert isinstance(observed, float)
     assert abs(observed - 3.5) < 0.01 * 5
+
+
+def test_sample_in_group_by_draws_per_group(seed: int) -> None:
+    local_rng = np.random.default_rng(seed=seed)
+    n_per_group, n_groups = 200, 40
+    lo = local_rng.integers(-20, 10, size=n_groups * n_per_group)
+    dframe = pl.DataFrame(
+        {
+            "group": np.repeat(np.arange(n_groups), n_per_group),
+            "lo": lo,
+            "hi": lo + local_rng.integers(0, 30, size=n_groups * n_per_group),
+        },
+    )
+    agg = (
+        dframe.group_by("group", maintain_order=True)
+        .agg(
+            sum_const=DiscreteUniform(min=1, max=6).sample(seed=seed).sum(),
+            sum_varying=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).sample(seed=seed).sum(),
+            size=pl.len(),
+        )
+        .sort("group")
+    )
+    assert agg.get_column("size").eq(n_per_group).all()
+    # Constant bounds + constant seed + identical per-group indices => identical sums across groups.
+    assert len(set(agg.get_column("sum_const").to_list())) == 1
+    # Per-row bounds vary across groups, so per-group sums must vary too.
+    assert len(set(agg.get_column("sum_varying").to_list())) > 1
 
 
 def test_sample_null_bound_row_is_null(seed: int) -> None:

--- a/tests/distributions/discrete_uniform/samples_test.py
+++ b/tests/distributions/discrete_uniform/samples_test.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import DiscreteUniform
+from tests._polars_compat import arr_explode
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@pytest.mark.parametrize("size", [1, 4, 16])
+def test_samples_shape_and_dtype(
+    size: int,
+    frame: Callable[..., pl.DataFrame],
+    seed: int,
+) -> None:
+    n = 32
+    result = frame(size=n).select(s=DiscreteUniform(min=1, max=6).samples(size=size, seed=seed))
+    assert result.height == n
+    assert result.schema["s"] == pl.Array(pl.Int64, size)
+
+
+def test_samples_seed_reproducible(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    dframe = frame(size=128)
+    s1 = dframe.select(s=DiscreteUniform(min=-4, max=5).samples(size=8, seed=seed))["s"]
+    s2 = dframe.select(s=DiscreteUniform(min=-4, max=5).samples(size=8, seed=seed))["s"]
+    assert_series_equal(s1, s2)
+
+
+def test_samples_columns_are_not_all_equal(
+    frame: Callable[..., pl.DataFrame],
+    seed: int,
+) -> None:
+    # Regression: the same seed must derive distinct sub-seeds so the `size`
+    # columns are independent draws, not `size` copies of the same draw.
+    size = 8
+    dframe = frame(size=512)
+    result = dframe.select(s=DiscreteUniform(min=1, max=50).samples(size=size, seed=seed))["s"]
+    columns = [result.arr.get(i) for i in range(size)]
+    distinct = {tuple(c.to_list()) for c in columns}
+    assert len(distinct) == size
+
+
+def test_samples_mean_close_to_midpoint_for_large_total(
+    frame: Callable[..., pl.DataFrame],
+    seed: int,
+) -> None:
+    n, size = 4_000, 16
+    result = arr_explode(frame(n).select(s=DiscreteUniform(min=1, max=6).samples(size=size, seed=seed))["s"])
+    mean = cast("float", result.mean())
+    assert abs(mean - 3.5) < 0.01 * 5
+
+
+def test_samples_scalar_fast_path_matches_per_row() -> None:
+    n, size = 256, 4
+    dframe = pl.DataFrame({"lo": [-3] * n, "hi": [7] * n}).head(n)
+    scalar = dframe.head(n).select(s=DiscreteUniform(min=-3, max=7).samples(size=size, seed=11))["s"]
+    per_row = (
+        dframe.head(n)
+        .with_columns(pl.col("lo").cast(pl.Int64), pl.col("hi").cast(pl.Int64))
+        .select(s=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).samples(size=size, seed=11))["s"]
+    )
+    assert_series_equal(scalar, per_row)
+
+
+@pytest.mark.parametrize("bad_size", [0, -1])
+def test_samples_rejects_non_positive_size(bad_size: int) -> None:
+    with pytest.raises(ValueError, match="size must be a positive integer"):
+        DiscreteUniform(min=1, max=6).samples(size=bad_size, seed=0)
+
+
+def test_samples_null_bound_row_is_null_array(seed: int) -> None:
+    # When a bound is null on a row, the entire array for that row must be null,
+    # not an array of inner-null elements.
+    size = 4
+    dframe = pl.DataFrame({"lo": [1, None, 1], "hi": [6, 6, 6]}, schema={"lo": pl.Int64, "hi": pl.Int64})
+    result = dframe.select(s=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).samples(size=size, seed=seed))["s"]
+    assert result.dtype == pl.Array(pl.Int64, size)
+    assert_series_equal(result.is_null(), pl.Series("s", [False, True, False]))

--- a/tests/distributions/discrete_uniform/samples_test.py
+++ b/tests/distributions/discrete_uniform/samples_test.py
@@ -58,14 +58,18 @@ def test_samples_mean_close_to_midpoint_for_large_total(
 
 def test_samples_scalar_fast_path_matches_per_row() -> None:
     n, size = 256, 4
-    dframe = pl.DataFrame({"lo": [-3] * n, "hi": [7] * n}).head(n)
-    scalar = dframe.head(n).select(s=DiscreteUniform(min=-3, max=7).samples(size=size, seed=11))["s"]
-    per_row = (
-        dframe.head(n)
-        .with_columns(pl.col("lo").cast(pl.Int64), pl.col("hi").cast(pl.Int64))
-        .select(s=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).samples(size=size, seed=11))["s"]
-    )
+    dframe = pl.DataFrame({"lo": [-3] * n, "hi": [7] * n}, schema={"lo": pl.Int64, "hi": pl.Int64})
+    scalar = dframe.select(s=DiscreteUniform(min=-3, max=7).samples(size=size, seed=11))["s"]
+    per_row = dframe.select(s=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).samples(size=size, seed=11))["s"]
     assert_series_equal(scalar, per_row)
+
+
+def test_samples_of_size_one_matches_sample(frame: Callable[..., pl.DataFrame], seed: int) -> None:
+    # Both paths draw through the same `fn draw`, so the first draw of a row's stream is shared.
+    dframe = frame(size=128)
+    one = dframe.select(s=DiscreteUniform(min=1, max=6).samples(size=1, seed=seed))["s"].arr.get(0)
+    single = dframe.select(k=DiscreteUniform(min=1, max=6).sample(seed=seed))["k"]
+    assert_series_equal(one, single, check_names=False)
 
 
 @pytest.mark.parametrize("bad_size", [0, -1])

--- a/tests/distributions/discrete_uniform/sf_test.py
+++ b/tests/distributions/discrete_uniform/sf_test.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import DiscreteUniform
+
+
+@pytest.mark.parametrize(
+    ("lo", "hi", "value", "expected"),
+    [
+        (1, 6, 0.5, 1.0),
+        (1, 6, 1.0, 5 / 6),
+        (1, 6, 3.7, 3 / 6),
+        (1, 6, 6.0, 0.0),
+        (1, 6, 9.0, 0.0),
+        (-3, 2, -4.0, 1.0),
+        (3, 3, 3.0, 0.0),
+    ],
+)
+def test_sf_scalar(lo: int, hi: int, value: float, expected: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).sf(value)).item(0, "v")
+    assert result == pytest.approx(expected)
+
+
+def test_sf_column_value() -> None:
+    df = pl.DataFrame({"x": [0.5, 2.0, 6.0]})
+    result = df.select(r=DiscreteUniform(min=1, max=6).sf(pl.col("x")))["r"]
+    expected = pl.Series("r", [1.0, 4 / 6, 0.0], dtype=pl.Float64)
+    assert_series_equal(result, expected)
+
+
+def test_sf_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
+    result = bounds_with_null.select(r=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).sf(2.0))["r"]
+    assert_series_equal(result, pl.Series("r", [4 / 6, None, None], dtype=pl.Float64))

--- a/tests/distributions/discrete_uniform/sf_test.py
+++ b/tests/distributions/discrete_uniform/sf_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from fractions import Fraction
+
 import polars as pl
 import pytest
 from polars.testing import assert_series_equal
@@ -34,3 +36,26 @@ def test_sf_column_value() -> None:
 def test_sf_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
     result = bounds_with_null.select(r=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).sf(2.0))["r"]
     assert_series_equal(result, pl.Series("r", [4 / 6, None, None], dtype=pl.Float64))
+
+
+@pytest.mark.parametrize("offset", [0, 1, 5, 9, 10])
+def test_sf_is_exact_for_an_int_value_in_a_narrow_support_past_the_float_grid(
+    offset: int, unit_frame: pl.DataFrame
+) -> None:
+    """The `cdf` mirror: `max - floor(value)` is subtracted in `Int64` and stays exact."""
+    lo = 2**62
+    hi = lo + 10
+    n = hi - lo + 1
+    result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).sf(lo + offset)).item(0, "v")
+    assert result == pytest.approx(float(Fraction(hi - lo - offset, n)), rel=1e-15)
+
+
+def test_sf_below_min_is_exactly_one_for_every_support_count_up_to_4000() -> None:
+    """The `cdf(max) == 1` mirror: below the support the survival mass is exactly 1, not `N * (1/N)`."""
+    counts = range(1, 4001)
+    df = pl.DataFrame(
+        {"lo": [0] * len(counts), "hi": [c - 1 for c in counts], "x": [-1.0] * len(counts)},
+        schema_overrides={"lo": pl.Int64, "hi": pl.Int64},
+    )
+    result = df.select(r=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).sf("x"))["r"]
+    assert_series_equal(result, pl.Series("r", [1.0] * len(counts), dtype=pl.Float64))

--- a/tests/distributions/discrete_uniform/validation_test.py
+++ b/tests/distributions/discrete_uniform/validation_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -81,6 +82,27 @@ def test_any_integer_bound_dtype_is_accepted(dtype: pl.DataType) -> None:
     df = pl.DataFrame({"lo": [1, 2], "hi": [6, 7]}, schema={"lo": dtype, "hi": dtype})
     result = df.select(v=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).mean())["v"]
     assert result.to_list() == [3.5, 4.5]
+
+
+@pytest.mark.parametrize("dtype", [pl.Int8, pl.Int16])
+def test_support_wider_than_the_bound_dtype_does_not_wrap(dtype: pl.DataType) -> None:
+    """Bound arithmetic widens to Int64, so a support wider than the bounds' own dtype stays exact."""
+    df = pl.DataFrame({"lo": [-100], "hi": [100], "x": [99]}, schema={"lo": dtype, "hi": dtype, "x": dtype})
+    d = DiscreteUniform(min=pl.col("lo"), max=pl.col("hi"))
+    result = df.select(
+        mean=d.mean(),
+        median=d.median(),
+        cdf=d.cdf(pl.col("x")),
+        sf=d.sf(pl.col("x")),
+        log_cdf=d.log_cdf(pl.col("x")),
+        log_sf=d.log_sf(pl.col("x")),
+    )
+    assert result["mean"][0] == 0.0
+    assert result["median"][0] == 0.0
+    assert result["cdf"][0] == pytest.approx(200 / 201)
+    assert result["sf"][0] == pytest.approx(1 / 201)
+    assert result["log_cdf"][0] == pytest.approx(math.log(200 / 201))
+    assert result["log_sf"][0] == pytest.approx(math.log(1 / 201))
 
 
 def test_unsigned_bound_above_int64_max_raises() -> None:

--- a/tests/distributions/discrete_uniform/validation_test.py
+++ b/tests/distributions/discrete_uniform/validation_test.py
@@ -9,46 +9,62 @@ from polars_stats import DiscreteUniform
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
 # Every public method must report `max < min` (or an overflowing width) as a ComputeError, not
 # silently compute. All of them derive from the Rust-validated support count; the samplers validate
-# in their own plugin.
-_METHODS: dict[str, Callable[[DiscreteUniform], pl.Expr]] = {
-    "pmf": lambda d: d.pmf(pl.col("x")),
-    "log_pmf": lambda d: d.log_pmf(pl.col("x")),
-    "cdf": lambda d: d.cdf(pl.col("x")),
-    "log_cdf": lambda d: d.log_cdf(pl.col("x")),
-    "sf": lambda d: d.sf(pl.col("x")),
-    "log_sf": lambda d: d.log_sf(pl.col("x")),
-    "ppf": lambda d: d.ppf(0.5),
-    "isf": lambda d: d.isf(0.5),
-    "mean": lambda d: d.mean(),
-    "variance": lambda d: d.variance(),
-    "std": lambda d: d.std(),
-    "median": lambda d: d.median(),
-    "entropy": lambda d: d.entropy(),
-    "sample": lambda d: d.sample(seed=0),
-    "samples": lambda d: d.samples(size=4, seed=0),
+# in their own plugin. `value` is the evaluation point, so one dict drives both the column-routed
+# sweep and the frameless one below; `ppf` / `isf` ignore it and keep a fixed quantile.
+_METHODS: dict[str, Callable[[DiscreteUniform, float | pl.Expr], pl.Expr]] = {
+    "pmf": lambda d, v: d.pmf(v),
+    "log_pmf": lambda d, v: d.log_pmf(v),
+    "cdf": lambda d, v: d.cdf(v),
+    "log_cdf": lambda d, v: d.log_cdf(v),
+    "sf": lambda d, v: d.sf(v),
+    "log_sf": lambda d, v: d.log_sf(v),
+    "ppf": lambda d, _v: d.ppf(0.5),
+    "isf": lambda d, _v: d.isf(0.5),
+    "mean": lambda d, _v: d.mean(),
+    "variance": lambda d, _v: d.variance(),
+    "std": lambda d, _v: d.std(),
+    "median": lambda d, _v: d.median(),
+    "entropy": lambda d, _v: d.entropy(),
+    "sample": lambda d, _v: d.sample(seed=0),
+    "samples": lambda d, _v: d.samples(size=4, seed=0),
+    "support_size": lambda d, _v: d.support_size,
 }
 
+_INVERTED = "max must be greater than or equal to min"
 
-@pytest.mark.parametrize("lo_hi", [(6, 1), (-2, -7)])
+
+@pytest.mark.parametrize(("lo", "hi"), [(6, 1), (-2, -7)])
 @pytest.mark.parametrize("expr_fn", _METHODS.values(), ids=list(_METHODS))
 def test_method_raises_on_inverted_bounds_column(
-    lo_hi: tuple[int, int], expr_fn: Callable[[DiscreteUniform], pl.Expr]
+    lo: int, hi: int, expr_fn: Callable[[DiscreteUniform, float | pl.Expr], pl.Expr]
 ) -> None:
-    lo, hi = lo_hi
     df = pl.DataFrame({"lo": [0, lo], "hi": [5, hi], "x": [2.0, 2.0]})
     d = DiscreteUniform(min=pl.col("lo"), max=pl.col("hi"))
-    with pytest.raises(pl.exceptions.ComputeError, match="max must be greater than or equal to min"):
-        df.select(r=expr_fn(d))
+    with pytest.raises(pl.exceptions.ComputeError, match=_INVERTED):
+        df.select(r=expr_fn(d, pl.col("x")))
 
 
 @pytest.mark.parametrize("expr_fn", _METHODS.values(), ids=list(_METHODS))
-def test_method_raises_on_inverted_bounds_scalar(expr_fn: Callable[[DiscreteUniform], pl.Expr]) -> None:
+def test_method_raises_on_inverted_bounds_scalar(
+    expr_fn: Callable[[DiscreteUniform, float | pl.Expr], pl.Expr],
+) -> None:
     df = pl.DataFrame({"x": [2.0]})
-    d = DiscreteUniform(min=6, max=1)
-    with pytest.raises(pl.exceptions.ComputeError, match="max must be greater than or equal to min"):
-        df.select(r=expr_fn(d))
+    with pytest.raises(pl.exceptions.ComputeError, match=_INVERTED):
+        df.select(r=expr_fn(DiscreteUniform(min=6, max=1), pl.col("x")))
+
+
+# `pl.select` resolves `pl.len()` to 0, so a method whose output height is anchored to the frame
+# instead of to its own inputs evaluates zero rows and reports nothing. Constant bounds are validated
+# by their own length-1 plugin call, so every method must raise here too.
+@pytest.mark.parametrize("expr_fn", _METHODS.values(), ids=list(_METHODS))
+def test_method_raises_on_inverted_bounds_without_a_frame(
+    expr_fn: Callable[[DiscreteUniform, float | pl.Expr], pl.Expr],
+) -> None:
+    with pytest.raises(pl.exceptions.ComputeError, match=_INVERTED):
+        pl.select(r=expr_fn(DiscreteUniform(min=5, max=0), 2.0))
 
 
 def test_float_bound_column_is_refused() -> None:
@@ -58,6 +74,29 @@ def test_float_bound_column_is_refused() -> None:
     d = DiscreteUniform(min=pl.col("lo"), max=pl.col("hi"))
     with pytest.raises(pl.exceptions.ComputeError, match="bounds must be integer columns"):
         df.select(r=d.mean())
+
+
+@pytest.mark.parametrize("dtype", [pl.Int8, pl.Int16, pl.Int32, pl.UInt8, pl.UInt32, pl.UInt64])
+def test_any_integer_bound_dtype_is_accepted(dtype: pl.DataType) -> None:
+    df = pl.DataFrame({"lo": [1, 2], "hi": [6, 7]}, schema={"lo": dtype, "hi": dtype})
+    result = df.select(v=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).mean())["v"]
+    assert result.to_list() == [3.5, 4.5]
+
+
+def test_unsigned_bound_above_int64_max_raises() -> None:
+    # A `UInt64` column holds values `Int64` cannot; the strict cast reports them rather than wrapping.
+    df = pl.DataFrame({"lo": [0, 1], "hi": [2**63 + 5, 20]}, schema={"lo": pl.UInt64, "hi": pl.UInt64})
+    d = DiscreteUniform(min=pl.col("lo"), max=pl.col("hi"))
+    with pytest.raises(pl.exceptions.ComputeError, match="bounds must be integers that fit in i64"):
+        df.select(r=d.mean())
+
+
+@pytest.mark.parametrize("null_bound", ["lo", "hi"])
+def test_null_dtype_bound_column_propagates_null(null_bound: str) -> None:
+    schema = {"lo": pl.Int64, "hi": pl.Int64} | {null_bound: pl.Null}
+    df = pl.DataFrame({"lo": [1, 2], "hi": [6, 7]} | {null_bound: [None, None]}, schema=schema)
+    result = df.select(v=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).support_size)["v"]
+    assert result.to_list() == [None, None]
 
 
 def test_support_width_overflowing_int64_raises() -> None:
@@ -71,3 +110,15 @@ def test_min_equal_max_point_mass_is_valid(unit_frame: pl.DataFrame) -> None:
     result = unit_frame.select(pmf=DiscreteUniform(min=3, max=3).pmf(3.0), mean=DiscreteUniform(min=3, max=3).mean())
     assert result["pmf"][0] == pytest.approx(1.0)
     assert result["mean"][0] == pytest.approx(3.0)
+
+
+@pytest.mark.parametrize(("lo", "hi", "expected"), [(1, 6, 6.0), (-5, 9, 15.0), (3, 3, 1.0), (-20, -10, 11.0)])
+def test_support_size_counts_the_inclusive_support(lo: int, hi: int, expected: float, unit_frame: pl.DataFrame) -> None:
+    """`max - min + 1`: both bounds inclusive, so a one-point mass counts 1 rather than 0."""
+    result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).support_size).item(0, "v")
+    assert result == expected
+
+
+def test_support_size_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
+    result = bounds_with_null.select(v=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).support_size)["v"]
+    assert result.to_list() == [6.0, None, None]

--- a/tests/distributions/discrete_uniform/validation_test.py
+++ b/tests/distributions/discrete_uniform/validation_test.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+
+from polars_stats import DiscreteUniform
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+# Every public method must report `max < min` (or an overflowing width) as a ComputeError, not
+# silently compute. All of them derive from the Rust-validated support count; the samplers validate
+# in their own plugin.
+_METHODS: dict[str, Callable[[DiscreteUniform], pl.Expr]] = {
+    "pmf": lambda d: d.pmf(pl.col("x")),
+    "log_pmf": lambda d: d.log_pmf(pl.col("x")),
+    "cdf": lambda d: d.cdf(pl.col("x")),
+    "log_cdf": lambda d: d.log_cdf(pl.col("x")),
+    "sf": lambda d: d.sf(pl.col("x")),
+    "log_sf": lambda d: d.log_sf(pl.col("x")),
+    "ppf": lambda d: d.ppf(0.5),
+    "isf": lambda d: d.isf(0.5),
+    "mean": lambda d: d.mean(),
+    "variance": lambda d: d.variance(),
+    "std": lambda d: d.std(),
+    "median": lambda d: d.median(),
+    "entropy": lambda d: d.entropy(),
+    "sample": lambda d: d.sample(seed=0),
+    "samples": lambda d: d.samples(size=4, seed=0),
+}
+
+
+@pytest.mark.parametrize("lo_hi", [(6, 1), (-2, -7)])
+@pytest.mark.parametrize("expr_fn", _METHODS.values(), ids=list(_METHODS))
+def test_method_raises_on_inverted_bounds_column(
+    lo_hi: tuple[int, int], expr_fn: Callable[[DiscreteUniform], pl.Expr]
+) -> None:
+    lo, hi = lo_hi
+    df = pl.DataFrame({"lo": [0, lo], "hi": [5, hi], "x": [2.0, 2.0]})
+    d = DiscreteUniform(min=pl.col("lo"), max=pl.col("hi"))
+    with pytest.raises(pl.exceptions.ComputeError, match="max must be greater than or equal to min"):
+        df.select(r=expr_fn(d))
+
+
+@pytest.mark.parametrize("expr_fn", _METHODS.values(), ids=list(_METHODS))
+def test_method_raises_on_inverted_bounds_scalar(expr_fn: Callable[[DiscreteUniform], pl.Expr]) -> None:
+    df = pl.DataFrame({"x": [2.0]})
+    d = DiscreteUniform(min=6, max=1)
+    with pytest.raises(pl.exceptions.ComputeError, match="max must be greater than or equal to min"):
+        df.select(r=expr_fn(d))
+
+
+def test_float_bound_column_is_refused() -> None:
+    # The dtype rule is column-level and judged before values: a float bound column is refused even
+    # though casting it would be lossless here, because in general it would silently truncate.
+    df = pl.DataFrame({"lo": [0.0, 1.0], "hi": [5.0, 6.0]})
+    d = DiscreteUniform(min=pl.col("lo"), max=pl.col("hi"))
+    with pytest.raises(pl.exceptions.ComputeError, match="bounds must be integer columns"):
+        df.select(r=d.mean())
+
+
+def test_support_width_overflowing_int64_raises() -> None:
+    df = pl.DataFrame({"x": [0.0]})
+    d = DiscreteUniform(min=-(2**63), max=2**63 - 1)
+    with pytest.raises(pl.exceptions.ComputeError, match="support width"):
+        df.select(r=d.mean())
+
+
+def test_min_equal_max_point_mass_is_valid(unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(pmf=DiscreteUniform(min=3, max=3).pmf(3.0), mean=DiscreteUniform(min=3, max=3).mean())
+    assert result["pmf"][0] == pytest.approx(1.0)
+    assert result["mean"][0] == pytest.approx(3.0)

--- a/tests/distributions/discrete_uniform/variance_test.py
+++ b/tests/distributions/discrete_uniform/variance_test.py
@@ -16,8 +16,8 @@ def test_variance(lo: int, hi: int, expected: float, unit_frame: pl.DataFrame) -
     assert result == pytest.approx(expected)
 
 
-def test_std() -> None:
-    got = pl.DataFrame({"_": [0]}).select(v=DiscreteUniform(min=1, max=6).std())["v"][0]
+def test_std(unit_frame: pl.DataFrame) -> None:
+    got = unit_frame.select(v=DiscreteUniform(min=1, max=6).std()).item(0, "v")
     assert got == pytest.approx((35 / 12) ** 0.5)
 
 

--- a/tests/distributions/discrete_uniform/variance_test.py
+++ b/tests/distributions/discrete_uniform/variance_test.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from polars.testing import assert_series_equal
+
+from polars_stats import DiscreteUniform
+
+
+@pytest.mark.parametrize(
+    ("lo", "hi", "expected"),
+    [(1, 6, 35 / 12), (-3, 2, 35 / 12), (3, 3, 0.0), (0, 100, (101**2 - 1) / 12)],
+)
+def test_variance(lo: int, hi: int, expected: float, unit_frame: pl.DataFrame) -> None:
+    result = unit_frame.select(v=DiscreteUniform(min=lo, max=hi).variance()).item(0, "v")
+    assert result == pytest.approx(expected)
+
+
+def test_std() -> None:
+    got = pl.DataFrame({"_": [0]}).select(v=DiscreteUniform(min=1, max=6).std())["v"][0]
+    assert got == pytest.approx((35 / 12) ** 0.5)
+
+
+def test_variance_propagates_null_in_bounds(bounds_with_null: pl.DataFrame) -> None:
+    result = bounds_with_null.select(v=DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")).variance())["v"]
+    assert_series_equal(result, pl.Series("v", [35 / 12, None, None], dtype=pl.Float64))

--- a/tests/distributions/moment_fast_path_test.py
+++ b/tests/distributions/moment_fast_path_test.py
@@ -32,7 +32,16 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
-from polars_stats import Bernoulli, Beta, Binomial, Geometric, LogNormal, Normal, Uniform
+from polars_stats import (
+    Bernoulli,
+    Beta,
+    Binomial,
+    DiscreteUniform,
+    Geometric,
+    LogNormal,
+    Normal,
+    Uniform,
+)
 from tests._polars_compat import assert_series_equal
 
 if TYPE_CHECKING:
@@ -71,6 +80,8 @@ _CASES: dict[str, tuple[_UnivariateDistribution, _UnivariateDistribution, bool]]
     "geometric p=-0.1": (Geometric(-0.1), Geometric(_col(-0.1)), True),
     "geometric p=1.5": (Geometric(1.5), Geometric(_col(1.5)), True),
     "geometric p=nan": (Geometric(_NAN), Geometric(_col(_NAN)), True),
+    # Inverted bounds: the one invalid parameterisation the discrete uniform has.
+    "discreteuniform min>max": (DiscreteUniform(6, 1), DiscreteUniform(_col(6), _col(1)), True),
     "binomial p=1.5": (Binomial(5, 1.5), Binomial(_col(5, pl.Int64()), _col(1.5)), True),
     "binomial p=nan": (Binomial(5, _NAN), Binomial(_col(5, pl.Int64()), _col(_NAN)), True),
     "beta a=0": (Beta(0.0, 1.0), Beta(_col(0.0), _col(1.0)), True),
@@ -150,6 +161,12 @@ _DEGENERATE: dict[str, tuple[_UnivariateDistribution, _UnivariateDistribution, f
     "binomial p=0 entropy": (Binomial(5, 0.0), Binomial(_col(5, pl.Int64()), _col(0.0)), 0.0),
     "binomial p=1 entropy": (Binomial(5, 1.0), Binomial(_col(5, pl.Int64()), _col(1.0)), 0.0),
     "binomial n=0 entropy": (Binomial(0, 0.5), Binomial(_col(0, pl.Int64()), _col(0.5)), 0.0),
+    # `min == max` is the legitimate one-point mass: entropy collapses to 0.
+    "discreteuniform min=max entropy": (
+        DiscreteUniform(4, 4),
+        DiscreteUniform(_col(4, pl.Int64()), _col(4, pl.Int64())),
+        0.0,
+    ),
 }
 
 

--- a/tests/distributions/output_name_test.py
+++ b/tests/distributions/output_name_test.py
@@ -22,7 +22,17 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
-from polars_stats import Bernoulli, Beta, Binomial, Exponential, Geometric, LogNormal, Normal, Uniform
+from polars_stats import (
+    Bernoulli,
+    Beta,
+    Binomial,
+    DiscreteUniform,
+    Exponential,
+    Geometric,
+    LogNormal,
+    Normal,
+    Uniform,
+)
 
 if TYPE_CHECKING:
     from polars_stats.distributions._base import _UnivariateDistribution
@@ -32,6 +42,7 @@ _FRAME = pl.DataFrame({"p": [0.5, 0.5], "mu": [0.0, 0.0], "n": [5, 5]})
 _SCALAR_PARAMS: dict[str, _UnivariateDistribution] = {
     "bernoulli": Bernoulli(p=0.5),
     "binomial": Binomial(n=5, p=0.5),
+    "discreteuniform": DiscreteUniform(min=-2, max=5),
     "geometric": Geometric(p=0.5),
     "normal": Normal(mu=0.0, sigma=1.0),
     "lognormal": LogNormal(mu=0.0, sigma=1.0),
@@ -44,6 +55,7 @@ _SCALAR_PARAMS: dict[str, _UnivariateDistribution] = {
 _COLUMN_PARAMS: dict[str, tuple[_UnivariateDistribution, str]] = {
     "bernoulli": (Bernoulli(p=pl.col("p")), "p"),
     "binomial": (Binomial(n=pl.col("n"), p=0.5), "n"),
+    "discreteuniform": (DiscreteUniform(min=pl.col("n"), max=pl.col("n")), "n"),
     "geometric": (Geometric(p=pl.col("p")), "p"),
     "normal": (Normal(mu=pl.col("mu"), sigma=1.0), "mu"),
     "lognormal": (LogNormal(mu=pl.col("mu"), sigma=1.0), "mu"),
@@ -115,6 +127,7 @@ _VALIDATOR_EXPRS: dict[str, tuple[pl.Expr, str]] = {
     "lognormal_sigma": (LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma"))._checked_params, "mu"),
     "beta_params": (Beta(a=pl.col("a"), b=pl.col("b"))._checked_params, "a"),
     "binomial_params": (Binomial(n=pl.col("n"), p=pl.col("p"))._checked_params, "n"),
+    "discreteuniform_range": (DiscreteUniform(min=pl.col("n"), max=pl.col("n"))._checked_params, "n"),
 }
 
 

--- a/tests/distributions/plugin_nan_test.py
+++ b/tests/distributions/plugin_nan_test.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
-from polars_stats import Beta, Binomial, LogNormal, Normal
+from polars_stats import Beta, Binomial, DiscreteUniform, LogNormal, Normal
 from polars_stats.distributions._base import DiscreteDistribution
 
 if TYPE_CHECKING:
@@ -48,6 +48,8 @@ _CASES = [
     ("beta-columns", Beta(a=_col(2.0), b=_col(3.0))),
     ("binomial-scalar", Binomial(n=5, p=0.4)),
     ("binomial-columns", Binomial(n=_col(5, pl.Int64()), p=_col(0.4))),
+    ("discreteuniform-scalar", DiscreteUniform(min=-2, max=9)),
+    ("discreteuniform-columns", DiscreteUniform(min=_col(-2, pl.Int64()), max=_col(9, pl.Int64()))),
 ]
 
 

--- a/tests/distributions/value_arg_str_test.py
+++ b/tests/distributions/value_arg_str_test.py
@@ -14,7 +14,17 @@ import polars as pl
 import pytest
 from polars.testing import assert_series_equal
 
-from polars_stats import Bernoulli, Beta, Binomial, Exponential, Geometric, LogNormal, Normal, Uniform
+from polars_stats import (
+    Bernoulli,
+    Beta,
+    Binomial,
+    DiscreteUniform,
+    Exponential,
+    Geometric,
+    LogNormal,
+    Normal,
+    Uniform,
+)
 from polars_stats.distributions._base import ContinuousDistribution
 
 if TYPE_CHECKING:
@@ -27,6 +37,7 @@ DISTRIBUTIONS: list[tuple[_UnivariateDistribution, str]] = [
     (Uniform(min="lo", max="hi"), "Uniform"),
     (Bernoulli(p="p"), "Bernoulli"),
     (Binomial(n="n", p="p"), "Binomial"),
+    (DiscreteUniform(min="n", max="n"), "DiscreteUniform"),  # min == max is a valid point mass
     (Geometric(p="p"), "Geometric"),
     (Exponential(rate="p"), "Exponential"),  # `p` is positive on every row, a valid rate
     (Beta(a="p", b="sigma"), "Beta"),  # both columns are positive on every row, valid shapes

--- a/tests/distributions/value_keyed_fast_path_test.py
+++ b/tests/distributions/value_keyed_fast_path_test.py
@@ -1,4 +1,6 @@
-"""Validation contract of the constant-parameter value-keyed fast path (Normal, LogNormal, Binomial, Beta).
+"""Validation contract of the constant-parameter value-keyed fast path.
+
+Covers Normal, LogNormal, Binomial, Beta and DiscreteUniform, the distributions with per-method Rust plugins.
 
 `pdf` / `pmf` / `cdf` / `sf` / `ppf` with all-scalar parameters route through a dedicated ``<name>_<method>_scalar``
 plugin that validates and builds the `statrs` distribution once (via the shared `build_dist`), instead of rebuilding it
@@ -28,7 +30,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
-from polars_stats import Beta, Binomial, LogNormal, Normal
+from polars_stats import Beta, Binomial, DiscreteUniform, LogNormal, Normal
 from polars_stats.distributions._base import ContinuousDistribution
 from tests._polars_compat import assert_series_equal
 
@@ -74,6 +76,17 @@ _CASES: dict[str, tuple[Callable[[], _UnivariateDistribution], Callable[[], _Uni
     # An infinite shape is *rejected* by statrs, unlike the Normal / LogNormal scale; both paths must
     # agree on that too.
     "beta a=inf (rejected)": (lambda: Beta(_INF, 1.0), lambda: Beta(_col(_INF), _col(1.0)), True),
+    "discreteuniform min>max": (
+        lambda: DiscreteUniform(6, 1),
+        lambda: DiscreteUniform(_col(6, pl.Int64()), _col(1, pl.Int64())),
+        True,
+    ),
+    # `min == max` is the legitimate one-point mass; both paths must accept it identically.
+    "discreteuniform min=max (accepted)": (
+        lambda: DiscreteUniform(3, 3),
+        lambda: DiscreteUniform(_col(3, pl.Int64()), _col(3, pl.Int64())),
+        False,
+    ),
 }
 
 

--- a/tests/property/_specs.py
+++ b/tests/property/_specs.py
@@ -7,7 +7,17 @@ from typing import TYPE_CHECKING, Any
 import polars as pl
 from hypothesis import strategies as st
 
-from polars_stats import Bernoulli, Beta, Binomial, Exponential, Geometric, LogNormal, Normal, Uniform
+from polars_stats import (
+    Bernoulli,
+    Beta,
+    Binomial,
+    DiscreteUniform,
+    Exponential,
+    Geometric,
+    LogNormal,
+    Normal,
+    Uniform,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -157,6 +167,27 @@ _GEOMETRIC = DistSpec(
     support=lambda p: [float(k) for k in range(1, _geometric_support_limit(p[0]) + 1)],
 )
 
+_DISCRETE_UNIFORM = DistSpec(
+    name="discreteuniform",
+    continuous=False,
+    # Both bounds inclusive; the pair strategy draws independently and filters to a valid ordering.
+    # Widths stay modest because several property tests evaluate every support point in `support`.
+    params=st.tuples(st.integers(min_value=-15, max_value=25), st.integers(min_value=-15, max_value=25)).filter(
+        lambda p: p[0] <= p[1]
+    ),
+    make=lambda p: DiscreteUniform(min=int(p[0]), max=int(p[1])),
+    make_columns=lambda p: DiscreteUniform(min=_col(int(p[0]), pl.Int64()), max=_col(int(p[1]), pl.Int64())),
+    make_masked=lambda p, m: DiscreteUniform(
+        min=pl.when(~m).then(_col(int(p[0]), pl.Int64())), max=_col(int(p[1]), pl.Int64())
+    ),
+    make_literals=lambda p: DiscreteUniform(min=_lit(int(p[0]), pl.Int64()), max=_lit(int(p[1]), pl.Int64())),
+    make_series=lambda p: DiscreteUniform(min=_series(int(p[0]), pl.Int64()), max=_series(int(p[1]), pl.Int64())),
+    example=(1, 6),
+    density=lambda d, c: d.pmf(c),
+    eval_range=lambda p: (p[0] - 1.0, p[1] + 1.0),
+    support=lambda p: [float(k) for k in range(int(p[0]), int(p[1]) + 1)],
+)
+
 _NORMAL = DistSpec(
     name="normal",
     continuous=True,
@@ -248,7 +279,17 @@ _BETA = DistSpec(
     integration_bounds=lambda _: (0.0, 1.0),
 )
 
-ALL_SPECS = [_BERNOULLI, _BINOMIAL, _GEOMETRIC, _NORMAL, _UNIFORM, _LOGNORMAL, _EXPONENTIAL, _BETA]
+ALL_SPECS = [
+    _BERNOULLI,
+    _BINOMIAL,
+    _DISCRETE_UNIFORM,
+    _GEOMETRIC,
+    _NORMAL,
+    _UNIFORM,
+    _LOGNORMAL,
+    _EXPONENTIAL,
+    _BETA,
+]
 CONTINUOUS_SPECS = [s for s in ALL_SPECS if s.continuous]
 DISCRETE_SPECS = [s for s in ALL_SPECS if not s.continuous]
 

--- a/tests/scipy_parity/discrete_uniform_test.py
+++ b/tests/scipy_parity/discrete_uniform_test.py
@@ -47,11 +47,7 @@ _CASES: list[Case[DiscreteUniform]] = [
 @pytest.mark.parametrize("bounds", _BOUNDS, ids=[f"bounds={b}" for b in _BOUNDS])
 @pytest.mark.parametrize("case", _CASES, ids=lambda c: c.name)
 def test_method_matches_scipy(case: Case[DiscreteUniform], bounds: tuple[int, int]) -> None:
-    """Every closed-form method matches `scipy.stats.randint(low=min, high=max + 1)` across grids.
-
-    `median` is absent deliberately: this crate reports the midpoint where scipy answers `ppf(0.5)`,
-    asserted in `tests/distributions/discrete_uniform/median_test.py` instead.
-    """
+    """Every closed form matches `randint(low=min, high=max + 1)`; `median` diverges by design, see `median_test.py`."""
     lo, hi = bounds
     assert_case_matches_scipy(
         case,
@@ -64,11 +60,7 @@ def test_method_matches_scipy(case: Case[DiscreteUniform], bounds: tuple[int, in
 
 @pytest.mark.parametrize(("lo", "hi"), [(1, 12), (1, 6), (-5, 9), (0, 100)])
 def test_ppf_exact_integer_parity_across_a_full_support(lo: int, hi: int) -> None:
-    """The closed-form ppf matches scipy to exact integer equality at every cdf step and both ulp neighbours.
-
-    Integer equality rather than a float tolerance: a shared closed form should agree exactly, and a
-    one-sided rounding difference shows up as an off-by-one. Endpoints stay out, per `_QUANTILES`.
-    """
+    """Exact integer parity with scipy at every cdf step and both ulp neighbours; a shared closed form has no slack."""
     n = hi - lo + 1
     edges = [k / n for k in range(1, n)]
     quantiles = sorted(set(edges + [e - 2**-53 for e in edges] + [e + 2**-53 for e in edges]))
@@ -78,11 +70,7 @@ def test_ppf_exact_integer_parity_across_a_full_support(lo: int, hi: int) -> Non
 
 
 def test_cdf_max_is_one_where_an_exclusive_reading_is_not() -> None:
-    """`cdf(max)` is exactly 1, which treating the bound as exclusive cannot say.
-
-    The behavioural marker of the inclusive convention: passing `max` as `randint`'s exclusive `high`
-    reads one support point fewer, answering `(max - min) / (max - min + 1)` at `max` instead of 1.
-    """
+    """`cdf(max)` is exactly 1; an exclusive reading of the bound answers `(max - min) / (max - min + 1)` there."""
     lo, hi = 1, 6
     ours = pl.DataFrame({"x": [float(hi)]}).select(r=DiscreteUniform(min=lo, max=hi).cdf("x"))["r"][0]
     assert ours == 1.0

--- a/tests/scipy_parity/discrete_uniform_test.py
+++ b/tests/scipy_parity/discrete_uniform_test.py
@@ -7,20 +7,15 @@ from scipy.stats import randint as scipy_randint
 from polars_stats import DiscreteUniform
 from tests.scipy_parity._harness import Case, assert_case_matches_scipy
 
-# Parameter and evaluation grids for the parity sweep. Owned by this test category and independent
-# of the per-method functional tests under `tests/distributions/discrete_uniform`.
 # Both bounds are INCLUSIVE here; scipy's `high` is exclusive, so every frozen reference is built
-# with `high=max + 1`. That reparameterisation is the loudest in the catalogue and is itself under
-# test: a swapped convention would fail every row below.
+# with `high=max + 1`. A swapped convention would fail every row below.
 _BOUNDS = [(0, 5), (-4, 4), (1, 2), (7, 60), (-20, -10)]
-# Interior quantiles only, for two reasons: scipy's discrete ppf/isf return the below-support
-# sentinel `low - 1` at the exact endpoints q in {0, 1}, which this support-clamped inverse does
-# not reproduce (same divergence as every other family); and the one-point mass `min == max` is
-# excluded from this sweep entirely because scipy's own `_stats` divides by zero there.
+# Interior quantiles only: scipy answers its below-support sentinel `low - 1` at q in {0, 1}, and the
+# one-point mass `min == max` is out of the sweep because scipy's own `_stats` divides by zero there.
 _QUANTILES = [0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95]
-# Spans below the support, integer points on it, non-integers, and past the inclusive max.
+# Below the support, integer points on it, non-integers, and past the inclusive max. Per-bound, so the
+# off-support probes stay near each support.
 _VALUE_GRIDS = {
-    # A per-bound grid keeps the off-support probes near each support.
     (0, 5): [-3.0, -1.0, 0.5, 1.0, 2.0, 3.7, 5.0, 8.0],
     (-4, 4): [-9.0, -4.0, -1.5, 0.0, 2.0, 4.0, 6.0],
     (1, 2): [0.0, 0.5, 1.0, 1.6, 2.0, 3.0],
@@ -54,11 +49,8 @@ _CASES: list[Case[DiscreteUniform]] = [
 def test_method_matches_scipy(case: Case[DiscreteUniform], bounds: tuple[int, int]) -> None:
     """Every closed-form method matches `scipy.stats.randint(low=min, high=max + 1)` across grids.
 
-    Table-driven: adding a method is one row in `_CASES`. `median` is deliberately absent: this
-    crate reports the midpoint `(min + max) / 2` per the issue's convention, where scipy answers
-    `ppf(0.5)`, a support point for even-width supports -- a documented divergence asserted in
-    `tests/distributions/discrete_uniform/median_test.py` instead. Method-specific behaviour
-    (inclusive bounds, null propagation) is asserted in the per-method test files.
+    `median` is absent deliberately: this crate reports the midpoint where scipy answers `ppf(0.5)`,
+    asserted in `tests/distributions/discrete_uniform/median_test.py` instead.
     """
     lo, hi = bounds
     assert_case_matches_scipy(
@@ -70,16 +62,13 @@ def test_method_matches_scipy(case: Case[DiscreteUniform], bounds: tuple[int, in
     )
 
 
-def test_ppf_exact_integer_parity_across_a_full_support() -> None:
-    """The closed-form ppf matches scipy to exact integer equality at every cdf step of a support.
+@pytest.mark.parametrize(("lo", "hi"), [(1, 12), (1, 6), (-5, 9), (0, 100)])
+def test_ppf_exact_integer_parity_across_a_full_support(lo: int, hi: int) -> None:
+    """The closed-form ppf matches scipy to exact integer equality at every cdf step and both ulp neighbours.
 
-    The issue requires verbatim parity including rounding at step boundaries; a shared closed form
-    makes that hold even under half-ulp nudges of each step edge, which is where a one-sided
-    rounding difference would show up as an off-by-one. The exact endpoints stay out of the grid:
-    at q <= 0 / q >= 1 scipy answers its below-support sentinel (`low - 1`), this implementation
-    clamps to the support -- the same documented divergence as every other family.
+    Integer equality rather than a float tolerance: a shared closed form should agree exactly, and a
+    one-sided rounding difference shows up as an off-by-one. Endpoints stay out, per `_QUANTILES`.
     """
-    lo, hi = 1, 12
     n = hi - lo + 1
     edges = [k / n for k in range(1, n)]
     quantiles = sorted(set(edges + [e - 2**-53 for e in edges] + [e + 2**-53 for e in edges]))
@@ -89,11 +78,10 @@ def test_ppf_exact_integer_parity_across_a_full_support() -> None:
 
 
 def test_cdf_max_is_one_where_an_exclusive_reading_is_not() -> None:
-    """`cdf(max)` is exactly 1; treating the bound as exclusive, as scipy does, cannot say that.
+    """`cdf(max)` is exactly 1, which treating the bound as exclusive cannot say.
 
-    This is the behavioural marker of the inclusive convention: a port that passes `max` as
-    `randint`'s exclusive `high` reads one support point fewer, answering
-    `(max - min) / (max - min + 1)` at `max` instead of 1.
+    The behavioural marker of the inclusive convention: passing `max` as `randint`'s exclusive `high`
+    reads one support point fewer, answering `(max - min) / (max - min + 1)` at `max` instead of 1.
     """
     lo, hi = 1, 6
     ours = pl.DataFrame({"x": [float(hi)]}).select(r=DiscreteUniform(min=lo, max=hi).cdf("x"))["r"][0]

--- a/tests/scipy_parity/discrete_uniform_test.py
+++ b/tests/scipy_parity/discrete_uniform_test.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from scipy.stats import randint as scipy_randint
+
+from polars_stats import DiscreteUniform
+from tests.scipy_parity._harness import Case, assert_case_matches_scipy
+
+# Parameter and evaluation grids for the parity sweep. Owned by this test category and independent
+# of the per-method functional tests under `tests/distributions/discrete_uniform`.
+# Both bounds are INCLUSIVE here; scipy's `high` is exclusive, so every frozen reference is built
+# with `high=max + 1`. That reparameterisation is the loudest in the catalogue and is itself under
+# test: a swapped convention would fail every row below.
+_BOUNDS = [(0, 5), (-4, 4), (1, 2), (7, 60), (-20, -10)]
+# Interior quantiles only, for two reasons: scipy's discrete ppf/isf return the below-support
+# sentinel `low - 1` at the exact endpoints q in {0, 1}, which this support-clamped inverse does
+# not reproduce (same divergence as every other family); and the one-point mass `min == max` is
+# excluded from this sweep entirely because scipy's own `_stats` divides by zero there.
+_QUANTILES = [0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95]
+# Spans below the support, integer points on it, non-integers, and past the inclusive max.
+_VALUE_GRIDS = {
+    # A per-bound grid keeps the off-support probes near each support.
+    (0, 5): [-3.0, -1.0, 0.5, 1.0, 2.0, 3.7, 5.0, 8.0],
+    (-4, 4): [-9.0, -4.0, -1.5, 0.0, 2.0, 4.0, 6.0],
+    (1, 2): [0.0, 0.5, 1.0, 1.6, 2.0, 3.0],
+    (7, 60): [2.0, 7.0, 15.0, 30.5, 44.0, 60.0, 61.0],
+    (-20, -10): [-25.0, -20.0, -14.0, -11.0, -10.0, -5.0],
+}
+
+
+def _value_grid(bounds: tuple[int, int]) -> list[float]:
+    return _VALUE_GRIDS[bounds]
+
+
+_CASES: list[Case[DiscreteUniform]] = [
+    Case("pmf", "value", lambda d, c: d.pmf(c), "pmf"),
+    Case("log_pmf", "value", lambda d, c: d.log_pmf(c), "logpmf"),
+    Case("cdf", "value", lambda d, c: d.cdf(c), "cdf"),
+    Case("log_cdf", "value", lambda d, c: d.log_cdf(c), "logcdf"),
+    Case("sf", "value", lambda d, c: d.sf(c), "sf"),
+    Case("log_sf", "value", lambda d, c: d.log_sf(c), "logsf"),
+    Case("ppf", "quantile", lambda d, c: d.ppf(c), "ppf"),
+    Case("isf", "quantile", lambda d, c: d.isf(c), "isf"),
+    Case("mean", "scalar", lambda d, _: d.mean(), "mean"),
+    Case("variance", "scalar", lambda d, _: d.variance(), "var"),
+    Case("std", "scalar", lambda d, _: d.std(), "std"),
+    Case("entropy", "scalar", lambda d, _: d.entropy(), "entropy"),
+]
+
+
+@pytest.mark.parametrize("bounds", _BOUNDS, ids=[f"bounds={b}" for b in _BOUNDS])
+@pytest.mark.parametrize("case", _CASES, ids=lambda c: c.name)
+def test_method_matches_scipy(case: Case[DiscreteUniform], bounds: tuple[int, int]) -> None:
+    """Every closed-form method matches `scipy.stats.randint(low=min, high=max + 1)` across grids.
+
+    Table-driven: adding a method is one row in `_CASES`. `median` is deliberately absent: this
+    crate reports the midpoint `(min + max) / 2` per the issue's convention, where scipy answers
+    `ppf(0.5)`, a support point for even-width supports -- a documented divergence asserted in
+    `tests/distributions/discrete_uniform/median_test.py` instead. Method-specific behaviour
+    (inclusive bounds, null propagation) is asserted in the per-method test files.
+    """
+    lo, hi = bounds
+    assert_case_matches_scipy(
+        case,
+        dist=DiscreteUniform(min=lo, max=hi),
+        scipy_frozen=scipy_randint(low=lo, high=hi + 1),
+        value_grid=_value_grid(bounds),
+        quantiles=_QUANTILES,
+    )
+
+
+def test_ppf_exact_integer_parity_across_a_full_support() -> None:
+    """The closed-form ppf matches scipy to exact integer equality at every cdf step of a support.
+
+    The issue requires verbatim parity including rounding at step boundaries; a shared closed form
+    makes that hold even under half-ulp nudges of each step edge, which is where a one-sided
+    rounding difference would show up as an off-by-one. The exact endpoints stay out of the grid:
+    at q <= 0 / q >= 1 scipy answers its below-support sentinel (`low - 1`), this implementation
+    clamps to the support -- the same documented divergence as every other family.
+    """
+    lo, hi = 1, 12
+    n = hi - lo + 1
+    edges = [k / n for k in range(1, n)]
+    quantiles = sorted(set(edges + [e - 2**-53 for e in edges] + [e + 2**-53 for e in edges]))
+    got = pl.DataFrame({"q": quantiles}).select(r=DiscreteUniform(min=lo, max=hi).ppf("q"))["r"]
+    expected = [scipy_randint.ppf(q, low=lo, high=hi + 1) for q in quantiles]
+    assert got.to_list() == expected
+
+
+def test_cdf_max_is_one_where_an_exclusive_reading_is_not() -> None:
+    """`cdf(max)` is exactly 1; treating the bound as exclusive, as scipy does, cannot say that.
+
+    This is the behavioural marker of the inclusive convention: a port that passes `max` as
+    `randint`'s exclusive `high` reads one support point fewer, answering
+    `(max - min) / (max - min + 1)` at `max` instead of 1.
+    """
+    lo, hi = 1, 6
+    ours = pl.DataFrame({"x": [float(hi)]}).select(r=DiscreteUniform(min=lo, max=hi).cdf("x"))["r"][0]
+    assert ours == 1.0
+    exclusive_reading = (hi - lo) / (hi - lo + 1)
+    assert exclusive_reading < 1.0

--- a/tools/accuracy_audit.py
+++ b/tools/accuracy_audit.py
@@ -54,7 +54,17 @@ from typing import TYPE_CHECKING, Literal, cast
 import mpmath as mp
 import polars as pl
 
-from polars_stats import Bernoulli, Beta, Binomial, Exponential, Geometric, LogNormal, Normal, Uniform
+from polars_stats import (
+    Bernoulli,
+    Beta,
+    Binomial,
+    DiscreteUniform,
+    Exponential,
+    Geometric,
+    LogNormal,
+    Normal,
+    Uniform,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -737,6 +747,79 @@ def geometric_points(params: Params, rng: random.Random, count: int) -> list[Poi
     return points
 
 
+# DiscreteUniform oracles. `params` is `(min, max)`, both bounds inclusive.
+
+
+def _discrete_uniform_n(params: Params) -> int:
+    """The support count `max - min + 1`, as a Python int."""
+    return int(params[1]) - int(params[0]) + 1
+
+
+def discrete_uniform_pmf(params: Params, x: float) -> mp.mpf:
+    """`1 / N` on the inclusive integer support `{min, ..., max}`, `0` off it."""
+    lo, hi = int(params[0]), int(params[1])
+    if x < lo or x > hi or not x.is_integer():
+        return mp.mpf(0)
+    return 1 / mp.mpf(_discrete_uniform_n(params))
+
+
+def discrete_uniform_log_pmf(params: Params, x: float) -> mp.mpf:
+    """`ln` of [`discrete_uniform_pmf`], taken at oracle precision."""
+    return ln(discrete_uniform_pmf(params, x))
+
+
+def discrete_uniform_cdf(params: Params, x: float) -> mp.mpf:
+    """`(clamp(floor(x) - min + 1, 0, N)) / N`, so `cdf(max)` is exactly `1`."""
+    n = _discrete_uniform_n(params)
+    k = math.floor(x) - int(params[0]) + 1
+    k = max(0, min(k, n))
+    return mp.mpf(k) / n
+
+
+def discrete_uniform_sf(params: Params, x: float) -> mp.mpf:
+    """`(N - clamp(floor(x) - min + 1, 0, N)) / N`, the exact complement of [`discrete_uniform_cdf`]."""
+    n = _discrete_uniform_n(params)
+    k = math.floor(x) - int(params[0]) + 1
+    k = max(0, min(k, n))
+    return mp.mpf(n - k) / n
+
+
+def discrete_uniform_ppf(params: Params, q: float) -> mp.mpf:
+    """Smallest support point with `cdf(k) >= q`, by exact binary search over the oracle cdf."""
+    if q <= 0:
+        return mp.mpf(int(params[0]))
+    if q >= 1:
+        return mp.mpf(int(params[1]))
+    target = mp.mpf(q)
+    lo = int(params[0])
+    found = smallest_satisfying(_discrete_uniform_n(params), lambda k: discrete_uniform_cdf(params, lo + k) >= target)
+    return mp.mpf(lo + int(found))
+
+
+def discrete_uniform_isf(params: Params, q: float) -> mp.mpf:
+    """Smallest support point with `sf(k) <= q`, by exact binary search over the oracle sf."""
+    if q >= 1:
+        return mp.mpf(int(params[0]))
+    if q <= 0:
+        # `sf(max) = 0` already satisfies the inequality at the top support point.
+        return mp.mpf(int(params[1]))
+    target = mp.mpf(q)
+    lo = int(params[0])
+    found = smallest_satisfying(_discrete_uniform_n(params), lambda k: discrete_uniform_sf(params, lo + k) <= target)
+    return mp.mpf(lo + int(found))
+
+
+def discrete_uniform_points(params: Params, rng: random.Random, count: int) -> list[Point]:
+    """Both bounds and their outside, half-integers between them, and random support integers."""
+    lo, hi = int(params[0]), int(params[1])
+    points: list[Point] = [
+        (v, "danger")
+        for v in (lo - 2.5, lo - 1.0, lo - 0.5, float(lo), lo + 0.5, (lo + hi) / 2, hi - 0.5, float(hi), hi + 1.5)
+    ]
+    points.extend((float(rng.randint(lo, hi)), "random") for _ in range(count))
+    return points
+
+
 # Shared moment oracles, lifted into the standard signature.
 
 
@@ -1282,6 +1365,51 @@ def build_registry() -> tuple[DistributionSpec, ...]:
                     constant(lambda p: (1 - mp.mpf(p[0])) / mp.mpf(p[0]) ** 2),
                     at_median(geometric_ppf),
                     geometric_entropy,
+                    CLOSED_FORM_RTOL,
+                ),
+            ),
+        ),
+        DistributionSpec(
+            name="DiscreteUniform",
+            build=lambda p: DiscreteUniform(min=p[0], max=p[1]),
+            param_names=("min", "max"),
+            param_dtypes=(pl.Int64(), pl.Int64()),
+            # Both bounds inclusive. The regimes cover negative bounds, a one-point mass (`min ==
+            # max`), a two-point support, and a wide span that stresses the inverse searches.
+            params=(
+                (0, 5),
+                (-4, 4),
+                (1, 2),
+                (3, 3),
+                (7, 60),
+                (-20, -10),
+                (-1000, 1000),
+                (0, 10**6),
+            ),
+            methods=(
+                MethodSpec("pmf", discrete_uniform_pmf, CLOSED_FORM_RTOL, discrete_uniform_points),
+                MethodSpec("log_pmf", discrete_uniform_log_pmf, LOG_RTOL, discrete_uniform_points),
+                MethodSpec("cdf", discrete_uniform_cdf, CLOSED_FORM_RTOL, discrete_uniform_points),
+                MethodSpec(
+                    "log_cdf",
+                    log_pair(discrete_uniform_cdf, discrete_uniform_sf),
+                    LOG_RTOL,
+                    discrete_uniform_points,
+                ),
+                MethodSpec("sf", discrete_uniform_sf, CLOSED_FORM_RTOL, discrete_uniform_points),
+                MethodSpec(
+                    "log_sf",
+                    log_pair(discrete_uniform_sf, discrete_uniform_cdf),
+                    LOG_RTOL,
+                    discrete_uniform_points,
+                ),
+                MethodSpec("ppf", discrete_uniform_ppf, DISCRETE_PPF_RTOL, quantile_points),
+                MethodSpec("isf", discrete_uniform_isf, DISCRETE_PPF_RTOL, survival_points),
+                *moments(
+                    constant(lambda p: (mp.mpf(int(p[0])) + mp.mpf(int(p[1]))) / 2),
+                    constant(lambda p: (mp.mpf(_discrete_uniform_n(p)) ** 2 - 1) / 12),
+                    constant(lambda p: (mp.mpf(int(p[0])) + mp.mpf(int(p[1]))) / 2),
+                    constant(lambda p: mp.log(_discrete_uniform_n(p))),
                     CLOSED_FORM_RTOL,
                 ),
             ),

--- a/tools/accuracy_audit.py
+++ b/tools/accuracy_audit.py
@@ -1095,6 +1095,16 @@ def build_registry() -> tuple[DistributionSpec, ...]:
     from `tests/property/_specs.py` is silently untested.
     """
     f64 = (pl.Float64(), pl.Float64())
+    # Shared between the DiscreteUniform spec and its Int64-edge twin below, which audits the same
+    # closed forms at bounds where `min + max` overflows.
+    discrete_uniform_midpoint = constant(lambda p: (mp.mpf(int(p[0])) + mp.mpf(int(p[1]))) / 2)
+    discrete_uniform_moments = moments(
+        discrete_uniform_midpoint,
+        constant(lambda p: (mp.mpf(_discrete_uniform_n(p)) ** 2 - 1) / 12),
+        discrete_uniform_midpoint,
+        constant(lambda p: mp.log(_discrete_uniform_n(p))),
+        CLOSED_FORM_RTOL,
+    )
     return (
         DistributionSpec(
             name="Normal",
@@ -1407,13 +1417,7 @@ def build_registry() -> tuple[DistributionSpec, ...]:
                 ),
                 MethodSpec("ppf", discrete_uniform_ppf, DISCRETE_PPF_RTOL, quantile_points),
                 MethodSpec("isf", discrete_uniform_isf, DISCRETE_PPF_RTOL, survival_points),
-                *moments(
-                    constant(lambda p: (mp.mpf(int(p[0])) + mp.mpf(int(p[1]))) / 2),
-                    constant(lambda p: (mp.mpf(_discrete_uniform_n(p)) ** 2 - 1) / 12),
-                    constant(lambda p: (mp.mpf(int(p[0])) + mp.mpf(int(p[1]))) / 2),
-                    constant(lambda p: mp.log(_discrete_uniform_n(p))),
-                    CLOSED_FORM_RTOL,
-                ),
+                *discrete_uniform_moments,
             ),
         ),
         DistributionSpec(
@@ -1439,13 +1443,7 @@ def build_registry() -> tuple[DistributionSpec, ...]:
                 (-(2**63) + 1, -(2**63) + 11),
                 (-(2**63) + 1, -(2**62)),
             ),
-            methods=moments(
-                constant(lambda p: (mp.mpf(int(p[0])) + mp.mpf(int(p[1]))) / 2),
-                constant(lambda p: (mp.mpf(_discrete_uniform_n(p)) ** 2 - 1) / 12),
-                constant(lambda p: (mp.mpf(int(p[0])) + mp.mpf(int(p[1]))) / 2),
-                constant(lambda p: mp.log(_discrete_uniform_n(p))),
-                CLOSED_FORM_RTOL,
-            ),
+            methods=discrete_uniform_moments,
         ),
     )
 

--- a/tools/accuracy_audit.py
+++ b/tools/accuracy_audit.py
@@ -1375,7 +1375,8 @@ def build_registry() -> tuple[DistributionSpec, ...]:
             param_names=("min", "max"),
             param_dtypes=(pl.Int64(), pl.Int64()),
             # Both bounds inclusive. The regimes cover negative bounds, a one-point mass (`min ==
-            # max`), a two-point support, and a wide span that stresses the inverse searches.
+            # max`), a two-point support, a wide span that stresses the inverse searches, and a
+            # support large enough that the log methods have a tail to lose (`1 / N ~ 1e-9`).
             params=(
                 (0, 5),
                 (-4, 4),
@@ -1385,6 +1386,7 @@ def build_registry() -> tuple[DistributionSpec, ...]:
                 (-20, -10),
                 (-1000, 1000),
                 (0, 10**6),
+                (0, 10**9),
             ),
             methods=(
                 MethodSpec("pmf", discrete_uniform_pmf, CLOSED_FORM_RTOL, discrete_uniform_points),
@@ -1412,6 +1414,37 @@ def build_registry() -> tuple[DistributionSpec, ...]:
                     constant(lambda p: mp.log(_discrete_uniform_n(p))),
                     CLOSED_FORM_RTOL,
                 ),
+            ),
+        ),
+        DistributionSpec(
+            # The moments only, at bounds where `min + max` overflows `Int64`: the regime that
+            # catches an integer formula wrapping, which no span inside `10**6` can reach.
+            #
+            # The value-keyed methods are absent because a probe arrives as a `float` and a support
+            # this narrow collapses onto one `Float64` (the step is 1024 wide at `2**62`), so no
+            # answer can distinguish its points; `cdf_test.py` and `sf_test.py` pin the exact `int`
+            # spelling instead. `ppf` / `isf` are absent for a different reason: they genuinely lose
+            # points here, on the output side, and that limit is recorded in
+            # `docs/explanation/accuracy.md` rather than audited.
+            name="DiscreteUniformI64Edge",
+            build=lambda p: DiscreteUniform(min=p[0], max=p[1]),
+            param_names=("min", "max"),
+            param_dtypes=(pl.Int64(), pl.Int64()),
+            params=(
+                # Narrow and wide on each side. Every pair overflows `min + max` while keeping the
+                # width `max - min + 1` inside `i64::MAX`, which is what the validator itself checks:
+                # a pair that overflows the width is a legitimate `ComputeError`, not a probe.
+                (2**62, 2**62 + 10),
+                (2**62, 2**63 - 1),
+                (-(2**63) + 1, -(2**63) + 11),
+                (-(2**63) + 1, -(2**62)),
+            ),
+            methods=moments(
+                constant(lambda p: (mp.mpf(int(p[0])) + mp.mpf(int(p[1]))) / 2),
+                constant(lambda p: (mp.mpf(_discrete_uniform_n(p)) ** 2 - 1) / 12),
+                constant(lambda p: (mp.mpf(int(p[0])) + mp.mpf(int(p[1]))) / 2),
+                constant(lambda p: mp.log(_discrete_uniform_n(p))),
+                CLOSED_FORM_RTOL,
             ),
         ),
     )


### PR DESCRIPTION
## Summary

Adds `DiscreteUniform(min, max)` — the discrete uniform over the integers `{min, ..., max}`, with **both bounds inclusive**, wrapping `statrs::distribution::DiscreteUniform`. Equivalent to `scipy.stats.randint(low=min, high=max + 1)`; the inclusive-vs-exclusive `max` is called out in bold in the class docstring and the catalogue row, per the issue.

Closes #62.

## Design decisions from the issue

- **Integer coercion: option 1.** A new `coerce_int` helper beside `coerce_param` / `coerce_n` (dtype `Int64`, integer types only, no value guard at construction) — signed bounds are legitimate here and likely for later distributions (`NegativeBinomial`, `Hypergeometric`), so the funnel belongs in `_base.py`. Commented on the issue before starting.
- **Entropy lives in Python** as the elementary `log(N)`; statrs implements none.
- **Median is the midpoint** `(min + max) / 2` per the issue's convention — a documented divergence from scipy's `ppf(0.5)`-based median, which lands on a support point for even-width supports.

## Implementation notes

- Rust surface is sampler-only (`Int64` draws via statrs' `Distribution<i64>`, plus scalar fast paths and a new `samples_i64_output` / `DrawValue for i64` in `rng.rs`) plus the `discreteuniform_range` validator returning the support count `N = max - min + 1` with an `i128`-computed overflow guard. Every closed form divides by that count.
- `_ppf` replicates scipy's `randint._ppf` **including its correction step** (`vals1 = clip(vals - 1); where(cdf(vals1) >= q, vals1, vals)`), so parity holds to exact integer equality across half-ulp perturbations of every cdf step edge, not just a tolerance band.
- `_isf` is a direct closed form (`max - floor(q*N)`, clamped), not the base `ppf(1 - q)`: the complement's rounding flips whole support points on this distribution.
- `_cdf`/`_sf` multiply by a materialised `1 / N` rather than dividing: polars evaluates a division by a broadcast scalar through a different kernel than column-by-column (reciprocal-multiply under the in-memory engine), and the two disagreed in the last bit. The same concern shapes `_ppf`, whose correction needs the honestly-rounded quotient — it consumes a **row-aligned** validator output (`discreteuniform_range_rowwise`, aligned against the row index inside the plugin per the house alignment rule).
- Null propagation through every `when` chain is explicit (the issue's trap #4): a null bound turns the support test's *condition* null, so the off-support fallback would silently answer `0`/`-inf`; each chain re-checks `n.is_not_null()` to route those rows back to null. Pinned per-method on both engines.

## Known divergences from scipy

- `median` is the midpoint, not `ppf(0.5)` (issue convention).
- `ppf(0)` / `isf(1)` clamp to the support floor instead of scipy's below-support sentinel `low - 1`.
- `min == max` (the one-point mass) is valid here; scipy's own moment internals divide by zero there, so the parity sweep excludes it (unit tests cover it).

## Validation

- New tests: `tests/distributions/discrete_uniform/` (18 files) + `tests/scipy_parity/discrete_uniform_test.py`; entries in all five shared registries.
- Full suite: **3891 passed under both `POLARS_ENGINE_AFFINITY=in-memory` and `streaming`**, coverage 99.5%+.
- `tools/accuracy_audit.py`: mpmath oracles at 50 digits across 8 parameter regimes (negative bounds, one-point mass, two-point support, wide spans): **4208 probes, 0 non-OK**. Geometric regression audit also clean.
- `make lint` equivalents (ruff/rumdl/ryl/cargo fmt/clippy) and typing (pyrefly/pyright/mypy) all green; benchmark registry entry included (`sample` runs ~3.6x faster than scipy).
