### PR TITLE
feat: readable `__repr__` on the distribution classes

### DIFF
--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 import math
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, ClassVar
@@ -316,12 +315,19 @@ class _UnivariateDistribution(ABC):
     def __repr__(self) -> str:
         """One line shaped like the constructor call, e.g.: `Normal(mu=0.0, sigma=col("s"))`.
 
-        Names come from the subclass's `__init__` signature, values from `str` of each `_param_exprs`
-        entry, so a new distribution needs no per-class code.
+        All-constant parameters render from `_scalar_kwargs`, keyed by the constructor's own parameter
+        names, so the values stay exact. With any column-valued parameter that dict is `None` and each
+        value becomes `str` of its `_param_exprs` entry, polars' one-line display, under names read
+        positionally off the `__init__` signature.
         """
         cls = type(self)
-        _self, *names = inspect.signature(cls.__init__).parameters
-        params = ", ".join(f"{name}={expr!s}" for name, expr in zip(names, self._param_exprs, strict=True))
+        if (scalars := self._scalar_kwargs) is not None:
+            params = ", ".join(f"{name}={value}" for name, value in scalars.items())
+        else:
+            import inspect  # noqa: PLC0415
+
+            _self, *names = inspect.signature(cls.__init__).parameters
+            params = ", ".join(f"{name}={expr!s}" for name, expr in zip(names, self._param_exprs, strict=True))
         return f"{cls.__name__}({params})"
 
     def sample(self, seed: int | None = None) -> pl.Expr:

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import math
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, ClassVar
@@ -311,6 +312,17 @@ class _UnivariateDistribution(ABC):
         pinned by `output_name_test.py`), and the Rust side reads them positionally.
         Constant parameters additionally ride in `_scalar_kwargs` for the fast path.
         """
+
+    def __repr__(self) -> str:
+        """One line shaped like the constructor call, e.g.: `Normal(mu=0.0, sigma=col("s"))`.
+
+        Names come from the subclass's `__init__` signature, values from `str` of each `_param_exprs`
+        entry, so a new distribution needs no per-class code.
+        """
+        cls = type(self)
+        _self, *names = inspect.signature(cls.__init__).parameters
+        params = ", ".join(f"{name}={expr!s}" for name, expr in zip(names, self._param_exprs, strict=True))
+        return f"{cls.__name__}({params})"
 
     def sample(self, seed: int | None = None) -> pl.Expr:
         """Draw one random variate per row.

--- a/tests/_polars_compat.py
+++ b/tests/_polars_compat.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from polars import Series
 
 __all__ = (
+    "LITERAL_DISPLAYS_AS_VALUE",
     "PARTITIONED_BROADCAST_AVAILABLE",
     "arr_explode",
     "assert_series_equal",
@@ -39,6 +40,20 @@ _NEEDS_RENAMING = Version("1.32.3") > PL_VERSION
 _REL_NAME = "rtol" if _NEEDS_RENAMING else "rel_tol"
 _ABS_NAME = "atol" if _NEEDS_RENAMING else "abs_tol"
 _EXPLODE_HAS_EMPTY_AS_NULL = Version("1.36.0") <= PL_VERSION
+
+LITERAL_DISPLAYS_AS_VALUE = Version("1.36.1") <= PL_VERSION
+"""Whether `str()` of a dtype-typed literal expression is just the value.
+
+`coerce_param` builds every constant parameter as `pl.lit(value, dtype=...)`. Through polars 1.35.2 that
+is a dyn literal plus a cast, and `str` shows the whole tree (`dyn float: 1.0.strict_cast(Float64)`); from
+1.36.1 the literal carries the dtype and `str` gives `1.0`. 1.36.0 is yanked, so 1.36.1 is the first
+installable version with the new form.
+
+Only a *mixed* parameterisation is affected: with every parameter constant, `__repr__` renders from
+`_scalar_kwargs` and never consults polars' display. `col("m")` and `Series[lo]` are identical on every
+supported version. When the polars floor reaches 1.36.1 this constant and its gate can be deleted.
+"""
+
 
 PARTITIONED_BROADCAST_AVAILABLE = Version("1.34.0") <= PL_VERSION
 """Whether polars handles a length-1 input *inside* `over` / `group_by().agg()` correctly.

--- a/tests/distributions/repr_test.py
+++ b/tests/distributions/repr_test.py
@@ -8,6 +8,7 @@ import polars as pl
 import pytest
 
 import polars_stats as ps
+from tests._polars_compat import LITERAL_DISPLAYS_AS_VALUE
 from tests.property._specs import ALL_SPECS
 
 if TYPE_CHECKING:
@@ -46,18 +47,31 @@ def test_column_parameters_repr_without_an_address(spec: DistSpec) -> None:
 
 
 def test_documented_forms() -> None:
-    """One exact string per kind of parameter a constructor accepts."""
+    """One exact string per kind of parameter a constructor accepts, on every supported polars."""
     assert repr(ps.Normal(0.0, 1.0)) == "Normal(mu=0.0, sigma=1.0)"
     assert repr(ps.Normal()) == "Normal(mu=0.0, sigma=1.0)"
     assert repr(ps.Binomial(10, 0.5)) == "Binomial(n=10, p=0.5)"
-    assert repr(ps.Normal(pl.col("m"), 1.0)) == 'Normal(mu=col("m"), sigma=1.0)'
     assert repr(ps.Normal("m", "s")) == 'Normal(mu=col("m"), sigma=col("s"))'
+
+
+@pytest.mark.skipif(not LITERAL_DISPLAYS_AS_VALUE, reason="polars < 1.36.1 renders a typed literal with its cast")
+def test_documented_forms_with_a_mixed_parameterisation() -> None:
+    """A constant beside a column-valued parameter renders through polars, not through `_scalar_kwargs`.
+
+    One column-valued parameter collapses `_scalar_kwargs` to `None`, so the constant takes the
+    expression path and inherits polars' display form for a typed literal, which changed in 1.36.1.
+    """
+    assert repr(ps.Normal(pl.col("m"), 1.0)) == 'Normal(mu=col("m"), sigma=1.0)'
     assert repr(ps.Uniform(pl.Series("lo", [0.0, 1.0]), 2.0)) == "Uniform(min=Series[lo], max=2.0)"
 
 
 def test_disagreeing_constructor_and_param_exprs_raise(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A length mismatch between `__init__` and `_param_exprs` raises instead of mislabelling parameters."""
-    dist = ps.Normal(0.0, 1.0)
+    """A length mismatch between `__init__` and `_param_exprs` raises instead of mislabelling parameters.
+
+    Column-valued so the expression path runs: an all-constant distribution renders from
+    `_scalar_kwargs`, which is keyed by name and never reads `_param_exprs`.
+    """
+    dist = ps.Normal(pl.col("m"), pl.col("s"))
     monkeypatch.setattr(type(dist), "_param_exprs", property(lambda self: (self._mu,)))
 
     with pytest.raises(ValueError, match="argument 2 is shorter"):

--- a/tests/distributions/repr_test.py
+++ b/tests/distributions/repr_test.py
@@ -1,0 +1,77 @@
+"""`__repr__` contract: every distribution shows as a one-line constructor call."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+
+import polars_stats as ps
+from tests.property._specs import ALL_SPECS
+
+if TYPE_CHECKING:
+    from tests.property._specs import DistSpec
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+def test_scalar_parameters_repr_as_their_values(spec: DistSpec) -> None:
+    """`ClassName(name=value, ...)`, one line, one `name=value` per constant parameter."""
+    dist = spec.make(spec.example)
+    got = repr(dist)
+
+    assert "\n" not in got
+    assert got.startswith(f"{type(dist).__name__}(")
+    assert got.endswith(")")
+
+    assert dist._scalar_kwargs is not None
+    for name, value in dist._scalar_kwargs.items():
+        assert f"{name}={value}" in got
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+def test_column_parameters_repr_without_an_address(spec: DistSpec) -> None:
+    """A column-valued parameter defers to the expression's own one-line form.
+
+    `repr(pl.Expr)` carries the object's memory address, so the `0x` assertion keeps a
+    column-parameterised distribution's repr deterministic.
+    """
+    dist = spec.make_columns(spec.example)
+    got = repr(dist)
+
+    assert "\n" not in got
+    assert "0x" not in got
+    assert got.startswith(f"{type(dist).__name__}(")
+    assert got.endswith(")")
+
+
+def test_documented_forms() -> None:
+    """One exact string per kind of parameter a constructor accepts."""
+    assert repr(ps.Normal(0.0, 1.0)) == "Normal(mu=0.0, sigma=1.0)"
+    assert repr(ps.Normal()) == "Normal(mu=0.0, sigma=1.0)"
+    assert repr(ps.Binomial(10, 0.5)) == "Binomial(n=10, p=0.5)"
+    assert repr(ps.Normal(pl.col("m"), 1.0)) == 'Normal(mu=col("m"), sigma=1.0)'
+    assert repr(ps.Normal("m", "s")) == 'Normal(mu=col("m"), sigma=col("s"))'
+    assert repr(ps.Uniform(pl.Series("lo", [0.0, 1.0]), 2.0)) == "Uniform(min=Series[lo], max=2.0)"
+
+
+def test_disagreeing_constructor_and_param_exprs_raise(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A length mismatch between `__init__` and `_param_exprs` raises instead of mislabelling parameters."""
+    dist = ps.Normal(0.0, 1.0)
+    monkeypatch.setattr(type(dist), "_param_exprs", property(lambda self: (self._mu,)))
+
+    with pytest.raises(ValueError, match="argument 2 is shorter"):
+        repr(dist)
+
+
+def test_no_value_equality_or_hash() -> None:
+    """Instances keep identity semantics.
+
+    Two instances parameterised by `pl.Expr` cannot be compared without evaluating them against a
+    frame, so `__eq__` / `__hash__` are deliberately not defined.
+    """
+    left, right = ps.Normal(0.0, 1.0), ps.Normal(0.0, 1.0)
+
+    assert left != right
+    # Hashed by identity, so a set keeps both.
+    assert len({left, right}) == len([left, right])


### PR DESCRIPTION
Closes #21 