### PR TITLE
refactor: Define one shared expm1 identity, not three copies

### DIFF
--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, ClassVar
 
@@ -237,6 +238,40 @@ def propagate_null_and_nan(value: pl.Expr, result: pl.Expr) -> pl.Expr:
     guarded = pl.when(value.is_null()).then(pl.lit(None)).when(value.is_nan()).then(float("nan")).otherwise(result)
     name = value.meta.output_name(raise_if_undetermined=False)
     return guarded if name is None else guarded.alias(name)
+
+
+_LN_2 = math.log(2.0)
+"""`log(2)`, the leading term of `log_abs_expm1`."""
+
+
+def expm1(t: pl.Expr) -> pl.Expr:
+    """`exp(t) - 1`, spelled so that the subtraction never cancels.
+
+    Polars exposes no `expm1`, and the literal `exp(t) - 1` cancels to `0` below `|t| ~ 1.1e-16`. The
+    identity `exp(t) - 1 = 2 exp(t / 2) sinh(t / 2)` has no subtraction and holds for either sign of
+    `t`.
+
+    `sinh(t / 2)` overflows above `|t| ~ 1420`. For `t > 0` that is moot: the true `exp(t) - 1`
+    overflows at `t ~ 710`, so the identity fails no earlier than the answer does. For `t < 0` the
+    answer is within an ulp of `-1` long before `-1420`, so reaching the far tail needs a cut-over to
+    a direct form; callers on that side pick their own crossover.
+    """
+    half = t / 2
+    return 2 * half.exp() * half.sinh()
+
+
+def log_abs_expm1(t: pl.Expr) -> pl.Expr:
+    """`log|exp(t) - 1|`, the log of `expm1` without forming it.
+
+    `log(2) + t / 2 + log|sinh(t / 2)|`, which is `expm1`'s identity read term by term on the log
+    scale. Each term is large exactly where the answer is large, so the rounding stays relative;
+    `expm1(t).log()` would instead round the answer's own magnitude away.
+
+    The absolute value carries both signs of `t`: a no-op for `t > 0`, and for `t < 0` it makes this
+    the log of the complement `1 - exp(t)`. The overflow and cut-over limits of `expm1` are unchanged.
+    """
+    half = t / 2
+    return _LN_2 + half + half.sinh().abs().log()
 
 
 class _UnivariateDistribution(ABC):

--- a/polars_stats/distributions/_exponential.py
+++ b/polars_stats/distributions/_exponential.py
@@ -8,6 +8,7 @@ import polars as pl
 from polars_stats.distributions._base import (
     ContinuousDistribution,
     coerce_param,
+    expm1,
     scalar_float,
     scalar_kwargs,
 )
@@ -15,8 +16,8 @@ from polars_stats.distributions._base import (
 if TYPE_CHECKING:
     from polars_stats._typing import IntoExprColumn
 
-_CDF_SINH_MAX_HALF = 0.5
-"""Crossover of `Exponential._cdf`, in units of `rate * x / 2`.
+_CDF_SINH_MAX = 1.0
+"""Crossover of `Exponential._cdf`, in units of `rate * x`.
 
 Above `rate * x = 1` the plain `1 - exp(-t)` is already exact, and the `sinh` identity that replaces
 it below would overflow past `t ~ 1420`. The two branches agree to `1e-16` here.
@@ -86,20 +87,12 @@ class Exponential(ContinuousDistribution):
     def _cdf(self, value: pl.Expr) -> pl.Expr:
         """``1 - exp(-rate * x)`` on ``x >= 0``, ``0`` for ``x < 0``, keeping the left tail exact.
 
-        Polars exposes no ``expm1``, and ``1 - exp(-t)`` cancels to ``0`` below ``t ~ 1.1e-16``.
-        The identity ``1 - exp(-t) = 2 exp(-t / 2) sinh(t / 2)`` has no subtraction and is spellable
-        with what Polars does expose, so the small branch keeps full relative precision. ``sinh``
-        overflows above ``t ~ 1420``, hence the split at ``t = 1``, where the plain form is already
-        exact; the two agree to ``1e-16`` at the crossover.
+        ``1 - exp(-t)`` cancels to ``0`` below ``t ~ 1.1e-16``, so the small branch reads it as
+        ``-expm1(-t)``. ``sinh`` overflows above ``t ~ 1420``, hence the split at `_CDF_SINH_MAX`,
+        where the plain form is already exact; the two agree to ``1e-16`` at the crossover.
         """
-        half = self._checked_rate * value / 2
-        return (
-            pl.when(value < 0)
-            .then(0.0)
-            .when(half < _CDF_SINH_MAX_HALF)
-            .then(2 * (-half).exp() * half.sinh())
-            .otherwise(1 - (-2 * half).exp())
-        )
+        t = self._checked_rate * value
+        return pl.when(value < 0).then(0.0).when(t < _CDF_SINH_MAX).then(-expm1(-t)).otherwise(1 - (-t).exp())
 
     def _log_cdf(self, value: pl.Expr) -> pl.Expr:
         """``log(cdf)`` in the left tail, ``log1p(-sf)`` in the right; ``-inf`` for ``x <= 0``.

--- a/polars_stats/distributions/_geometric.py
+++ b/polars_stats/distributions/_geometric.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 from typing import TYPE_CHECKING, ClassVar
 
 import polars as pl
@@ -8,15 +7,14 @@ import polars as pl
 from polars_stats.distributions._base import (
     DiscreteDistribution,
     coerce_param,
+    expm1,
+    log_abs_expm1,
     scalar_float,
     scalar_kwargs,
 )
 
 if TYPE_CHECKING:
     from polars_stats._typing import IntoExprColumn
-
-_LN_2 = math.log(2.0)
-"""The constant in the `expm1` identity `Geometric._cdf` and `Geometric._log_cdf` are spelled through."""
 
 _CDF_DIRECT_COMPLEMENT_MAX = -20.0
 """Crossover of `Geometric._cdf`, in units of `log(sf)`.
@@ -146,17 +144,13 @@ class Geometric(DiscreteDistribution):
     def _cdf(self, value: pl.Expr) -> pl.Expr:
         """``0`` below the support, else ``-expm1(log_tail)``.
 
-        Polars has no ``expm1``, so it is spelled through the identity
-        ``expm1(t) = 2 exp(t / 2) sinh(t / 2)``, and read directly as ``1 - exp(t)`` past
-        `_CDF_DIRECT_COMPLEMENT_MAX`. The literal ``1 - (1 - p)**k`` would instead inherit the
-        rounding of both ``1 - p`` and the subtraction against ``1``.
+        Below `_CDF_DIRECT_COMPLEMENT_MAX` it is read directly as ``1 - exp(log_tail)``. The literal
+        ``1 - (1 - p)**k`` would instead inherit the rounding of both ``1 - p`` and the subtraction
+        against ``1``.
         """
         log_tail = self._log_tail(value)
-        half = log_tail / 2
         complement = (
-            pl.when(log_tail <= _CDF_DIRECT_COMPLEMENT_MAX)
-            .then(1.0 - log_tail.exp())
-            .otherwise(-2.0 * half.exp() * half.sinh())
+            pl.when(log_tail <= _CDF_DIRECT_COMPLEMENT_MAX).then(1.0 - log_tail.exp()).otherwise(-expm1(log_tail))
         )
         return pl.when(value < 1).then(0.0).otherwise(self._when_p_valid(complement))
 
@@ -165,15 +159,12 @@ class Geometric(DiscreteDistribution):
 
         Two regimes, split at `_LOG_CDF_LOG1P_MAX` where the answer's own magnitude stops dwarfing
         the absolute granularity of the pieces. Below it ``log1p`` carries the difference from ``1``
-        exactly; above it the `_cdf` pieces assemble on the log scale, each one large precisely where
-        the answer is large, so their rounding stays relative.
+        exactly; above it `log_abs_expm1` assembles the answer on the log scale, keeping the rounding
+        relative.
         """
         log_tail = self._log_tail(value)
-        half = log_tail / 2
         log_complement = (
-            pl.when(log_tail <= _LOG_CDF_LOG1P_MAX)
-            .then((-log_tail.exp()).log1p())
-            .otherwise(_LN_2 + half + (-half.sinh()).log())
+            pl.when(log_tail <= _LOG_CDF_LOG1P_MAX).then((-log_tail.exp()).log1p()).otherwise(log_abs_expm1(log_tail))
         )
         return pl.when(value < 1).then(float("-inf")).otherwise(self._when_p_valid(log_complement))
 

--- a/polars_stats/distributions/_lognormal.py
+++ b/polars_stats/distributions/_lognormal.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, ClassVar
 from polars_stats.distributions._base import (
     ContinuousDistribution,
     coerce_param,
+    expm1,
+    log_abs_expm1,
     scalar_float,
     scalar_kwargs,
 )
@@ -18,9 +20,6 @@ if TYPE_CHECKING:
 
 _TWO_PI_E = math.tau * math.e
 """2 * pi * e, the constant inside the log-normal's differential entropy `mu + 0.5 * log(2 * pi * e * sigma^2)`."""
-
-_LN_2 = math.log(2.0)
-"""`log(2)`, the constant in the `expm1` identity below."""
 
 
 class LogNormal(ContinuousDistribution):
@@ -115,7 +114,7 @@ class LogNormal(ContinuousDistribution):
 
     @property
     def _half_sigma_sq(self) -> pl.Expr:
-        """``sigma ** 2 / 2``, the argument both moment identities below are written in."""
+        """``sigma ** 2 / 2``, the exponent `mean` and `std` are written in."""
         return self._sigma**2 / 2
 
     def mean(self) -> pl.Expr:
@@ -125,13 +124,11 @@ class LogNormal(ContinuousDistribution):
     def variance(self) -> pl.Expr:
         """Variance, ``(exp(sigma ** 2) - 1) * exp(2 * mu + sigma ** 2)``.
 
-        The leading factor is spelled ``2 * exp(t / 2) * sinh(t / 2)``, which is ``expm1(t)``
-        identically. Polars has no ``expm1``, and the literal ``exp(t) - 1`` cancels for a small
-        ``sigma``. The identity holds full precision on both sides and overflows no earlier than the
-        result does.
+        The leading factor goes through `expm1`, since the literal ``exp(sigma ** 2) - 1`` cancels
+        for a small ``sigma``. It needs no cut-over: the argument is positive, so the identity
+        overflows no earlier than the result does.
         """
-        half = self._half_sigma_sq
-        return self._moment(2 * half.exp() * half.sinh() * (2 * self._mu + self._sigma**2).exp())
+        return self._moment(expm1(self._sigma**2) * (2 * self._mu + self._sigma**2).exp())
 
     def std(self) -> pl.Expr:
         """Standard deviation, ``exp(0.5 * log(exp(sigma ** 2) - 1) + mu + sigma ** 2 / 2)``.
@@ -144,7 +141,7 @@ class LogNormal(ContinuousDistribution):
         at a large ``sigma``, because one is representable and the other is not.
         """
         half = self._half_sigma_sq
-        return self._moment((0.5 * (_LN_2 + half + half.sinh().log()) + self._mu + half).exp())
+        return self._moment((0.5 * log_abs_expm1(self._sigma**2) + self._mu + half).exp())
 
     def median(self) -> pl.Expr:
         """Median, ``exp(mu)``."""


### PR DESCRIPTION
Moves the `2 exp(t/2) sinh(t/2)` spelling of `expm1` and its log form into `_base.py` as `expm1` / `log_abs_expm1`, replacing three independent copies of the identity and two copies of `log(2)`.

