### PR TITLE
refactor(exponential): compute the value-keyed closed forms in Rust

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -173,10 +173,15 @@ code rather than halfway through, write the scipy-parity test first, and keep a 
           are the worked examples: every value-keyed method is a one-line `_value_plugin` hook over a Rust body, and
           only the moments stay in `_<name>.py`.
         * Split such a body into a `derive` that turns the parameters into their branch answers and a `select` that
-          picks one by the evaluation value (`bernoulli.rs`'s `Mass::pmf` / `Mass::at`). The Polars expression it
-          replaces computed `1 - p` once on a length-1 literal and broadcast it; a body that recomputes per row
-          regressed the constant-parameter path by up to 195% at 10M rows. `derive` runs once per call on that path
-          and once per row only when a parameter is a column.
+          picks one by the evaluation value (`bernoulli.rs`'s `Mass::pmf` / `Mass::at`, `exponential.rs`'s
+          `derive_cdf` / `Sides::at`). The Polars expression it replaces computed `1 - p` once on a length-1 literal
+          and broadcast it; a body that recomputes per row regressed the constant-parameter path by up to 195% at
+          10M rows. `derive` runs once per call on the constant path and once per row when a parameter is a column.
+        * A one-parameter distribution pairs those two through `value_keyed_derived_per_row` and
+          `value_keyed_derived_scalar` in `src/distributions/mod.rs`; both plugin shells are one line and neither
+          names a driver internal. They are not `value_keyed_per_row`, which nulls a row on **any** null input: a
+          null parameter has to reach `derive` as `None` so the branches whose answer carries no parameter still
+          answer (`Bernoulli.pmf(2) = 0`, `Exponential.cdf(-1) = 0`).
     * Factor the validating constructor into a `build_dist(...) -> PolarsResult<Dist>` helper so an invalid parameter
       maps through a `ComputeError` consistently.
 2. **Python.** Add `polars_stats/distributions/_<name>.py`, subclassing `ContinuousDistribution` or
@@ -290,8 +295,8 @@ rather than an argument to accept. Both rules were bought the same way: a `pdf`-
 found again elsewhere, and three distributions cleared from the `isf` fix by reasoning that each fell to the first
 probe aimed at it.
 
-**Where the recipes live.** `Exponential._log_sf` (an exact closed form), `Exponential._cdf` and `LogNormal.variance`
-(the `sinh` identity standing in for the `expm1` Polars does not expose), `Exponential._log_cdf` and
+**Where the recipes live.** `exponential.rs`'s `derive_ln_sf` (an exact closed form), its `derive_cdf` and
+`LogNormal.variance` (the `sinh` identity standing in for the `expm1` Polars does not expose), its `derive_ln_cdf` and
 `Uniform._log_cdf` (`log1p` on the near-certain side), `normal.rs`'s `ln_erfc` (a special function ported to log
 space, the pattern for the hard cases), and the `isf_value` bodies in `normal.rs` (a symmetry) and `lognormal.rs`
 (composing one).

--- a/docs/explanation/accuracy.md
+++ b/docs/explanation/accuracy.md
@@ -107,7 +107,7 @@ magnitudes are in the inherited limits below.
   and `Uniform(pl.col("lo"), pl.col("hi")).cdf("x")` evaluate the same closed form, but polars folds the
   constant spelling over one row and the column spelling over `n`, and the two kernels do not round
   identically. It reaches the methods evaluated as polars expressions rather than in Rust: `Uniform`'s
-  moments and value-keyed methods, `Exponential`'s value-keyed methods, and `Geometric.std` / `.entropy`.
+  moments and value-keyed methods, and `Geometric.std` / `.entropy`.
   The difference is at or below `1e-15` relative, roughly 4x a double's ULP. Everything backed by `statrs`
   runs the same Rust body either way and stays bit-identical.
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -63,20 +63,20 @@ scalar).
 ## Plugin granularity
 
 **One Rust file per distribution, one `#[polars_expr]` per method that genuinely needs Rust**: the closed-form moments
-(Bernoulli's `mean`, `variance`, `entropy`; Uniform's, Exponential's, ...) live in Python as `pl.Expr` and compose with
+(Bernoulli's `mean`, `variance`, `entropy`; Exponential's, Uniform's, ...) live in Python as `pl.Expr` and compose with
 the expression engine. Methods that go through `statrs` (sampling, transcendental `pdf`/`pmf`, `cdf`, `inverse_cdf`,
 native `ln_pdf`/`ln_pmf`, native `sf`) get a Rust plugin function, and so do the elementary value-keyed closed forms:
 they branch on the evaluation value, which puts the validator inside a `when` arm where polars can mask it away
 (see [Design notes](design.md#one-rust-file-per-distribution-one-plugin-function-per-method-that-needs-rust)).
-`Exponential`, `Geometric` and `Uniform` are the three that have not moved yet.
+`Geometric` and `Uniform` are the two that have not moved yet.
 
 **Parameter validation needs Rust.** A bare `pl.Expr` cannot raise per row, so any method computed in Python routes its
 parameters through one small validating plugin that raises on a bad row and returns a reused quantity. For a
 closed-form distribution that covers the whole surface: `Uniform.range` returns `max - min` and raises on
-`max <= min`, `Exponential` validates `rate > 0`. Everywhere else it covers the closed-form moments only, since the
-value-keyed methods already validate inside their own plugin: `normal_sigma` validates `sigma > 0`, so `Normal.mean()`
-raises exactly as `Normal.pdf()` does, and `bernoulli_proba` does the same for `Bernoulli`'s moments. Either way a
-pure-math `mean` makes one FFI round-trip and reports an invalid parameterisation consistently, trading a little
+`max <= min`. Everywhere else it covers the closed-form moments only, since the value-keyed methods already validate
+inside their own plugin: `normal_sigma` validates `sigma > 0`, so `Normal.mean()` raises exactly as `Normal.pdf()`
+does, and `bernoulli_proba` and `exponential_rate` do the same for `Bernoulli`'s and `Exponential`'s moments. Either
+way a pure-math `mean` makes one FFI round-trip and reports an invalid parameterisation consistently, trading a little
 throughput for a uniform error surface.
 
 ## Sampling

--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -41,8 +41,8 @@ unconditionally or named in a `when(...)` condition, and moves to Rust when it i
 what branching on the evaluation value always looks like.
 
 The table below is the rule, which every new distribution follows. It is not yet a description of the tree:
-`Exponential`, `Geometric` and `Uniform` still assemble their value-keyed methods in Polars and are being ported one
-at a time; the [reference index](../reference/index.md) carries the resulting known limitation. Method by method:
+`Geometric` and `Uniform` still assemble their value-keyed methods in Polars and are being ported one at a time; the
+[reference index](../reference/index.md) carries the resulting known limitation. Method by method:
 
 | Method | In Rust? | Notes |
 |---|---|---|
@@ -104,8 +104,8 @@ path is selected only when the parameters are known scalars, so nothing column-v
 ### Constant parameters validate once, not per row
 
 The moments (`mean`, `variance`, `std`, `entropy`) and the value-keyed closed forms still assembled in Polars
-(`Uniform`, `Exponential`, `Geometric`) do not build a distribution; they compute a Polars expression. But they still
-route their *validation* through a small Rust plugin (`normal_sigma`, `uniform_range`, `bernoulli_proba`,
+(`Uniform`, `Geometric`) do not build a distribution; they compute a Polars expression. But they still route their
+*validation* through a small Rust plugin (`normal_sigma`, `uniform_range`, `bernoulli_proba`,
 `binomial_params`, `lognormal_sigma`, `exponential_rate`, `beta_params`) so an invalid parameterisation raises the same
 `ComputeError` as the sampler and value-keyed methods rather than silently producing a nonsense moment (see "Invalid
 parameters raise"). With column parameters that plugin runs over the parameter columns, validating each row.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -68,21 +68,20 @@ mean of a different distribution on every row.
 
 !!! warning "Known limitation on polars >= 1.44"
 
-    On polars 1.44.0 and newer, `Exponential`, `Geometric` and `Uniform` may **return a value instead
-    of raising `ComputeError`** when a *column-valued* parameter is invalid on a row the selected
-    branch does not cover.
+    On polars 1.44.0 and newer, `Geometric` and `Uniform` may **return a value instead of raising
+    `ComputeError`** when a *column-valued* parameter is invalid on a row the selected branch does
+    not cover.
 
     Polars 1.44.0 ([pola-rs/polars#28498](https://github.com/pola-rs/polars/pull/28498)) masks the arms
     of a `when/then/otherwise` to null on the rows an arm does not select, so a validator reached only
-    from inside an arm never sees the offending row. These three distributions assemble their
+    from inside an arm never sees the offending row. These two distributions assemble their
     value-keyed closed forms (`pdf`/`pmf`, `log_pdf`/`log_pmf`, `cdf`, `log_cdf`, `sf`, `log_sf`,
-    `ppf`, `isf`) as branching Polars expressions, so they are affected. `Exponential.log_cdf` is the
-    one method among them that still raises.
+    `ppf`, `isf`) as branching Polars expressions, so they are affected.
 
     **Not affected:** every other distribution (they compute in Rust and validate unconditionally),
-    the moments (`mean`, `variance`, `std`, `median`, `entropy`) of all three, and every *valid*
-    computation, whose results are unchanged. `Bernoulli` was affected up to and including v0.0.2 and
-    no longer is: its closed forms now compute in Rust.
+    the moments (`mean`, `variance`, `std`, `median`, `entropy`) of both, and every *valid*
+    computation, whose results are unchanged. `Bernoulli` and `Exponential` were affected up to and
+    including v0.0.2 and no longer are: their closed forms now compute in Rust.
 
     One narrower case survives for *every* distribution and *both* parameter spellings, scalar
     included: a **null or `NaN` evaluation point** is masked out of the plugin's input by the wrapper

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -462,7 +462,7 @@ class _UnivariateDistribution(ABC):
 
         A value-keyed method belongs here even where its closed form is elementary: a branching Polars
         expression cannot be trusted to reach its validator on every row (see docs/explanation/design.md).
-        `Exponential`, `Geometric` and `Uniform` have not moved yet and still assemble theirs in Polars.
+        `Geometric` and `Uniform` have not moved yet and still assemble theirs in Polars.
         """
         return (
             register_plugin(f"{function_name}_scalar", (value,), kwargs=self._scalar_kwargs)

--- a/polars_stats/distributions/_exponential.py
+++ b/polars_stats/distributions/_exponential.py
@@ -3,25 +3,17 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING, ClassVar
 
-import polars as pl
-
 from polars_stats.distributions._base import (
     ContinuousDistribution,
     coerce_param,
-    expm1,
     scalar_float,
     scalar_kwargs,
 )
 
 if TYPE_CHECKING:
+    import polars as pl
+
     from polars_stats._typing import IntoExprColumn
-
-_CDF_SINH_MAX = 1.0
-"""Crossover of `Exponential._cdf`, in units of `rate * x`.
-
-Above `rate * x = 1` the plain `1 - exp(-t)` is already exact, and the `sinh` identity that replaces
-it below would overflow past `t ~ 1420`. The two branches agree to `1e-16` here.
-"""
 
 
 class Exponential(ContinuousDistribution):
@@ -37,8 +29,16 @@ class Exponential(ContinuousDistribution):
 
     An invalid ``rate`` (``rate <= 0`` or ``NaN``) is not checked at construction; matching every
     other distribution, it raises ``InvalidOperation`` (a ``ComputeError``) when any method is
-    evaluated. A null ``rate`` propagates to null. The support is ``x >= 0``: ``pdf`` and ``cdf`` are
-    ``0`` for ``x < 0``, and ``sf`` is ``1`` there.
+    evaluated. The support is ``x >= 0``: ``pdf`` and ``cdf`` are ``0`` for ``x < 0``, and ``sf`` is
+    ``1`` there.
+
+    A null ``rate`` propagates to null wherever the result depends on it. Below the support it does
+    not: ``pdf`` and ``cdf`` stay ``0``, ``sf`` stays ``1``, ``log_pdf`` and ``log_cdf`` stay
+    ``-inf``, ``log_sf`` stays ``0``. Both inverses null at every quantile.
+
+    The value-keyed methods compute in Rust, so an invalid ``rate`` is reported whichever branch the
+    evaluation point selects. The moments stay in Polars, reading ``rate`` through the same Rust
+    validator.
     """
 
     _rate: pl.Expr
@@ -56,90 +56,51 @@ class Exponential(ContinuousDistribution):
     def _checked_rate(self) -> pl.Expr:
         """``rate`` (λ) validated in Rust to be strictly positive (raises otherwise), as a length-n column.
 
-        Validated in Rust so every closed-form method (moments and pdf/cdf/ppf) reports an invalid
-        ``rate`` consistently with ``sample`` rather than silently computing with a non-positive rate.
-        Null propagates.
+        Validated in Rust so the closed-form moments report an invalid ``rate`` consistently with
+        ``sample`` rather than silently computing with a non-positive rate. Null propagates.
 
         `_checked` validates once for a scalar ``rate`` (length-1 input) and per-row for a column,
         returning the raw ``rate`` behind the validity gate either way (length-n on both paths). The
         analogue of ``Bernoulli._checked_p``: the validated quantity is the parameter itself.
+
+        Read only by the moments; the value-keyed methods validate inside their own plugin.
         """
         return self._checked("exponential_rate", self._rate)
 
     def _pdf(self, value: pl.Expr) -> pl.Expr:
-        """``rate * exp(-rate * x)`` on ``x >= 0``, ``0`` for ``x < 0``, keeping the subnormal range exact.
-
-        Reassociated as ``(rate * exp(-rate * x / 2)) * exp(-rate * x / 2)``: the same product with
-        the rounding moved to the end. Written literally, ``exp(-rate * x)`` rounds into the
-        gradual-underflow range while the scale is still to be applied, and the multiply then
-        magnifies what the subnormal threw away. Halving the exponent keeps the intermediate normal,
-        so only the final multiply underflows, at the cost of one multiply and no branch.
-        """
-        r = self._checked_rate
-        half = (-r * value / 2).exp()
-        return pl.when(value >= 0).then((r * half) * half).otherwise(0.0)
+        """``rate * exp(-rate * x)`` on ``x >= 0``, ``0`` for ``x < 0``."""
+        return self._value_plugin("exponential_pdf", value)
 
     def _log_pdf(self, value: pl.Expr) -> pl.Expr:
         """``log(rate) - rate * x`` on ``x >= 0``, ``-inf`` for ``x < 0``."""
-        r = self._checked_rate
-        return pl.when(value >= 0).then(r.log() - r * value).otherwise(float("-inf"))
+        return self._value_plugin("exponential_ln_pdf", value)
 
     def _cdf(self, value: pl.Expr) -> pl.Expr:
-        """``1 - exp(-rate * x)`` on ``x >= 0``, ``0`` for ``x < 0``, keeping the left tail exact.
-
-        ``1 - exp(-t)`` cancels to ``0`` below ``t ~ 1.1e-16``, so the small branch reads it as
-        ``-expm1(-t)``. ``sinh`` overflows above ``t ~ 1420``, hence the split at `_CDF_SINH_MAX`,
-        where the plain form is already exact; the two agree to ``1e-16`` at the crossover.
-        """
-        t = self._checked_rate * value
-        return pl.when(value < 0).then(0.0).when(t < _CDF_SINH_MAX).then(-expm1(-t)).otherwise(1 - (-t).exp())
+        """``1 - exp(-rate * x)`` on ``x >= 0``, ``0`` for ``x < 0``."""
+        return self._value_plugin("exponential_cdf", value)
 
     def _log_cdf(self, value: pl.Expr) -> pl.Expr:
-        """``log(cdf)`` in the left tail, ``log1p(-sf)`` in the right; ``-inf`` for ``x <= 0``.
-
-        As ``cdf -> 1`` the cdf rounds to ~1 and its log to a tiny, inaccurate value, so that side
-        goes through ``log1p`` of the small ``sf``. As ``cdf -> 0`` the log is well conditioned and
-        ``_cdf`` is exact there, so that side is simply its log.
-        """
-        return (
-            pl.when(self._checked_rate * value < 1).then(self._cdf(value).log()).otherwise((-self._sf(value)).log1p())
-        )
+        """``log(cdf)`` in the left tail, ``log1p(-sf)`` in the right; ``-inf`` for ``x <= 0``."""
+        return self._value_plugin("exponential_ln_cdf", value)
 
     def _sf(self, value: pl.Expr) -> pl.Expr:
-        """``exp(-rate * x)`` on ``x >= 0``, ``1`` for ``x < 0`` (closed form, accurate in the upper tail)."""
-        r = self._checked_rate
-        return pl.when(value >= 0).then((-r * value).exp()).otherwise(1.0)
+        """``exp(-rate * x)`` on ``x >= 0``, ``1`` for ``x < 0``."""
+        return self._value_plugin("exponential_sf", value)
 
     def _log_sf(self, value: pl.Expr) -> pl.Expr:
         """``-rate * x`` on ``x >= 0``, ``0`` for ``x < 0``."""
-        r = self._checked_rate
-        return pl.when(value >= 0).then(-r * value).otherwise(0.0)
+        return self._value_plugin("exponential_ln_sf", value)
 
     def _ppf(self, quantile: pl.Expr) -> pl.Expr:
-        """``-log1p(-q) / rate``; null for ``q`` outside ``[0, 1]``.
-
-        Through ``log1p`` rather than ``log(1 - q)``: the latter rounds ``1 - q`` to exactly ``1``
-        below ``q ~ 1.1e-16`` and collapses to ``-0.0``. The negation is written ``0.0 - q`` so an
-        unsigned quantile column promotes to ``Float64`` (polars rejects ``neg`` on an unsigned
-        dtype).
-        """
-        return (
-            pl.when(quantile.is_between(0, 1))
-            .then(-(0.0 - quantile).log1p() / self._checked_rate)
-            .otherwise(pl.lit(None, dtype=pl.Float64()))
-        )
+        """``-log1p(-q) / rate``; null for ``q`` outside ``[0, 1]``."""
+        return self._value_plugin("exponential_ppf", quantile)
 
     def _isf(self, quantile: pl.Expr) -> pl.Expr:
-        """``-log(q) / rate``, the exact inverse survival function.
+        """``-log(q) / rate``; null for ``q`` outside ``[0, 1]``.
 
         Overrides the base ``ppf(1 - quantile)``, which forms the complement and then undoes it.
-        The closed form never builds it, and is exact for every ``q`` in ``(0, 1]``.
         """
-        return (
-            pl.when(quantile.is_between(0, 1))
-            .then(-quantile.log() / self._checked_rate)
-            .otherwise(pl.lit(None, dtype=pl.Float64()))
-        )
+        return self._value_plugin("exponential_isf", quantile)
 
     def mean(self) -> pl.Expr:
         """Expected value, ``1 / rate``."""

--- a/polars_stats/distributions/_exponential.py
+++ b/polars_stats/distributions/_exponential.py
@@ -32,13 +32,12 @@ class Exponential(ContinuousDistribution):
     evaluated. The support is ``x >= 0``: ``pdf`` and ``cdf`` are ``0`` for ``x < 0``, and ``sf`` is
     ``1`` there.
 
-    A null ``rate`` propagates to null wherever the result depends on it. Below the support it does
-    not: ``pdf`` and ``cdf`` stay ``0``, ``sf`` stays ``1``, ``log_pdf`` and ``log_cdf`` stay
-    ``-inf``, ``log_sf`` stays ``0``. Both inverses null at every quantile.
+    A null ``rate`` propagates to null wherever the result depends on it; the below-support constants
+    (``pdf`` and ``cdf`` ``0``, ``sf`` ``1``, ``log_pdf`` and ``log_cdf`` ``-inf``, ``log_sf`` ``0``)
+    do not. Both inverses null at every quantile, in range and out.
 
     The value-keyed methods compute in Rust, so an invalid ``rate`` is reported whichever branch the
-    evaluation point selects. The moments stay in Polars, reading ``rate`` through the same Rust
-    validator.
+    value selects. The moments stay in Polars, reading ``rate`` through the same Rust validator.
     """
 
     _rate: pl.Expr
@@ -56,14 +55,9 @@ class Exponential(ContinuousDistribution):
     def _checked_rate(self) -> pl.Expr:
         """``rate`` (λ) validated in Rust to be strictly positive (raises otherwise), as a length-n column.
 
-        Validated in Rust so the closed-form moments report an invalid ``rate`` consistently with
-        ``sample`` rather than silently computing with a non-positive rate. Null propagates.
-
-        `_checked` validates once for a scalar ``rate`` (length-1 input) and per-row for a column,
-        returning the raw ``rate`` behind the validity gate either way (length-n on both paths). The
-        analogue of ``Bernoulli._checked_p``: the validated quantity is the parameter itself.
-
-        Read only by the moments; the value-keyed methods validate inside their own plugin.
+        Null propagates. Read only by the moments, so they report an invalid ``rate`` consistently
+        with ``sample`` rather than silently computing with a non-positive one; the value-keyed
+        methods validate inside their own plugin instead.
         """
         return self._checked("exponential_rate", self._rate)
 

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -1,10 +1,11 @@
-use polars::prelude::arity::try_binary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution;
 use statrs::distribution::Bernoulli;
 
-use crate::distributions::{align_inputs, validate_params_unary, value_keyed_scalar};
+use crate::distributions::{
+    align_inputs, validate_params_unary, value_keyed_derived_per_row, value_keyed_derived_scalar,
+};
 use crate::rng::{
     binary_param_rows, sample_by_index, sample_per_row_binary, samples_bool_output,
     samples_by_index, samples_per_row, SampleKwargs, SampleScalarKwargs, SamplesKwargs,
@@ -28,23 +29,15 @@ impl BernoulliParamsKwargs {
         build_dist(self.p)
     }
 
-    /// Constant-parameter twin of the per-row [`bernoulli_value_keyed`], sharing its `derive` and
-    /// `select` bodies: validate and derive `p` once per call, then map `select` over the
-    /// evaluation-point column. The Python side routes here only once every parameter is a Python
-    /// scalar, so `derive` always sees `Some`.
-    fn value_keyed<Branches, Derive, Select>(
+    /// Binds the constant parameter and `build_dist` into [`value_keyed_derived_scalar`], which owns
+    /// the validate-and-derive-once contract the fast path rests on.
+    fn value_keyed<Branches>(
         &self,
         value: &Series,
-        derive: Derive,
-        select: Select,
-    ) -> PolarsResult<Series>
-    where
-        Derive: Fn(Option<f64>) -> Branches,
-        Select: Fn(&Branches, f64) -> Option<f64>,
-    {
-        self.build()?;
-        let branches = derive(Some(self.p));
-        value_keyed_scalar(value, |v| select(&branches, v))
+        derive: impl Fn(Option<f64>) -> Branches,
+        select: impl Fn(&Branches, f64) -> Option<f64>,
+    ) -> PolarsResult<Series> {
+        value_keyed_derived_scalar(value, self.p, build_dist, derive, select)
     }
 }
 
@@ -231,106 +224,53 @@ fn isf_at(p: &Option<f64>, quantile: f64) -> Option<f64> {
     p.map(|p| f64::from(p > quantile))
 }
 
-/// Apply `derive` then `select` element-wise over `(value, p)`; shared by the eight value-keyed
-/// plugins. Each method derives its own type ([`Mass`], [`Steps`], [`PpfCutoffs`], `Option<f64>`),
-/// so pairing one method's `derive` with another's `select` does not compile.
-///
-/// Null contract: a null `value` nulls the row without validating, matching
-/// [`value_keyed_per_row`](crate::distributions::value_keyed_per_row) and the samplers. A null `p`
-/// is **not** a row-level short-circuit, which is what separates this driver from the shared one: it
-/// reaches `derive` as `None` so the slots that carry no `p` still answer. Nothing is validated on a
-/// null-`p` row, since there is no parameterisation to reject.
-///
-/// `NaN` contract: a `NaN` value short-circuits to `NaN`, but only after `p` has been validated, so
-/// an invalid parameterisation still raises on a `NaN` row.
-///
-/// Bernoulli is the only consumer today. `Exponential` is the next single-parameter catalogue entry
-/// whose closed forms move into Rust, so hoist this into `mod.rs` beside `value_keyed_per_row` when
-/// its port makes it a second consumer, not before.
-fn bernoulli_value_keyed<Branches, Derive, Select>(
-    inputs: &[Series],
-    derive: Derive,
-    select: Select,
-) -> PolarsResult<Series>
-where
-    Derive: Fn(Option<f64>) -> Branches,
-    Select: Fn(&Branches, f64) -> Option<f64>,
-{
-    let inputs = align_inputs(inputs)?;
-    let value = inputs[0].cast(&DataType::Float64)?;
-    let proba = inputs[1].cast(&DataType::Float64)?;
-    let name = inputs[0].name().clone();
-
-    let ca: Float64Chunked = try_binary_elementwise(
-        value.f64()?,
-        proba.f64()?,
-        |value_opt, proba_opt| -> PolarsResult<Option<f64>> {
-            let Some(value) = value_opt else {
-                return Ok(None);
-            };
-            // Validate before the `NaN` short-circuit, so an invalid `p` still raises on a `NaN`
-            // row, exactly as `value_keyed_per_row` orders it.
-            if let Some(proba) = proba_opt {
-                build_dist(proba)?;
-            }
-            Ok(if value.is_nan() {
-                Some(f64::NAN)
-            } else {
-                select(&derive(proba_opt), value)
-            })
-        },
-    )?;
-
-    Ok(ca.with_name(name).into_series())
-}
-
 /// Element-wise pmf: `1 - p` at 0, `p` at 1, `0` off the support.
-/// See [`bernoulli_value_keyed`] for the null/error contract.
+/// See [`value_keyed_derived_per_row`] for the null/error contract.
 #[polars_expr(output_type=Float64)]
 fn bernoulli_pmf(inputs: &[Series]) -> PolarsResult<Series> {
-    bernoulli_value_keyed(inputs, Mass::pmf, Mass::at)
+    value_keyed_derived_per_row(inputs, build_dist, Mass::pmf, Mass::at)
 }
 
 /// Element-wise log-pmf; see [`Mass::ln_pmf`] for the `ln_1p` reason.
 #[polars_expr(output_type=Float64)]
 fn bernoulli_ln_pmf(inputs: &[Series]) -> PolarsResult<Series> {
-    bernoulli_value_keyed(inputs, Mass::ln_pmf, Mass::at)
+    value_keyed_derived_per_row(inputs, build_dist, Mass::ln_pmf, Mass::at)
 }
 
 /// Element-wise cdf `P(X <= value)`; see [`Steps::cdf`].
 #[polars_expr(output_type=Float64)]
 fn bernoulli_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    bernoulli_value_keyed(inputs, Steps::cdf, Steps::at)
+    value_keyed_derived_per_row(inputs, build_dist, Steps::cdf, Steps::at)
 }
 
 /// Element-wise log-cdf; see [`Steps::ln_cdf`].
 #[polars_expr(output_type=Float64)]
 fn bernoulli_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    bernoulli_value_keyed(inputs, Steps::ln_cdf, Steps::at)
+    value_keyed_derived_per_row(inputs, build_dist, Steps::ln_cdf, Steps::at)
 }
 
 /// Element-wise survival function `P(X > value)`; see [`Steps::sf`] for why it is not `1 - cdf`.
 #[polars_expr(output_type=Float64)]
 fn bernoulli_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    bernoulli_value_keyed(inputs, Steps::sf, Steps::at)
+    value_keyed_derived_per_row(inputs, build_dist, Steps::sf, Steps::at)
 }
 
 /// Element-wise log-sf; see [`Steps::ln_sf`].
 #[polars_expr(output_type=Float64)]
 fn bernoulli_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    bernoulli_value_keyed(inputs, Steps::ln_sf, Steps::at)
+    value_keyed_derived_per_row(inputs, build_dist, Steps::ln_sf, Steps::at)
 }
 
 /// Element-wise ppf (inverse cdf), returning the support point as `f64`; see [`PpfCutoffs::at`].
 #[polars_expr(output_type=Float64)]
 fn bernoulli_ppf(inputs: &[Series]) -> PolarsResult<Series> {
-    bernoulli_value_keyed(inputs, PpfCutoffs::derive, PpfCutoffs::at)
+    value_keyed_derived_per_row(inputs, build_dist, PpfCutoffs::derive, PpfCutoffs::at)
 }
 
 /// Element-wise inverse survival function; see [`isf_at`] for why it never forms a complement.
 #[polars_expr(output_type=Float64)]
 fn bernoulli_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    bernoulli_value_keyed(inputs, isf_proba, isf_at)
+    value_keyed_derived_per_row(inputs, build_dist, isf_proba, isf_at)
 }
 
 /// Constant-parameter fast path for [`bernoulli_pmf`].

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -29,8 +29,8 @@ impl BernoulliParamsKwargs {
         build_dist(self.p)
     }
 
-    /// Binds the constant parameter and `build_dist` into [`value_keyed_derived_scalar`], which owns
-    /// the validate-and-derive-once contract the fast path rests on.
+    /// Binds the constant parameter and `build_dist` into [`value_keyed_derived_scalar`], which
+    /// validates and derives once per call rather than per row.
     fn value_keyed<Branches>(
         &self,
         value: &Series,

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -3,7 +3,9 @@ use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::Exp;
 
-use crate::distributions::{align_inputs, validate_params_unary};
+use crate::distributions::{
+    align_inputs, validate_params_unary, value_keyed_derived_per_row, value_keyed_derived_scalar,
+};
 use crate::rng::{
     binary_param_rows, sample_by_index, sample_per_row_binary, samples_by_index,
     samples_f64_output, samples_per_row, SampleKwargs, SampleScalarKwargs, SamplesKwargs,
@@ -33,15 +35,25 @@ impl ExponentialParamsKwargs {
     fn build(&self) -> PolarsResult<Exp> {
         build_dist(self.rate)
     }
+
+    /// Binds the constant parameter and `build_dist` into [`value_keyed_derived_scalar`], which owns
+    /// the validate-and-derive-once contract the fast path rests on.
+    fn value_keyed<Branches>(
+        &self,
+        value: &Series,
+        derive: impl Fn(Option<f64>) -> Branches,
+        select: impl Fn(&Branches, f64) -> Option<f64>,
+    ) -> PolarsResult<Series> {
+        value_keyed_derived_scalar(value, self.rate, build_dist, derive, select)
+    }
 }
 
 /// Element-wise validation of the rate (λ): returns `rate` unchanged, raising `InvalidOperation`
 /// if `rate` is `NaN` or `rate <= 0`. `null` propagates.
 ///
-/// Exponential is an elementary closed-form distribution, so its pdf / cdf / ppf and moments are
-/// pure Polars expressions; routing the rate through this validator is what lets them report an
-/// invalid parameterisation consistently with `exponential_sample`, instead of silently computing
-/// with a non-positive rate.
+/// The moments derive from this so they report an invalid rate consistently with
+/// `exponential_sample`, instead of silently computing with a non-positive rate. The value-keyed
+/// methods validate inside their own plugin instead.
 #[polars_expr(output_type=Float64)]
 fn exponential_rate(inputs: &[Series]) -> PolarsResult<Series> {
     let rate = inputs[0].cast(&DataType::Float64)?;
@@ -50,6 +62,321 @@ fn exponential_rate(inputs: &[Series]) -> PolarsResult<Series> {
         build_dist(rate)?;
         Ok(rate)
     })
+}
+
+/// Crossover of [`derive_cdf`], in units of `t = rate * x`.
+///
+/// Above `t = 1` the plain `1 - exp(-t)` is already exact, and the [`expm1`] identity that replaces
+/// it below would overflow past `t ~ 1420`. The two branches agree to `1e-16` here.
+const CDF_SINH_MAX: f64 = 1.0;
+
+/// `exp(t) - 1` through the identity `2 exp(t / 2) sinh(t / 2)`, which has no subtraction to cancel.
+///
+/// **Deliberately not `f64::exp_m1`,** which differs from this identity by one ulp on roughly a
+/// fifth of the left tail. Every expected value in `tests/distributions/exponential/` is this
+/// identity's rounding, and `_base.expm1` spells it the same way for the distributions still
+/// assembled in Polars.
+///
+/// `sinh(t / 2)` overflows above `|t| ~ 1420`; the only caller crosses over at [`CDF_SINH_MAX`],
+/// long before that.
+#[inline]
+fn expm1(t: f64) -> f64 {
+    let half = t / 2.0;
+    2.0 * half.exp() * half.sinh()
+}
+
+// Exponential hoists less than Bernoulli: every on-support answer is a function of the rate *and*
+// the evaluation point, so a `derive_*` captures only the rate-only terms and the rest stays in the
+// arm. They are free functions rather than associated ones because each returns a distinct opaque
+// arm type.
+
+/// The two sides of the support, for the six value-keyed methods.
+///
+/// `below_support` is a plain `f64` derived with **no rate in scope**: below `x = 0` every answer is
+/// the rate-free support constant, so a null rate must not null it. Writing it as an `f64` rather
+/// than an `Option<f64>` leaves nothing to thread a rate through by accident. All six constants are
+/// pinned by `tests/distributions/exponential/null_params_test.py`.
+///
+/// `on_support` is `None` exactly when the rate is null, which nulls the answers that read it.
+struct Sides<Arm> {
+    below_support: f64,
+    on_support: Option<Arm>,
+}
+
+impl<Arm: Fn(f64) -> f64> Sides<Arm> {
+    /// `x < 0` takes the support constant, everything else the arm.
+    ///
+    /// Written `x < 0` rather than a negated `x >= 0`, so `-0.0` lands on the support. A `NaN` point
+    /// never reaches here: both drivers short-circuit it.
+    fn at(&self, value: f64) -> Option<f64> {
+        if value < 0.0 {
+            Some(self.below_support)
+        } else {
+            self.on_support.as_ref().map(|arm| arm(value))
+        }
+    }
+}
+
+/// `rate * exp(-rate * x)` on `x >= 0`, `0` below, keeping the subnormal range exact.
+///
+/// Reassociated as `(rate * exp(-rate * x / 2)) * exp(-rate * x / 2)`: the same product with the
+/// rounding moved to the end. Written literally, `exp(-rate * x)` rounds into the gradual-underflow
+/// range while the scale is still to be applied, and the final multiply then magnifies what the
+/// subnormal threw away. Halving the exponent keeps the intermediate normal, at the cost of one
+/// multiply and no branch.
+fn derive_pdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
+    Sides {
+        below_support: 0.0,
+        on_support: rate.map(|rate| {
+            move |x: f64| {
+                let half_exp = (-rate * x / 2.0).exp();
+                (rate * half_exp) * half_exp
+            }
+        }),
+    }
+}
+
+/// `ln(rate) - rate * x` on `x >= 0`, `-inf` below. `ln(rate)` is the only term the rate alone fixes,
+/// so it is the only one [`value_keyed_derived_scalar`] can lift out of the loop.
+fn derive_ln_pdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
+    Sides {
+        below_support: f64::NEG_INFINITY,
+        on_support: rate.map(|rate| {
+            let ln_rate = rate.ln();
+            move |x: f64| ln_rate - rate * x
+        }),
+    }
+}
+
+/// `1 - exp(-rate * x)` on `x >= 0`, `0` below, keeping the left tail exact.
+///
+/// `1 - exp(-t)` cancels to `0` below `t ~ 1.1e-16`, so the small branch reads it as `-expm1(-t)`;
+/// see [`CDF_SINH_MAX`] for why the crossover is where it is.
+fn derive_cdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
+    Sides {
+        below_support: 0.0,
+        on_support: rate.map(|rate| {
+            move |x: f64| {
+                let t = rate * x;
+                if t < CDF_SINH_MAX {
+                    -expm1(-t)
+                } else {
+                    1.0 - (-t).exp()
+                }
+            }
+        }),
+    }
+}
+
+/// `ln(cdf)` in the left tail, `ln_1p(-sf)` in the right; `-inf` below the support.
+///
+/// As `cdf -> 1` the cdf rounds to ~1 and its log to a tiny, inaccurate value, so that side goes
+/// through `ln_1p` of the small `sf`. As `cdf -> 0` the log is well conditioned and [`derive_cdf`] is exact
+/// there, so that side is simply its log.
+///
+/// The predicate is `rate * x < 1`, a statement about where `ln(cdf)` is well conditioned, not a
+/// comparison against the computed cdf. It coincides with [`CDF_SINH_MAX`] rather than deriving from
+/// it, which is what lets the left arm inline [`derive_cdf`]'s `expm1` branch: on the support and
+/// below `t = 1` that is the only branch it would take.
+fn derive_ln_cdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
+    Sides {
+        below_support: f64::NEG_INFINITY,
+        on_support: rate.map(|rate| {
+            move |x: f64| {
+                let t = rate * x;
+                if t < 1.0 {
+                    (-expm1(-t)).ln()
+                } else {
+                    (-(-t).exp()).ln_1p()
+                }
+            }
+        }),
+    }
+}
+
+/// `exp(-rate * x)` on `x >= 0`, `1` below.
+///
+/// The closed form, never `1 - cdf`: the complement quantises the upper tail to the `1.1e-16`
+/// spacing of `1.0` and reaches `0.0` below that.
+fn derive_sf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
+    Sides {
+        below_support: 1.0,
+        on_support: rate.map(|rate| move |x: f64| (-rate * x).exp()),
+    }
+}
+
+/// `-rate * x` on `x >= 0`, `0` below: the plain log of [`derive_sf`].
+fn derive_ln_sf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
+    Sides {
+        below_support: 0.0,
+        on_support: rate.map(|rate| move |x: f64| -rate * x),
+    }
+}
+
+/// `ppf` / `isf`: the arm inside the closed quantile domain, null outside it.
+///
+/// One slot, not two: no part of either inverse survives a null rate, at any quantile in range or
+/// out, so there is no rate-free constant to keep separate from the arm.
+struct Domain<Arm> {
+    inside: Option<Arm>,
+}
+
+impl<Arm: Fn(f64) -> f64> Domain<Arm> {
+    /// `None` (null) outside `[0, 1]`, matching the `quantile.is_between(0, 1)` this replaces.
+    /// `-0.0` is inside, since `-0.0 == 0.0`.
+    fn at(&self, quantile: f64) -> Option<f64> {
+        if !(0.0..=1.0).contains(&quantile) {
+            return None;
+        }
+        self.inside.as_ref().map(|arm| arm(quantile))
+    }
+}
+
+/// `-ln_1p(-q) / rate`, the exact inverse cdf; null outside `[0, 1]`.
+///
+/// Through `ln_1p` rather than `ln(1 - q)`: the latter rounds `1 - q` to exactly `1` below
+/// `q ~ 1.1e-16` and collapses to `-0.0`.
+///
+/// **The rate is divided by, never reciprocated.** `x * (1 / rate)` rounds twice where `x / rate`
+/// rounds once, and at a subnormal rate the reciprocal reaches `inf` and `NaN` where the division
+/// stays finite. So neither inverse hoists anything into its `derive`.
+///
+/// The negation keeps `ppf(-0.0) = -0.0`.
+fn derive_ppf(rate: Option<f64>) -> Domain<impl Fn(f64) -> f64> {
+    Domain {
+        inside: rate.map(|rate| move |quantile: f64| (-((-quantile).ln_1p())) / rate),
+    }
+}
+
+/// `-ln(q) / rate`, the exact inverse survival function; null outside `[0, 1]`.
+///
+/// Never `ppf(1 - q)`: that forms the complement and then undoes it, losing the answer whenever
+/// either step saturates.
+fn derive_isf(rate: Option<f64>) -> Domain<impl Fn(f64) -> f64> {
+    Domain {
+        inside: rate.map(|rate| move |quantile: f64| (-quantile.ln()) / rate),
+    }
+}
+
+/// Element-wise pdf; see [`derive_pdf`] for the subnormal reassociation.
+/// See [`value_keyed_derived_per_row`] for the null/error contract.
+#[polars_expr(output_type=Float64)]
+fn exponential_pdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_per_row(inputs, build_dist, derive_pdf, Sides::at)
+}
+
+/// Element-wise log-pdf; see [`derive_ln_pdf`].
+#[polars_expr(output_type=Float64)]
+fn exponential_ln_pdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_per_row(inputs, build_dist, derive_ln_pdf, Sides::at)
+}
+
+/// Element-wise cdf `P(X <= value)`; see [`derive_cdf`] and [`CDF_SINH_MAX`].
+#[polars_expr(output_type=Float64)]
+fn exponential_cdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_per_row(inputs, build_dist, derive_cdf, Sides::at)
+}
+
+/// Element-wise log-cdf; see [`derive_ln_cdf`].
+#[polars_expr(output_type=Float64)]
+fn exponential_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_per_row(inputs, build_dist, derive_ln_cdf, Sides::at)
+}
+
+/// Element-wise survival function `P(X > value)`; see [`derive_sf`] for why it is not `1 - cdf`.
+#[polars_expr(output_type=Float64)]
+fn exponential_sf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_per_row(inputs, build_dist, derive_sf, Sides::at)
+}
+
+/// Element-wise log-sf; see [`derive_ln_sf`].
+#[polars_expr(output_type=Float64)]
+fn exponential_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_per_row(inputs, build_dist, derive_ln_sf, Sides::at)
+}
+
+/// Element-wise ppf (inverse cdf); see [`derive_ppf`].
+#[polars_expr(output_type=Float64)]
+fn exponential_ppf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_per_row(inputs, build_dist, derive_ppf, Domain::at)
+}
+
+/// Element-wise inverse survival function; see [`derive_isf`] for why it never forms a complement.
+#[polars_expr(output_type=Float64)]
+fn exponential_isf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_per_row(inputs, build_dist, derive_isf, Domain::at)
+}
+
+/// Constant-rate fast path for [`exponential_pdf`].
+#[polars_expr(output_type=Float64)]
+fn exponential_pdf_scalar(
+    inputs: &[Series],
+    kwargs: ExponentialParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_pdf, Sides::at)
+}
+
+/// Constant-rate fast path for [`exponential_ln_pdf`].
+#[polars_expr(output_type=Float64)]
+fn exponential_ln_pdf_scalar(
+    inputs: &[Series],
+    kwargs: ExponentialParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_ln_pdf, Sides::at)
+}
+
+/// Constant-rate fast path for [`exponential_cdf`].
+#[polars_expr(output_type=Float64)]
+fn exponential_cdf_scalar(
+    inputs: &[Series],
+    kwargs: ExponentialParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_cdf, Sides::at)
+}
+
+/// Constant-rate fast path for [`exponential_ln_cdf`].
+#[polars_expr(output_type=Float64)]
+fn exponential_ln_cdf_scalar(
+    inputs: &[Series],
+    kwargs: ExponentialParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_ln_cdf, Sides::at)
+}
+
+/// Constant-rate fast path for [`exponential_sf`].
+#[polars_expr(output_type=Float64)]
+fn exponential_sf_scalar(
+    inputs: &[Series],
+    kwargs: ExponentialParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_sf, Sides::at)
+}
+
+/// Constant-rate fast path for [`exponential_ln_sf`].
+#[polars_expr(output_type=Float64)]
+fn exponential_ln_sf_scalar(
+    inputs: &[Series],
+    kwargs: ExponentialParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_ln_sf, Sides::at)
+}
+
+/// Constant-rate fast path for [`exponential_ppf`].
+#[polars_expr(output_type=Float64)]
+fn exponential_ppf_scalar(
+    inputs: &[Series],
+    kwargs: ExponentialParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_ppf, Domain::at)
+}
+
+/// Constant-rate fast path for [`exponential_isf`].
+#[polars_expr(output_type=Float64)]
+fn exponential_isf_scalar(
+    inputs: &[Series],
+    kwargs: ExponentialParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_isf, Domain::at)
 }
 
 /// One Exponential draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -36,8 +36,8 @@ impl ExponentialParamsKwargs {
         build_dist(self.rate)
     }
 
-    /// Binds the constant parameter and `build_dist` into [`value_keyed_derived_scalar`], which owns
-    /// the validate-and-derive-once contract the fast path rests on.
+    /// Binds the constant rate and `build_dist` into [`value_keyed_derived_scalar`], which
+    /// validates and derives once per call rather than per row.
     fn value_keyed<Branches>(
         &self,
         value: &Series,
@@ -72,10 +72,9 @@ const CDF_SINH_MAX: f64 = 1.0;
 
 /// `exp(t) - 1` through the identity `2 exp(t / 2) sinh(t / 2)`, which has no subtraction to cancel.
 ///
-/// **Deliberately not `f64::exp_m1`,** which differs from this identity by one ulp on roughly a
-/// fifth of the left tail. Every expected value in `tests/distributions/exponential/` is this
-/// identity's rounding, and `_base.expm1` spells it the same way for the distributions still
-/// assembled in Polars.
+/// Not `f64::exp_m1`, which differs from this identity by one ulp on roughly a fifth of the left
+/// tail. Every expected value in `tests/distributions/exponential/` is this identity's rounding, and
+/// `_base.expm1` spells it the same way for the distributions still assembled in Polars.
 ///
 /// `sinh(t / 2)` overflows above `|t| ~ 1420`; the only caller crosses over at [`CDF_SINH_MAX`],
 /// long before that.
@@ -86,28 +85,26 @@ fn expm1(t: f64) -> f64 {
 }
 
 // Exponential hoists less than Bernoulli: every on-support answer is a function of the rate *and*
-// the evaluation point, so a `derive_*` captures only the rate-only terms and the rest stays in the
-// arm. They are free functions rather than associated ones because each returns a distinct opaque
-// arm type.
+// the evaluation point, so a `derive_*` captures the rate-only terms and the rest stays in the arm.
+// Free functions rather than associated ones, because each returns a distinct opaque arm type.
 
 /// The two sides of the support, for the six value-keyed methods.
 ///
-/// `below_support` is a plain `f64` derived with **no rate in scope**: below `x = 0` every answer is
-/// the rate-free support constant, so a null rate must not null it. Writing it as an `f64` rather
-/// than an `Option<f64>` leaves nothing to thread a rate through by accident. All six constants are
-/// pinned by `tests/distributions/exponential/null_params_test.py`.
-///
-/// `on_support` is `None` exactly when the rate is null, which nulls the answers that read it.
+/// Below `x = 0` every answer is the rate-free support constant, so a null rate must not null it.
+/// `below_support` is an `f64` rather than an `Option<f64>`, leaving nothing to thread a rate
+/// through by accident; all six constants are pinned by
+/// `tests/distributions/exponential/null_params_test.py`. `on_support` is `None` exactly when the
+/// rate is null.
 struct Sides<Arm> {
     below_support: f64,
     on_support: Option<Arm>,
 }
 
 impl<Arm: Fn(f64) -> f64> Sides<Arm> {
-    /// `x < 0` takes the support constant, everything else the arm.
+    /// `x < 0` takes the support constant, everything else the arm, so `-0.0` is on the support.
     ///
-    /// Written `x < 0` rather than a negated `x >= 0`, so `-0.0` lands on the support. A `NaN` point
-    /// never reaches here: both drivers short-circuit it.
+    /// A `NaN` point never reaches here: both drivers short-circuit it. That is what lets this be a
+    /// bare `<`; the `!(x >= 0)` a negated predicate would spell puts `NaN` below the support.
     fn at(&self, value: f64) -> Option<f64> {
         if value < 0.0 {
             Some(self.below_support)
@@ -171,13 +168,13 @@ fn derive_cdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
 /// `ln(cdf)` in the left tail, `ln_1p(-sf)` in the right; `-inf` below the support.
 ///
 /// As `cdf -> 1` the cdf rounds to ~1 and its log to a tiny, inaccurate value, so that side goes
-/// through `ln_1p` of the small `sf`. As `cdf -> 0` the log is well conditioned and [`derive_cdf`] is exact
-/// there, so that side is simply its log.
+/// through `ln_1p` of the small `sf`. As `cdf -> 0` the log is well conditioned and [`derive_cdf`] is
+/// exact there, so that side is its log.
 ///
-/// The predicate is `rate * x < 1`, a statement about where `ln(cdf)` is well conditioned, not a
-/// comparison against the computed cdf. It coincides with [`CDF_SINH_MAX`] rather than deriving from
-/// it, which is what lets the left arm inline [`derive_cdf`]'s `expm1` branch: on the support and
-/// below `t = 1` that is the only branch it would take.
+/// The predicate `rate * x < 1` says where `ln(cdf)` is well conditioned; it is not a comparison
+/// against the computed cdf. It coincides with [`CDF_SINH_MAX`] rather than deriving from it, which
+/// is what lets the left arm inline [`derive_cdf`]'s `expm1` branch: on the support and below
+/// `t = 1` that is the only branch it would take.
 fn derive_ln_cdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
     Sides {
         below_support: f64::NEG_INFINITY,
@@ -215,8 +212,8 @@ fn derive_ln_sf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
 
 /// `ppf` / `isf`: the arm inside the closed quantile domain, null outside it.
 ///
-/// One slot, not two: no part of either inverse survives a null rate, at any quantile in range or
-/// out, so there is no rate-free constant to keep separate from the arm.
+/// One slot rather than [`Sides`]' two, because no part of either inverse survives a null rate, at
+/// any quantile in range or out.
 struct Domain<Arm> {
     inside: Option<Arm>,
 }
@@ -237,11 +234,9 @@ impl<Arm: Fn(f64) -> f64> Domain<Arm> {
 /// Through `ln_1p` rather than `ln(1 - q)`: the latter rounds `1 - q` to exactly `1` below
 /// `q ~ 1.1e-16` and collapses to `-0.0`.
 ///
-/// **The rate is divided by, never reciprocated.** `x * (1 / rate)` rounds twice where `x / rate`
-/// rounds once, and at a subnormal rate the reciprocal reaches `inf` and `NaN` where the division
-/// stays finite. So neither inverse hoists anything into its `derive`.
-///
-/// The negation keeps `ppf(-0.0) = -0.0`.
+/// The rate is divided by, never reciprocated: `x * (1 / rate)` rounds twice where `x / rate` rounds
+/// once, and at a subnormal rate the reciprocal reaches `inf` and `NaN` where the division stays
+/// finite. So neither inverse hoists anything into its `derive`.
 fn derive_ppf(rate: Option<f64>) -> Domain<impl Fn(f64) -> f64> {
     Domain {
         inside: rate.map(|rate| move |quantile: f64| (-((-quantile).ln_1p())) / rate),

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -102,8 +102,8 @@ where
 ///
 /// Validates and derives once per call, then maps `select` over the evaluation-point column. The
 /// Python side routes here only once the parameter is a Python scalar, so `derive` always sees
-/// `Some`, and this is the path where the rate-only terms a `derive` hoists (`ln(rate)`) are
-/// computed once instead of per row.
+/// `Some`, and the parameter-only terms it hoists (`Bernoulli`'s `1 - p`, `Exponential`'s
+/// `ln(rate)`) are computed once instead of per row.
 pub(crate) fn value_keyed_derived_scalar<Dist, Branches, Validate, Derive, Select>(
     value: &Series,
     param: f64,

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -98,6 +98,29 @@ where
     Ok(ca.with_name(name).into_series())
 }
 
+/// Constant-parameter twin of [`value_keyed_derived_per_row`], over [`value_keyed_scalar`].
+///
+/// Validates and derives once per call, then maps `select` over the evaluation-point column. The
+/// Python side routes here only once the parameter is a Python scalar, so `derive` always sees
+/// `Some`, and this is the path where the rate-only terms a `derive` hoists (`ln(rate)`) are
+/// computed once instead of per row.
+pub(crate) fn value_keyed_derived_scalar<Dist, Branches, Validate, Derive, Select>(
+    value: &Series,
+    param: f64,
+    validate: Validate,
+    derive: Derive,
+    select: Select,
+) -> PolarsResult<Series>
+where
+    Validate: Fn(f64) -> PolarsResult<Dist>,
+    Derive: Fn(Option<f64>) -> Branches,
+    Select: Fn(&Branches, f64) -> Option<f64>,
+{
+    validate(param)?;
+    let branches = derive(Some(param));
+    value_keyed_scalar(value, |v| select(&branches, v))
+}
+
 /// Shared driver for the column-parameter value-keyed per-row paths.
 ///
 /// The column-parameter counterpart of [`value_keyed_scalar`]: at least one distribution parameter
@@ -156,14 +179,78 @@ where
     Ok(ca.with_name(name).into_series())
 }
 
+/// Shared driver for the value-keyed methods of a **one-parameter** distribution that computes its
+/// own closed form instead of building a `statrs` distribution.
+///
+/// `derive` turns the parameter into that method's branch table and `select` picks the branch the
+/// evaluation point lands on. Each method derives its own type, so pairing one method's `derive`
+/// with another's `select` does not compile. Both run per row here; [`value_keyed_derived_scalar`]
+/// is the twin that runs `derive` once per call.
+///
+/// Null contract, and the reason this is not [`value_keyed_per_row`]: that driver nulls the row on
+/// **any** null input without calling `build`, which is right for a `statrs`-backed distribution and
+/// wrong here. A null parameter reaches `derive` as `None`, so the branches whose answer is a
+/// parameter-free constant still answer: `Bernoulli`'s `pmf(2) = 0` and `Exponential`'s
+/// `cdf(-1) = 0` survive a null parameter, and each distribution's `null_param(s)_test.py` pins it.
+/// A null **value** still nulls the row without validating, matching the samplers. Nothing is
+/// validated on a null-parameter row, since there is no parameterisation to reject.
+///
+/// `NaN` contract: a `NaN` value short-circuits to `NaN`, but only after `validate` has run, so an
+/// invalid parameterisation still raises on a `NaN` row, exactly as [`value_keyed_per_row`] orders
+/// it.
+///
+/// `validate` is each distribution's `build_dist`; its return value is discarded, since these
+/// methods compute from the parameter rather than from the built distribution.
+///
+/// Keep `validate`, `derive` and `select` generic `Fn`s: they monomorphise into the row loop, where
+/// a `&dyn Fn` or a `fn` pointer would cost an indirect call per row.
+pub(crate) fn value_keyed_derived_per_row<Dist, Branches, Validate, Derive, Select>(
+    inputs: &[Series],
+    validate: Validate,
+    derive: Derive,
+    select: Select,
+) -> PolarsResult<Series>
+where
+    Validate: Fn(f64) -> PolarsResult<Dist>,
+    Derive: Fn(Option<f64>) -> Branches,
+    Select: Fn(&Branches, f64) -> Option<f64>,
+{
+    let inputs = align_inputs(inputs)?;
+    let value = inputs[0].cast(&DataType::Float64)?;
+    let param = inputs[1].cast(&DataType::Float64)?;
+    let name = inputs[0].name().clone();
+
+    let ca: Float64Chunked = try_binary_elementwise(
+        value.f64()?,
+        param.f64()?,
+        |value_opt, param_opt| -> PolarsResult<Option<f64>> {
+            let Some(value) = value_opt else {
+                return Ok(None);
+            };
+            // Validate before the `NaN` short-circuit, so an invalid parameter still raises on a
+            // `NaN` row. Pinned by `tests/distributions/plugin_nan_test.py`.
+            if let Some(param) = param_opt {
+                validate(param)?;
+            }
+            Ok(if value.is_nan() {
+                Some(f64::NAN)
+            } else {
+                select(&derive(param_opt), value)
+            })
+        },
+    )?;
+
+    Ok(ca.with_name(name).into_series())
+}
+
 /// Shared driver for the two-parameter validation plugins: `validate` builds the distribution per
 /// row and returns the `Float64` to emit, either a parameter itself (`sigma`) or a quantity derived
 /// from both (Uniform's `max - min`), `?`-propagating the `InvalidOperation` out of `build_dist`.
 /// Any null input nulls the row without calling `validate`, matching the samplers.
 ///
 /// These plugins are what let the closed-form moments, and the value-keyed methods still assembled
-/// in Polars (`Exponential`, `Geometric`, `Uniform`), report an invalid parameterisation through the
-/// same Rust `build_dist`. The constant-parameter fast path calls the same plugin on length-1
+/// in Polars (`Geometric`, `Uniform`), report an invalid parameterisation through the same Rust
+/// `build_dist`. The constant-parameter fast path calls the same plugin on length-1
 /// `pl.lit` inputs, so it is built once instead of per row.
 ///
 /// The two parameter dtypes are independent, so a mixed `(u64, f64)` parameterisation (Binomial)

--- a/tests/distributions/exponential/null_params_test.py
+++ b/tests/distributions/exponential/null_params_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -39,12 +40,39 @@ def test_method_propagates_null_in_rate(expr_fn: Callable[[Exponential], pl.Expr
 
 
 def test_value_keyed_below_support_ignores_null_rate() -> None:
-    # Closed-form trait shared with Uniform: below the support the value-keyed methods return the
-    # rate-independent support constant (pdf / cdf -> 0, sf -> 1), so a null rate does NOT null the
-    # row there. statrs-backed distributions (Binomial) null it instead. Bernoulli keeps the same
-    # contract in Rust (tests/distributions/bernoulli/null_param_test.py).
+    # Closed-form trait shared with Uniform: below the support all six value-keyed methods return the
+    # rate-independent support constant, so a null rate does NOT null the row there. statrs-backed
+    # distributions (Binomial) null it instead. Bernoulli keeps the same contract in Rust
+    # (tests/distributions/bernoulli/null_param_test.py).
     df = pl.DataFrame({"rate": [1.0, None, 2.0]}, schema={"rate": pl.Float64})
     e = Exponential(rate=pl.col("rate"))
     assert df.select(r=e.pdf(pl.lit(-1.0)))["r"].to_list() == [0.0, 0.0, 0.0]
     assert df.select(r=e.cdf(pl.lit(-1.0)))["r"].to_list() == [0.0, 0.0, 0.0]
     assert df.select(r=e.sf(pl.lit(-1.0)))["r"].to_list() == [1.0, 1.0, 1.0]
+    assert df.select(r=e.log_pdf(pl.lit(-1.0)))["r"].to_list() == [-math.inf] * 3
+    assert df.select(r=e.log_cdf(pl.lit(-1.0)))["r"].to_list() == [-math.inf] * 3
+    assert df.select(r=e.log_sf(pl.lit(-1.0)))["r"].to_list() == [0.0, 0.0, 0.0]
+
+
+@pytest.mark.parametrize("method", ["ppf", "isf"])
+@pytest.mark.parametrize("quantile", [0.0, 0.5, 1.0, 2.0])
+def test_inverse_nulls_under_a_null_rate(method: str, quantile: float) -> None:
+    """Null inside `[0, 1]` because the answer needs the rate, and null outside it by the domain contract.
+
+    Endpoints as well as interior: unlike the six value-keyed methods, neither inverse has a
+    rate-free branch anywhere in its domain, so no `q` survives a null rate.
+    """
+    df = pl.DataFrame({"rate": [None]}, schema={"rate": pl.Float64})
+    assert df.select(r=getattr(Exponential(rate=pl.col("rate")), method)(quantile))["r"].item() is None
+
+
+def test_nan_value_stays_nan_under_a_null_rate() -> None:
+    """A `NaN` evaluation point short-circuits before the branches, so a null rate does not null it.
+
+    Reached through the private hook, since the public wrapper answers `NaN` on its own. Only the
+    hook can see the short-circuit, and only there does it matter: polars orders `NaN` above every
+    number, so a `value >= 0` predicate would put `NaN` on the support and let a null rate null it.
+    """
+    df = pl.DataFrame({"rate": [None]}, schema={"rate": pl.Float64})
+    result = df.select(r=Exponential(rate=pl.col("rate"))._pdf(pl.lit(math.nan)))["r"].item()
+    assert math.isnan(result)

--- a/tests/distributions/exponential/null_params_test.py
+++ b/tests/distributions/exponential/null_params_test.py
@@ -57,11 +57,7 @@ def test_value_keyed_below_support_ignores_null_rate() -> None:
 @pytest.mark.parametrize("method", ["ppf", "isf"])
 @pytest.mark.parametrize("quantile", [0.0, 0.5, 1.0, 2.0])
 def test_inverse_nulls_under_a_null_rate(method: str, quantile: float) -> None:
-    """Null inside `[0, 1]` because the answer needs the rate, and null outside it by the domain contract.
-
-    Endpoints as well as interior: unlike the six value-keyed methods, neither inverse has a
-    rate-free branch anywhere in its domain, so no `q` survives a null rate.
-    """
+    """Endpoints as well as interior: neither inverse has a rate-free branch anywhere in its domain."""
     df = pl.DataFrame({"rate": [None]}, schema={"rate": pl.Float64})
     assert df.select(r=getattr(Exponential(rate=pl.col("rate")), method)(quantile))["r"].item() is None
 
@@ -69,9 +65,8 @@ def test_inverse_nulls_under_a_null_rate(method: str, quantile: float) -> None:
 def test_nan_value_stays_nan_under_a_null_rate() -> None:
     """A `NaN` evaluation point short-circuits before the branches, so a null rate does not null it.
 
-    Reached through the private hook, since the public wrapper answers `NaN` on its own. Only the
-    hook can see the short-circuit, and only there does it matter: polars orders `NaN` above every
-    number, so a `value >= 0` predicate would put `NaN` on the support and let a null rate null it.
+    Reached through the private hook, since the public wrapper answers `NaN` on its own. Without the
+    short-circuit `NaN` would land on the support (it is not `< 0`) and the null rate would null it.
     """
     df = pl.DataFrame({"rate": [None]}, schema={"rate": pl.Float64})
     result = df.select(r=Exponential(rate=pl.col("rate"))._pdf(pl.lit(math.nan)))["r"].item()

--- a/tests/distributions/plugin_nan_test.py
+++ b/tests/distributions/plugin_nan_test.py
@@ -14,9 +14,9 @@ in two places:
 * `Binomial`: `NaN < 0.0` is false and `NaN.floor() as u64` saturates to `0`, so unguarded bodies
   would return a confident `P(X <= 0)` (and a `pmf` of `0.0`).
 
-`Bernoulli` reimplements the short-circuit in its own driver (`bernoulli_value_keyed`), which the
-shared one could not serve because it nulls a row on any null parameter. Covered here so the two
-cannot drift.
+`Bernoulli` and `Exponential` take a third driver (`value_keyed_derived_per_row`), which repeats the
+short-circuit: the shared per-row one nulls a row on any null parameter, and their off-support
+answers are contracted to survive one. Covered here so the drivers cannot drift.
 
 Both plugin shapes are covered: scalar-parameter instances route to the `<method>_scalar` twins,
 column-parameter instances to the per-row plugins.
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
-from polars_stats import Bernoulli, Beta, Binomial, DiscreteUniform, LogNormal, Normal
+from polars_stats import Bernoulli, Beta, Binomial, DiscreteUniform, Exponential, LogNormal, Normal
 from polars_stats.distributions._base import DiscreteDistribution
 
 if TYPE_CHECKING:
@@ -54,6 +54,8 @@ _CASES = [
     ("beta-columns", Beta(a=_col(2.0), b=_col(3.0))),
     ("binomial-scalar", Binomial(n=5, p=0.4)),
     ("binomial-columns", Binomial(n=_col(5, pl.Int64()), p=_col(0.4))),
+    ("exponential-scalar", Exponential(rate=1.5)),
+    ("exponential-columns", Exponential(rate=_col(1.5))),
     ("discreteuniform-scalar", DiscreteUniform(min=-2, max=9)),
     ("discreteuniform-columns", DiscreteUniform(min=_col(-2, pl.Int64()), max=_col(9, pl.Int64()))),
 ]

--- a/tests/distributions/validation_contract_test.py
+++ b/tests/distributions/validation_contract_test.py
@@ -89,16 +89,14 @@ change it, which is what separates it from the `NaN` point the second test does 
 
 
 _LEAKING_METHODS: dict[str, frozenset[str]] = {
-    "Exponential": frozenset({"pdf", "log_pdf", "cdf", "sf", "log_sf", "ppf", "isf"}),
     "Geometric": frozenset({"pmf", "log_pmf", "cdf", "log_cdf", "sf", "log_sf", "ppf", "isf"}),
     "Uniform": frozenset({"pdf", "log_pdf", "cdf", "log_cdf", "sf", "log_sf", "ppf", "isf"}),
 }
 """The (distribution, method) pairs that `ARM_MASKING_HIDES_VALIDATION` is expected to break.
 
 Measured, not assumed: these are exactly the pairs that fail on polars 1.44.1 and pass on 1.43.2.
-`Exponential.log_cdf` is absent because it alone among the three remaining distributions' 24
-value-keyed methods still raises, so gating it would `XPASS` under `xfail_strict`. Porting a
-distribution's closed forms to Rust deletes its entry here; the last one to go deletes the dict.
+Every value-keyed method of the two remaining distributions leaks. Porting a distribution's closed
+forms to Rust deletes its entry here; the last one to go deletes the dict.
 """
 
 _METHOD_VALUES: tuple[tuple[str, tuple[float, ...]], ...] = (

--- a/tests/distributions/value_keyed_fast_path_test.py
+++ b/tests/distributions/value_keyed_fast_path_test.py
@@ -1,7 +1,7 @@
 """Validation contract of the constant-parameter value-keyed fast path.
 
-Covers Normal, LogNormal, Binomial, Beta, DiscreteUniform and Bernoulli: the distributions with
-per-method Rust plugins.
+Covers Normal, LogNormal, Binomial, Beta, DiscreteUniform, Bernoulli and Exponential: the
+distributions with per-method Rust plugins.
 
 `pdf` / `pmf` / `cdf` / `sf` / `ppf` with all-scalar parameters route through a dedicated ``<name>_<method>_scalar``
 plugin that validates and builds the `statrs` distribution once (via the shared `build_dist`), instead of rebuilding it
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
-from polars_stats import Bernoulli, Beta, Binomial, DiscreteUniform, LogNormal, Normal
+from polars_stats import Bernoulli, Beta, Binomial, DiscreteUniform, Exponential, LogNormal, Normal
 from polars_stats.distributions._base import ContinuousDistribution
 from tests._polars_compat import assert_series_equal
 
@@ -83,6 +83,12 @@ _CASES: dict[str, tuple[Callable[[], _UnivariateDistribution], Callable[[], _Uni
     # An infinite shape is *rejected* by statrs, unlike the Normal / LogNormal scale; both paths must
     # agree on that too.
     "beta a=inf (rejected)": (lambda: Beta(_INF, 1.0), lambda: Beta(_col(_INF), _col(1.0)), True),
+    "exponential rate=nan": (lambda: Exponential(_NAN), lambda: Exponential(_col(_NAN)), True),
+    "exponential rate=0": (lambda: Exponential(0.0), lambda: Exponential(_col(0.0)), True),
+    "exponential rate=-1": (lambda: Exponential(-1.0), lambda: Exponential(_col(-1.0)), True),
+    # An infinite rate is accepted by statrs as the degenerate point mass at 0, like the Normal
+    # scale and unlike the Beta shape; both paths must accept it identically.
+    "exponential rate=inf (accepted)": (lambda: Exponential(_INF), lambda: Exponential(_col(_INF)), False),
     "discreteuniform min>max": (
         lambda: DiscreteUniform(6, 1),
         lambda: DiscreteUniform(_col(6, pl.Int64()), _col(1, pl.Int64())),

--- a/tests/property/_specs.py
+++ b/tests/property/_specs.py
@@ -295,10 +295,10 @@ DISCRETE_SPECS = [s for s in ALL_SPECS if not s.continuous]
 
 # These specs compute in Polars, not in a Rust body, so with constant parameters their operands are
 # length-1 literals that polars may fold differently from the column kernel. Every IEEE operation is
-# exactly rounded, so the measured 1-ULP gap (`Exponential.ppf`, Uniform's `variance` / `std`) is a
-# different operation *order*, not a different formula. Extend from a failing assertion, never by
-# widening the tolerance.
-ULP_TOLERANT_VALUE_SPECS = frozenset({"uniform", "exponential"})
+# exactly rounded, so the measured 1-ULP gap (Uniform's `variance` / `std`) is a different operation
+# *order*, not a different formula. Extend from a failing assertion, never by widening the tolerance.
+# A spec whose closed forms move into Rust leaves this set: one body then feeds both paths.
+ULP_TOLERANT_VALUE_SPECS = frozenset({"uniform"})
 """Specs whose value-keyed methods compare to `ULP_REL_TOL` instead of bit-exactly."""
 
 ULP_TOLERANT_MOMENT_SPECS = frozenset({"uniform", "geometric"})

--- a/tests/property/fast_path_context_test.py
+++ b/tests/property/fast_path_context_test.py
@@ -139,9 +139,9 @@ def test_moment_fast_path_matches_per_row_across_contexts(spec: DistSpec, moment
 def test_value_keyed_fast_path_matches_per_row_across_contexts(spec: DistSpec, data: st.DataObject) -> None:
     """Density / log-density / cdf / sf / ppf scalar fast paths equal the per-row path under every context.
 
-    This is where the `Exponential` / `Geometric` / `Uniform` closed forms get their cross-context
-    coverage: their value-keyed methods are pure Polars, routing validation through the same
-    `_checked` gate as the moments, so a broadcast bug in that gate is the only way they diverge.
+    This is where the `Geometric` / `Uniform` closed forms get their cross-context coverage: their
+    value-keyed methods are pure Polars, routing validation through the same `_checked` gate as the
+    moments, so a broadcast bug in that gate is the only way they diverge.
     """
     params = data.draw(spec.params)
     scalar = spec.make(params)

--- a/tests/property/value_keyed_test.py
+++ b/tests/property/value_keyed_test.py
@@ -7,10 +7,10 @@ In Rust both plugins call the same named per-method body, so for any parameteris
 must agree bit for bit, including null propagation and ppf's null-outside-``[0, 1]`` contract. A
 divergence (e.g. a parameter-order swap in a scalar kwargs struct) must fail here.
 
-Bit-equality holds wherever a single Rust body feeds both paths. ``uniform``, ``exponential`` and
-``geometric`` have no Rust value-keyed plugin: both evaluate the same Polars expression, and the
-scalar path does it on length-1 operands, so polars may fold it differently. Where that moves the
-last bit (``ULP_TOLERANT_VALUE_SPECS``) the comparison is 1 ULP; the rest stay exact.
+Bit-equality holds wherever a single Rust body feeds both paths. ``uniform`` and ``geometric`` have
+no Rust value-keyed plugin: both evaluate the same Polars expression, and the scalar path does it on
+length-1 operands, so polars may fold it differently. Where that moves the last bit
+(``ULP_TOLERANT_VALUE_SPECS``) the comparison is 1 ULP; the rest stay exact.
 """
 
 from __future__ import annotations

--- a/tests/scipy_parity/exponential_test.py
+++ b/tests/scipy_parity/exponential_test.py
@@ -73,11 +73,11 @@ _TINY_ARGUMENTS = [1e-300, 1e-100, 1e-20, 1e-16, 1e-12]
 def test_cdf_keeps_the_left_tail_where_one_minus_exp_cancels(rate: float, t: float) -> None:
     """`cdf(t / rate)` is `t` to full relative precision, for `t` far below the `1 - exp` floor.
 
-    Polars exposes no `expm1`, so `1 - exp(-t)` cancelled: below `t ~ 1.1e-16` the exponential
-    rounds to exactly `1` and the cdf collapsed to `0`, while between there and `t ~ 1e-4` it
-    carried a relative error of `~1.1e-16 / t` (11% at `1e-16`). `_cdf` now uses the identity
-    `1 - exp(-t) = 2 exp(-t / 2) sinh(t / 2)`, which Polars can spell and which has no subtraction.
-    scipy is a valid oracle only above its own cancellation floor, so the limit `cdf -> t` is used.
+    The literal `1 - exp(-t)` cancelled: below `t ~ 1.1e-16` the exponential rounds to exactly `1`
+    and the cdf collapsed to `0`, while between there and `t ~ 1e-4` it carried a relative error of
+    `~1.1e-16 / t` (11% at `1e-16`). `exponential.rs`'s `derive_cdf` uses the identity
+    `1 - exp(-t) = 2 exp(-t / 2) sinh(t / 2)` instead, which has no subtraction. scipy is a valid
+    oracle only above its own cancellation floor, so the limit `cdf -> t` is used.
     """
     got = pl.DataFrame({"x": [t / rate]}).select(r=Exponential(rate=rate).cdf(pl.col("x")))["r"].item()
     assert got == pytest.approx(t, rel=1e-15)
@@ -117,7 +117,8 @@ def test_isf_is_exact_rather_than_ppf_of_the_complement(rate: float, q: float) -
 
 
 # The `pdf` regression from `make audit`. `rate * exp(-rate * x)` rounds `exp` into the subnormal
-# range and *then* scales that error up; `exp(log(rate) - rate * x)` rounds once, at the end.
+# range and *then* scales that error up; `(rate * exp(-rate * x / 2)) * exp(-rate * x / 2)` keeps the
+# intermediate normal, so only the final multiply underflows.
 #
 # Oracled by hard-coded correctly-rounded values, verified against a 50-digit `mpmath` oracle at 0.13
 # and 0.25 subnormal ulps respectively (against 42.9 and 4.3e7 before). scipy is not usable here: it


### PR DESCRIPTION
Moves `Exponential`'s eight value-keyed methods from branching Polars expressions into Rust plugins, so an invalid rate raises whichever branch the evaluation point selects instead of being masked away by polars 1.44's when/then arm nulling. 

Column-regime throughput improves 73% at 10M rows and the scalar and per-row paths become bit-identical, dropping exponential from `ULP_TOLERANT_VALUE_SPECS`.