### PR TITLE
feat: validate `seed` and `size` at call time in `sample(s)`

### DIFF
--- a/docs/reference/parameters-and-contracts.md
+++ b/docs/reference/parameters-and-contracts.md
@@ -88,7 +88,13 @@ A violation raises `ComputeError` and fails the whole evaluation. See
 ## Sampling
 
 `sample(seed)` returns one variate per row; `samples(size, seed)` returns `Array(inner=<element dtype>, shape=size)`.
-A `size <= 0` raises `ValueError` at call time.
+Both arguments are checked at call time. A `size <= 0` raises `ValueError`, and so does a `seed` outside
+`[0, 2**63)`. The seed crosses FFI as a pickled kwarg that Rust decodes as `i64`, one bit short of the `u64` it
+is read into, so polars' own `Expr.sample` takes seeds this library refuses. A `seed` or `size` that is not an
+`int` raises `TypeError`, `bool` and `numpy.int64` included.
+
+`size` has no maximum. A call allocates `rows * size` elements up front, so an oversized `size` fails in the
+allocator rather than in a guard, and a large enough one kills the process instead of raising.
 
 Element dtype is per distribution and is not normalised to `Float64`:
 

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, TypeGuard
 
 import polars as pl
 from polars.exceptions import PolarsError
@@ -73,6 +73,16 @@ def row_index_expr(params: Iterable[pl.Expr]) -> pl.Expr:
     return pl.int_range(0, pl.max_horizontal(pl.len(), *spans), dtype=pl.UInt64).alias(_ROW_INDEX_NAME)
 
 
+def _is_number(value: object) -> TypeGuard[int | float]:
+    """Whether `value` is a plain `int` or `float`. A `bool` is neither, though it subclasses `int`."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _is_int(value: object) -> TypeGuard[int]:
+    """Whether `value` is a plain `int`, with the `bool` exclusion `_is_number` makes."""
+    return _is_number(value) and isinstance(value, int)
+
+
 def _coerce(
     value: float | IntoExprColumn,
     *,
@@ -112,7 +122,7 @@ def _coerce(
         return pl.col(value)
     if isinstance(value, pl.Series):
         return pl.lit(value)
-    if isinstance(value, scalar_types) and not isinstance(value, bool):
+    if _is_number(value) and isinstance(value, scalar_types):
         return pl.lit(value, dtype=dtype)
     msg = f"{name} should be {scalar_label} or IntoExprColumn (pl.Expr, str, pl.Series), found {type(value)}"
     raise TypeError(msg)
@@ -127,21 +137,15 @@ def coerce_param(value: float | IntoExprColumn, *, name: str) -> pl.Expr:
     return _coerce(value, name=name, scalar_label="a float", scalar_types=float, dtype=pl.Float64())
 
 
-_MAX_SCALAR_COUNT = 2**63 - 1
-"""Largest count a *constant* `n` may take, which is `i64::MAX` rather than the `u64::MAX` Rust reads.
-
-The constant-parameter fast paths pass `n` as a plugin kwarg, and kwargs cross FFI as pickle, whose
-integers are `i64`. A larger constant would decode into some methods and not others (`mean` rides as a
-`pl.lit` input rather than a kwarg), so it is refused at construction instead. A column has no such
-limit: Rust widens it to `UInt64` and the whole range is a valid trial count.
-"""
+_MAX_WIRE_INT = 2**63 - 1
+"""Largest integer that reaches a plugin, `i64::MAX`: kwargs cross FFI as pickle, whose integers are `i64`."""
 
 
 def coerce_n(value: int | IntoExprColumn, *, name: str = "n") -> pl.Expr:
     """Coerce an integer count parameter (e.g. binomial trial count `n`) into a `pl.Expr`.
 
     Accepts a Python `int` or an `IntoExprColumn`; a `bool` (an `int` subclass, but not a sensible count),
-    a `float`, or any other type raises `TypeError`. An `int` outside `[0, _MAX_SCALAR_COUNT]` raises
+    a `float`, or any other type raises `TypeError`. An `int` outside `[0, _MAX_WIRE_INT]` raises
     `ValueError`, the one parameter *value* judged at construction rather than at evaluation, because the
     scalar literal is `UInt64` (the dtype the Rust plugins read `n` as) and polars would otherwise refuse
     it with a message about `i64` and `u64`. A column keeps its dtype until Rust widens it to `UInt64`,
@@ -151,8 +155,8 @@ def coerce_n(value: int | IntoExprColumn, *, name: str = "n") -> pl.Expr:
         if trials < 0:
             msg = f"{name} must be a non-negative integer, got {trials}"
             raise ValueError(msg)
-        if trials > _MAX_SCALAR_COUNT:
-            msg = f"{name} must be at most {_MAX_SCALAR_COUNT} as a Python int, got {trials}: pass a column instead"
+        if trials > _MAX_WIRE_INT:
+            msg = f"{name} must be at most {_MAX_WIRE_INT} as a Python int, got {trials}: pass a column instead"
             raise ValueError(msg)
     return _coerce(value, name=name, scalar_label="an int", scalar_types=int, dtype=pl.UInt64())
 
@@ -165,7 +169,7 @@ def scalar_float(value: float | IntoExprColumn) -> float | None:
     than as a length-1 input the plugin must broadcast (see `_coerce`). `bool` is an `int` subclass
     but never a valid parameter, so it is excluded and falls back to the per-row path.
     """
-    return float(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else None
+    return float(value) if _is_number(value) else None
 
 
 def scalar_int(value: int | IntoExprColumn) -> int | None:
@@ -173,7 +177,7 @@ def scalar_int(value: int | IntoExprColumn) -> int | None:
 
     The integer-count counterpart to `scalar_float` (e.g. binomial `n`), for the same fast-path routing.
     """
-    return value if isinstance(value, int) and not isinstance(value, bool) else None
+    return value if _is_int(value) else None
 
 
 def scalar_kwargs(**params: float | None) -> dict[str, float | int] | None:
@@ -198,6 +202,32 @@ def as_expr(value: float | IntoExprColumn) -> pl.Expr:
     A `bool` or other non-numeric type raises `TypeError`. See `_coerce` for the coercion rules.
     """
     return _coerce(value, name="value", scalar_label="a number (int or float)", scalar_types=(int, float))
+
+
+def _checked_int(value: object, *, name: str, expected: str = "an int") -> int:
+    """Return `value` if it is a plain `int`, else raise `TypeError` naming what arrived instead."""
+    if _is_int(value):
+        return value
+    msg = f"{name} should be {expected}, found {type(value)}"
+    raise TypeError(msg)
+
+
+def _checked_seed(seed: object) -> int | None:
+    """Return a sampler `seed` the plugin kwargs can carry to Rust, or `None` for OS entropy."""
+    if seed is None:
+        return None
+    if not 0 <= (seed := _checked_int(seed, name="seed", expected="an int or None")) <= _MAX_WIRE_INT:
+        msg = f"seed must be in [0, 2**63), got {seed}"
+        raise ValueError(msg)
+    return seed
+
+
+def _checked_size(size: object) -> int:
+    """Return a positive draw count. There is no maximum: an oversized one dies in the allocator, not here."""
+    if (size := _checked_int(size, name="size")) <= 0:
+        msg = f"size must be a positive integer, got {size}"
+        raise ValueError(msg)
+    return size
 
 
 def register_plugin(
@@ -344,6 +374,7 @@ class _UnivariateDistribution(ABC):
         parameter the name follows the first parameter expression (polars root-name semantics, so
         `.name.*` modifiers keep working).
         """
+        seed = _checked_seed(seed)
         if self._scalar_kwargs is not None:
             return register_plugin(
                 f"{self._plugin_prefix}_sample_scalar",
@@ -369,10 +400,7 @@ class _UnivariateDistribution(ABC):
         Naming follows `sample`: `"samples"` with all-constant parameters, the first parameter
         expression's root name otherwise.
         """
-        if size <= 0:
-            msg = f"size must be a positive integer, got {size}"
-            raise ValueError(msg)
-        out = self._samples(size=size, seed=seed)
+        out = self._samples(size=_checked_size(size), seed=_checked_seed(seed))
         return out.alias("samples") if self._scalar_kwargs is not None else out
 
     def _samples(self, size: int, seed: int | None = None) -> pl.Expr:

--- a/tests/distributions/sampler_args_test.py
+++ b/tests/distributions/sampler_args_test.py
@@ -1,0 +1,125 @@
+"""Call-time contract of the two sampler kwargs, `seed` and `size`."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import numpy as np
+import polars as pl
+import pytest
+from polars.exceptions import ComputeError
+
+import polars_stats as ps
+from polars_stats.distributions._base import _MAX_WIRE_INT
+from tests.property._specs import ALL_SPECS
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from polars_stats.distributions._base import _UnivariateDistribution
+    from tests.property._specs import DistSpec
+
+    SamplingCallable = Callable[[_UnivariateDistribution, int | None], pl.Expr]
+
+_ROWS = 3
+_FRAME = pl.DataFrame({"_": range(_ROWS)})
+_SIZE = 2
+
+_SEED_RANGE_MESSAGE = r"seed must be in \[0, 2\*\*63\), got"
+_SEED_TYPE_MESSAGE = r"seed should be an int or None, found "
+
+_OUT_OF_RANGE = [-1, -(2**70), _MAX_WIRE_INT + 1, 2**64 - 1, 2**64, 2**70]
+"""A negative seed and one past the `i64` ceiling, since the guard has to catch both directions."""
+
+_NON_INTEGERS = [1.0, 1.5, True, "7", np.int64(5)]
+"""Every non-`int` a `seed` or `size` arrives as, including `True` and `np.int64(5)`, which pass a range check."""
+
+
+_CALLS: dict[str, SamplingCallable] = {
+    "sample": lambda dist, seed: dist.sample(seed=seed),
+    "samples": lambda dist, seed: dist.samples(size=_SIZE, seed=seed),
+}
+"""The two public samplers, the only two entry points that take a seed."""
+
+
+@pytest.mark.parametrize("call", _CALLS.values(), ids=_CALLS.keys())
+@pytest.mark.parametrize("path", ["scalar", "column"])
+@pytest.mark.parametrize("seed", _OUT_OF_RANGE)
+def test_an_out_of_range_seed_raises_at_call_time(seed: int, path: str, call: SamplingCallable) -> None:
+    """`ValueError` from building the expression, before any frame is touched."""
+    dist = ps.Normal(0.0, 1.0) if path == "scalar" else ps.Normal("m", "s")
+
+    with pytest.raises(ValueError, match=_SEED_RANGE_MESSAGE):
+        call(dist, seed)
+
+
+@pytest.mark.parametrize("call", _CALLS.values(), ids=_CALLS.keys())
+@pytest.mark.parametrize("path", ["scalar", "column"])
+@pytest.mark.parametrize("seed", _NON_INTEGERS, ids=[type(seed).__name__ for seed in _NON_INTEGERS])
+def test_a_non_integer_seed_raises_at_call_time(seed: object, path: str, call: SamplingCallable) -> None:
+    """`TypeError`, not the `ValueError` an out-of-range seed gets, and not a serde error at collect."""
+    dist = ps.Normal(0.0, 1.0) if path == "scalar" else ps.Normal("m", "s")
+
+    # `seed: int | None` is what the type checkers enforce; the cast is how this test reaches the
+    # callers who get past them.
+    with pytest.raises(TypeError, match=_SEED_TYPE_MESSAGE):
+        call(dist, cast("int | None", seed))
+
+
+def test_the_message_names_the_seed_it_rejected() -> None:
+    """The offending value is in the message, so a computed seed is identifiable without a debugger."""
+    with pytest.raises(ValueError, match=r"seed must be in \[0, 2\*\*63\), got -1$"):
+        ps.Normal(0.0, 1.0).sample(seed=-1)
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@pytest.mark.parametrize("call", _CALLS.values(), ids=_CALLS.keys())
+@pytest.mark.parametrize("path", ["scalar", "column"])
+def test_the_largest_accepted_seed_reaches_every_sampler_plugin(
+    spec: DistSpec, path: str, call: SamplingCallable
+) -> None:
+    """`_MAX_WIRE_INT` passes the guard *and* decodes on the wire, on all four plugin shapes."""
+    dist = spec.make(spec.example) if path == "scalar" else spec.make_columns(spec.example)
+
+    out = _FRAME.select(s=call(dist, _MAX_WIRE_INT))["s"]
+
+    assert out.len() == _ROWS
+    assert out.null_count() == 0
+
+
+@pytest.mark.parametrize("call", _CALLS.values(), ids=_CALLS.keys())
+def test_no_seed_is_still_accepted(call: SamplingCallable) -> None:
+    """`seed=None` means OS entropy, not an out-of-range seed."""
+    out = _FRAME.select(s=call(ps.Normal(0.0, 1.0), None))["s"]
+
+    assert out.len() == _ROWS
+    assert out.null_count() == 0
+
+
+def test_the_bound_is_the_wire_limit_not_a_chosen_one() -> None:
+    """One past `_MAX_WIRE_INT` really is undeliverable, so the guard is no stricter than it must be."""
+    expr = ps.Normal(0.0, 1.0)._samples(size=1, seed=_MAX_WIRE_INT + 1)
+
+    with pytest.raises(ComputeError, match="could not parse kwargs"):
+        _FRAME.select(expr)
+
+
+@pytest.mark.parametrize("seed", [None, 0])
+@pytest.mark.parametrize("size", _NON_INTEGERS, ids=[type(size).__name__ for size in _NON_INTEGERS])
+def test_a_non_integer_size_raises_at_call_time(size: object, seed: int | None) -> None:
+    """`TypeError`, and before `_checked_seed`, so a bad `size` is reported even with a good seed."""
+    with pytest.raises(TypeError, match=r"size should be an int, found "):
+        ps.Normal(0.0, 1.0).samples(size=cast("int", size), seed=seed)
+
+
+@pytest.mark.parametrize("size", [0, -1])
+def test_a_non_positive_size_still_raises_value_error(size: int) -> None:
+    """The pre-existing message is unchanged: eight per-distribution suites match on it."""
+    with pytest.raises(ValueError, match="size must be a positive integer"):
+        ps.Normal(0.0, 1.0).samples(size=size)
+
+
+def test_size_is_checked_before_seed() -> None:
+    """Argument order decides which of two bad arguments is reported, and it follows the signature."""
+    with pytest.raises(TypeError, match="size should be an int"):
+        ps.Normal(0.0, 1.0).samples(size=cast("int", 2.5), seed=-1)


### PR DESCRIPTION
A seed outside `[0, 2**63)`, or a seed/size that is not an int (`True` and `np.int64` included), used to cross FFI and fail at evaluation with a serde error naming neither the argument nor the bound. Both now raise `TypeError`/`ValueError` where the expression is built, and the `i64` wire ceiling is one shared constant (`_MAX_WIRE_INT`, also used by `coerce_n`) behind one pair of scalar predicates (`_is_number`/`_is_int`).
