### PR TITLE
refactor(benchmarks): add a parameter-regime axis, improve scipy runtime

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -2,15 +2,51 @@
 
 Manual comparison against `scipy.stats`, on speed and peak memory.
 
-It is **not** the CI regression guard, and nothing it produces is published today: the README and the
-docs deliberately carry no performance claims.
+This is **not** a CI regression guard, and nothing it produces is published today: the project README and `docs/`
+deliberately carry no performance claims. The goal of the comparison is to *locally* test for regressions or
+performance improvements tweaking the internals of an existing implementation.
 
-Two method families are compared:
+In the future, it might be used to report a comparison.
+
+Three method families are compared, one row per method in the `METHOD_SPECS` table in [_harness.py](_harness.py):
 
 * **sampling**: `sample` (one variate per row) and `samples` (`n_samples` per row) against `scipy.rvs`;
-* **value-keyed**: `density` (`pdf` / `pmf` by family), `cdf`, `sf` and `ppf` against the matching
-  frozen-scipy methods, both sides evaluating the same deterministic inputs (the distribution's own
-  seeded draws; uniform quantiles for `ppf`).
+* **value-keyed**: `density` (`pdf` / `pmf` by family), `log_density`, `cdf`, `log_cdf`, `sf`, `log_sf`, `ppf` and `isf`
+  against the matching frozen-scipy methods, both sides evaluating the same deterministic inputs
+  (the distribution's own seeded draws; uniform quantiles for `ppf` / `isf`);
+* **moments**: `mean`, `variance`, `std` and `entropy` against the frozen-scipy moments. These take no value column,
+  so whether they scale with `--rows` depends on the regime.
+
+## Parameter regimes
+
+Every cell is measured in one of three **regimes**, which is how the parameters are supplied.
+They are three different code paths on both sides, so a report labels every row with its regime:
+
+| regime      | `polars_stats` | `scipy`             | what it exercises |
+| ----------- | -------------- | ------------------- | ----------------- |
+| `scalar`    | Python numbers | plain scalars       | constant-parameter **fast path**: parameters validated once and passed as plugin kwargs |
+| `column`    | `pl.col(...)`  | length-`rows` array | the **general per-row path**, one parameter value per row |
+| `broadcast` | `pl.lit(...)`  | length-1 array      | the per-row path fed a length-1 input, which `align_inputs` broadcasts up to the call's row count |
+
+**Never compare a cell against one in another regime**: a `column` cell does strictly more work per row by design,
+so the comparison is meaningless and flattering in whichever direction you read it.
+The regime is part of every case's id and a column of every report so the two cannot be diffed by accident.
+Within a regime the comparison is fair, and `column` is the honest one to quote for a per-row workload.
+
+The regime also decides whether a **moment** is a throughput comparison: with `scalar` or `broadcast` parameters both
+sides return a single value and are O(1), so `--rows` does not scale the work: those cells track per-call overhead only,
+and the reported ratio is mostly `collect()` dispatch rather than moment arithmetic.
+With `column` parameters both sides return one value per row and are O(n).
+
+Before quoting a `column`-regime moment ratio, know what the scipy side is paying. The frozen API's
+own broadcast/validate/mask machinery dominates those cells, and `entropy` is worse: `rv_generic.entropy`
+always dispatches through `np.vectorize(self._entropy)`, *even when `_entropy` already handles arrays*.
+`beta._entropy` is a vectorised `_lazyselect` over four asymptotic branches, so scipy runs that whole
+machinery once per element, around what has been a closed form since scipy 1.11. That is why
+`beta.entropy` at 1M rows takes so long, and why that one cell is the single largest contributor to a
+full sweep's runtime.
+
+See "Keeping the scipy side native" below before reading anything into those numbers.
 
 ## Running
 
@@ -21,7 +57,9 @@ group, which provides the extra tooling (`cyclopts`, `rich`, `psutil`, plus `sci
 uv run --group benchmarks benchmarks/run.py  # all distributions, rich table in the terminal
 uv run --group benchmarks benchmarks/run.py normal binomial  # a subset of distributions
 uv run --group benchmarks benchmarks/run.py --methods sample density ppf  # a subset of methods
+uv run --group benchmarks benchmarks/run.py --regimes scalar column  # a subset of regimes
 uv run --group benchmarks benchmarks/run.py normal --rows 1_000_000 10_000_000 --n-samples 5 10 20  # sweep a grid
+uv run --group benchmarks benchmarks/run.py --memory  # also measure peak RSS (slow: a subprocess per cell per side)
 uv run --group benchmarks benchmarks/run.py --format markdown  # write benchmarks/results/<dist>.md
 uv run --group benchmarks benchmarks/run.py --format json  # write benchmarks/results/<dist>.json
 uv run --group benchmarks benchmarks/run.py --help
@@ -30,61 +68,132 @@ uv run --group benchmarks benchmarks/run.py --help
 | argument | default | meaning |
 | --- | --- | --- |
 | `distributions` (positional) | all | which distributions to compare, e.g. `normal binomial` |
-| `--methods` | all | which methods to compare: `sample`, `samples`, `density` (= `pdf`/`pmf`), `cdf`, `sf`, `ppf` |
+| `--methods` | all | which methods to compare: `sample`, `samples`, `density` (= `pdf`/`pmf`), `log_density`, `cdf`, `log_cdf`, `sf`, `log_sf`, `ppf`, `isf`, `mean`, `variance`, `std`, `entropy` |
+| `--regimes` | all | which parameter regimes to compare: `scalar`, `column`, `broadcast` |
 | `--rows` | `1_000_000` | one or more row counts to sweep; rows for every method |
 | `--n-samples` | `10` | one or more draws-per-row widths to sweep for `samples` |
-| `--iterations` | `50` | timed runs per cell; runtime reported as `p50 ± std` |
-| `--seed` | `0` | seed for the samplers and the value-keyed evaluation inputs (reproducible) |
+| `--max-iterations` | `50` | **upper bound** on timed runs per cell |
+| `--max-seconds` | `30.0` | wall-clock budget for one cell's timed loop |
+| `--min-iterations` | `3` | lower bound on timed runs per cell, applied even when the budget is up |
+| `--memory` | off | also measure peak RSS per cell per side, in an isolated subprocess |
+| `--seed` | `0` | seed for the samplers, the evaluation inputs and the parameter draws (reproducible) |
 | `--format` | `rich` | `rich` (coloured terminal table), `markdown`, or `json` |
 | `--output-dir` | `benchmarks/results/` | where `markdown` / `json` files are written |
 
-`--rows` and `--n-samples` accept multiple values and are swept as a grid in one report: every method
-except `samples` is benchmarked once per `rows` value (`n_samples` does not apply, shown as `-`);
+(see `uv run --group benchmarks benchmarks/run.py --help`).
+
+Everything above `--memory` is a field of `Sweep` (and its nested `Budget`) in [_harness.py](_harness.py),
+which the CLI flattens: the dataclass owns the defaults, the help text and the validation, so there is one declaration
+rather than a signature that restates them.
+
+`--methods`, `--regimes`, `--rows` and `--n-samples` accept multiple values and are swept as a grid in one report: every
+method except `samples` is benchmarked once per regime per `rows` value (`n_samples` does not apply, reported as `-`);
 `samples` over the full `rows` x `n_samples` product.
+
+Regime is the outermost axis, so each regime's rows are contiguous. A repeated value on any of those flags is rejected
+rather than silently measuring the same cell twice. A progress line names the case in flight, so a long sweep is visibly
+running rather than hung.
+
+**A cell is measured under a time budget, not a fixed iteration count**: cell costs span orders of magnitude:
+a `scalar` moment costs microseconds while a `column`-regime `entropy` for a distribution whose entropy scipy does not
+vectorise runs into **tens of seconds per call** at 1M rows, well past the default `--max-seconds`.
+A count high enough for the cheap cells makes the expensive ones unrunnable, which is how a sweep gets abandoned
+half-run. So the warmup call is timed and used to plan the iteration count, `--max-seconds` then caps the loop,
+and `--min-iterations` guarantees a meaningful median either way.
+
+A cell whose *single* call already costs more than the whole budget is measured exactly once,
+since `--min-iterations` of those would blow the budget several times over.
+
+**Read the `iters` column before quoting a cell**: it carries the count each side actually ran, and a cell that fell
+back to one or to `--min-iterations` says so there. At one iteration the spread is reported as `-` (`null` in JSON)
+rather than a flattering `0.000`; above one it is a sample standard deviation (`ddof=1`).
+
+A cell that raises is reported as `SKIPPED` and the sweep continues, and an interrupt still writes the cells already
+measured. A long sweep therefore cannot lose an hour of completed work to one bad cell.
 
 Output formats:
 
-* `rich`: a coloured table on the terminal (speedup green when `polars_stats` wins). Nothing is written.
-* `markdown`: a `## <dist>` document with an environment stamp and table. Written to
-  `benchmarks/results/<dist>.md`.
-* `json`: machine-readable (environment, config, per-method timing and memory). Written to
-  `benchmarks/results/<dist>.json`.
+* `rich`: a coloured table on the terminal (ratio green when `polars_stats` wins). Nothing is written.
+* `markdown`: a `## <dist>` document with an environment stamp and table. Written to `benchmarks/results/<dist>.md`.
+* `json`: machine-readable (schema version, environment, sweep config, per-cell timing and memory).
+  Written to `benchmarks/results/<dist>.json`.
 
-`benchmarks/results/` is git-ignored: the files are machine-specific. If numbers are ever published,
-commit a curated table rather than the raw per-run output.
+Both file formats stamp the rows, methods, regimes and budget the run actually used, so a narrower re-run cannot be
+mistaken for a wider one. `benchmarks/results/` is git-ignored: the files are machine-specific, and a run overwrites
+the previous file for the same distribution.
 
-## Build mode (important for fair numbers)
+If numbers are ever published, commit a curated table rather than the raw per-run output.
+
+## Build mode (enforced)
 
 `uv run --group benchmarks` measures whatever `polars_stats` is installed in the project environment.
 
-Build it in **release** mode first (`make install-release`, i.e. `maturin develop --release`). A debug
-`maturin develop` build runs the Rust extension unoptimised and would make `polars_stats` look far
-slower than scipy's optimised C, invalidating the comparison.
+Build it in **release** mode first (`make install-release`, i.e. `maturin develop --release`).
+A debug `maturin develop` build runs the Rust extension unoptimised and would make `polars_stats` look far slower than
+scipy's optimised C, invalidating the comparison.
+
+This is checked, not just documented, because a debug run produces a table that looks entirely normal.
+`src/lib.rs` exposes `cfg!(debug_assertions)` as `polars_stats._internal.__debug_build__`, and
+`require_release_build()` refuses to start otherwise - including against an extension too old to carry the flag,
+since it cannot vouch for itself. The profile is also stamped into every report header and the JSON `environment`,
+so a saved report always says which build produced it.
 
 ## Layout
 
-* [run.py](run.py): the single runnable script and `cyclopts` CLI. Holds the `REGISTRY` of distributions
-  (each a `Comparison`: the `polars_stats` instance and the matching frozen `scipy.stats` distribution,
-  reparameterised to scipy's convention) and dispatches to the harness.
-* [_harness.py](_harness.py): the comparison routine. Builds the calls, times them, measures peak memory
-  in isolated subprocesses, checks shapes, renders the report. Imported, never run directly.
+* [run.py](run.py): the single runnable script and `cyclopts` CLI. Holds the `REGISTRY` of distributions and drives the
+  harness. Each entry is a `Comparison`: a `ParamSpec` per parameter (the fixed value the `scalar` and `broadcast`
+  regimes use, plus the domain the `column` regime draws from) and a **factory** turning one regime's realised
+  parameters into both sides' distributions, applying scipy's reparameterisation. A factory rather than a frozen
+  instance pair is what lets one registry serve all three regimes; there is deliberately no second registry and
+  no second entry point.
+* [_harness.py](_harness.py): the comparison routine. Builds the calls, times them, measures peak memory in isolated
+  subprocesses, gates correctness, renders the report. Imported, never run directly. Its seams are `METHOD_SPECS` (the
+  method metadata table), `Case` (one measurable cell, as frozen and picklable data carrying its own `id`),
+  `Sweep` (a grid, and the CLI's option surface), and `Contender` (a `(Comparison, Case) -> Call` builder registered by
+  name in `CONTENDERS`, with ratios taken against `REFERENCE_CONTENDER`).
 
-Adding a distribution is one entry in `REGISTRY`.
+Adding a distribution is one entry in `REGISTRY`: its `ParamSpec`s and its factory.
+Adding a method is a token in `Method` plus a row in `METHOD_SPECS`, and the import-time check that pairs the two will
+fail the run if you add only one.
+
+The correctness gate checks itself at import, for the same reason. `_outputs_agree` is the harness's only correctness
+signal and its failure mode is silent - a broken gate reports `ok` for every cell forever - so `_check_gate_can_reject()`
+runs six cases on synthesised frames (a real match, a value past the tolerance, a short reference, a null reference,
+matching draws, a wrong draw width) and refuses to import if any verdict is wrong.
+The passing case is part of it deliberately: a gate stuck on `False` would satisfy the rejections.
+It costs well under a millisecond and needs neither the plugin nor scipy.
+
+A `ParamSpec` domain must be chosen so that **every** draw is a valid parameterisation. A joint constraint like
+`min < max` is expressed as two non-overlapping domains rather than a rejection step, so realisation never has to retry.
+Parameter draws are derived from `(regime, rows, seed)` alone, so both sides and the memory subprocesses regenerate
+identical arrays; they take their own seed stream, so widening a domain cannot shift the evaluation inputs.
+
+An integer parameter must carry `integer=True`; `Params.plugin_int` checks the realised dtype, so a missing flag raises
+in every regime rather than surfacing deep inside the plugin.
+
+A `Comparison.build` must be a module-level function, checked on construction, because a lambda or closure would not
+survive pickling into the memory subprocess.
 
 ## What is measured
 
-* **Time:** wall-clock of the full native call, as **median ± standard deviation** (ms) over
-  `--iterations` runs, after one warmup. Measured in-process; the reported speedup is
-  `scipy p50 / polars_stats p50`. The `polars_stats` side runs on the lazy **streaming** engine
-  (`collect(engine="streaming")`), the chunked path users hit at scale.
-* **Peak memory:** peak resident-set growth (MiB) of a single call, each measured **in a fresh spawned subprocess**.
-  Isolation is required: an in-process measurement after the timing loop is meaningless because each library's
-  allocator retains freed pages differently (scipy would read ~0 while `polars_stats` re-allocates).
+* **Time:** wall-clock of the full native call, as **median +/- sample standard deviation** (ms) over as many iterations
+  as the budget allowed, after one warmup. Measured in-process; the reported ratio is `scipy p50 / polars_stats p50`.
+  The `polars_stats` side runs on the lazy **streaming** engine (`collect(engine="streaming")`), the chunked path users
+  hit at scale, and its timed closure includes both query-plan construction and `collect()` dispatch where scipy's bound
+  method has no equivalent.
+  That asymmetry is a fixed per-call cost, so it is negligible on a large cell and dominant on the cheapest ones.
+* **Peak memory:** **opt-in, via `--memory`**, because it spawns one subprocess per contender per cell and that cost
+  dominates a full sweep. Peak resident-set growth (MiB) of a single call, each measured **in a fresh spawned subprocess**.
+  Isolation is required: an in-process measurement after the timing loop is meaningless because each library's allocator
+  retains freed pages differently (scipy would read ~0 while `polars_stats` re-allocates).
   RSS (not `tracemalloc`) so the native Rust/Arrow and NumPy allocations are counted.
-* **Correctness gate:** for the samplers, values cannot match across independent RNGs, so the gate is a
-  shape check (column length and array width vs scipy's output shape). The value-keyed methods evaluate
-  the same inputs on both sides, so their gate is `np.allclose` to loose tolerances (the scipy-parity
-  test suite owns the tight per-method bounds). Flagged `MISMATCH` if it diverges. Warn-only.
+  Without `--memory` the MiB columns are omitted entirely.
+* **Correctness gate:** for the samplers, values cannot match across independent RNGs, so the gate is a shape check
+  (column length and array width vs scipy's output shape). The value-keyed methods evaluate the same inputs on both
+  sides, so their gate is `np.allclose` to loose tolerances (the scipy-parity test suite owns the tight per-method bounds).
+  Moments are gated on both sides' shapes: height 1 for `scalar` and `broadcast`, `rows` for `column`.
+  A null on the `polars_stats` side fails the gate outright, because `to_numpy` renders it as `NaN` and the comparison
+  treats `NaN` as agreeing with scipy's own. Flagged `MISMATCH` if it diverges. Warn-only.
 
 Caveats on the memory numbers (read before quoting them):
 
@@ -94,7 +203,41 @@ Caveats on the memory numbers (read before quoting them):
   polars operation in a process pays once; a long-running process amortises it away. This inflates the
   `polars_stats` memory at small `--rows`, where the fixed init dominates the output size.
 * One measurement per call (not a distribution); allocation sizes are deterministic, but the sampled
-  peak can miss a very short transient.
+  peak can miss a very short transient. The sampler polls every 0.5 ms, which is coarser than the whole
+  call on a `scalar` moment cell, so those readings are near-baseline rather than a real peak.
 
-Out of scope: summary statistics (`mean`/`variance`/`entropy`/...; cheap closed forms, nothing to
-compare at scale) and the column-parameter regime (no scipy equivalent to compare against).
+## Keeping the scipy side native
+
+Both sides must be measured on the path a real user of that library would take, and two of those
+choices are invisible in the output.
+
+**RNG family (samplers)**: scipy's samplers are handed a `numpy.random.Generator`, not an int seed.
+`random_state=<int>` makes scipy build a legacy `RandomState` and draw from **MT19937**, while our Rust side draws from
+`Pcg64Mcg` ([src/rng.rs](../src/rng.rs)) - so an int seed compares a modern PCG generator against a 1997 Mersenne Twister.
+That is an artefact of the seed's *type*, not of the API a scipy user writes, and it was worth 1.1x to 2.4x depending on
+the distribution. Worse, it was not a uniform offset: it reordered the distributions, flattering `sample` on `normal`
+(measured 6.2x before, 2.4x after) and `discrete_uniform` (2.6x before, 1.3x after) while *understating* `uniform`.
+The generator is constructed per call, so scipy pays the same construct-from-seed cost our side does and
+every timed iteration still draws identical values; construction is ~3 us.
+
+**API generation (everything)**: the harness measures the **classic frozen API** (`norm(loc, scale)` then `.pdf(x)`),
+which is what the overwhelming majority of scipy code written today looks like.
+That is a deliberate, defensible baseline, but it is not scipy at its fastest.
+Measured against the newer random-variable API (`scipy.stats.Normal`, `make_distribution`, scipy >= 1.15) on `normal`
+with column parameters: the new API is roughly 1.3x to 1.9x faster on the value-keyed methods, effectively free for
+`mean` and `variance` (it returns the parameter array rather than computing through the generic machinery),
+and **~700x** faster on `beta.entropy`, where the frozen path falls back to a per-element `np.vectorize` loop.
+So read every ratio as *against the classic frozen API*, and never quote one as "faster than scipy" without that
+qualifier.
+
+A `scipy-new` contender would be one registration in `CONTENDERS`, but it would not be a like-for-like baseline *today*:
+the new API ships native classes for only a few families (`Normal`, `Uniform`, `Binomial`), so most of the registry
+would have to go through `make_distribution`, and the location-scale families do not accept `loc` / `scale` there at all.
+The frozen API therefore stays the baseline.
+The numbers above exist to size what that choice costs, not to suggest switching.
+
+One further scipy constraint worth knowing, since it is invisible in the output: with array parameters,
+`rvs(size=(rows, draws))` cannot broadcast against the length-`rows` parameters, so the `column` regime draws
+`size=(draws, rows)` and transposes back to the layout the `polars_stats` side returns. The transpose is a view rather
+than a copy, which means scipy never pays for the row-major layout our side materialises.
+The `column`-regime `samples` ratio is optimistic for scipy by roughly one pass over the output.

--- a/benchmarks/_harness.py
+++ b/benchmarks/_harness.py
@@ -1,64 +1,61 @@
-"""Shared comparison harness for the ``polars_stats`` vs ``scipy.stats`` benchmarks.
+"""Comparison harness for the ``polars_stats`` vs ``scipy.stats`` benchmarks.
 
-Two method families are compared:
+Every cell is measured in one of three parameter `Regime`s. They are different code paths on both sides and
+**must never be cross-compared**: a column cell does strictly more work per row by design.
 
-* **sampling**: `sample` (one variate per row) and `samples` (``n_samples`` variates per row),
-  against ``scipy.rvs``. Independent RNGs mean values cannot match, so correctness is a shape-only
-  gate.
-* **value-keyed**: `density` / `log_density` (`pdf` / `pmf` and `log_pdf` / `log_pmf` by family),
-  `cdf`, `log_cdf`, `sf`, `log_sf` and `ppf`, against the matching frozen-scipy method. Both sides
-  evaluate the *same* deterministic inputs (the distribution's own seeded draws; open-interval
-  quantiles for `ppf`), so here the `match` column is a real ``np.allclose`` value check, not just
-  a shape check.
+The regime is part of `Case.id` and a column of every report so the two cannot be diffed by accident.
 
-`run.py` owns the `Comparison` registry (one entry per distribution) and the CLI; it calls `run_comparison` over a
-`Sweep` of sizes. This module is *not* runnable; run ``uv run --group benchmarks benchmarks/run.py`` instead.
-
-For each method and each side we report:
-
-* **time**: median wall-clock over ``iterations`` runs, as ``p50 ± std`` (ms), warmup excluded;
-* **peak memory**: peak resident-set growth (MiB) of one call, each measured in a fresh **isolated
-  subprocess** where a background thread samples RSS, so it captures the native Rust/Arrow and NumPy
-  allocations that `tracemalloc` would miss without the timing loop's allocator state skewing it.
+This module is not runnable; run ``uv run --group benchmarks benchmarks/run.py`` instead.
 """
 
 # ruff: noqa: T201
+# pyright: reportUnknownParameterType=false
+# `ScipyFrozen` aliases scipy-stubs' generic frozen types, whose own arguments are partly Unknown.
+# `[tool.pyright] include` keeps benchmarks/ out of `make typing`, but an editor still checks it.
 from __future__ import annotations
 
 import gc
 import json
 import multiprocessing as mp
+import pickle
 import platform
 import threading
 import time
-from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING, Literal
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING, Annotated, Literal, NamedTuple, Protocol, TypedDict, TypeVar, cast, get_args
 
 import numpy as np
 import polars as pl
 import psutil  # type: ignore[import-untyped]
 import scipy
+from cyclopts import Parameter
 from rich.console import Console
 from rich.table import Table
 
+from polars_stats import _internal
 from polars_stats.distributions._base import ContinuousDistribution
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable, Iterator, Mapping, Sequence
     from pathlib import Path
+    from typing import NoReturn, TypeAlias
 
+    import numpy.typing as npt
     from scipy.stats._distn_infrastructure import rv_continuous_frozen, rv_discrete_frozen
+    from typing_extensions import TypeIs
 
     from polars_stats.distributions._base import _UnivariateDistribution
 
-    # The frozen instance a spec passes (`norm(...)`, `binom(n, p)`, ...). Typing against scipy's own frozen
-    # types rather than a hand-rolled Protocol keeps it honest against scipy-stubs.
-    ScipyFrozen = rv_continuous_frozen | rv_discrete_frozen
+    ScipyFrozen: TypeAlias = rv_continuous_frozen | rv_discrete_frozen
+    Distribution: TypeAlias = _UnivariateDistribution
+    Array: TypeAlias = "npt.NDArray[np.float64] | npt.NDArray[np.int64]"
 
-    Distribution = _UnivariateDistribution
-    """Any `polars_stats` distribution"""
+    Outcome: TypeAlias = "pl.DataFrame | Array | np.float64 | float"
+    """What one contender's call returns: a collected frame, an array, or a single moment."""
 
-    Side = Literal["polars_stats", "scipy"]
+    Call: TypeAlias = Callable[[], "Outcome"]
+    DistFactory: TypeAlias = Callable[["Params"], tuple[Distribution, ScipyFrozen]]
+    MemoryReply: TypeAlias = "_PeakMiB | _ChildFailure"
 
 
 Method = Literal[
@@ -77,378 +74,794 @@ Method = Literal[
     "std",
     "entropy",
 ]
-"""A benchmarkable method. `density` / `log_density` resolve to `pdf` / `log_pdf` (continuous) or
-`pmf` / `log_pmf` (discrete) per distribution; `log_cdf` / `log_sf` call scipy's `logcdf` / `logsf`.
 
-`mean` / `variance` / `std` / `entropy` are the parameter-only moments: they take no value column, and
-the registry's parameters are scalars, so the expression is built only from constants and `select`
-returns a height-1 scalar column (see `_coerce` in `polars_stats/distributions/_base.py`), matching
-scipy's single scalar. Both sides are therefore O(1) and `rows` does not scale the work: the cell tracks
-the polars_stats per-call overhead (time and peak memory) across a change, not a length-`rows` cost.
+MethodKind = Literal["sampler", "value", "moment"]
+"""Which family a method belongs to: how a contender builds its call, and how `matches` is gated.
+
+`sampler` is gated on shape alone, since independent RNGs cannot agree on values. `value` evaluates a
+shared input column on both sides, so values must agree. `moment` takes no input column, so its
+output height follows the regime.
 """
 
-ALL_METHODS: tuple[Method, ...] = (
-    "sample",
-    "samples",
-    "density",
-    "log_density",
-    "cdf",
-    "log_cdf",
-    "sf",
-    "log_sf",
-    "ppf",
-    "isf",
-    "mean",
-    "variance",
-    "std",
-    "entropy",
-)
-
-_INVERSE_METHODS: frozenset[Method] = frozenset({"ppf", "isf"})
-"""Value-keyed methods whose input is a quantile rather than a support point; see `_eval_inputs`."""
-
-_VALUE_METHODS: frozenset[Method] = frozenset(
-    {"density", "log_density", "cdf", "log_cdf", "sf", "log_sf", *_INVERSE_METHODS}
-)
-
-_MOMENT_METHODS: frozenset[Method] = frozenset({"mean", "variance", "std", "entropy"})
-"""Parameter-only moments: no value column, and with constant parameters no dependence on the frame's length."""
-
+ValueInput = Literal["support", "quantile"]
+DensityToken = Literal["pdf", "pmf"]
 OutputFormat = Literal["markdown", "json", "rich"]
-"""How a report is emitted: a markdown file, a JSON file, or a rich table printed to the terminal."""
+Regime = Literal["scalar", "column", "broadcast"]
+"""How a distribution's parameters are supplied: Python numbers, `pl.col`, or `pl.lit`.
 
-# Value-keyed match tolerances: statrs and scipy implement the same special functions with
-# different algorithms, so agreement is to high relative precision, not bit-equality. The
-# scipy-parity test suite owns the tight per-method bounds; this is a sanity gate.
+Three different code paths on both sides, never cross-compared. `README.md` has the table.
+"""
+
+ALL_REGIMES: tuple[Regime, ...] = get_args(Regime)
+
+_DENSITY = "{d}"
+"""Stands in for the family-specific density token in a `MethodSpec` attribute name."""
+
+_VALUE_COLUMN = "x"
+"""Frame column holding the shared evaluation inputs. A parameter may not take this name."""
+
+_PARAM_STREAM = 0x9E37
+"""Second seed word for the parameter draws, keeping them off the evaluation-input stream."""
+
+REFERENCE_CONTENDER = "polars_stats"
+"""The contender every ratio is taken against, and the one `matches` compares the others to."""
+
+SCHEMA_VERSION = 3
+"""`json` report schema. 3 nested the per-contender numbers under `measurements` and stamps
+`methods`; 2 added the regime axis, per-cell iteration counts and nullable peak memory."""
+
+# statrs and scipy implement the same special functions with different algorithms, so agreement is to
+# high relative precision, not bit-equality. The scipy-parity suite owns the tight per-method bounds.
 _MATCH_RTOL = 1e-5
 _MATCH_ATOL = 1e-12
 
 _MIB = 1024.0 * 1024.0
-# Background memory sampler poll interval. Short enough to catch the transient peak of `samples`
-# (`concat_arr` of `n_samples` columns before the final array), long enough not to peg a core.
-_POLL_S = 5e-4
+
+_POLL_INTERVAL_S = 5e-4
+"""Short enough to catch the transient peak of `samples`, long enough not to peg a core."""
+
+_CHILD_REPLY_TIMEOUT_S = 600.0
+_CHILD_JOIN_TIMEOUT_S = 30.0
+
+_Axis = TypeVar("_Axis", bound="int | str")
+
+
+def _unreachable(kind: str) -> NoReturn:
+    msg = f"unhandled MethodSpec kind: {kind!r}"
+    raise AssertionError(msg)
+
+
+@dataclass(frozen=True)
+class MethodSpec:
+    """One row of the method metadata table: what to call on either side, and how to gate it.
+
+    Both attribute names are `{d}`-templated for the density family, resolved against the
+    distribution's own `pdf` / `pmf` token. `plugin_attr` doubles as the report label.
+    """
+
+    kind: MethodKind
+    plugin_attr: str
+    scipy_attr: str
+    value_input: ValueInput | None = None
+    multi_draw: bool = False
+
+
+METHOD_SPECS: Mapping[Method, MethodSpec] = {
+    "sample": MethodSpec(kind="sampler", plugin_attr="sample", scipy_attr="rvs"),
+    "samples": MethodSpec(kind="sampler", plugin_attr="samples", scipy_attr="rvs", multi_draw=True),
+    "density": MethodSpec(kind="value", plugin_attr=_DENSITY, scipy_attr=_DENSITY, value_input="support"),
+    "log_density": MethodSpec(
+        kind="value", plugin_attr=f"log_{_DENSITY}", scipy_attr=f"log{_DENSITY}", value_input="support"
+    ),
+    "cdf": MethodSpec(kind="value", plugin_attr="cdf", scipy_attr="cdf", value_input="support"),
+    "log_cdf": MethodSpec(kind="value", plugin_attr="log_cdf", scipy_attr="logcdf", value_input="support"),
+    "sf": MethodSpec(kind="value", plugin_attr="sf", scipy_attr="sf", value_input="support"),
+    "log_sf": MethodSpec(kind="value", plugin_attr="log_sf", scipy_attr="logsf", value_input="support"),
+    "ppf": MethodSpec(kind="value", plugin_attr="ppf", scipy_attr="ppf", value_input="quantile"),
+    "isf": MethodSpec(kind="value", plugin_attr="isf", scipy_attr="isf", value_input="quantile"),
+    "mean": MethodSpec(kind="moment", plugin_attr="mean", scipy_attr="mean"),
+    "variance": MethodSpec(kind="moment", plugin_attr="variance", scipy_attr="var"),
+    "std": MethodSpec(kind="moment", plugin_attr="std", scipy_attr="std"),
+    "entropy": MethodSpec(kind="moment", plugin_attr="entropy", scipy_attr="entropy"),
+}
+"""What a method is and what to call on either side. Insertion order is report order."""
+
+ALL_METHODS: tuple[Method, ...] = tuple(METHOD_SPECS)
+
+if set(METHOD_SPECS) != set(get_args(Method)):
+    # A token without a row would only fail deep inside a sweep.
+    _msg = (
+        "METHOD_SPECS and Method are out of step: "
+        f"{sorted(set(get_args(Method)) - set(METHOD_SPECS))} lack a row, "
+        f"{sorted(set(METHOD_SPECS) - set(get_args(Method)))} lack a token"
+    )
+    raise RuntimeError(_msg)
+
+
+@dataclass(frozen=True)
+class ParamSpec:
+    """How to realise one parameter: a fixed value, plus the inclusive domain `column` draws from.
+
+    `[low, high]` must be chosen so that *every* draw is a valid parameterisation, including any joint
+    constraint: an ordered pair like `min < max` is expressed as two non-overlapping domains rather
+    than as a rejection step, so realisation never has to retry. Holding `scalar` fixed is what makes
+    `broadcast` an honest comparison against `scalar`: same numbers, different path.
+    """
+
+    scalar: float | int
+    low: float
+    high: float
+    integer: bool = False
+
+    def __post_init__(self) -> None:
+        if self.low > self.high:
+            msg = f"domain is empty: low={self.low} > high={self.high}"
+            raise ValueError(msg)
+        if not self.low <= self.scalar <= self.high:
+            msg = f"scalar={self.scalar} lies outside its own domain [{self.low}, {self.high}]"
+            raise ValueError(msg)
+
+    def draw(self, rng: np.random.Generator, rows: int) -> Array:
+        """One `column`-regime array of `rows` valid values."""
+        if self.integer:
+            return rng.integers(int(self.low), int(self.high) + 1, size=rows, dtype=np.int64)
+        return rng.uniform(self.low, self.high, size=rows).astype(np.float64, copy=False)
+
+    @property
+    def fixed(self) -> Array:
+        """The length-1 array the `scalar` and `broadcast` regimes share."""
+        if self.integer:
+            return np.array([self.scalar], dtype=np.int64)
+        return np.array([self.scalar], dtype=np.float64)
+
+
+def _only_value(values: Array) -> float | int:
+    return int(values[0]) if np.issubdtype(values.dtype, np.integer) else float(values[0])
+
+
+@dataclass(frozen=True)
+class Params:
+    """One regime's realised parameters, in the two forms a `DistFactory` needs.
+
+    `plugin` and `scipy` are the same numbers viewed differently, so a factory spells each parameter
+    once per side and stays regime-agnostic.
+    """
+
+    regime: Regime
+    values: Mapping[str, Array]
+    """Per parameter: length `rows` under `column`, length 1 otherwise."""
+
+    def plugin(self, name: str) -> float | int | pl.Expr:
+        """The parameter as `polars_stats` should receive it, which is what selects the code path.
+
+        A Python number routes to the constant-parameter fast path; `pl.lit` gives a length-1 input
+        the plugin broadcasts; `pl.col` gives the per-row path.
+        """
+        if self.regime == "column":
+            return pl.col(name)
+        value = _only_value(self.values[name])
+        return pl.lit(value) if self.regime == "broadcast" else value
+
+    def plugin_int(self, name: str) -> int | pl.Expr:
+        """`plugin` narrowed for the constructors that require an `int`.
+
+        The check is on the realised dtype, so a `ParamSpec` missing `integer=True` raises here in
+        every regime rather than deep inside the plugin.
+        """
+        if not np.issubdtype(self.values[name].dtype, np.integer):
+            msg = f"{name!r} realised as a float; declare it as ParamSpec(..., integer=True)"
+            raise TypeError(msg)
+        value = self.plugin(name)
+        return value if isinstance(value, (int, pl.Expr)) else int(value)
+
+    def scipy(self, name: str) -> float | int | Array:
+        """The parameter as frozen scipy should receive it: a scalar, or the array to broadcast."""
+        return _only_value(self.values[name]) if self.regime == "scalar" else self.values[name]
+
+    @property
+    def columns(self) -> dict[str, Array]:
+        """The parameter columns the frame must carry, which is only the `column` regime's."""
+        return dict(self.values) if self.regime == "column" else {}
 
 
 @dataclass(frozen=True)
 class Comparison:
-    """A distribution to benchmark: its `polars_stats` instance and the matching frozen scipy one.
+    """A distribution to benchmark: one `ParamSpec` per parameter, and a factory building both sides.
 
-    Arguments:
-        name: Distribution id, used in the report header and as the CLI selector.
-        dist: A `polars_stats` distribution instance with scalar parameters.
-        scipy_frozen: The matching frozen `scipy.stats` distribution, reparameterised to scipy's
-            convention by the caller (e.g. ``lognorm(s=sigma, scale=exp(mu))``).
+    `build` turns realised `Params` into `(polars_stats instance, frozen scipy)`, applying scipy's
+    reparameterisation (e.g. ``lognorm(s=sigma, scale=exp(mu))``). It must be a module-level function:
+    a `Comparison` is pickled into the memory subprocess, so a lambda or closure would not survive.
     """
 
     name: str
-    dist: Distribution
-    scipy_frozen: ScipyFrozen
+    params: Mapping[str, ParamSpec]
+    build: DistFactory
+    density_token: DensityToken = field(init=False)
+    """`pdf` or `pmf`, resolved once here rather than per cell: resolving it builds the pair."""
+
+    def __post_init__(self) -> None:
+        if _VALUE_COLUMN in self.params:
+            msg = f"{self.name}: a parameter may not be named {_VALUE_COLUMN!r}"
+            raise ValueError(msg)
+        try:
+            pickle.dumps(self.build)
+        except (AttributeError, TypeError, pickle.PicklingError) as exc:
+            msg = f"{self.name}: build must be picklable to reach the memory subprocess ({exc})"
+            raise TypeError(msg) from exc
+
+        dist, _ = self.build(_draw_params(self, regime="scalar", rows=1, seed=0))
+        token: DensityToken = "pdf" if isinstance(dist, ContinuousDistribution) else "pmf"
+        object.__setattr__(self, "density_token", token)
+
+    def label(self, method: Method) -> str:
+        """The report label for `method`: the `polars_stats` attribute actually called."""
+        return METHOD_SPECS[method].plugin_attr.format(d=self.density_token)
 
 
 @dataclass(frozen=True)
-class RunConfig:
-    """One cell of the sweep: the sizes a single `sample` / `samples` measurement uses.
+class Budget:
+    """How hard to measure one cell: whichever limit binds first.
 
-    Built only by `run_comparison` from an already-validated `Sweep`, so it carries no validation of its own.
+    A cell whose *single* call already costs more than `max_seconds` is measured exactly once, since
+    `min_iterations` of those would overshoot the budget several times over.
     """
 
-    rows: int = 1_000_000
-    n_samples: int = 10
-    iterations: int = 50
-    seed: int = 0
+    max_iterations: Annotated[int, Parameter(help="Upper bound on timed runs per cell.")] = 50
+    max_seconds: Annotated[float, Parameter(help="Wall-clock budget for one cell's timed loop.")] = 30.0
+    min_iterations: Annotated[int, Parameter(help="Lower bound on timed runs per cell.")] = 3
+
+    def __post_init__(self) -> None:
+        if self.min_iterations < 1 or self.max_iterations < self.min_iterations:
+            msg = (
+                "need 1 <= min_iterations <= max_iterations; "
+                f"got min_iterations={self.min_iterations}, max_iterations={self.max_iterations}"
+            )
+            raise ValueError(msg)
+        if not np.isfinite(self.max_seconds) or self.max_seconds <= 0:
+            msg = f"max_seconds must be finite and > 0, got {self.max_seconds}"
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class Case:
+    """One measurable cell: which distribution, which method, which regime, at which sizes.
+
+    Frozen, hashable and picklable on purpose. Picklable is load-bearing: `_isolated_peak_mib` ships
+    a case to a spawned subprocess, which rebuilds the call there from the case plus a contender
+    *name*. A built closure could not cross that boundary.
+
+    `n_samples` is the draws-per-row width for the one method that has one, and `None` for the rest.
+    One `seed` covers the samplers, the evaluation inputs and the parameter draws.
+    """
+
+    distribution: str
+    method: Method
+    regime: Regime
+    rows: int
+    n_samples: int | None
+    seed: int
+
+    @property
+    def spec(self) -> MethodSpec:
+        return METHOD_SPECS[self.method]
+
+    @property
+    def draws_per_row(self) -> int:
+        """The draws-per-row width, for the one method that has one."""
+        if self.n_samples is None:
+            msg = f"{self.method} has no draws axis, so no width"
+            raise AssertionError(msg)
+        return self.n_samples
+
+    @property
+    def id(self) -> str:
+        """A stable label for this cell, used in report diffs and subprocess error messages."""
+        draws = "" if self.n_samples is None else f",draws={self.n_samples}"
+        return f"{self.distribution}.{self.method}[{self.regime},rows={self.rows}{draws},seed={self.seed}]"
+
+
+def _distinct(axis: str, values: tuple[_Axis, ...]) -> tuple[_Axis, ...]:
+    if len(set(values)) != len(values):
+        msg = f"{axis} contains a repeated value, which would measure the same cell twice: {list(values)}"
+        raise ValueError(msg)
+    return values
+
+
+_MULTI = Parameter(consume_multiple=True, negative_iterable="")
+"""`--rows 1 2 3`, not `--rows 1 --rows 2`, and no `--empty-rows` counterpart."""
 
 
 @dataclass(frozen=True)
 class Sweep:
-    """A grid of sizes to benchmark in one report: each `rows`, crossed with each `n_samples` for `samples`.
+    """A grid to benchmark in one report: regimes x methods x `rows`, crossed with `n_samples`.
 
     Every method except `samples` works one value per row and ignores `n_samples`, so it is
-    benchmarked once per `rows` value; `samples` is benchmarked over the full `rows` x `n_samples`
-    product.
+    benchmarked once per `rows` value; `samples` runs the full `rows` x `n_samples` product.
+
+    This is also the CLI's option surface: `run.py` flattens it, so the defaults here are the
+    defaults a bare `benchmarks/run.py` uses.
     """
 
-    rows: tuple[int, ...] = (1_000_000,)
-    n_samples: tuple[int, ...] = (10,)
-    iterations: int = 50
-    seed: int = 0
+    rows: Annotated[tuple[int, ...], _MULTI, Parameter(help="Row counts to sweep over.")] = (1_000_000,)
+    n_samples: Annotated[tuple[int, ...], _MULTI, Parameter(help="Draws-per-row widths for `samples`.")] = (10,)
+    regimes: Annotated[tuple[Regime, ...], _MULTI, Parameter(help="Parameter regimes to compare.")] = ALL_REGIMES
+    methods: Annotated[tuple[Method, ...], _MULTI, Parameter(help="Methods to compare.")] = ALL_METHODS
+    budget: Annotated[Budget, Parameter(name="*")] = field(default_factory=Budget)
+    seed: Annotated[int, Parameter(help="Seed for the samplers, evaluation inputs and parameter draws.")] = 0
 
     def __post_init__(self) -> None:
-        if not self.rows or not self.n_samples:
-            msg = "rows and n_samples must each contain at least one value"
+        if not self.rows or not self.n_samples or not self.regimes or not self.methods:
+            msg = "rows, n_samples, regimes and methods must each contain at least one value"
             raise ValueError(msg)
-        if min(*self.rows, *self.n_samples, self.iterations) < 1:
-            msg = (
-                "every rows / n_samples value and iterations must be >= 1; "
-                f"got rows={self.rows}, n_samples={self.n_samples}, iterations={self.iterations}"
-            )
+        if any(value < 1 for value in (*self.rows, *self.n_samples)):
+            msg = f"every rows / n_samples value must be >= 1; got rows={self.rows}, n_samples={self.n_samples}"
             raise ValueError(msg)
+        for axis, values in (
+            ("rows", self.rows),
+            ("n_samples", self.n_samples),
+            ("regimes", self.regimes),
+            ("methods", self.methods),
+        ):
+            _distinct(axis, values)
+
+    def cases(self, distribution: str) -> Iterator[Case]:
+        """Expand this sweep into one `Case` per cell, in report order.
+
+        Regime is the outermost axis, so each regime's block is contiguous and internally ordered
+        exactly as a single-regime run would be.
+        """
+        for regime in self.regimes:
+            for method in self.methods:
+                widths: tuple[int | None, ...] = self.n_samples if METHOD_SPECS[method].multi_draw else (None,)
+                for rows in self.rows:
+                    for width in widths:
+                        yield Case(
+                            distribution=distribution,
+                            method=method,
+                            regime=regime,
+                            rows=rows,
+                            n_samples=width,
+                            seed=self.seed,
+                        )
+
+
+class Timing(NamedTuple):
+    """Median and sample standard deviation (ms) of a timed loop, and how many runs it managed."""
+
+    p50_ms: float
+    std_ms: float
+    iterations: int
+
+
+class MeasurementPayload(TypedDict):
+    """One contender's numbers as they appear in a `json` report."""
+
+    p50_ms: float
+    std_ms: float | None
+    iterations: int
+    peak_mib: float | None
 
 
 @dataclass(frozen=True)
 class Measurement:
-    """One contender's cost for one method: median +/- std runtime (ms) and peak memory growth (MiB)."""
+    """One contender's cost for one cell: median +/- std runtime (ms) over `iterations` runs.
+
+    `std_ms` is `nan` for a single-iteration cell, which the reports render as `-` rather than a
+    flattering zero. `peak_mib` is `None` unless peak memory was requested, since measuring it costs
+    a subprocess.
+    """
 
     p50_ms: float
     std_ms: float
-    peak_mib: float
+    iterations: int
+    peak_mib: float | None = None
+
+    @property
+    def payload(self) -> MeasurementPayload:
+        """This measurement as a `json` report object, with `nan` nulled out to keep it parseable."""
+        payload = cast("MeasurementPayload", asdict(self))
+        if np.isnan(self.std_ms):
+            payload["std_ms"] = None
+        return payload
 
 
 @dataclass(frozen=True)
 class Result:
-    method: str
-    rows: int
-    n_samples: int | None
-    """None for `sample` method: one draw per row, so n_samples does not apply"""
-    polars_stats: Measurement
-    scipy: Measurement
+    """One case's outcome: a `Measurement` per contender, plus the correctness verdict.
+
+    Keyed by contender name rather than holding a fixed pair of fields, so a ratio is always taken
+    explicitly against a named reference.
+    """
+
+    case: Case
+    label: str
+    """The report label: the `polars_stats` method actually called (`density` -> `pdf` / `pmf`)."""
+    measurements: Mapping[str, Measurement]
     matches: bool
 
-    @property
-    def speedup(self) -> float:
-        """Median scipy time over median polars_stats time: > 1 means polars_stats is faster."""
-        return self.scipy.p50_ms / self.polars_stats.p50_ms if self.polars_stats.p50_ms > 0 else float("nan")
+    def ratio(self, contender: str, *, reference: str = REFERENCE_CONTENDER) -> float:
+        """`contender`'s median time over `reference`'s: > 1 means the reference is faster."""
+        base = self.measurements[reference].p50_ms
+        return self.measurements[contender].p50_ms / base if base > 0 else float("nan")
 
 
-def _time(fn: Callable[[], object], *, iterations: int) -> tuple[float, float]:
-    """Median and standard deviation of wall-clock time in ms over `iterations` runs, after one warmup.
+class Contender(Protocol):
+    """Builds the zero-argument call that one competitor runs for one case.
 
-    Median as the centre (robust to the occasional GC pause or scheduler hiccup); std as the reported
-    spread, measured in its own loop so the memory sampler never perturbs the timing.
+    A builder, not a prepared call: input construction happens when the builder runs, so it is
+    outside the returned closure and charged to neither time nor peak memory. Registered by name in
+    `CONTENDERS`, because the name is what crosses into the memory subprocess, not the closure.
     """
-    fn()  # warmup: pays first-touch allocation and lazy-import costs once, outside the timed loop
-    samples = np.empty(iterations, dtype=np.float64)
-    for i in range(iterations):
-        start = time.perf_counter()
-        fn()
-        samples[i] = time.perf_counter() - start
-    return float(np.median(samples)) * 1_000.0, float(np.std(samples)) * 1_000.0
+
+    def __call__(self, comp: Comparison, case: Case, /) -> Call: ...
 
 
-def _peak_memory(fn: Callable[[], object]) -> float:
-    """Peak resident-set growth in MiB during a single `fn()` call, over a gc-collected baseline.
+def _time_call(call: Call, budget: Budget) -> tuple[Outcome, Timing]:
+    """Time `call` under `budget`, returning the warmup's output for the correctness gate.
 
-    A daemon thread polls process RSS while `fn` runs; the result is held alive until the final reading
-    so the output buffer counts toward the peak. RSS (not `tracemalloc`) so native polars/Arrow and
-    NumPy allocations are included. Approximate by nature: the allocator may not release pages between
-    contenders, so treat these as same-machine relative numbers, not absolute footprints.
+    The warmup is excluded from the reported numbers, and its duration plans the iteration count. A
+    call that already costs more than the whole budget is measured exactly once rather than
+    `min_iterations` times.
+    """
+    start = time.perf_counter()
+    outcome = call()
+    warmup_s = time.perf_counter() - start
+
+    if warmup_s > budget.max_seconds:
+        planned = 1
+    else:
+        affordable = budget.max_iterations if warmup_s <= 0.0 else int(budget.max_seconds / warmup_s)
+        planned = max(budget.min_iterations, min(budget.max_iterations, affordable))
+
+    durations_s = np.empty(planned, dtype=np.float64)
+    deadline = time.perf_counter() + budget.max_seconds
+    measured = 0
+    for index in range(planned):
+        call_start = time.perf_counter()
+        call()
+        durations_s[index] = time.perf_counter() - call_start
+        measured = index + 1
+        if measured >= budget.min_iterations and time.perf_counter() >= deadline:
+            break
+
+    timed_s = durations_s[:measured]
+    std_s = float(np.std(timed_s, ddof=1)) if measured > 1 else float("nan")
+    return outcome, Timing(float(np.median(timed_s)) * 1_000.0, std_s * 1_000.0, measured)
+
+
+def _peak_mib(call: Call) -> float:
+    """Peak resident-set growth in MiB during a single `call()`, over a gc-collected baseline.
+
+    The result is held alive until the final reading so the output buffer counts toward the peak.
+    Same-machine relative numbers, not absolute footprints: the allocator may not release pages
+    between contenders.
     """
     proc = psutil.Process()
     gc.collect()
-    baseline = proc.memory_info().rss
-    peak = baseline
+    baseline: int = proc.memory_info().rss
+    peak: int = baseline
     stop = threading.Event()
 
     def poll() -> None:
         nonlocal peak
         while not stop.is_set():
             peak = max(peak, proc.memory_info().rss)
-            time.sleep(_POLL_S)
+            time.sleep(_POLL_INTERVAL_S)
 
     sampler = threading.Thread(target=poll, daemon=True)
     sampler.start()
     try:
-        result = fn()
-        peak = max(peak, proc.memory_info().rss)
+        result = call()
     finally:
         stop.set()
         sampler.join()
+    peak = max(peak, proc.memory_info().rss)
     del result
     gc.collect()
-    return max(0.0, (peak - baseline) / _MIB)  # type: ignore[no-any-return]
+    return max(0.0, (peak - baseline) / _MIB)
 
 
-def _length_frame(rows: int) -> pl.LazyFrame:
+def _sized_frame(rows: int) -> pl.LazyFrame:
     """A `rows`-long frame; the sampler expressions key off `pl.len()`, not its contents."""
     return pl.LazyFrame({"_": pl.Boolean()}).clear(rows)
 
 
-def _density_name(dist: Distribution) -> Literal["pdf", "pmf"]:
-    """The family-specific density method `density` resolves to (both as report label and call)."""
-    return "pdf" if isinstance(dist, ContinuousDistribution) else "pmf"
+def _draw_params(comp: Comparison, *, regime: Regime, rows: int, seed: int) -> Params:
+    """Draw a case's parameters, deterministically from `(regime, rows, seed)` alone.
+
+    Determinism is required, not merely nice: both contenders and each isolated memory subprocess
+    call this independently and must agree on the numbers, or the two sides would be measured on
+    different distributions. The draws take their own seed stream so that widening a parameter domain
+    cannot shift the evaluation inputs.
+    """
+    rng = np.random.default_rng([seed, _PARAM_STREAM])
+    values = {name: spec.draw(rng, rows) if regime == "column" else spec.fixed for name, spec in comp.params.items()}
+    return Params(regime=regime, values=values)
 
 
-def _report_name(dist: Distribution, method: Method) -> str:
-    """The report label: the `polars_stats` method actually called (`density` -> `pdf` / `pmf`, ...)."""
-    if method == "density":
-        return _density_name(dist)
-    if method == "log_density":
-        return f"log_{_density_name(dist)}"
-    return method
-
-
-def _scipy_name(dist: Distribution, method: Method) -> str:
-    """The frozen-scipy attribute for a value-keyed method (`log_cdf` -> `logcdf`, `log_density` -> `logpdf`)."""
-    return _report_name(dist, method).replace("log_", "log")
-
-
-def _eval_inputs(comp: Comparison, config: RunConfig, method: Method) -> np.ndarray:
+def _evaluation_points(case: Case, frozen: ScipyFrozen) -> Array:
     """Deterministic evaluation inputs for a value-keyed method, shared by both sides.
 
-    Derived only from `(comp, config)` so the two sides (and the isolated memory subprocesses)
-    regenerate the identical array. The inverses (`ppf`, `isf`) get uniform quantiles from `[0, 1)`;
-    the other methods get the distribution's own seeded draws, which cover the support with realistic
-    density. Feeding an inverse the support draws instead puts almost every row on the
-    null-outside-`[0, 1]` path, which measures the guard rather than the algorithm.
+    The inverses get uniform quantiles from ``[0, 1)``; every other method gets the distribution's
+    own seeded draws. Feeding an inverse the support draws instead puts almost every row on the
+    null-outside-``[0, 1]`` path, which measures the guard rather than the algorithm.
+
+    These take the plain int seed rather than `_scipy_generator`: this is input construction, outside
+    every timed closure, so only its reproducibility matters. The length is asserted because scipy
+    requires the evaluation point to broadcast against `column` parameters.
     """
-    if method in _INVERSE_METHODS:
-        return np.random.default_rng(config.seed).uniform(0.0, 1.0, size=config.rows)
-    return np.asarray(comp.scipy_frozen.rvs(size=config.rows, random_state=config.seed), dtype=np.float64)
-
-
-def _value_expr(dist: Distribution, method: Method) -> pl.Expr:
-    """The `polars_stats` expression for a value-keyed method, evaluated on the shared `x` column."""
-    if method not in _VALUE_METHODS:
-        msg = f"not a value-keyed method: {method}"
-        raise AssertionError(msg)
-    # `_report_name` resolves `density` / `log_density` to the family-specific `pdf` / `log_pmf` / ...;
-    # the other tokens are the method names themselves.
-    return getattr(dist, _report_name(dist, method))(pl.col("x"))  # type: ignore[no-any-return]
-
-
-def _build_fn(comp: Comparison, method: Method, config: RunConfig, side: Side) -> Callable[[], object]:
-    """The single source of the timed/measured call, so timing, memory, and the match check never drift.
-
-    Returns a zero-arg closure. Input construction (the length frame for samplers, the shared
-    evaluation column for value-keyed methods) happens up front, outside the closure, so it is not
-    part of what is timed or charged to peak memory.
-    """
-    rows, n, seed = config.rows, config.n_samples, config.seed
-    match side:
-        case "scipy":
-            frozen = comp.scipy_frozen
-            if method in _VALUE_METHODS:
-                values = _eval_inputs(comp, config, method)
-                fn = getattr(frozen, _scipy_name(comp.dist, method))
-                return lambda: fn(values)
-            if method in _MOMENT_METHODS:
-                # scipy's variance is `var`; `mean` / `std` / `entropy` share the name. Each is one
-                # scalar, the baseline the equally scalar polars_stats moment is measured against.
-                # The bound method is itself the zero-arg callable the timing loop invokes.
-                return getattr(frozen, "var" if method == "variance" else method)  # type: ignore[no-any-return]
-            size: int | tuple[int, int] = rows if method == "sample" else (rows, n)
-            return lambda: frozen.rvs(size=size, random_state=seed)
-        case "polars_stats":
-            dist = comp.dist
-            if method in _VALUE_METHODS:
-                lf = pl.LazyFrame({"x": _eval_inputs(comp, config, method)})
-                expr = _value_expr(dist, method)
-            elif method in _MOMENT_METHODS:
-                lf = _length_frame(rows)
-                expr = getattr(dist, method)()
-            else:
-                lf = _length_frame(rows)
-                expr = dist.sample(seed=seed) if method == "sample" else dist.samples(n, seed=seed)
-            return lambda: lf.select(s=expr).collect(engine="streaming")
+    match case.spec.value_input:
+        case "quantile":
+            values: Array = np.random.default_rng(case.seed).uniform(0.0, 1.0, size=case.rows)
+        case "support":
+            values = np.asarray(frozen.rvs(size=case.rows, random_state=case.seed), dtype=np.float64)
         case _:
-            msg = "Unreachable path"
+            msg = f"{case.method} is not a value-keyed method, so it has no evaluation inputs"
             raise AssertionError(msg)
+    if values.shape != (case.rows,):
+        msg = f"{case.id}: evaluation inputs have shape {values.shape}, expected {(case.rows,)}"
+        raise AssertionError(msg)
+    return values
 
 
-def _matches(method: Method, config: RunConfig, polars_out: object, scipy_out: object) -> bool:
-    """Correctness gate.
+def _input_frame(params: Params, case: Case, points: Array | None) -> pl.LazyFrame:
+    """The frame a `polars_stats` call selects from.
 
-    * Samplers: shape-only (independent RNGs cannot match values).
-    * Value-keyed methods evaluate the same inputs on both sides, so values must agree to `np.allclose` within
-        the loose `_MATCH_RTOL`/`_MATCH_ATOL` (the scipy-parity suite owns the tight bounds).
+    Under `column` the parameter columns set the call's row count. Otherwise it comes from the frame,
+    which a moment needs only one row of: with length-1 parameters the `select` returns height 1
+    whatever it is given, so building a `rows`-long one would allocate a column nothing reads.
     """
-    assert isinstance(polars_out, pl.DataFrame)  # noqa: S101  # help the type checker
-    if method in _MOMENT_METHODS:
-        # Built only from the constant parameters, the moment expression is a scalar column, so
-        # `select` returns height 1 whatever the frame's length (see `_coerce` in
-        # `polars_stats/distributions/_base.py`); scipy returns one scalar. Gate on that shape and on
-        # the single entry matching the scipy scalar.
-        ours = polars_out.to_series().cast(pl.Float64).to_numpy()
-        theirs = np.asarray(scipy_out, dtype=np.float64)
-        return polars_out.height == 1 and np.allclose(ours, theirs, rtol=_MATCH_RTOL, atol=_MATCH_ATOL, equal_nan=True)
-    assert isinstance(scipy_out, np.ndarray)  # noqa: S101  # help the type checker
-    if method == "samples":
-        dtype = polars_out.to_series().dtype
+    columns: dict[str, Array] = params.columns
+    if points is not None:
+        columns[_VALUE_COLUMN] = points
+    if columns:
+        return pl.LazyFrame(columns)
+    return _sized_frame(1 if case.spec.kind == "moment" else case.rows)
+
+
+def _polars_stats_call(comp: Comparison, case: Case) -> Call:
+    """One lazy `select` on the streaming engine, the path users hit at scale."""
+    params = _draw_params(comp, regime=case.regime, rows=case.rows, seed=case.seed)
+    dist, frozen = comp.build(params)
+    spec = case.spec
+    attr = spec.plugin_attr.format(d=comp.density_token)
+    points = _evaluation_points(case, frozen) if spec.kind == "value" else None
+    lf = _input_frame(params, case, points)
+    match spec.kind:
+        case "value":
+            expr = getattr(dist, attr)(pl.col(_VALUE_COLUMN))
+        case "moment":
+            expr = getattr(dist, attr)()
+        case "sampler":
+            expr = dist.samples(case.draws_per_row, seed=case.seed) if spec.multi_draw else dist.sample(seed=case.seed)
+        case _:
+            _unreachable(spec.kind)
+    return lambda: lf.select(s=expr).collect(engine="streaming")
+
+
+def _scipy_generator(seed: int) -> np.random.Generator:
+    """The RNG scipy's samplers are handed, which is what keeps the sampler cells comparable.
+
+    Passing `random_state=<int>` instead makes scipy build a legacy `RandomState` per call and draw
+    from MT19937, while our Rust side draws from `Pcg64Mcg` (`src/rng.rs`). That is a 1.1x to 2.4x
+    handicap depending on the distribution, and it is an artefact of the seed's *type*, not of the
+    API a scipy user writes. A `Generator` puts both sides on the same PCG family.
+
+    Built per call, not once per cell, so scipy pays the same construct-from-seed cost our side does
+    and every timed iteration still draws identical values. Construction is ~3 us.
+    """
+    return np.random.default_rng(seed)
+
+
+def _scipy_call(comp: Comparison, case: Case) -> Call:
+    """The frozen distribution's matching method on NumPy arrays."""
+    params = _draw_params(comp, regime=case.regime, rows=case.rows, seed=case.seed)
+    _, frozen = comp.build(params)
+    spec = case.spec
+    attr = spec.scipy_attr.format(d=comp.density_token)
+    match spec.kind:
+        case "value":
+            points = _evaluation_points(case, frozen)
+            evaluate = cast("Callable[[Array], Outcome]", getattr(frozen, attr))
+            return lambda: evaluate(points)
+        case "moment":
+            return cast("Call", getattr(frozen, attr))
+        case "sampler":
+            seed = case.seed
+            if not spec.multi_draw:
+                rows = case.rows
+                return lambda: frozen.rvs(size=rows, random_state=_scipy_generator(seed))
+            if case.regime == "column":
+                # `(rows, draws)` cannot broadcast against length-`rows` parameters, only
+                # `(draws, rows)` can. The transpose back is a view, so scipy never materialises the
+                # row-major layout the polars_stats side returns.
+                transposed = (case.draws_per_row, case.rows)
+                return lambda: frozen.rvs(size=transposed, random_state=_scipy_generator(seed)).T
+            size = (case.rows, case.draws_per_row)
+            return lambda: frozen.rvs(size=size, random_state=_scipy_generator(seed))
+        case _:
+            _unreachable(spec.kind)
+
+
+CONTENDERS: Mapping[str, Contender] = {
+    REFERENCE_CONTENDER: _polars_stats_call,
+    "scipy": _scipy_call,
+}
+"""The registered contenders. Insertion order is column order, reference first."""
+
+
+CHALLENGERS: tuple[str, ...] = tuple(name for name in CONTENDERS if name != REFERENCE_CONTENDER)
+"""The contenders a report shows a ratio for, in registration order."""
+
+
+def _is_array(outcome: Outcome) -> TypeIs[Array]:
+    return isinstance(outcome, np.ndarray)
+
+
+def _outputs_agree(case: Case, reference_out: Outcome, other_out: Outcome) -> bool:
+    """Correctness gate for one reference-vs-challenger output pair.
+
+    * Samplers: shape-only, since independent RNGs cannot match values.
+    * Value-keyed methods evaluate the same inputs on both sides, so values must agree to
+      `np.allclose` within the loose `_MATCH_RTOL` / `_MATCH_ATOL`. The scipy-parity suite owns the
+      tight bounds.
+    * Moments: height follows the regime. With length-1 parameters both sides return one value; with
+      parameter columns both return one value per row.
+
+    Shaped around a polars frame against a NumPy array. A contender returning a frame rather than an
+    array would need this widened.
+    """
+    if not isinstance(reference_out, pl.DataFrame):
+        msg = f"{case.id}: reference contender returned {type(reference_out).__name__}, expected a DataFrame"
+        raise TypeError(msg)
+    spec = case.spec
+    if spec.kind == "moment":
+        expected = case.rows if case.regime == "column" else 1
+        allowed = ((case.rows,),) if case.regime == "column" else ((), (1,))
+        if reference_out.height != expected or np.shape(other_out) not in allowed:
+            return False
+        return _values_agree(reference_out, other_out)
+    if not _is_array(other_out):
+        msg = f"{case.id}: challenger returned {type(other_out).__name__}, expected an array"
+        raise TypeError(msg)
+    if spec.multi_draw:
+        dtype = reference_out.to_series().dtype
         return (
-            polars_out.height == config.rows
+            reference_out.height == case.rows
             and isinstance(dtype, pl.Array)
-            and getattr(dtype, "size", None) == config.n_samples
-            and scipy_out.shape == (config.rows, config.n_samples)
+            and dtype.size == case.draws_per_row
+            and other_out.shape == (case.rows, case.draws_per_row)
         )
-    if polars_out.height != config.rows or scipy_out.shape != (config.rows,):
+    if reference_out.height != case.rows or other_out.shape != (case.rows,):
         return False
-    if method == "sample":
-        return True
-    ours = polars_out.to_series().cast(pl.Float64).to_numpy()
-    theirs = np.asarray(scipy_out, dtype=np.float64)
-    return np.allclose(ours, theirs, rtol=_MATCH_RTOL, atol=_MATCH_ATOL, equal_nan=True)
+    return True if spec.kind == "sampler" else _values_agree(reference_out, other_out)
 
 
-def _mem_entry(queue: object, comp: Comparison, method: Method, config: RunConfig, side: Side) -> None:
-    """Subprocess entrypoint: measure peak memory of one isolated call and post it back."""
-    try:
-        result = _peak_memory(_build_fn(comp, method, config, side))
-        queue.put(("ok", result))  # type: ignore[attr-defined]
-    except BaseException as exc:  # noqa: BLE001 - surface any child failure to the parent as a message
-        queue.put(("err", repr(exc)))  # type: ignore[attr-defined]
+def _values_agree(reference_out: pl.DataFrame, other_out: Outcome) -> bool:
+    """Whether the two sides agree to the harness's loose sanity tolerances.
 
-
-def _peak_memory_isolated(comp: Comparison, method: Method, config: RunConfig, side: Side) -> float:
-    """Peak memory of one call, measured in a fresh spawned process.
-
-    Isolation is the point: an in-process measurement after the timing loop is unreliable because each
-    library's allocator retains freed pages differently (scipy would read ~0 while polars re-allocates).
-    A fresh process per call sidesteps that, at the cost of one interpreter start each.
+    A null on our side fails the gate outright. `to_numpy` renders it as `nan`, which `equal_nan`
+    would otherwise read as agreeing with a genuine scipy `nan`, quietly turning a regression into
+    an `ok`.
     """
-    ctx = mp.get_context("spawn")
-    queue = ctx.Queue()
-    proc = ctx.Process(target=_mem_entry, args=(queue, comp, method, config, side))
-    proc.start()
-    try:
-        status, payload = queue.get(timeout=600)
-    except Exception as exc:
-        proc.terminate()
-        proc.join()
-        msg = f"memory subprocess for {comp.name}.{method} ({side}) did not report back"
-        raise RuntimeError(msg) from exc
-    proc.join()
-    if status != "ok":
-        msg = f"memory subprocess for {comp.name}.{method} ({side}) failed: {payload}"
-        raise RuntimeError(msg)
-    return float(payload)
-
-
-def _measure(comp: Comparison, method: Method, config: RunConfig) -> Result:
-    sides: tuple[Side, ...] = ("polars_stats", "scipy")
-    fns = {side: _build_fn(comp, method, config, side) for side in sides}
-    matches = _matches(method, config, fns["polars_stats"](), fns["scipy"]())
-    measurements = {
-        side: Measurement(
-            *_time(fns[side], iterations=config.iterations),
-            peak_mib=_peak_memory_isolated(comp, method, config, side),
-        )
-        for side in sides
-    }
-    return Result(
-        # `density` / `log_density` are the sweep tokens; the report shows the method actually called.
-        method=_report_name(comp.dist, method),
-        rows=config.rows,
-        n_samples=config.n_samples if method == "samples" else None,
-        polars_stats=measurements["polars_stats"],
-        scipy=measurements["scipy"],
-        matches=matches,
+    reference = reference_out.to_series().cast(pl.Float64)
+    if reference.null_count():
+        return False
+    return np.allclose(
+        reference.to_numpy(),
+        np.asarray(other_out, dtype=np.float64),
+        rtol=_MATCH_RTOL,
+        atol=_MATCH_ATOL,
+        equal_nan=True,
     )
 
 
-def run_comparison(comp: Comparison, sweep: Sweep, methods: Sequence[Method] = ALL_METHODS) -> list[Result]:
-    """Benchmark each requested method across the sweep grid.
+def _check_gate_can_reject() -> None:
+    """Prove `_outputs_agree` both accepts a real match and rejects each way it can be wrong.
 
-    Every method is measured once per `rows` value; `samples` additionally crosses `rows` with each
-    `n_samples` width.
+    The gate is the harness's only correctness signal, and its failure mode is silent: a broken gate
+    reports `ok` for every cell forever. Nothing else in the repo exercises it, so it is checked here
+    on the same terms as the `METHOD_SPECS` table above -- at import, not mid-sweep. The positive
+    case is part of the check on purpose, since a gate stuck on `False` would satisfy the rest.
     """
-    results: list[Result] = []
-    for method in methods:
-        widths = sweep.n_samples if method == "samples" else (1,)
-        results.extend(
-            _measure(comp, method, RunConfig(rows=rows, n_samples=n, iterations=sweep.iterations, seed=sweep.seed))
-            for rows in sweep.rows
-            for n in widths
-        )
-    return results
+    value = Case("_check", "cdf", "scalar", 3, None, 0)
+    ok = pl.DataFrame({"s": [0.25, 0.5, 0.75]})
+    draws = Case("_check", "samples", "scalar", 2, 3, 0)
+    wide = pl.DataFrame({"s": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]}, schema={"s": pl.Array(pl.Float64, 3)})
+    expectations = (
+        ("matching values", True, value, ok, np.array([0.25, 0.5, 0.75])),
+        ("value past rtol", False, value, ok, np.array([0.25, 0.5, 0.7501])),
+        ("short reference", False, value, pl.DataFrame({"s": [0.25, 0.5]}), np.array([0.25, 0.5, 0.75])),
+        ("null reference", False, value, pl.DataFrame({"s": [0.25, None, 0.75]}), np.array([0.25, 0.5, 0.75])),
+        ("matching draws", True, draws, wide, np.zeros((2, 3))),
+        ("wrong draw width", False, draws, wide, np.zeros((2, 2))),
+    )
+    for label, expected, case, reference, other in expectations:
+        if _outputs_agree(case, reference, other) is not expected:
+            msg = f"_outputs_agree is broken: {label!r} should be {expected}"
+            raise RuntimeError(msg)
+
+
+_check_gate_can_reject()
+
+
+class _PeakMiB(NamedTuple):
+    value: float
+
+
+class _ChildFailure(NamedTuple):
+    detail: str
+
+
+def _peak_memory_worker(queue: mp.Queue[MemoryReply], comp: Comparison, case: Case, contender: str) -> None:
+    """Subprocess entrypoint: rebuild `contender`'s call from the registry and post back its peak."""
+    try:
+        queue.put(_PeakMiB(_peak_mib(CONTENDERS[contender](comp, case))))
+    except BaseException as exc:  # noqa: BLE001 - surface any child failure to the parent as a message
+        queue.put(_ChildFailure(repr(exc)))
+
+
+def _isolated_peak_mib(comp: Comparison, case: Case, contender: str) -> float:
+    """Peak memory of one call, measured in a fresh spawned process."""
+    ctx = mp.get_context("spawn")
+    queue: mp.Queue[MemoryReply] = ctx.Queue()
+    proc = ctx.Process(target=_peak_memory_worker, args=(queue, comp, case, contender))
+    proc.start()
+    try:
+        reply = queue.get(timeout=_CHILD_REPLY_TIMEOUT_S)
+    except BaseException:
+        proc.terminate()
+        raise
+    finally:
+        proc.join(timeout=_CHILD_JOIN_TIMEOUT_S)
+        if proc.is_alive():
+            proc.kill()
+            proc.join(timeout=_CHILD_JOIN_TIMEOUT_S)
+    if isinstance(reply, _PeakMiB):
+        return reply.value
+    msg = f"memory subprocess for {case.id} ({contender}) failed: {reply.detail}"
+    raise RuntimeError(msg)
+
+
+def _measure(comp: Comparison, case: Case, *, budget: Budget, memory: bool) -> Result:
+    """Time every registered contender on one case, gate correctness, and optionally profile memory.
+
+    The correctness gate reads each timed loop's own warmup output, so no contender is called an
+    extra time to produce it.
+    """
+    outcomes: dict[str, Outcome] = {}
+    timings: dict[str, Timing] = {}
+    for name, build in CONTENDERS.items():
+        outcomes[name], timings[name] = _time_call(build(comp, case), budget)
+    reference_out = outcomes[REFERENCE_CONTENDER]
+    verdicts = [
+        _outputs_agree(case, reference_out, out) for name, out in outcomes.items() if name != REFERENCE_CONTENDER
+    ]
+    peaks = {name: _isolated_peak_mib(comp, case, name) for name in CONTENDERS} if memory else {}
+    return Result(
+        case=case,
+        label=comp.label(case.method),
+        measurements={name: Measurement(*timing, peak_mib=peaks.get(name)) for name, timing in timings.items()},
+        matches=bool(verdicts) and all(verdicts),
+    )
+
+
+def measure_cases(comp: Comparison, sweep: Sweep, *, memory: bool = False) -> Iterator[Result]:
+    """Yield one `Result` per cell of the sweep grid, in report order.
+
+    A cell that raises is reported and skipped rather than discarding the cells already measured;
+    the caller can therefore still emit a partial report after an interrupt.
+    """
+    cases = list(sweep.cases(comp.name))
+    try:
+        for index, case in enumerate(cases, start=1):
+            print(f"  [{index}/{len(cases)}] {case.id}", end="\r", flush=True)
+            try:
+                yield _measure(comp, case, budget=sweep.budget, memory=memory)
+            except Exception as exc:  # noqa: BLE001 - one bad cell must not abandon the sweep
+                print(f"\nSKIPPED {case.id}: {exc!r}")
+    finally:
+        print(" " * 100, end="\r")
 
 
 def emit(
@@ -470,101 +883,273 @@ def emit(
     return path
 
 
-def _environment() -> dict[str, str]:
-    """Version + platform stamp, so a saved report carries the context it was measured in."""
+def _memory_measured(results: Sequence[Result]) -> bool:
+    return any(m.peak_mib is not None for r in results for m in r.measurements.values())
+
+
+class ReportRow(NamedTuple):
+    """One report row's values, before either renderer styles them.
+
+    The two file renderers and the terminal renderer differ only in presentation, so the cell
+    *contents* are computed once here.
+    """
+
+    regime: str
+    label: str
+    rows: str
+    n_samples: str
+    iterations: str
+    times: tuple[str, ...]
+    ratios: tuple[float, ...]
+    peaks: tuple[str, ...]
+    matches: bool
+
+    @property
+    def head(self) -> tuple[str, ...]:
+        return (self.regime, self.label, self.rows, self.n_samples, self.iterations)
+
+
+def _report_headers(*, memory: bool) -> list[str]:
+    """The report's column headers, shared by every renderer."""
+    contenders, challengers = tuple(CONTENDERS), CHALLENGERS
+    return [
+        "regime",
+        "method",
+        "rows",
+        "n_samples",
+        f"iters ({'/'.join(contenders)})",
+        *(f"{name} (ms)" for name in contenders),
+        *(f"{name} / {REFERENCE_CONTENDER}" for name in challengers),
+        *(f"{name} (MiB)" for name in contenders if memory),
+        "match",
+    ]
+
+
+def _report_row(result: Result, *, memory: bool, plus_minus: str) -> ReportRow:
+    contenders = tuple(CONTENDERS)
+
+    def timing(name: str) -> str:
+        m = result.measurements[name]
+        spread = "-" if np.isnan(m.std_ms) else f"{m.std_ms:.3f}"
+        return f"{m.p50_ms:.3f} {plus_minus} {spread}"
+
+    case = result.case
+    return ReportRow(
+        regime=case.regime,
+        label=result.label,
+        rows=f"{case.rows:_}",
+        n_samples="-" if case.n_samples is None else str(case.n_samples),
+        iterations="/".join(str(result.measurements[name].iterations) for name in contenders),
+        times=tuple(timing(name) for name in contenders),
+        ratios=tuple(result.ratio(name) for name in CHALLENGERS),
+        peaks=tuple(f"{result.measurements[name].peak_mib:.1f}" for name in contenders if memory),
+        matches=result.matches,
+    )
+
+
+BuildProfile = Literal["release", "debug", "unknown"]
+
+
+def build_profile() -> BuildProfile:
+    """Whether the installed extension was compiled with optimisations.
+
+    `unknown` means the extension predates the `__debug_build__` flag, so it cannot vouch for
+    itself; the guard treats that the same as `debug` rather than assuming the good case.
+    """
+    if (flag := getattr(_internal, "__debug_build__", None)) is None:
+        return "unknown"
+    return "debug" if flag else "release"
+
+
+def require_release_build() -> None:
+    """Refuse to measure an unoptimised build, which is the one failure the numbers cannot show.
+
+    A debug `maturin develop` runs the Rust math unoptimised and would make `polars_stats` look far
+    slower than scipy's optimised C. The resulting table looks entirely normal, so this is checked
+    rather than documented.
+    """
+    if (profile := build_profile()) == "release":
+        return
+    detail = (
+        "the installed polars_stats was built with `maturin develop` (debug profile)"
+        if profile == "debug"
+        else "the installed polars_stats predates the build-profile flag, so it cannot report its profile"
+    )
+    msg = (
+        f"refusing to benchmark: {detail}. A debug build runs the Rust math unoptimised, which would "
+        "make polars_stats look far slower than scipy and invalidate every number. "
+        "Run `make install-release` first."
+    )
+    raise RuntimeError(msg)
+
+
+class Environment(TypedDict):
+    """The version and platform stamp a saved report carries."""
+
+    python: str
+    platform: str
+    polars: str
+    scipy: str
+    numpy: str
+    polars_stats: str
+    build: BuildProfile
+
+
+def _environment() -> Environment:
     return {
         "python": f"{platform.python_implementation()} {platform.python_version()}",
         "platform": platform.platform(),
         "polars": pl.__version__,
         "scipy": scipy.__version__,
         "numpy": np.__version__,
+        "polars_stats": _internal.__version__,
+        "build": build_profile(),
     }
 
 
-def _header_lines(sweep: Sweep) -> list[str]:
+def _header_lines(sweep: Sweep, results: Sequence[Result]) -> list[str]:
     env = _environment()
-    rows = ", ".join(f"{r:_}" for r in sweep.rows)
-    draws = ", ".join(str(n) for n in sweep.n_samples)
+    budget = sweep.budget
+    memory = "peak RSS (MiB), isolated subprocess" if _memory_measured(results) else "not measured (pass --memory)"
     return [
-        f"- rows: {rows}; `samples` draws per row: {draws}",
-        f"- {sweep.iterations} iterations; time p50 +/- std (ms), memory peak RSS (MiB)",
+        f"- rows: {', '.join(f'{r:_}' for r in sweep.rows)}; `samples` draws per row: "
+        f"{', '.join(str(n) for n in sweep.n_samples)}",
+        f"- methods: {', '.join(sweep.methods)}",
+        (
+            f"- regimes: {', '.join(sweep.regimes)}. **Never compare across regimes**: a column cell"
+            " does strictly more work per row by design"
+        ),
+        (
+            f"- budget per cell: <= {budget.max_iterations} iterations, <= {budget.max_seconds:g}s,"
+            f" >= {budget.min_iterations}; `iters` is the count actually measured, per contender"
+        ),
+        f"- time p50 +/- std (ms); memory: {memory}",
         f"- {env['python']} on {env['platform']}",
-        f"- polars {env['polars']}, scipy {env['scipy']}, numpy {env['numpy']}",
+        f"- polars_stats {env['polars_stats']} ({env['build']} build), polars {env['polars']},"
+        f" scipy {env['scipy']}, numpy {env['numpy']}",
     ]
 
 
 def _render_markdown(comp: Comparison, results: Sequence[Result], sweep: Sweep) -> str:
-    """A markdown document (heading, environment stamp, table), ready to paste into the README / docs."""
+    """A markdown document (heading, environment stamp, table), ready to paste into the docs."""
+    memory = _memory_measured(results)
+    headers = _report_headers(memory=memory)
+    aligns = ["---", "---", *("---:" for _ in headers[2:-1]), ":---:"]
     lines = [
         f"## {comp.name}: polars_stats vs scipy.stats",
         "",
-        *_header_lines(sweep),
+        *_header_lines(sweep, results),
         "",
-        "| method | rows | n_samples | polars_stats (ms) | scipy (ms) | speedup | polars_stats (MiB) | scipy (MiB) | match |",  # noqa: E501
-        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | :---: |",
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join(aligns) + " |",
     ]
-    for r in results:
-        flag = "ok" if r.matches else "**MISMATCH**"
-        n_samples = "-" if r.n_samples is None else str(r.n_samples)
-        lines.append(
-            f"| `{r.method}` | {r.rows:_} | {n_samples} "
-            f"| {r.polars_stats.p50_ms:.3f} +/- {r.polars_stats.std_ms:.3f} "
-            f"| {r.scipy.p50_ms:.3f} +/- {r.scipy.std_ms:.3f} "
-            f"| {r.speedup:.2f}x | {r.polars_stats.peak_mib:.1f} | {r.scipy.peak_mib:.1f} | {flag} |"
-        )
+    for result in results:
+        row = _report_row(result, memory=memory, plus_minus="+/-")
+        cells = [
+            row.regime,
+            f"`{row.label}`",
+            *row.head[2:],
+            *row.times,
+            *(f"{ratio:.2f}x" for ratio in row.ratios),
+            *row.peaks,
+            "ok" if row.matches else "**MISMATCH**",
+        ]
+        lines.append("| " + " | ".join(cells) + " |")
     return "\n".join(lines) + "\n"
 
 
+class SweepPayload(TypedDict):
+    """The sweep configuration as it appears in a `json` report."""
+
+    rows: list[int]
+    n_samples: list[int]
+    regimes: list[str]
+    methods: list[str]
+    budget: dict[str, float]
+    seed: int
+
+
+class ResultPayload(TypedDict):
+    """One cell as it appears in a `json` report."""
+
+    regime: Regime
+    method: str
+    rows: int
+    n_samples: int | None
+    measurements: dict[str, MeasurementPayload]
+    ratio: float
+    matches: bool
+
+
+class ReportPayload(TypedDict):
+    """A whole `json` report."""
+
+    schema: int
+    distribution: str
+    environment: Environment
+    sweep: SweepPayload
+    results: list[ResultPayload]
+
+
 def _render_json(comp: Comparison, results: Sequence[Result], sweep: Sweep) -> str:
-    """Machine-readable report: environment, sweep, and one object per (method, rows, n_samples) cell."""
-    payload = {
+    """Machine-readable report: schema, environment, sweep, and one object per cell."""
+    challenger = CHALLENGERS[0]
+    payload: ReportPayload = {
+        "schema": SCHEMA_VERSION,
         "distribution": comp.name,
         "environment": _environment(),
-        "sweep": asdict(sweep),
+        "sweep": {
+            "rows": list(sweep.rows),
+            "n_samples": list(sweep.n_samples),
+            "regimes": list(sweep.regimes),
+            "methods": list(sweep.methods),
+            "budget": asdict(sweep.budget),
+            "seed": sweep.seed,
+        },
         "results": [
             {
-                "method": r.method,
-                "rows": r.rows,
-                "n_samples": r.n_samples,
-                "polars_stats": asdict(r.polars_stats),
-                "scipy": asdict(r.scipy),
-                "speedup": r.speedup,
-                "matches": r.matches,
+                "regime": result.case.regime,
+                "method": result.label,
+                "rows": result.case.rows,
+                "n_samples": result.case.n_samples,
+                "measurements": {name: m.payload for name, m in result.measurements.items()},
+                "ratio": result.ratio(challenger),
+                "matches": result.matches,
             }
-            for r in results
+            for result in results
         ],
     }
-    return json.dumps(payload, indent=2) + "\n"
+    return json.dumps(payload, indent=2, allow_nan=False) + "\n"
 
 
 def _render_rich(comp: Comparison, results: Sequence[Result], sweep: Sweep) -> None:
-    """Print a coloured table to the terminal (speedup green when polars_stats wins, red otherwise)."""
+    """Print a coloured table to the terminal (ratio green when polars_stats wins, red otherwise)."""
     env = _environment()
+    memory = _memory_measured(results)
+    budget = sweep.budget
     table = Table(
         title=f"{comp.name}: polars_stats vs scipy.stats",
         caption=(
-            f"{sweep.iterations} iters | time p50 +/- std (ms), peak RSS (MiB) "
-            f"| polars {env['polars']}, scipy {env['scipy']}, numpy {env['numpy']}"
+            f"<= {budget.max_iterations} iters / <= {budget.max_seconds:g}s per cell "
+            f"| time p50 +/- std (ms){', peak RSS (MiB)' if memory else ''} "
+            f"| regimes are separate paths, never cross-compared "
+            f"| polars_stats {env['polars_stats']} ({env['build']}), polars {env['polars']},"
+            f" scipy {env['scipy']}, numpy {env['numpy']}"
         ),
     )
-    table.add_column("method", style="bold cyan")
-    table.add_column("rows", justify="right")
-    table.add_column("n_samples", justify="right")
-    for header in ("polars_stats (ms)", "scipy (ms)", "speedup", "polars_stats (MiB)", "scipy (MiB)"):
+    headers = _report_headers(memory=memory)
+    table.add_column(headers[0], style="magenta")
+    table.add_column(headers[1], style="bold cyan")
+    for header in headers[2:-1]:
         table.add_column(header, justify="right")
-    table.add_column("match", justify="center")
-    for r in results:
-        speedup_style = "green" if r.speedup >= 1.0 else "red"
-        match = "[green]ok[/]" if r.matches else "[red]MISMATCH[/]"
+    table.add_column(headers[-1], justify="center")
+    for result in results:
+        row = _report_row(result, memory=memory, plus_minus="±")
         table.add_row(
-            r.method,
-            f"{r.rows:_}",
-            "-" if r.n_samples is None else str(r.n_samples),
-            f"{r.polars_stats.p50_ms:.3f} ± {r.polars_stats.std_ms:.3f}",
-            f"{r.scipy.p50_ms:.3f} ± {r.scipy.std_ms:.3f}",
-            f"[{speedup_style}]{r.speedup:.2f}x[/]",
-            f"{r.polars_stats.peak_mib:.1f}",
-            f"{r.scipy.peak_mib:.1f}",
-            match,
+            *row.head,
+            *row.times,
+            *(f"[{'green' if ratio >= 1.0 else 'red'}]{ratio:.2f}x[/]" for ratio in row.ratios),
+            *row.peaks,
+            "[green]ok[/]" if row.matches else "[red]MISMATCH[/]",
         )
     Console().print(table)

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -1,100 +1,190 @@
 """Entrypoint for the ``polars_stats`` vs ``scipy.stats`` benchmarks.
 
-Compare the sampling methods (`sample` / `samples` vs ``scipy.rvs``) and the value-keyed methods
-(`pdf` / `pmf`, `log_pdf` / `log_pmf`, `cdf`, `log_cdf`, `sf`, `log_sf`, `ppf` vs their frozen-scipy
-counterparts) on speed and peak memory, sweeping over one or more row counts and sample widths in a
-single report::
+```terminal
+uv run --group benchmarks benchmarks/run.py                                   # all distributions and methods
+uv run --group benchmarks benchmarks/run.py normal binomial                   # a subset of distributions
+uv run --group benchmarks benchmarks/run.py --methods sample density ppf      # a subset of methods
+uv run --group benchmarks benchmarks/run.py --regimes scalar column           # a subset of regimes
+uv run --group benchmarks benchmarks/run.py normal --rows 1_000_000 10_000_000 --n-samples 5 10 20
+uv run --group benchmarks benchmarks/run.py --memory                          # also measure peak RSS
+uv run --group benchmarks benchmarks/run.py --format markdown                 # write benchmarks/results/<dist>.md
+```
 
-    uv run --group benchmarks benchmarks/run.py                                   # all distributions and methods
-    uv run --group benchmarks benchmarks/run.py normal binomial                   # a subset of distributions
-    uv run --group benchmarks benchmarks/run.py --methods sample density ppf      # a subset of methods
-    uv run --group benchmarks benchmarks/run.py normal --rows 1_000_000 10_000_000 --n-samples 5 10 20
-    uv run --group benchmarks benchmarks/run.py --format markdown                 # write benchmarks/results/<dist>.md
-
-The harness does the work; each distribution is just one `Comparison` in the registry below.
+The harness does the work; each distribution is one `Comparison` in the registry below.
 """
 
+# pyright: reportUnknownParameterType=false
+# See the same suppression in `_harness.py`: every factory below returns a `ScipyFrozen`, which
+# aliases scipy-stubs' generic frozen types and carries their partly-Unknown arguments here.
 from __future__ import annotations
 
-from math import exp
 from pathlib import Path
-from typing import Annotated, get_args
+from typing import TYPE_CHECKING, Annotated
 
+import numpy as np
 from cyclopts import App, Parameter
 from scipy.stats import bernoulli, beta, binom, expon, geom, lognorm, norm, randint, uniform
 
-from benchmarks._harness import ALL_METHODS, Comparison, Method, OutputFormat, Sweep, emit, run_comparison
+from benchmarks._harness import Comparison, OutputFormat, ParamSpec, Sweep, emit, measure_cases, require_release_build
 from polars_stats import Bernoulli, Beta, Binomial, DiscreteUniform, Exponential, Geometric, LogNormal, Normal, Uniform
 
-# `--rows 1 2 3` (multiple tokens per flag), not `--rows 1 --rows 2`; without this a list option takes
-# a single token and the rest leak onto the positional `distributions`.
-_MultiInt = Annotated[list[int], Parameter(consume_multiple=True)]
-_MultiMethod = Annotated[list[Method], Parameter(consume_multiple=True)]
+if TYPE_CHECKING:
+    from benchmarks._harness import Distribution, Params, Result, ScipyFrozen
 
-# One row per distribution: the polars_stats instance and the matching frozen scipy distribution,
-# reparameterised to scipy's convention. Adding a distribution is one entry here.
+_ReportFormat = Annotated[OutputFormat, Parameter(name="--format")]
+
+_DEFAULT_SWEEP = Sweep()
+"""Frozen, so it is safe as a default: `Sweep` is also the CLI's option surface."""
+
+
+# Each factory spells its parameters once per side, so it stays regime-agnostic. Module-level, not
+# lambdas: a `Comparison` is pickled into the memory subprocess.
+
+
+def _normal(p: Params) -> tuple[Distribution, ScipyFrozen]:
+    return Normal(mu=p.plugin("mu"), sigma=p.plugin("sigma")), norm(loc=p.scipy("mu"), scale=p.scipy("sigma"))
+
+
+def _lognormal(p: Params) -> tuple[Distribution, ScipyFrozen]:
+    return (
+        LogNormal(mu=p.plugin("mu"), sigma=p.plugin("sigma")),
+        lognorm(s=p.scipy("sigma"), scale=np.exp(p.scipy("mu"))),
+    )
+
+
+def _uniform(p: Params) -> tuple[Distribution, ScipyFrozen]:
+    low, high = p.scipy("min"), p.scipy("max")
+    return Uniform(min=p.plugin("min"), max=p.plugin("max")), uniform(loc=low, scale=high - low)
+
+
+def _exponential(p: Params) -> tuple[Distribution, ScipyFrozen]:
+    return Exponential(rate=p.plugin("rate")), expon(scale=1.0 / p.scipy("rate"))
+
+
+def _beta(p: Params) -> tuple[Distribution, ScipyFrozen]:
+    return Beta(a=p.plugin("a"), b=p.plugin("b")), beta(a=p.scipy("a"), b=p.scipy("b"))
+
+
+def _bernoulli(p: Params) -> tuple[Distribution, ScipyFrozen]:
+    return Bernoulli(p=p.plugin("p")), bernoulli(p.scipy("p"))
+
+
+def _binomial(p: Params) -> tuple[Distribution, ScipyFrozen]:
+    return Binomial(n=p.plugin_int("n"), p=p.plugin("p")), binom(p.scipy("n"), p.scipy("p"))
+
+
+def _discrete_uniform(p: Params) -> tuple[Distribution, ScipyFrozen]:
+    # scipy's `randint` is half-open on the right where `DiscreteUniform` is inclusive.
+    return (
+        DiscreteUniform(min=p.plugin_int("min"), max=p.plugin_int("max")),
+        randint(low=p.scipy("min"), high=p.scipy("max") + 1),
+    )
+
+
+def _geometric(p: Params) -> tuple[Distribution, ScipyFrozen]:
+    return Geometric(p=p.plugin("p")), geom(p.scipy("p"))
+
+
+# Ordered domains (`min` below `max`) are kept non-overlapping so every draw is a valid
+# parameterisation.
 REGISTRY: dict[str, Comparison] = {
-    "normal": Comparison("normal", Normal(mu=0.0, sigma=1.0), norm(loc=0.0, scale=1.0)),
-    "lognormal": Comparison("lognormal", LogNormal(mu=0.0, sigma=1.0), lognorm(s=1.0, scale=exp(0.0))),
-    "uniform": Comparison("uniform", Uniform(min=0.0, max=1.0), uniform(loc=0.0, scale=1.0)),
-    "exponential": Comparison("exponential", Exponential(rate=1.0), expon(scale=1.0)),
-    "beta": Comparison("beta", Beta(a=2.0, b=3.0), beta(a=2.0, b=3.0)),
-    "bernoulli": Comparison("bernoulli", Bernoulli(p=0.3), bernoulli(0.3)),
-    "binomial": Comparison("binomial", Binomial(n=10, p=0.3), binom(10, 0.3)),
-    "discrete_uniform": Comparison("discrete_uniform", DiscreteUniform(min=-2, max=9), randint(low=-2, high=10)),
-    "geometric": Comparison("geometric", Geometric(p=0.3), geom(0.3)),
+    "normal": Comparison(
+        name="normal",
+        params={"mu": ParamSpec(0.0, -1.0, 1.0), "sigma": ParamSpec(1.0, 0.5, 2.0)},
+        build=_normal,
+    ),
+    "lognormal": Comparison(
+        name="lognormal",
+        params={"mu": ParamSpec(0.0, -1.0, 1.0), "sigma": ParamSpec(1.0, 0.5, 2.0)},
+        build=_lognormal,
+    ),
+    "uniform": Comparison(
+        name="uniform",
+        params={"min": ParamSpec(0.0, -1.0, 0.0), "max": ParamSpec(1.0, 0.5, 1.5)},
+        build=_uniform,
+    ),
+    "exponential": Comparison(
+        name="exponential",
+        params={"rate": ParamSpec(1.0, 0.5, 2.0)},
+        build=_exponential,
+    ),
+    "beta": Comparison(
+        name="beta",
+        params={"a": ParamSpec(2.0, 1.0, 4.0), "b": ParamSpec(3.0, 1.0, 4.0)},
+        build=_beta,
+    ),
+    "bernoulli": Comparison(
+        name="bernoulli",
+        params={"p": ParamSpec(0.3, 0.1, 0.9)},
+        build=_bernoulli,
+    ),
+    "binomial": Comparison(
+        name="binomial",
+        params={"n": ParamSpec(10, 5, 20, integer=True), "p": ParamSpec(0.3, 0.1, 0.9)},
+        build=_binomial,
+    ),
+    "discrete_uniform": Comparison(
+        name="discrete_uniform",
+        params={"min": ParamSpec(-2, -5, -1, integer=True), "max": ParamSpec(9, 5, 12, integer=True)},
+        build=_discrete_uniform,
+    ),
+    "geometric": Comparison(
+        name="geometric",
+        params={"p": ParamSpec(0.3, 0.1, 0.9)},
+        build=_geometric,
+    ),
 }
 
-app = App(name="bench", help="Benchmark polars_stats sampling against scipy.stats.")
+if mismatched := {key: comp.name for key, comp in REGISTRY.items() if key != comp.name}:
+    # A key that disagrees with its own name would write to the wrong report file.
+    _msg = f"REGISTRY keys must equal their Comparison.name; mismatched: {mismatched}"
+    raise RuntimeError(_msg)
+
+app = App(name="bench", help="Benchmark polars_stats against scipy.stats.")
 
 
 @app.default
-def main(  # noqa: PLR0913
+def main(
     distributions: list[str] | None = None,
     *,
-    methods: _MultiMethod | None = None,
-    rows: _MultiInt | None = None,
-    n_samples: _MultiInt | None = None,
-    iterations: int = 50,
-    seed: int = 0,
-    format: OutputFormat = "rich",  # noqa: A002
+    sweep: Annotated[Sweep, Parameter(name="*")] = _DEFAULT_SWEEP,
+    memory: bool = False,
+    fmt: _ReportFormat = "rich",
     output_dir: Path | None = None,
 ) -> None:
-    """Compare each requested distribution's methods against scipy.
+    """Compare each requested distribution's methods against scipy, in each requested regime.
+
+    Cells from different regimes are different code paths on both sides and must never be compared
+    against each other. `density` / `log_density` resolve to `pdf` / `pmf` and `log_pdf` / `log_pmf`
+    per distribution family.
 
     Arguments:
         distributions: Distributions to compare (e.g. `normal binomial`). Defaults to all of them.
-        methods: Methods to compare (e.g. `--methods sample density log_sf ppf`); `density` /
-            `log_density` resolve to `pdf` / `pmf` and `log_pdf` / `log_pmf` per distribution
-            family. Defaults to all of them.
-        rows: Row counts to sweep over (e.g. `--rows 1_000_000 10_000_000`). Defaults to `[1_000_000]`.
-        n_samples: Sample widths to sweep over for `samples` (e.g. `--n-samples 5 10 20`). Defaults to `[10]`.
-        iterations: Timed runs per cell; runtime is reported as p50 +/- std.
-        seed: Seed for the samplers and the value-keyed evaluation inputs (reproducible).
-        format: `rich` prints a coloured table to the terminal; `markdown` / `json` write a file per
-            distribution to the output directory.
+        sweep: The grid to benchmark. Its fields are the `--rows` / `--n-samples` / `--regimes` /
+            `--methods` / `--seed` and budget flags; see `Sweep` and `Budget` for the defaults.
+        memory: Also measure peak RSS per contender per cell. Off by default: it spawns one
+            subprocess per contender per cell, which dominates the runtime of a full sweep.
+        fmt: `rich` prints a coloured table to the terminal; `markdown` / `json` write a
+            file per distribution to the output directory.
         output_dir: Where the `markdown` / `json` files are written. Defaults to `benchmarks/results/`.
     """
+    require_release_build()
     names = distributions or list(REGISTRY)
     if unknown := [n for n in names if n not in REGISTRY]:
         msg = f"unknown distribution(s): {', '.join(unknown)}. Available: {', '.join(REGISTRY)}"
         raise ValueError(msg)
-    selected = tuple(methods) if methods else ALL_METHODS
-    if bad := [m for m in selected if m not in get_args(Method)]:
-        msg = f"unknown method(s): {', '.join(bad)}. Available: {', '.join(get_args(Method))}"
-        raise ValueError(msg)
-
-    sweep = Sweep(
-        rows=tuple(rows) if rows else (1_000_000,),
-        n_samples=tuple(n_samples) if n_samples else (10,),
-        iterations=iterations,
-        seed=seed,
-    )
     results_dir = output_dir or (Path(__file__).parent / "results")
 
     for name in names:
-        results = run_comparison(REGISTRY[name], sweep, methods=selected)
-        emit(REGISTRY[name], results, sweep, fmt=format, output_dir=results_dir)
+        comp = REGISTRY[name]
+        results: list[Result] = []
+        try:
+            for result in measure_cases(comp, sweep, memory=memory):
+                results.append(result)  # noqa: PERF402 - an interrupt must leave the partial list intact
+        finally:
+            # `finally`, so an interrupt still reports the cells already measured before it stops.
+            if results:
+                emit(comp, results, sweep, fmt=fmt, output_dir=results_dir)
 
 
 if __name__ == "__main__":

--- a/polars_stats/_internal.pyi
+++ b/polars_stats/_internal.pyi
@@ -1,1 +1,2 @@
+__debug_build__: bool
 __version__: str

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use pyo3_polars::PolarsAllocator;
 #[pymodule]
 fn _internal(_py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    m.add("__debug_build__", cfg!(debug_assertions))?;
     Ok(())
 }
 


### PR DESCRIPTION
Reworks the `polars_stats` vs `scipy.stats` harness around a three-way parameter **regime** axis (`scalar` / `column` / `broadcast`), and fixes two ways the old numbers were wrong.

* scipy was being benchmarked on a legacy RNG which is much slower
* Release builds are enforced:`src/lib.rs` exposes `cfg!(debug_assertions)` as `polars_stats._internal.__debug_build__`; the harness refuses to run against a debug build (or one too old to report its profile) and stamps the profile into every report.
* The correctness gate no longer passes nulls: a polars null renders as `NaN` via `to_numpy`, and `equal_nan=True` read that as agreeing with scipy's `NaN`.
* The gate now checks itself at import: six cases covering both directions, since a broken gate reports `ok` for every cell silently.
