### PR TITLE
refactor(bernoulli): compute the value-keyed closed forms in Rust

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -156,10 +156,27 @@ code rather than halfway through, write the scipy-parity test first, and keep a 
       then maps the body through the shared `value_keyed_scalar` driver. Putting the driver on the kwargs struct is
       what makes the hoist structural: a shell cannot build the distribution itself, so it cannot rebuild per row.
     * When a method is an **elementary** closed form (no special function: a Normal's
-      `0.5*log(2*pi*e*sigma^2)`, the Uniform / Exponential / Cauchy `pdf` / `cdf` / `ppf`, `mean = n*p`, ...):
-      **leave it in Python as a Polars expression, do not bind it in Rust.** A Rust binding for arithmetic Polars does
-      natively is dead FFI surface. `Uniform` and `Bernoulli` are the canonical closed-form distributions: only
-      `sample` and the validator touch Rust, everything else is a Polars hook in `_<name>.py`.
+      `0.5*log(2*pi*e*sigma^2)`, a Bernoulli's `1 - p` at 0, `mean = n*p`, ...), the test is **whether every row
+      reaches the validator**, not whether Polars can express the arithmetic:
+
+        * The validated parameter is read **unconditionally** (`Bernoulli.mean` is `_checked_p`), or it is named in a
+          `when(...)` **condition** (`Bernoulli.entropy`'s `when((p == 0) | (p == 1))`): **leave it in Python as a
+          Polars expression.** A Rust binding for arithmetic Polars does natively is dead FFI surface. In practice
+          this is the moments: `mean`, `variance`, `std`, `median`, `entropy`.
+        * The validated parameter is read **only inside a `when` / `then` / `otherwise` arm**, which is what every
+          method that branches on the *evaluation value* looks like: **compute it in Rust.** From polars 1.44 an arm
+          is masked to null on the rows it does not select, so the validator never sees an invalid parameter on those
+          rows and the method silently returns a value instead of raising
+          ([pola-rs/polars#29005](https://github.com/pola-rs/polars/issues/29005)), and no Polars expression can
+          spell a guard that survives the optimiser. In practice this is the value-keyed set: `pdf` / `pmf`,
+          `log_pdf` / `log_pmf`, `cdf`, `log_cdf`, `sf`, `log_sf`, `ppf`, `isf`. `DiscreteUniform` and `Bernoulli`
+          are the worked examples: every value-keyed method is a one-line `_value_plugin` hook over a Rust body, and
+          only the moments stay in `_<name>.py`.
+        * Split such a body into a `derive` that turns the parameters into their branch answers and a `select` that
+          picks one by the evaluation value (`bernoulli.rs`'s `Mass::pmf` / `Mass::at`). The Polars expression it
+          replaces computed `1 - p` once on a length-1 literal and broadcast it; a body that recomputes per row
+          regressed the constant-parameter path by up to 195% at 10M rows. `derive` runs once per call on that path
+          and once per row only when a parameter is a column.
     * Factor the validating constructor into a `build_dist(...) -> PolarsResult<Dist>` helper so an invalid parameter
       maps through a `ComputeError` consistently.
 2. **Python.** Add `polars_stats/distributions/_<name>.py`, subclassing `ContinuousDistribution` or
@@ -185,7 +202,7 @@ code rather than halfway through, write the scipy-parity test first, and keep a 
       its `Series`. For a statrs-backed
       distribution whose moment formulas may omit a parameter, expose the validator as `_checked_params` and gate
       every closed-form moment through `self._moment(<formula>)`; for a closed-form distribution whose validator
-      is already part of every formula (`Uniform`, `Bernoulli`), weave it in directly and do not call `_moment`.
+      is already part of every moment formula (`Uniform`, `Bernoulli`), weave it in directly and do not call `_moment`.
 
     **Never override the public `pdf` / `cdf` / ... methods**, nor the base-owned `sample` / `samples` /
     `_samples_columns` / `_value_plugin` / `_moment`. Export the class from `polars_stats/__init__.py`.

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -62,19 +62,22 @@ scalar).
 
 ## Plugin granularity
 
-**One Rust file per distribution, one `#[polars_expr]` per method that genuinely needs Rust**: trivial closed forms
-(Bernoulli's `pmf`, `cdf`, `ppf`, moments; Uniform's `pdf`, `cdf`, ...) live in Python as `pl.Expr` and compose with the
-expression engine. Methods that go through `statrs` (sampling, transcendental `pdf`/`pmf`, `cdf`, `inverse_cdf`, native
-`ln_pdf`/`ln_pmf`, native `sf`) get a Rust plugin function.
+**One Rust file per distribution, one `#[polars_expr]` per method that genuinely needs Rust**: the closed-form moments
+(Bernoulli's `mean`, `variance`, `entropy`; Uniform's, Exponential's, ...) live in Python as `pl.Expr` and compose with
+the expression engine. Methods that go through `statrs` (sampling, transcendental `pdf`/`pmf`, `cdf`, `inverse_cdf`,
+native `ln_pdf`/`ln_pmf`, native `sf`) get a Rust plugin function, and so do the elementary value-keyed closed forms:
+they branch on the evaluation value, which puts the validator inside a `when` arm where polars can mask it away
+(see [Design notes](design.md#one-rust-file-per-distribution-one-plugin-function-per-method-that-needs-rust)).
+`Exponential`, `Geometric` and `Uniform` are the three that have not moved yet.
 
 **Parameter validation needs Rust.** A bare `pl.Expr` cannot raise per row, so any method computed in Python routes its
 parameters through one small validating plugin that raises on a bad row and returns a reused quantity. For a
-closed-form distribution that covers the whole surface: `Uniform.range` returns `max - min` and raises on `max <= min`,
-`Bernoulli` validates `p` in `[0, 1]`, `Exponential` validates `rate > 0`. For a statrs-backed distribution it covers
-the closed-form moments only, since the value-keyed methods already validate inside their own plugin: `normal_sigma`
-validates `sigma > 0`, so `Normal.mean()` raises exactly as `Normal.pdf()` does. Either way a pure-math `mean` makes
-one FFI round-trip and reports an invalid parameterisation consistently, trading a little throughput for a uniform
-error surface.
+closed-form distribution that covers the whole surface: `Uniform.range` returns `max - min` and raises on
+`max <= min`, `Exponential` validates `rate > 0`. Everywhere else it covers the closed-form moments only, since the
+value-keyed methods already validate inside their own plugin: `normal_sigma` validates `sigma > 0`, so `Normal.mean()`
+raises exactly as `Normal.pdf()` does, and `bernoulli_proba` does the same for `Bernoulli`'s moments. Either way a
+pure-math `mean` makes one FFI round-trip and reports an invalid parameterisation consistently, trading a little
+throughput for a uniform error surface.
 
 ## Sampling
 

--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -25,26 +25,38 @@ Three options were considered:
 2. one function per method with an internal `DistKind` enum dispatch and a row-level `match`;
 3. Rust only where a Polars expression cannot express the method, Python otherwise.
 
-The result is **1 & 3**. Closed-form methods sit happily in Python as `pl.Expr`; only methods that go through `statrs`
-get a Rust plugin function.
+The result is **1 & 3**. Rust gets the RNG, the special functions (`erf`, log-gamma, the regularized incomplete beta
+or gamma), and anything with no elementary closed form. A Rust binding for arithmetic Polars does natively is dead FFI
+surface: more to compile, one more plugin name to keep literal, one more path to hold in parity with its own fast-path
+twin, and no accuracy or speed gain for it.
 
-Rust gets the RNG, the special functions (`erf`, log-gamma, the regularized incomplete beta or gamma), and anything
-with no elementary closed form. A Rust binding for arithmetic Polars does natively is dead FFI surface: more to
-compile, one more plugin name to keep literal, one more path to hold in parity with its own fast-path twin, and no
-accuracy or speed gain for it. Method by method:
+Being expressible in Polars is necessary for staying in Python, but not sufficient. The second test is **whether every
+row reaches the validator**: a `pl.Expr` cannot raise per row, so a method that must reject an invalid parameterisation
+depends on the validating plugin actually running on the offending row. From polars 1.44 a `when` / `then` /
+`otherwise` **arm** is masked to null on the rows it does not select, so a validator reachable only from inside an arm
+never sees them and the method silently returns a value
+([pola-rs/polars#29005](https://github.com/pola-rs/polars/issues/29005)). The **condition** is not masked, and an
+unbranched expression has nothing to mask. So a closed form stays in Python when its validated parameter is read
+unconditionally or named in a `when(...)` condition, and moves to Rust when it is read only inside an arm, which is
+what branching on the evaluation value always looks like.
+
+The table below is the rule, which every new distribution follows. It is not yet a description of the tree:
+`Exponential`, `Geometric` and `Uniform` still assemble their value-keyed methods in Polars and are being ported one
+at a time; the [reference index](../reference/index.md) carries the resulting known limitation. Method by method:
 
 | Method | In Rust? | Notes |
 |---|---|---|
 | `sample` / `samples` | **always** | Not derivable in Python. Usually `statrs`' own `Distribution::sample`. |
 | parameter validation | **always** | One validation-only round-trip per distribution, since a bare `pl.Expr` cannot raise per row. |
-| `pdf` / `pmf`, `cdf` | if special-function | Native `Continuous::pdf` / `Discrete::pmf`, `*CDF::cdf`. Elementary forms stay in Polars. |
-| `ppf` | if special-function | `*CDF::inverse_cdf`, a closed form for some families and a binary search for others. Which one sets the parity tolerance. |
-| `log_pdf` / `log_pmf` | override the default | The base default is `_pdf(x).log()`, which underflows. Bind the native `ln_pdf` / `ln_pmf` whenever `statrs` has one. |
-| `sf` | override the default | Bind native `*CDF::sf` when present: better upper-tail accuracy than `1 - cdf`. |
-| `log_cdf` / `log_sf` | override the default | `statrs` exposes neither, so there is nothing to bind and nothing safe to inherit. See [Contributing > Numerical stability](../contributing.md#numerical-stability). |
+| `pdf` / `pmf`, `cdf` | **always** | Native `Continuous::pdf` / `Discrete::pmf`, `*CDF::cdf` where `statrs` has them; a hand-written Rust body where the closed form is elementary. Branching on the value puts the validator inside an arm, so these cannot stay in Polars. |
+| `ppf` | **always** | `*CDF::inverse_cdf`, a closed form for some families and a binary search for others. Which one sets the parity tolerance. Elementary inverses are hand-written Rust bodies, for the same arm-masking reason. |
+| `log_pdf` / `log_pmf` | **always**, override the default | The base default is `_pdf(x).log()`, which underflows. Bind the native `ln_pdf` / `ln_pmf` whenever `statrs` has one, otherwise hand-write the body. |
+| `sf` | **always**, override the default | Bind native `*CDF::sf` when present: better upper-tail accuracy than `1 - cdf`. |
+| `log_cdf` / `log_sf` | **always**, override the default | `statrs` exposes neither, so there is nothing to bind and nothing safe to inherit; each is a hand-written Rust body. See [Contributing > Numerical stability](../contributing.md#numerical-stability). |
 | `mean`, `variance`, `entropy` | Polars if closed-form | `n * p`, `loc`, `1 / rate`, `log(4 * pi * scale)`. Rust only where there is no closed form: a support sum, or log-gamma plus digamma. |
 | `median` | override the default | The base default is `ppf(0.5)`. Bind native `Median::median` only where it agrees with scipy; Binomial's does not. |
-| `std`, `isf` | Polars, and override | Both base defaults (`variance().sqrt()`, `ppf(1 - q)`) saturate long before the answer does. |
+| `std` | Polars, and override | The base default `variance().sqrt()` saturates long before the answer does. |
+| `isf` | **always**, override the default | The base default `ppf(1 - q)` saturates long before the answer does, and it is value-keyed, so it carries the same arm-masking constraint as `ppf`. |
 
 ### Expose the conventional parameterisation, document the scipy mapping
 
@@ -91,13 +103,12 @@ path is selected only when the parameters are known scalars, so nothing column-v
 
 ### Constant parameters validate once, not per row
 
-The moments (`mean`, `variance`, `std`, `entropy`) and the closed-form methods of `Uniform` / `Bernoulli`
-/ `Exponential` do not build a distribution; they compute a Polars expression. But they still route their *validation*
-through a small Rust plugin (`normal_sigma`, `uniform_range`, `bernoulli_proba`, `binomial_params`, `lognormal_sigma`,
-`exponential_rate`, `beta_params`) so an invalid
-parameterisation raises the same `ComputeError` as the sampler and value-keyed methods rather than silently producing a
-nonsense moment (see "Invalid parameters raise"). With column parameters that plugin runs over the parameter columns,
-validating each row.
+The moments (`mean`, `variance`, `std`, `entropy`) and the value-keyed closed forms still assembled in Polars
+(`Uniform`, `Exponential`, `Geometric`) do not build a distribution; they compute a Polars expression. But they still
+route their *validation* through a small Rust plugin (`normal_sigma`, `uniform_range`, `bernoulli_proba`,
+`binomial_params`, `lognormal_sigma`, `exponential_rate`, `beta_params`) so an invalid parameterisation raises the same
+`ComputeError` as the sampler and value-keyed methods rather than silently producing a nonsense moment (see "Invalid
+parameters raise"). With column parameters that plugin runs over the parameter columns, validating each row.
 
 For all-scalar parameters the same plugin is called on length-1 `pl.lit` inputs, so its elementwise closure runs once.
 The validated quantity (or, for `Beta.entropy` and `Binomial.entropy`, the entropy itself) is returned behind a

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -68,22 +68,30 @@ mean of a different distribution on every row.
 
 !!! warning "Known limitation on polars >= 1.44"
 
-    On polars 1.44.0 and newer, `Bernoulli`, `Exponential`, `Geometric` and `Uniform` may **return a
-    value instead of raising `ComputeError`** when a *column-valued* parameter is invalid on a row the
-    selected branch does not cover.
+    On polars 1.44.0 and newer, `Exponential`, `Geometric` and `Uniform` may **return a value instead
+    of raising `ComputeError`** when a *column-valued* parameter is invalid on a row the selected
+    branch does not cover.
 
     Polars 1.44.0 ([pola-rs/polars#28498](https://github.com/pola-rs/polars/pull/28498)) masks the arms
     of a `when/then/otherwise` to null on the rows an arm does not select, so a validator reached only
-    from inside an arm never sees the offending row. Those four distributions assemble their
+    from inside an arm never sees the offending row. These three distributions assemble their
     value-keyed closed forms (`pdf`/`pmf`, `log_pdf`/`log_pmf`, `cdf`, `log_cdf`, `sf`, `log_sf`,
-    `ppf`, `isf`) as branching Polars expressions, so they are affected; `Exponential.log_cdf` is the
-    one exception that still raises.
+    `ppf`, `isf`) as branching Polars expressions, so they are affected. `Exponential.log_cdf` is the
+    one method among them that still raises.
 
     **Not affected:** every other distribution (they compute in Rust and validate unconditionally),
-    the moments (`mean`, `variance`, `std`, `median`, `entropy`) of all four, every scalar
-    parameterisation, and every *valid* computation, whose results are unchanged.
+    the moments (`mean`, `variance`, `std`, `median`, `entropy`) of all three, and every *valid*
+    computation, whose results are unchanged. `Bernoulli` was affected up to and including v0.0.2 and
+    no longer is: its closed forms now compute in Rust.
+
+    One narrower case survives for *every* distribution and *both* parameter spellings, scalar
+    included: a **null or `NaN` evaluation point** is masked out of the plugin's input by the wrapper
+    that gives you `null -> null` and `NaN -> NaN`, so an invalid parameter goes unreported on those
+    rows. With a column parameter that is per row; with a scalar one it takes the whole batch, so
+    `Bernoulli(p=1.5).pmf(col)` returns `[nan, nan]` over an all-`NaN` column but still raises as soon
+    as one evaluation point is finite.
 
     **Workarounds:** pin `polars<1.44` yourself, or validate column parameters before passing them.
 
     Tracked as [pola-rs/polars#29005](https://github.com/pola-rs/polars/issues/29005). The limitation
-    goes away as each of the four moves its closed forms into Rust, which is in progress.
+    goes away as each of the three moves its closed forms into Rust, which is in progress.

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -453,13 +453,16 @@ class _UnivariateDistribution(ABC):
         )
 
     def _value_plugin(self, function_name: str, value: pl.Expr) -> pl.Expr:
-        """Register a value-keyed Rust plugin call `f(value, *params)` for a statrs-backed method.
+        """Register a value-keyed Rust plugin call `f(value, *params)`, statrs-backed or hand-written.
 
         Parameters are validated inside the plugin, so every value-keyed method reports an invalid
         parameterisation consistently and propagates input nulls per row. With all-constant parameters the
         call routes to the `f"{function_name}_scalar"` twin (validated once, passed as kwargs, only `value`
-        crosses FFI), bit-identical to the per-row path. Closed-form distributions (`Uniform`, `Bernoulli`)
-        never call this; their hooks compute the formula directly in Polars.
+        crosses FFI), bit-identical to the per-row path.
+
+        A value-keyed method belongs here even where its closed form is elementary: a branching Polars
+        expression cannot be trusted to reach its validator on every row (see docs/explanation/design.md).
+        `Exponential`, `Geometric` and `Uniform` have not moved yet and still assemble theirs in Polars.
         """
         return (
             register_plugin(f"{function_name}_scalar", (value,), kwargs=self._scalar_kwargs)

--- a/polars_stats/distributions/_bernoulli.py
+++ b/polars_stats/distributions/_bernoulli.py
@@ -29,6 +29,9 @@ class Bernoulli(DiscreteDistribution):
 
     A null ``p`` propagates to null wherever the result depends on ``p``; the off-support constants
     (``pmf(2) = 0``, ``cdf(-1) = 0``, ``sf(1) = 0``) do not.
+
+    The value-keyed methods compute in Rust, so an invalid ``p`` is reported whichever branch the
+    value selects. The moments stay in Polars, reading ``p`` through the same Rust validator.
     """
 
     _p: pl.Expr
@@ -44,90 +47,53 @@ class Bernoulli(DiscreteDistribution):
 
     @property
     def _checked_p(self) -> pl.Expr:
-        """``p`` validated in Rust to lie in ``[0, 1]`` (raises otherwise), as a length-n column.
+        """``p`` validated in Rust to lie in ``[0, 1]`` (raises otherwise), as a length-n column. Null propagates.
 
-        Validated in Rust so the closed-form methods (moments and pmf/cdf/ppf) report an invalid ``p`` consistently
-        with ``sample`` rather than silently computing a negative probability. Null propagates.
-
-        `_checked` validates once for a scalar ``p`` (length-1 input) and per-row for a column,
-        returning the raw ``p`` behind the validity gate either way (length-n on both paths).
+        Read only by the moments; the value-keyed methods validate inside their own plugin instead, which is what
+        makes them immune to a branch never reaching the validator.
         """
         return self._checked("bernoulli_proba", self._p)
 
     def _pmf(self, value: pl.Expr) -> pl.Expr:
-        """``1 - p`` at 0, ``p`` at 1, ``0`` elsewhere."""
-        p = self._checked_p
-        return pl.when(value.eq(0)).then(1 - p).when(value.eq(1)).then(p).otherwise(0.0)
+        """``1 - p`` at 0, ``p`` at 1, ``0`` elsewhere; the off-support ``0`` carries no ``p``."""
+        return self._value_plugin("bernoulli_pmf", value)
 
     def _log_pmf(self, value: pl.Expr) -> pl.Expr:
         """``log1p(-p)`` at 0, ``log(p)`` at 1, ``-inf`` elsewhere.
 
-        Overrides the base ``pmf().log()``, whose ``log(1 - p)`` collapses to ``0.0`` below
-        ``p ~ 1.1e-16``. See docs/contributing.md, "Numerical stability".
+        ``log1p``, not ``log(1 - p)``: the latter collapses to ``0.0`` below ``p ~ 1.1e-16``.
         """
-        p = self._checked_p
-        return pl.when(value.eq(0)).then((-p).log1p()).when(value.eq(1)).then(p.log()).otherwise(float("-inf"))
+        return self._value_plugin("bernoulli_ln_pmf", value)
 
     def _cdf(self, value: pl.Expr) -> pl.Expr:
         """``0`` for ``value < 0``, ``1 - p`` for ``0 <= value < 1``, ``1`` for ``value >= 1``."""
-        return pl.when(value.lt(0)).then(0.0).when(value.lt(1)).then(1 - self._checked_p).otherwise(1.0)
+        return self._value_plugin("bernoulli_cdf", value)
 
     def _log_cdf(self, value: pl.Expr) -> pl.Expr:
-        """``-inf`` for ``value < 0``, ``log1p(-p)`` for ``0 <= value < 1``, ``0`` for ``value >= 1``.
-
-        Same rounding as ``_log_pmf``: the base ``cdf().log()`` loses the whole small-``p`` regime.
-        """
-        return (
-            pl.when(value.lt(0)).then(float("-inf")).when(value.lt(1)).then((-self._checked_p).log1p()).otherwise(0.0)
-        )
+        """``-inf`` for ``value < 0``, ``log1p(-p)`` for ``0 <= value < 1``, ``0`` for ``value >= 1``."""
+        return self._value_plugin("bernoulli_ln_cdf", value)
 
     def _sf(self, value: pl.Expr) -> pl.Expr:
-        """``1`` for ``value < 0``, ``p`` for ``0 <= value < 1``, ``0`` for ``value >= 1``.
+        """``1`` for ``value < 0``, ``p`` for ``0 <= value < 1``, ``0`` for ``value >= 1``."""
+        return self._value_plugin("bernoulli_sf", value)
 
-        Overrides the base ``1 - cdf``, which recomputes ``p`` as ``1 - (1 - p)`` and so quantises it
-        to the ``1.1e-16`` spacing of ``1.0``, reaching ``0.0`` below that. ``log_sf`` inherits the
-        fix through the base ``sf().log()``, which is exact once ``sf`` is.
-        """
-        return pl.when(value.lt(0)).then(1.0).when(value.lt(1)).then(self._checked_p).otherwise(0.0)
+    def _log_sf(self, value: pl.Expr) -> pl.Expr:
+        """``0`` for ``value < 0``, ``log(p)`` for ``0 <= value < 1``, ``-inf`` for ``value >= 1``."""
+        return self._value_plugin("bernoulli_ln_sf", value)
 
     def _ppf(self, quantile: pl.Expr) -> pl.Expr:
         """Smallest ``x`` with ``cdf(x) >= quantile``: ``0.0`` if ``quantile <= 1 - p`` else ``1.0``.
 
-        A quantile outside ``[0, 1]`` yields null, the contract ``ppf`` guarantees; the bare
-        inequality alone has no notion of being out of range and answered ``0.0`` / ``1.0`` there.
-        The comparison's ``Boolean`` is cast to ``Float64`` so ``ppf`` / ``isf`` / ``median`` return the
-        support point numerically, matching scipy and leaving the wrapper's ``NaN -> NaN`` contract
-        representable (``Boolean`` has no ``NaN``).
-
-        ``quantile == 1`` is mapped separately because ``1 - p`` rounds to exactly ``1.0`` below
-        ``p ~ 1.1e-16``, which made the comparison false and answered ``0.0`` where ``1.0`` is the
-        only correct answer. Every representable ``quantile < 1`` is safely below the true ``1 - p``
-        for such a ``p``, so the branch is needed only at the endpoint; ``p == 0`` keeps ``0.0``.
+        A quantile outside ``[0, 1]`` yields null. The support point comes back as ``Float64``, as scipy reports it.
         """
-        p = self._checked_p
-        return (
-            pl.when(quantile.is_between(0, 1))
-            .then(
-                pl.when(quantile >= 1.0)
-                .then((p > 0.0).cast(pl.Float64()))
-                .otherwise((quantile > 1 - p).cast(pl.Float64()))
-            )
-            .otherwise(pl.lit(None, dtype=pl.Float64()))
-        )
+        return self._value_plugin("bernoulli_ppf", quantile)
 
     def _isf(self, quantile: pl.Expr) -> pl.Expr:
         """Smallest ``x`` with ``sf(x) <= quantile``: ``1.0`` if ``p > quantile`` else ``0.0``.
 
-        Exact for every ``(p, quantile)``: ``sf(0)`` *is* ``p``, so the test forms no complement.
-        The base-class ``ppf(1 - quantile)`` formed two and lost the answer whenever either
-        saturated (``Bernoulli(1e-17).isf(1e-20)`` returned ``0.0``, not ``1.0``). Endpoints follow
-        from the same comparison (``isf(1) = 0`` always, ``isf(0) = 1`` unless ``p`` is ``0``).
+        A quantile outside ``[0, 1]`` yields null.
         """
-        return (
-            pl.when(quantile.is_between(0, 1))
-            .then((self._checked_p > quantile).cast(pl.Float64()))
-            .otherwise(pl.lit(None, dtype=pl.Float64()))
-        )
+        return self._value_plugin("bernoulli_isf", quantile)
 
     def mean(self) -> pl.Expr:
         """Expected value, ``p``."""
@@ -142,7 +108,8 @@ class Bernoulli(DiscreteDistribution):
         """Shannon entropy, ``-p * log(p) - (1 - p) * log1p(-p)``.
 
         Uses the convention ``0 * log 0 = 0`` so the result is ``0`` at the degenerate endpoints ``p in {0, 1}``.
-        The second term goes through ``log1p`` for the reason in ``_log_pmf``.
+        The second term goes through ``log1p`` for the reason in ``_log_pmf``: ``log(1 - p)`` collapses to ``0.0``
+        below ``p ~ 1.1e-16``.
         """
         p = self._checked_p
         q = 1 - p

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -1,9 +1,10 @@
+use polars::prelude::arity::try_binary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution;
 use statrs::distribution::Bernoulli;
 
-use crate::distributions::{align_inputs, validate_params_unary};
+use crate::distributions::{align_inputs, validate_params_unary, value_keyed_scalar};
 use crate::rng::{
     binary_param_rows, sample_by_index, sample_per_row_binary, samples_bool_output,
     samples_by_index, samples_per_row, SampleKwargs, SampleScalarKwargs, SamplesKwargs,
@@ -26,13 +27,33 @@ impl BernoulliParamsKwargs {
     fn build(&self) -> PolarsResult<Bernoulli> {
         build_dist(self.p)
     }
+
+    /// Constant-parameter twin of the per-row [`bernoulli_value_keyed`], sharing its `derive` and
+    /// `select` bodies: validate and derive `p` once per call, then map `select` over the
+    /// evaluation-point column. The Python side routes here only once every parameter is a Python
+    /// scalar, so `derive` always sees `Some`.
+    fn value_keyed<Branches, Derive, Select>(
+        &self,
+        value: &Series,
+        derive: Derive,
+        select: Select,
+    ) -> PolarsResult<Series>
+    where
+        Derive: Fn(Option<f64>) -> Branches,
+        Select: Fn(&Branches, f64) -> Option<f64>,
+    {
+        self.build()?;
+        let branches = derive(Some(self.p));
+        value_keyed_scalar(value, |v| select(&branches, v))
+    }
 }
 
 /// Element-wise validation of the success probability: returns `p` unchanged, raising
 /// `InvalidOperation` if `p` is outside `[0, 1]`. `null` propagates.
 ///
-/// The closed-form Python methods derive from this so they report an invalid `p` consistently
-/// with `bernoulli_sample`, instead of silently computing a negative probability.
+/// The moments derive from this so they report an invalid `p` consistently with `bernoulli_sample`,
+/// instead of silently computing a negative variance. The value-keyed methods validate inside their
+/// own plugin instead.
 #[polars_expr(output_type=Float64)]
 fn bernoulli_proba(inputs: &[Series]) -> PolarsResult<Series> {
     let proba = inputs[0].cast(&DataType::Float64)?;
@@ -41,6 +62,332 @@ fn bernoulli_proba(inputs: &[Series]) -> PolarsResult<Series> {
         build_dist(proba)?;
         Ok(proba)
     })
+}
+
+// Per-method bodies, shared by the per-row plugins and their `*_scalar` twins. Each method pairs a
+// `derive` that turns `p` into its branch answers with an `at` that picks one by where the value
+// sits. `derive` runs once per call on the constant path and once per row only when `p` is a column,
+// which is what keeps the constant path from recomputing a logarithm 10M times.
+//
+// Every slot is an `Option<f64>`, so a null `p` nulls exactly the answers that read it. The slots
+// holding a plain `Some(constant)` are the off-support answers (`pmf(2) = 0`, `cdf(-1) = 0`,
+// `sf(1) = 0`), which are documented to survive a null `p`: writing them as constants leaves no `p`
+// in scope to thread through them by accident. Pinned by
+// `tests/distributions/bernoulli/null_param_test.py`.
+
+/// `pmf` / `log_pmf`: the answer at each of the two support points, and off the support.
+struct Mass {
+    at_zero: Option<f64>,
+    at_one: Option<f64>,
+    off_support: Option<f64>,
+}
+
+impl Mass {
+    /// `1 - p` at 0, `p` at 1, `0` off the support.
+    fn pmf(p: Option<f64>) -> Self {
+        Mass {
+            at_zero: p.map(|p| 1.0 - p),
+            at_one: p,
+            off_support: Some(0.0),
+        }
+    }
+
+    /// `ln_1p(-p)` at 0, `ln(p)` at 1, `-inf` off the support.
+    ///
+    /// `ln_1p`, not `ln(1 - p)`: the latter collapses to `0.0` below `p ~ 1.1e-16`. Both logarithms
+    /// are derived where a row reads one, which costs the column path a spare `ln` and saves the
+    /// constant path a per-row one.
+    fn ln_pmf(p: Option<f64>) -> Self {
+        Mass {
+            at_zero: p.map(|p| (-p).ln_1p()),
+            at_one: p.map(f64::ln),
+            off_support: Some(f64::NEG_INFINITY),
+        }
+    }
+
+    /// Exact `f64` equality, never a cast to an integer type, so a non-integral value is off the
+    /// support rather than an error: `pmf(0.5)` is `0.0`.
+    fn at(&self, value: f64) -> Option<f64> {
+        if value == 0.0 {
+            self.at_zero
+        } else if value == 1.0 {
+            self.at_one
+        } else {
+            self.off_support
+        }
+    }
+}
+
+/// `cdf` / `log_cdf` / `sf` / `log_sf`: the answer on each side of the two steps, at 0 and at 1.
+struct Steps {
+    below_zero: Option<f64>,
+    below_one: Option<f64>,
+    at_least_one: Option<f64>,
+}
+
+impl Steps {
+    /// `0` below 0, `1 - p` on `[0, 1)`, `1` at or above 1.
+    fn cdf(p: Option<f64>) -> Self {
+        Steps {
+            below_zero: Some(0.0),
+            below_one: p.map(|p| 1.0 - p),
+            at_least_one: Some(1.0),
+        }
+    }
+
+    /// `-inf` below 0, `ln_1p(-p)` on `[0, 1)`, `0` at or above 1; same `ln_1p` reason as
+    /// [`Mass::ln_pmf`].
+    fn ln_cdf(p: Option<f64>) -> Self {
+        Steps {
+            below_zero: Some(f64::NEG_INFINITY),
+            below_one: p.map(|p| (-p).ln_1p()),
+            at_least_one: Some(0.0),
+        }
+    }
+
+    /// `1` below 0, `p` on `[0, 1)`, `0` at or above 1.
+    ///
+    /// Read straight off `p`, never as `1 - cdf`: that recomputes `p` as `1 - (1 - p)` and so
+    /// quantises it to the `1.1e-16` spacing of `1.0`, reaching `0.0` below that.
+    fn sf(p: Option<f64>) -> Self {
+        Steps {
+            below_zero: Some(1.0),
+            below_one: p,
+            at_least_one: Some(0.0),
+        }
+    }
+
+    /// The plain log of [`Steps::sf`], slot for slot: `ln(1) = 0` and `ln(0) = -inf` are exact, and
+    /// the middle slot is `p` itself, so there is no complement for an `ln_1p` to rescue.
+    fn ln_sf(p: Option<f64>) -> Self {
+        Steps {
+            below_zero: Some(0.0),
+            below_one: p.map(f64::ln),
+            at_least_one: Some(f64::NEG_INFINITY),
+        }
+    }
+
+    fn at(&self, value: f64) -> Option<f64> {
+        if value < 0.0 {
+            self.below_zero
+        } else if value < 1.0 {
+            self.below_one
+        } else {
+            self.at_least_one
+        }
+    }
+}
+
+/// `ppf`: the cdf step the quantile is compared against, and the answer at `q == 1`.
+struct PpfCutoffs {
+    /// `1 - p`, the only step in the cdf.
+    step: Option<f64>,
+    /// `1.0` unless the mass at 1 is zero, in which case `0.0`.
+    at_quantile_one: Option<f64>,
+}
+
+impl PpfCutoffs {
+    fn derive(p: Option<f64>) -> Self {
+        PpfCutoffs {
+            step: p.map(|p| 1.0 - p),
+            at_quantile_one: p.map(|p| f64::from(p > 0.0)),
+        }
+    }
+
+    /// Smallest `x` with `cdf(x) >= q`: `0.0` if `q <= 1 - p` else `1.0`; `None` (null) outside
+    /// `[0, 1]`. The support point comes back as `Float64` rather than a `Boolean` so the wrapper's
+    /// `NaN -> NaN` contract stays representable.
+    ///
+    /// `q == 1` is a separate branch because `1 - p` rounds to exactly `1.0` below `p ~ 1.1e-16`,
+    /// which made `q > 1 - p` false and answered `0.0` where `1.0` is the only correct answer. Every
+    /// representable `q < 1` is safely below the true `1 - p` for such a `p`, so the branch is
+    /// needed only at the endpoint; `p == 0` keeps `0.0`.
+    fn at(&self, quantile: f64) -> Option<f64> {
+        if !(0.0..=1.0).contains(&quantile) {
+            return None;
+        }
+        if quantile == 1.0 {
+            self.at_quantile_one
+        } else {
+            self.step.map(|step| f64::from(quantile > step))
+        }
+    }
+}
+
+/// `isf` compares against `p` itself, so there is nothing to derive.
+fn isf_proba(p: Option<f64>) -> Option<f64> {
+    p
+}
+
+/// Smallest `x` with `sf(x) <= q`: `1.0` if `p > q` else `0.0`; `None` (null) outside `[0, 1]`.
+///
+/// Tested against `q` itself, never as `ppf(1 - q)`: `sf(0)` *is* `p`, so this comparison forms no
+/// complement, while `ppf(1 - q)` forms two and loses the answer whenever either saturates
+/// (`Bernoulli(1e-17).isf(1e-20)` gave `0.0` against a true `1.0`).
+fn isf_at(p: &Option<f64>, quantile: f64) -> Option<f64> {
+    if !(0.0..=1.0).contains(&quantile) {
+        return None;
+    }
+    p.map(|p| f64::from(p > quantile))
+}
+
+/// Apply `derive` then `select` element-wise over `(value, p)`; shared by the eight value-keyed
+/// plugins. Each method derives its own type ([`Mass`], [`Steps`], [`PpfCutoffs`], `Option<f64>`),
+/// so pairing one method's `derive` with another's `select` does not compile.
+///
+/// Null contract: a null `value` nulls the row without validating, matching
+/// [`value_keyed_per_row`](crate::distributions::value_keyed_per_row) and the samplers. A null `p`
+/// is **not** a row-level short-circuit, which is what separates this driver from the shared one: it
+/// reaches `derive` as `None` so the slots that carry no `p` still answer. Nothing is validated on a
+/// null-`p` row, since there is no parameterisation to reject.
+///
+/// `NaN` contract: a `NaN` value short-circuits to `NaN`, but only after `p` has been validated, so
+/// an invalid parameterisation still raises on a `NaN` row.
+///
+/// Bernoulli is the only consumer today. `Exponential` is the next single-parameter catalogue entry
+/// whose closed forms move into Rust, so hoist this into `mod.rs` beside `value_keyed_per_row` when
+/// its port makes it a second consumer, not before.
+fn bernoulli_value_keyed<Branches, Derive, Select>(
+    inputs: &[Series],
+    derive: Derive,
+    select: Select,
+) -> PolarsResult<Series>
+where
+    Derive: Fn(Option<f64>) -> Branches,
+    Select: Fn(&Branches, f64) -> Option<f64>,
+{
+    let inputs = align_inputs(inputs)?;
+    let value = inputs[0].cast(&DataType::Float64)?;
+    let proba = inputs[1].cast(&DataType::Float64)?;
+    let name = inputs[0].name().clone();
+
+    let ca: Float64Chunked = try_binary_elementwise(
+        value.f64()?,
+        proba.f64()?,
+        |value_opt, proba_opt| -> PolarsResult<Option<f64>> {
+            let Some(value) = value_opt else {
+                return Ok(None);
+            };
+            // Validate before the `NaN` short-circuit, so an invalid `p` still raises on a `NaN`
+            // row, exactly as `value_keyed_per_row` orders it.
+            if let Some(proba) = proba_opt {
+                build_dist(proba)?;
+            }
+            Ok(if value.is_nan() {
+                Some(f64::NAN)
+            } else {
+                select(&derive(proba_opt), value)
+            })
+        },
+    )?;
+
+    Ok(ca.with_name(name).into_series())
+}
+
+/// Element-wise pmf: `1 - p` at 0, `p` at 1, `0` off the support.
+/// See [`bernoulli_value_keyed`] for the null/error contract.
+#[polars_expr(output_type=Float64)]
+fn bernoulli_pmf(inputs: &[Series]) -> PolarsResult<Series> {
+    bernoulli_value_keyed(inputs, Mass::pmf, Mass::at)
+}
+
+/// Element-wise log-pmf; see [`Mass::ln_pmf`] for the `ln_1p` reason.
+#[polars_expr(output_type=Float64)]
+fn bernoulli_ln_pmf(inputs: &[Series]) -> PolarsResult<Series> {
+    bernoulli_value_keyed(inputs, Mass::ln_pmf, Mass::at)
+}
+
+/// Element-wise cdf `P(X <= value)`; see [`Steps::cdf`].
+#[polars_expr(output_type=Float64)]
+fn bernoulli_cdf(inputs: &[Series]) -> PolarsResult<Series> {
+    bernoulli_value_keyed(inputs, Steps::cdf, Steps::at)
+}
+
+/// Element-wise log-cdf; see [`Steps::ln_cdf`].
+#[polars_expr(output_type=Float64)]
+fn bernoulli_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
+    bernoulli_value_keyed(inputs, Steps::ln_cdf, Steps::at)
+}
+
+/// Element-wise survival function `P(X > value)`; see [`Steps::sf`] for why it is not `1 - cdf`.
+#[polars_expr(output_type=Float64)]
+fn bernoulli_sf(inputs: &[Series]) -> PolarsResult<Series> {
+    bernoulli_value_keyed(inputs, Steps::sf, Steps::at)
+}
+
+/// Element-wise log-sf; see [`Steps::ln_sf`].
+#[polars_expr(output_type=Float64)]
+fn bernoulli_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
+    bernoulli_value_keyed(inputs, Steps::ln_sf, Steps::at)
+}
+
+/// Element-wise ppf (inverse cdf), returning the support point as `f64`; see [`PpfCutoffs::at`].
+#[polars_expr(output_type=Float64)]
+fn bernoulli_ppf(inputs: &[Series]) -> PolarsResult<Series> {
+    bernoulli_value_keyed(inputs, PpfCutoffs::derive, PpfCutoffs::at)
+}
+
+/// Element-wise inverse survival function; see [`isf_at`] for why it never forms a complement.
+#[polars_expr(output_type=Float64)]
+fn bernoulli_isf(inputs: &[Series]) -> PolarsResult<Series> {
+    bernoulli_value_keyed(inputs, isf_proba, isf_at)
+}
+
+/// Constant-parameter fast path for [`bernoulli_pmf`].
+#[polars_expr(output_type=Float64)]
+fn bernoulli_pmf_scalar(inputs: &[Series], kwargs: BernoulliParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], Mass::pmf, Mass::at)
+}
+
+/// Constant-parameter fast path for [`bernoulli_ln_pmf`].
+#[polars_expr(output_type=Float64)]
+fn bernoulli_ln_pmf_scalar(
+    inputs: &[Series],
+    kwargs: BernoulliParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], Mass::ln_pmf, Mass::at)
+}
+
+/// Constant-parameter fast path for [`bernoulli_cdf`].
+#[polars_expr(output_type=Float64)]
+fn bernoulli_cdf_scalar(inputs: &[Series], kwargs: BernoulliParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], Steps::cdf, Steps::at)
+}
+
+/// Constant-parameter fast path for [`bernoulli_ln_cdf`].
+#[polars_expr(output_type=Float64)]
+fn bernoulli_ln_cdf_scalar(
+    inputs: &[Series],
+    kwargs: BernoulliParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], Steps::ln_cdf, Steps::at)
+}
+
+/// Constant-parameter fast path for [`bernoulli_sf`].
+#[polars_expr(output_type=Float64)]
+fn bernoulli_sf_scalar(inputs: &[Series], kwargs: BernoulliParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], Steps::sf, Steps::at)
+}
+
+/// Constant-parameter fast path for [`bernoulli_ln_sf`].
+#[polars_expr(output_type=Float64)]
+fn bernoulli_ln_sf_scalar(
+    inputs: &[Series],
+    kwargs: BernoulliParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], Steps::ln_sf, Steps::at)
+}
+
+/// Constant-parameter fast path for [`bernoulli_ppf`].
+#[polars_expr(output_type=Float64)]
+fn bernoulli_ppf_scalar(inputs: &[Series], kwargs: BernoulliParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], PpfCutoffs::derive, PpfCutoffs::at)
+}
+
+/// Constant-parameter fast path for [`bernoulli_isf`].
+#[polars_expr(output_type=Float64)]
+fn bernoulli_isf_scalar(inputs: &[Series], kwargs: BernoulliParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], isf_proba, isf_at)
 }
 
 /// One Bernoulli draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -161,10 +161,10 @@ where
 /// from both (Uniform's `max - min`), `?`-propagating the `InvalidOperation` out of `build_dist`.
 /// Any null input nulls the row without calling `validate`, matching the samplers.
 ///
-/// These plugins are what let the closed-form moments and (for Uniform / Bernoulli) value-keyed
-/// methods, which are pure Polars expressions, report an invalid parameterisation through the same
-/// Rust `build_dist`. The constant-parameter fast path calls the same plugin on length-1 `pl.lit`
-/// inputs, so it is built once instead of per row.
+/// These plugins are what let the closed-form moments, and the value-keyed methods still assembled
+/// in Polars (`Exponential`, `Geometric`, `Uniform`), report an invalid parameterisation through the
+/// same Rust `build_dist`. The constant-parameter fast path calls the same plugin on length-1
+/// `pl.lit` inputs, so it is built once instead of per row.
 ///
 /// The two parameter dtypes are independent, so a mixed `(u64, f64)` parameterisation (Binomial)
 /// fits, as in [`ternary_param_rows`](crate::rng::ternary_param_rows): the caller does the cast and

--- a/tests/distributions/bernoulli/null_param_test.py
+++ b/tests/distributions/bernoulli/null_param_test.py
@@ -1,0 +1,98 @@
+"""A null `p` nulls every answer that depends on it, and only those.
+
+`pmf(2) = 0`, `cdf(-1) = 0` and `sf(1) = 0` carry no `p`, so they survive a null one; the class
+docstring promises it and `Geometric` behaves the same way.
+
+The contract lives in how the Rust bodies derive their branches: `p` arrives as an `Option<f64>` and
+only the slots whose answer reads it are `p.map(...)`. Threading `p` through one `Option` chain
+around a whole body would null the constants out and leave the rest of the suite green, since the
+per-method null tests all evaluate on the support.
+"""
+
+from __future__ import annotations
+
+import math
+
+import polars as pl
+import pytest
+
+from polars_stats import Bernoulli
+
+_NEG_INF = float("-inf")
+
+# (method, value, expected) for the answers that hold with no `p` at all.
+_OFF_SUPPORT: list[tuple[str, float, float]] = [
+    ("pmf", -1.0, 0.0),
+    ("pmf", 0.5, 0.0),
+    ("pmf", 2.0, 0.0),
+    ("log_pmf", -1.0, _NEG_INF),
+    ("log_pmf", 0.5, _NEG_INF),
+    ("log_pmf", 2.0, _NEG_INF),
+    ("cdf", -1.0, 0.0),
+    ("cdf", 1.0, 1.0),
+    ("log_cdf", -1.0, _NEG_INF),
+    ("log_cdf", 1.0, 0.0),
+    ("sf", -1.0, 1.0),
+    ("sf", 1.0, 0.0),
+    ("log_sf", -1.0, 0.0),
+    ("log_sf", 1.0, _NEG_INF),
+]
+
+# (method, value) pairs whose answer reads `p`, so a null one must reach the result.
+_ON_SUPPORT: list[tuple[str, float]] = [
+    ("pmf", 0.0),
+    ("pmf", 1.0),
+    ("log_pmf", 0.0),
+    ("log_pmf", 1.0),
+    ("cdf", 0.0),
+    ("log_cdf", 0.0),
+    ("sf", 0.0),
+    ("log_sf", 0.0),
+]
+
+_MOMENTS = ["mean", "variance", "std", "median", "entropy"]
+
+
+def _null_p() -> pl.DataFrame:
+    return pl.DataFrame({"p": [None]}, schema={"p": pl.Float64})
+
+
+@pytest.mark.parametrize(
+    ("method", "value", "expected"),
+    _OFF_SUPPORT,
+    ids=[f"{method}({value})" for method, value, _ in _OFF_SUPPORT],
+)
+def test_off_support_constant_survives_a_null_p(method: str, value: float, expected: float) -> None:
+    result = _null_p().select(r=getattr(Bernoulli(p=pl.col("p")), method)(value))["r"].item()
+    assert result == expected
+
+
+@pytest.mark.parametrize(("method", "value"), _ON_SUPPORT, ids=[f"{method}({value})" for method, value in _ON_SUPPORT])
+def test_on_support_value_nulls_under_a_null_p(method: str, value: float) -> None:
+    assert _null_p().select(r=getattr(Bernoulli(p=pl.col("p")), method)(value))["r"].item() is None
+
+
+@pytest.mark.parametrize("method", _MOMENTS)
+def test_moment_nulls_under_a_null_p(method: str) -> None:
+    assert _null_p().select(r=getattr(Bernoulli(p=pl.col("p")), method)())["r"].item() is None
+
+
+@pytest.mark.parametrize("method", ["ppf", "isf"])
+@pytest.mark.parametrize("quantile", [0.0, 0.5, 1.0, 2.0])
+def test_inverse_nulls_under_a_null_p(method: str, quantile: float) -> None:
+    """Null inside `[0, 1]` because the answer needs `p`, and null outside it by the domain contract.
+
+    The endpoints are probed because `ppf(1.0)` reads its own derived slot rather than the cdf step.
+    """
+    assert _null_p().select(r=getattr(Bernoulli(p=pl.col("p")), method)(quantile))["r"].item() is None
+
+
+def test_nan_value_stays_nan_under_a_null_p() -> None:
+    """A `NaN` evaluation point short-circuits before the branches, so a null `p` does not null it.
+
+    The one row where the local driver diverges from the shared `value_keyed_per_row`, which nulls a
+    row on any null parameter. Reached through the private hook, since the public wrapper answers
+    `NaN` on its own.
+    """
+    result = _null_p().select(r=Bernoulli(p=pl.col("p"))._pmf(pl.lit(math.nan)))["r"].item()
+    assert math.isnan(result)

--- a/tests/distributions/bernoulli/validation_test.py
+++ b/tests/distributions/bernoulli/validation_test.py
@@ -11,8 +11,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 # Every public method must report an out-of-range `p` as a ComputeError, not silently compute a
-# negative probability. The deterministic methods all derive from the Rust-validated `_checked_p`;
-# the samplers validate in their own plugin.
+# negative probability. The moments read the Rust-validated `_checked_p`; the value-keyed methods and
+# the samplers validate inside their own plugin.
 _METHODS: dict[str, Callable[[Bernoulli], pl.Expr]] = {
     "pmf": lambda b: b.pmf(pl.col("x")),
     "log_pmf": lambda b: b.log_pmf(pl.col("x")),

--- a/tests/distributions/exponential/null_params_test.py
+++ b/tests/distributions/exponential/null_params_test.py
@@ -39,10 +39,10 @@ def test_method_propagates_null_in_rate(expr_fn: Callable[[Exponential], pl.Expr
 
 
 def test_value_keyed_below_support_ignores_null_rate() -> None:
-    # Closed-form trait shared with Uniform / Bernoulli: below the support the value-keyed methods
-    # return the rate-independent support constant (pdf / cdf -> 0, sf -> 1), so a null rate does NOT
-    # null the row there. statrs-backed distributions (Binomial) null it instead; this is the
-    # documented trade-off of computing the closed form in Polars rather than in a Rust plugin.
+    # Closed-form trait shared with Uniform: below the support the value-keyed methods return the
+    # rate-independent support constant (pdf / cdf -> 0, sf -> 1), so a null rate does NOT null the
+    # row there. statrs-backed distributions (Binomial) null it instead. Bernoulli keeps the same
+    # contract in Rust (tests/distributions/bernoulli/null_param_test.py).
     df = pl.DataFrame({"rate": [1.0, None, 2.0]}, schema={"rate": pl.Float64})
     e = Exponential(rate=pl.col("rate"))
     assert df.select(r=e.pdf(pl.lit(-1.0)))["r"].to_list() == [0.0, 0.0, 0.0]

--- a/tests/distributions/plugin_nan_test.py
+++ b/tests/distributions/plugin_nan_test.py
@@ -14,6 +14,10 @@ in two places:
 * `Binomial`: `NaN < 0.0` is false and `NaN.floor() as u64` saturates to `0`, so unguarded bodies
   would return a confident `P(X <= 0)` (and a `pmf` of `0.0`).
 
+`Bernoulli` reimplements the short-circuit in its own driver (`bernoulli_value_keyed`), which the
+shared one could not serve because it nulls a row on any null parameter. Covered here so the two
+cannot drift.
+
 Both plugin shapes are covered: scalar-parameter instances route to the `<method>_scalar` twins,
 column-parameter instances to the per-row plugins.
 """
@@ -26,7 +30,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
-from polars_stats import Beta, Binomial, DiscreteUniform, LogNormal, Normal
+from polars_stats import Bernoulli, Beta, Binomial, DiscreteUniform, LogNormal, Normal
 from polars_stats.distributions._base import DiscreteDistribution
 
 if TYPE_CHECKING:
@@ -40,6 +44,8 @@ def _col(value: float, dtype: PolarsDataType | None = None) -> pl.Expr:
 
 
 _CASES = [
+    ("bernoulli-scalar", Bernoulli(p=0.3)),
+    ("bernoulli-columns", Bernoulli(p=_col(0.3))),
     ("normal-scalar", Normal(mu=0.5, sigma=2.0)),
     ("normal-columns", Normal(mu=_col(0.5), sigma=_col(2.0))),
     ("lognormal-scalar", LogNormal(mu=0.5, sigma=2.0)),

--- a/tests/distributions/validation_contract_test.py
+++ b/tests/distributions/validation_contract_test.py
@@ -1,4 +1,11 @@
-"""Every value-keyed method reports an invalid parameterisation, whichever branch the value selects."""
+"""Every value-keyed method reports an invalid parameterisation, whichever branch the value selects.
+
+Two axes, one contract. The first test sweeps the *evaluation value* across every branch of every
+method, and is what the Rust ports exist to make green. The second holds the value at `NaN` and
+targets `propagate_null_and_nan` instead, a `when/then/otherwise` wrapped around every public
+value-keyed method: a second place the validator can sit inside an arm, one level above the
+distribution.
+"""
 
 from __future__ import annotations
 
@@ -31,7 +38,10 @@ if TYPE_CHECKING:
 class _Case:
     """One distribution parameterised from columns, where row 0 is valid and row 1 is not.
 
-    `fragment` is matched against the raised message, so it names the offending parameter.
+    `fragment` is matched against the raised message, so it names the offending parameter. It carries
+    enough of the validator's own wording to fail on the wrong parameter: a bare `"p"` matches the
+    `the plugin failed with message:` preamble polars wraps every plugin error in, which would make
+    the check unfailable for the four distributions whose parameter is one letter.
     """
 
     name: str
@@ -41,15 +51,22 @@ class _Case:
 
 
 _CASES: tuple[_Case, ...] = (
-    _Case("Bernoulli", Bernoulli(p=pl.col("p")), {"p": [0.3, 1.5]}, "p"),
-    _Case("Beta", Beta(a=pl.col("a"), b=pl.col("b")), {"a": [2.0, -1.0], "b": [3.0, 3.0]}, "a"),
-    _Case("Binomial", Binomial(n=pl.col("n"), p=pl.col("p")), {"n": [10, 10], "p": [0.3, 1.5]}, "p"),
-    _Case("DiscreteUniform", DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")), {"lo": [0, 5], "hi": [10, 2]}, "max"),
-    _Case("Exponential", Exponential(rate=pl.col("r")), {"r": [1.0, -1.0]}, "rate"),
-    _Case("Geometric", Geometric(p=pl.col("p")), {"p": [0.3, 1.5]}, "p"),
-    _Case("LogNormal", LogNormal(mu=pl.col("m"), sigma=pl.col("s")), {"m": [0.0, 0.0], "s": [1.0, -1.0]}, "sigma"),
-    _Case("Normal", Normal(mu=pl.col("m"), sigma=pl.col("s")), {"m": [0.0, 0.0], "s": [1.0, -1.0]}, "sigma"),
-    _Case("Uniform", Uniform(min=pl.col("lo"), max=pl.col("hi")), {"lo": [0.0, 5.0], "hi": [1.0, 2.0]}, "max"),
+    _Case("Bernoulli", Bernoulli(p=pl.col("p")), {"p": [0.3, 1.5]}, "p must be in"),
+    _Case("Beta", Beta(a=pl.col("a"), b=pl.col("b")), {"a": [2.0, -1.0], "b": [3.0, 3.0]}, "a and b must be"),
+    _Case("Binomial", Binomial(n=pl.col("n"), p=pl.col("p")), {"n": [10, 10], "p": [0.3, 1.5]}, "p must be in"),
+    _Case(
+        "DiscreteUniform",
+        DiscreteUniform(min=pl.col("lo"), max=pl.col("hi")),
+        {"lo": [0, 5], "hi": [10, 2]},
+        "max must be",
+    ),
+    _Case("Exponential", Exponential(rate=pl.col("r")), {"r": [1.0, -1.0]}, "rate must be"),
+    _Case("Geometric", Geometric(p=pl.col("p")), {"p": [0.3, 1.5]}, "p must be in"),
+    _Case(
+        "LogNormal", LogNormal(mu=pl.col("m"), sigma=pl.col("s")), {"m": [0.0, 0.0], "s": [1.0, -1.0]}, "sigma must be"
+    ),
+    _Case("Normal", Normal(mu=pl.col("m"), sigma=pl.col("s")), {"m": [0.0, 0.0], "s": [1.0, -1.0]}, "sigma must be"),
+    _Case("Uniform", Uniform(min=pl.col("lo"), max=pl.col("hi")), {"lo": [0.0, 5.0], "hi": [1.0, 2.0]}, "max must be"),
 )
 
 _VALUE_METHODS = ("pdf", "log_pdf", "pmf", "log_pmf", "cdf", "log_cdf", "sf", "log_sf")
@@ -66,12 +83,12 @@ _QUANTILES = (-0.5, 0.001, 0.5, 0.999, 1.5)
 A `None` quantile is deliberately *not* probed. Polars masks null rows out of an elementwise plugin's
 input on every supported version, so the parameters on a null row never reach the validator and no
 distribution raises, `DiscreteUniform` and the other Rust-backed ones included. That is a property of
-plugin dispatch, not of the branch the value selects, so it says nothing about this contract.
+plugin dispatch, not of the branch the value selects, and removing `propagate_null_and_nan` would not
+change it, which is what separates it from the `NaN` point the second test does probe.
 """
 
 
 _LEAKING_METHODS: dict[str, frozenset[str]] = {
-    "Bernoulli": frozenset({"pmf", "log_pmf", "cdf", "log_cdf", "sf", "log_sf", "ppf", "isf"}),
     "Exponential": frozenset({"pdf", "log_pdf", "cdf", "sf", "log_sf", "ppf", "isf"}),
     "Geometric": frozenset({"pmf", "log_pmf", "cdf", "log_cdf", "sf", "log_sf", "ppf", "isf"}),
     "Uniform": frozenset({"pdf", "log_pdf", "cdf", "log_cdf", "sf", "log_sf", "ppf", "isf"}),
@@ -79,9 +96,9 @@ _LEAKING_METHODS: dict[str, frozenset[str]] = {
 """The (distribution, method) pairs that `ARM_MASKING_HIDES_VALIDATION` is expected to break.
 
 Measured, not assumed: these are exactly the pairs that fail on polars 1.44.1 and pass on 1.43.2.
-`Exponential.log_cdf` is absent because it alone among the four distributions' 32 value-keyed methods
-still raises, so gating it would `XPASS` under `xfail_strict`. Porting a distribution's closed forms
-to Rust deletes its entry here; the last one to go deletes the dict and the constant with it.
+`Exponential.log_cdf` is absent because it alone among the three remaining distributions' 24
+value-keyed methods still raises, so gating it would `XPASS` under `xfail_strict`. Porting a
+distribution's closed forms to Rust deletes its entry here; the last one to go deletes the dict.
 """
 
 _METHOD_VALUES: tuple[tuple[str, tuple[float, ...]], ...] = (
@@ -129,3 +146,39 @@ def test_invalid_parameter_raises_whichever_branch_the_value_selects(
     assert not accepted, f"{case.name}.{method} accepted the invalid parameterisation at {accepted}"
     misnamed = [value for value, report in reports if report is not None and case.fragment not in report]
     assert not misnamed, f"{case.name}.{method} raised without naming `{case.fragment}` at {misnamed}"
+
+
+_NAN_METHODS = (*_VALUE_METHODS, *_QUANTILE_METHODS)
+"""Every value-keyed method, since the wrapper below sits on all of them identically."""
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_ids)
+def test_invalid_parameter_raises_at_a_nan_evaluation_point(case: _Case, request: pytest.FixtureRequest) -> None:
+    """One assertion per distribution, over every value-keyed method, at a `NaN` evaluation point.
+
+    The methods are looped inside rather than parametrised over, unlike the test above: leakage there
+    varies by method, so its gate needs method precision, while here all 72 (distribution, method)
+    pairs leak on polars 1.44.1 and all 72 raise on 1.43.2. One item per distribution matches that
+    shape and keeps the gate to one marker instead of seventy-two.
+
+    The leak is in `propagate_null_and_nan` (`_base.py`), not in any distribution: it spells the
+    null/`NaN` overlay as `when(...).then(...).otherwise(result)`, so from polars 1.44 the plugin in
+    `result` is masked out on exactly the `NaN` rows and never validates. Bypassing the wrapper makes
+    the same call raise, which is why `Bernoulli` and `DiscreteUniform` leak here despite computing
+    entirely in Rust. Porting a distribution does not fix this one; deleting the wrapper does.
+    """
+    # Passed as the marker's own condition rather than an `if`, since it is true for every item here:
+    # a Python-level branch would leave its false side unexecuted on polars >= 1.44.
+    reason = "pola-rs/polars#29005, at the wrapper rather than the hook"
+    request.applymarker(pytest.mark.xfail(ARM_MASKING_HIDES_VALIDATION, reason=reason))
+
+    probed = [(method, fn) for method in _NAN_METHODS if (fn := getattr(case.dist, method, None)) is not None]
+    # Eight of the ten always resolve; the other two are the wrong-family `pdf` / `pmf` pair. Asserted
+    # so a renamed method shrinks the sweep loudly instead of silently.
+    assert len(probed) == len(_NAN_METHODS) - 2
+    reports = [(method, _report(case, fn, float("nan"))) for method, fn in probed]
+    # Silence and a misnamed message are merged into one predicate, where the test above keeps them
+    # apart. Every probe here leaks on the gated version, so a second assertion would be a line no
+    # supported polars ever reaches.
+    unreported = [method for method, report in reports if report is None or case.fragment not in report]
+    assert not unreported, f"{case.name} did not report the invalid `{case.fragment}` at a NaN point in {unreported}"

--- a/tests/distributions/value_keyed_fast_path_test.py
+++ b/tests/distributions/value_keyed_fast_path_test.py
@@ -1,6 +1,7 @@
 """Validation contract of the constant-parameter value-keyed fast path.
 
-Covers Normal, LogNormal, Binomial, Beta and DiscreteUniform, the distributions with per-method Rust plugins.
+Covers Normal, LogNormal, Binomial, Beta, DiscreteUniform and Bernoulli: the distributions with
+per-method Rust plugins.
 
 `pdf` / `pmf` / `cdf` / `sf` / `ppf` with all-scalar parameters route through a dedicated ``<name>_<method>_scalar``
 plugin that validates and builds the `statrs` distribution once (via the shared `build_dist`), instead of rebuilding it
@@ -30,7 +31,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
-from polars_stats import Beta, Binomial, DiscreteUniform, LogNormal, Normal
+from polars_stats import Bernoulli, Beta, Binomial, DiscreteUniform, LogNormal, Normal
 from polars_stats.distributions._base import ContinuousDistribution
 from tests._polars_compat import assert_series_equal
 
@@ -58,6 +59,12 @@ def _col(value: float, dtype: pl.DataType | None = None) -> pl.Expr:
 # should raise. `int` `n` for binomial keeps its `Int64` column dtype.
 # id -> (scalar factory, column factory, should_raise)
 _CASES: dict[str, tuple[Callable[[], _UnivariateDistribution], Callable[[], _UnivariateDistribution], bool]] = {
+    "bernoulli p=nan": (lambda: Bernoulli(_NAN), lambda: Bernoulli(_col(_NAN)), True),
+    "bernoulli p=-0.1": (lambda: Bernoulli(-0.1), lambda: Bernoulli(_col(-0.1)), True),
+    "bernoulli p=1.5": (lambda: Bernoulli(1.5), lambda: Bernoulli(_col(1.5)), True),
+    # The degenerate point masses are legitimate parameterisations; both paths must accept them.
+    "bernoulli p=0 (accepted)": (lambda: Bernoulli(0.0), lambda: Bernoulli(_col(0.0)), False),
+    "bernoulli p=1 (accepted)": (lambda: Bernoulli(1.0), lambda: Bernoulli(_col(1.0)), False),
     "normal mu=nan": (lambda: Normal(_NAN, 1.0), lambda: Normal(_col(_NAN), _col(1.0)), True),
     "normal std=0": (lambda: Normal(0.0, 0.0), lambda: Normal(_col(0.0), _col(0.0)), True),
     "normal std=-1": (lambda: Normal(0.0, -1.0), lambda: Normal(_col(0.0), _col(-1.0)), True),

--- a/tests/property/fast_path_context_test.py
+++ b/tests/property/fast_path_context_test.py
@@ -139,9 +139,9 @@ def test_moment_fast_path_matches_per_row_across_contexts(spec: DistSpec, moment
 def test_value_keyed_fast_path_matches_per_row_across_contexts(spec: DistSpec, data: st.DataObject) -> None:
     """Density / log-density / cdf / sf / ppf scalar fast paths equal the per-row path under every context.
 
-    This is where the Uniform / Bernoulli closed forms (which route their *validation* through the
-    same `_checked` gate as the moments) get their cross-context coverage: their value-keyed methods
-    are pure Polars, so a broadcast bug in the scalar gate is the only way they could diverge.
+    This is where the `Exponential` / `Geometric` / `Uniform` closed forms get their cross-context
+    coverage: their value-keyed methods are pure Polars, routing validation through the same
+    `_checked` gate as the moments, so a broadcast bug in that gate is the only way they diverge.
     """
     params = data.draw(spec.params)
     scalar = spec.make(params)

--- a/tests/property/value_keyed_test.py
+++ b/tests/property/value_keyed_test.py
@@ -7,10 +7,10 @@ In Rust both plugins call the same named per-method body, so for any parameteris
 must agree bit for bit, including null propagation and ppf's null-outside-``[0, 1]`` contract. A
 divergence (e.g. a parameter-order swap in a scalar kwargs struct) must fail here.
 
-Bit-equality holds wherever a single Rust body feeds both paths. ``bernoulli``, ``uniform``, ``exponential`` and
-``geometric`` have no Rust value-keyed plugin: both evaluate the same Polars expression, and the scalar path does it on
-length-1 operands, so polars may fold it differently. Where that moves the last bit
-(``ULP_TOLERANT_VALUE_SPECS``) the comparison is 1 ULP; the rest stay exact.
+Bit-equality holds wherever a single Rust body feeds both paths. ``uniform``, ``exponential`` and
+``geometric`` have no Rust value-keyed plugin: both evaluate the same Polars expression, and the
+scalar path does it on length-1 operands, so polars may fold it differently. Where that moves the
+last bit (``ULP_TOLERANT_VALUE_SPECS``) the comparison is 1 ULP; the rest stay exact.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Moves Bernoulli's eight value-keyed methods (pmf, log_pmf, cdf, log_cdf, sf, log_sf, ppf, isf) from branching Polars expressions into one Rust plugin pass each, so an invalid `p` is reported whichever branch the value selects and the arm-masking gate can be deleted.

Answers are unchanged bit for bit on both engines; the column regime gets 38–81% faster by collapsing repeated bernoulli_proba FFI passes into one call. Also inverts the Rust-versus-Polars rule in contributing.md and design.md, which named Bernoulli as the canonical Python-side closed form, and adds the `null_param_test.p`y that was missing for the off-support/null-p contract.