### PR TITLE
release: v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "polars-stats"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "polars",
  "polars-arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars-stats"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 description = "Probability distributions as Polars expressions"
 license = "MIT"


### PR DESCRIPTION
Bumps `Cargo.toml` to 0.0.2. Tests run once, at tag time, per the release gating model.