### PR TITLE
refactor(uniform): compute the value-keyed closed forms in Rust

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -169,19 +169,26 @@ code rather than halfway through, write the scipy-parity test first, and keep a 
           rows and the method silently returns a value instead of raising
           ([pola-rs/polars#29005](https://github.com/pola-rs/polars/issues/29005)), and no Polars expression can
           spell a guard that survives the optimiser. In practice this is the value-keyed set: `pdf` / `pmf`,
-          `log_pdf` / `log_pmf`, `cdf`, `log_cdf`, `sf`, `log_sf`, `ppf`, `isf`. `DiscreteUniform` and `Bernoulli`
-          are the worked examples: every value-keyed method is a one-line `_value_plugin` hook over a Rust body, and
-          only the moments stay in `_<name>.py`.
+          `log_pdf` / `log_pmf`, `cdf`, `log_cdf`, `sf`, `log_sf`, `ppf`, `isf`. `DiscreteUniform`, `Bernoulli`,
+          `Exponential` and `Uniform` are the worked examples: every value-keyed method is a one-line
+          `_value_plugin` hook over a Rust body, and only the moments stay in `_<name>.py`.
         * Split such a body into a `derive` that turns the parameters into their branch answers and a `select` that
-          picks one by the evaluation value (`bernoulli.rs`'s `Mass::pmf` / `Mass::at`, `exponential.rs`'s
-          `derive_cdf` / `Sides::at`). The Polars expression it replaces computed `1 - p` once on a length-1 literal
-          and broadcast it; a body that recomputes per row regressed the constant-parameter path by up to 195% at
-          10M rows. `derive` runs once per call on the constant path and once per row when a parameter is a column.
+          picks one by the evaluation value. Where the branch answers are fixed once the parameters are, the table is
+          non-generic and `derive` is an associated constructor (`bernoulli.rs`'s `Mass::pmf` / `Mass::at`,
+          `uniform.rs`'s `Density::pdf`); where a branch still depends on the evaluation point, the table carries an
+          `Arm` type parameter and `derive` is a free function (`exponential.rs`'s `derive_cdf` / `Sides::at`,
+          `uniform.rs`'s `derive_cdf` / `Regions::at`). The Polars expression it replaces computed `1 - p` once on a
+          length-1 literal and broadcast it; a body that recomputes per row regressed the constant-parameter path by
+          up to 195% at 10M rows. `derive` runs once per call on the constant path and once per row when a parameter
+          is a column.
         * A one-parameter distribution pairs those two through `value_keyed_derived_per_row` and
-          `value_keyed_derived_scalar` in `src/distributions/mod.rs`; both plugin shells are one line and neither
-          names a driver internal. They are not `value_keyed_per_row`, which nulls a row on **any** null input: a
-          null parameter has to reach `derive` as `None` so the branches whose answer carries no parameter still
-          answer (`Bernoulli.pmf(2) = 0`, `Exponential.cdf(-1) = 0`).
+          `value_keyed_derived_scalar` in `src/distributions/mod.rs`. A two-parameter one takes
+          `value_keyed_derived_pair_per_row` beside them, and keeps its constant-parameter twin local
+          (`UniformParamsKwargs::value_keyed`) until a second distribution needs it; both plugin shells are still one
+          line and neither names a driver internal. They are not `value_keyed_per_row`, which nulls a row on **any**
+          null input: a null parameter has to reach `derive` as `None` so the branches whose answer carries no
+          parameter still
+          answer (`Bernoulli.pmf(2) = 0`, `Exponential.cdf(-1) = 0`, `Uniform.pdf` above a known `max`).
     * Factor the validating constructor into a `build_dist(...) -> PolarsResult<Dist>` helper so an invalid parameter
       maps through a `ComputeError` consistently.
 2. **Python.** Add `polars_stats/distributions/_<name>.py`, subclassing `ContinuousDistribution` or
@@ -297,9 +304,9 @@ probe aimed at it.
 
 **Where the recipes live.** `exponential.rs`'s `derive_ln_sf` (an exact closed form), its `derive_cdf` and
 `LogNormal.variance` (the `sinh` identity standing in for the `expm1` Polars does not expose), its `derive_ln_cdf` and
-`Uniform._log_cdf` (`log1p` on the near-certain side), `normal.rs`'s `ln_erfc` (a special function ported to log
-space, the pattern for the hard cases), and the `isf_value` bodies in `normal.rs` (a symmetry) and `lognormal.rs`
-(composing one).
+`uniform.rs`'s `derive_ln_cdf` (`log1p` on the near-certain side), `normal.rs`'s `ln_erfc` (a special function ported
+to log space, the pattern for the hard cases), and the `isf_value` bodies in `normal.rs` (a symmetry) and
+`lognormal.rs` (composing one).
 
 ## Conventions
 

--- a/docs/explanation/accuracy.md
+++ b/docs/explanation/accuracy.md
@@ -103,11 +103,11 @@ magnitudes are in the inherited limits below.
   99% of random supports of width `< 20` drawn from `[2**62, 2**63)`, because the bounds themselves
   are not representable there. It never happens for a support wider than one float step, nor anywhere
   inside `±2**53`.
-* **A constant parameter and a column parameter can differ in the last bit.** `Uniform(-2.5, 7.5).cdf("x")`
-  and `Uniform(pl.col("lo"), pl.col("hi")).cdf("x")` evaluate the same closed form, but polars folds the
+* **A constant parameter and a column parameter can differ in the last bit.** `Uniform(-2.5, 7.5).variance()`
+  and `Uniform(pl.col("lo"), pl.col("hi")).variance()` evaluate the same closed form, but polars folds the
   constant spelling over one row and the column spelling over `n`, and the two kernels do not round
   identically. It reaches the methods evaluated as polars expressions rather than in Rust: `Uniform`'s
-  moments and value-keyed methods, and `Geometric.std` / `.entropy`.
+  moments, and `Geometric.std` / `.entropy`.
   The difference is at or below `1e-15` relative, roughly 4x a double's ULP. Everything backed by `statrs`
   runs the same Rust body either way and stays bit-identical.
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -68,14 +68,15 @@ the expression engine. Methods that go through `statrs` (sampling, transcendenta
 native `ln_pdf`/`ln_pmf`, native `sf`) get a Rust plugin function, and so do the elementary value-keyed closed forms:
 they branch on the evaluation value, which puts the validator inside a `when` arm where polars can mask it away
 (see [Design notes](design.md#one-rust-file-per-distribution-one-plugin-function-per-method-that-needs-rust)).
-`Geometric` and `Uniform` are the two that have not moved yet.
+`Geometric` is the one that has not moved yet.
 
 **Parameter validation needs Rust.** A bare `pl.Expr` cannot raise per row, so any method computed in Python routes its
-parameters through one small validating plugin that raises on a bad row and returns a reused quantity. For a
-closed-form distribution that covers the whole surface: `Uniform.range` returns `max - min` and raises on
-`max <= min`. Everywhere else it covers the closed-form moments only, since the value-keyed methods already validate
+parameters through one small validating plugin that raises on a bad row and returns a reused quantity. For
+`Geometric`, the last distribution assembling its value-keyed methods in Polars, that covers the whole surface.
+Everywhere else it covers the closed-form moments only, since the value-keyed methods already validate
 inside their own plugin: `normal_sigma` validates `sigma > 0`, so `Normal.mean()` raises exactly as `Normal.pdf()`
-does, and `bernoulli_proba` and `exponential_rate` do the same for `Bernoulli`'s and `Exponential`'s moments. Either
+does, and `uniform_range` returns `max - min` and raises on `max <= min` for `Uniform`'s five moments, as
+`bernoulli_proba` and `exponential_rate` do for `Bernoulli`'s and `Exponential`'s. Either
 way a pure-math `mean` makes one FFI round-trip and reports an invalid parameterisation consistently, trading a little
 throughput for a uniform error surface.
 

--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -41,7 +41,7 @@ unconditionally or named in a `when(...)` condition, and moves to Rust when it i
 what branching on the evaluation value always looks like.
 
 The table below is the rule, which every new distribution follows. It is not yet a description of the tree:
-`Geometric` and `Uniform` still assemble their value-keyed methods in Polars and are being ported one at a time; the
+`Geometric` still assembles its value-keyed methods in Polars and is the last one left to port; the
 [reference index](../reference/index.md) carries the resulting known limitation. Method by method:
 
 | Method | In Rust? | Notes |
@@ -104,7 +104,7 @@ path is selected only when the parameters are known scalars, so nothing column-v
 ### Constant parameters validate once, not per row
 
 The moments (`mean`, `variance`, `std`, `entropy`) and the value-keyed closed forms still assembled in Polars
-(`Uniform`, `Geometric`) do not build a distribution; they compute a Polars expression. But they still route their
+(`Geometric`) do not build a distribution; they compute a Polars expression. But they still route their
 *validation* through a small Rust plugin (`normal_sigma`, `uniform_range`, `bernoulli_proba`,
 `binomial_params`, `lognormal_sigma`, `exponential_rate`, `beta_params`) so an invalid parameterisation raises the same
 `ComputeError` as the sampler and value-keyed methods rather than silently producing a nonsense moment (see "Invalid

--- a/docs/how-to/nulls-and-errors.md
+++ b/docs/how-to/nulls-and-errors.md
@@ -23,7 +23,10 @@ print(df.with_columns(density=ps.Normal().pdf("x")))
 ```
 
 A null *parameter* behaves the same way: that row's result is null, and no error is raised. This matters when
-parameters are estimated, because an under-sized group yields a null `sigma`.
+parameters are estimated, because an under-sized group yields a null `sigma`. The one refinement is that a null
+parameter nulls the answer only where the answer depends on it, so an off-support constant survives: on a row
+whose `lo` is null, `Uniform(min="lo", max="hi").pdf(5.0)` is still `0.0` wherever `hi` is below `5.0`; see
+[Reference / Parameters and contracts](../reference/parameters-and-contracts.md#nulls-nans-and-errors).
 
 ## Find the rows that would raise
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -68,20 +68,20 @@ mean of a different distribution on every row.
 
 !!! warning "Known limitation on polars >= 1.44"
 
-    On polars 1.44.0 and newer, `Geometric` and `Uniform` may **return a value instead of raising
+    On polars 1.44.0 and newer, `Geometric` may **return a value instead of raising
     `ComputeError`** when a *column-valued* parameter is invalid on a row the selected branch does
     not cover.
 
     Polars 1.44.0 ([pola-rs/polars#28498](https://github.com/pola-rs/polars/pull/28498)) masks the arms
     of a `when/then/otherwise` to null on the rows an arm does not select, so a validator reached only
-    from inside an arm never sees the offending row. These two distributions assemble their
-    value-keyed closed forms (`pdf`/`pmf`, `log_pdf`/`log_pmf`, `cdf`, `log_cdf`, `sf`, `log_sf`,
-    `ppf`, `isf`) as branching Polars expressions, so they are affected.
+    from inside an arm never sees the offending row. `Geometric` assembles its value-keyed closed
+    forms (`pmf`, `log_pmf`, `cdf`, `log_cdf`, `sf`, `log_sf`, `ppf`, `isf`) as branching Polars
+    expressions, so it is affected.
 
     **Not affected:** every other distribution (they compute in Rust and validate unconditionally),
-    the moments (`mean`, `variance`, `std`, `median`, `entropy`) of both, and every *valid*
-    computation, whose results are unchanged. `Bernoulli` and `Exponential` were affected up to and
-    including v0.0.2 and no longer are: their closed forms now compute in Rust.
+    `Geometric`'s own moments (`mean`, `variance`, `std`, `median`, `entropy`), and every *valid*
+    computation, whose results are unchanged. `Bernoulli`, `Exponential` and `Uniform` were affected
+    up to and including v0.0.2 and no longer are: their closed forms now compute in Rust.
 
     One narrower case survives for *every* distribution and *both* parameter spellings, scalar
     included: a **null or `NaN` evaluation point** is masked out of the plugin's input by the wrapper
@@ -93,4 +93,4 @@ mean of a different distribution on every row.
     **Workarounds:** pin `polars<1.44` yourself, or validate column parameters before passing them.
 
     Tracked as [pola-rs/polars#29005](https://github.com/pola-rs/polars/issues/29005). The limitation
-    goes away as each of the three moves its closed forms into Rust, which is in progress.
+    goes away once `Geometric` moves its closed forms into Rust, which is in progress.

--- a/docs/reference/parameters-and-contracts.md
+++ b/docs/reference/parameters-and-contracts.md
@@ -129,13 +129,21 @@ indistinguishable from a legitimately missing input, and would propagate wrong a
 | Wrong parameter *type* (a `list`, an `int` for a float parameter, a `bool`) | Python `__init__` | `TypeError`, no query runs |
 | Invalid parameter *value*, scalar or one column row | Rust evaluation | `ComputeError`, fails the whole evaluation, never silently nulls (one exception on polars >= 1.44, see [Known limitation](index.md#compatibility)) |
 | `null` value or quantile argument on a row | per row | `null` on that row |
-| `null` parameter on a row | per row | `null` on that row, no error |
+| `null` parameter on a row | per row | `null` on that row, no error, except where a branch that carries no parameter already settles the answer (see below) |
 | `NaN` value or quantile argument on a row | per row | `NaN` on that row (matches scipy) |
 | Non-numeric column as an argument or parameter | evaluation | Polars raises `InvalidOperationError` |
 | `q` outside `[0, 1]` in `ppf` / `isf` | per row | `null`, guaranteed for every distribution and both parameter regimes (pinned by `tests/property/ppf_domain_test.py`). `q` exactly `0` or `1` is in range and maps to a support bound |
 | `x` outside the support (e.g. `pdf` below a `Uniform`'s `min`) | per row | `0.0` (matches scipy) |
 | `pmf(3.5)` for a discrete distribution | per row | `0.0` (matches scipy) |
 | Deep-tail underflow (`sf` of a 60-sigma event) | per row | `0.0`; `log_sf` keeps resolution where it has a stable form, see [Numerical accuracy](../explanation/accuracy.md) |
+
+**A `null` parameter nulls the answer only where the answer depends on it.** Off the support the answer is often a
+constant that no parameter enters, and that constant survives: on a row whose `p` is null, `Bernoulli(p="p").pmf(2)`
+is `0.0`, not `null`, and so is `Exponential(rate="rate").cdf(-1)`. `Uniform` has two bounds, so the rule is per
+bound: an answer survives a null bound exactly when the *other*, known bound places the evaluation point outside the
+support. On a row whose `min` is null and whose `max` is `1.0`, `pdf(5.0)` is `0.0` and `cdf(5.0)` is `1.0`, while
+every method nulls at `0.5`. Both of `Uniform`'s
+inverses null at every quantile under either null bound, in range and out.
 
 Every distribution shipped today has finite moments on its valid parameter range, so this contract is exhaustive for
 them. The policy for distributions whose moments can be undefined is in

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -462,7 +462,7 @@ class _UnivariateDistribution(ABC):
 
         A value-keyed method belongs here even where its closed form is elementary: a branching Polars
         expression cannot be trusted to reach its validator on every row (see docs/explanation/design.md).
-        `Geometric` and `Uniform` have not moved yet and still assemble theirs in Polars.
+        `Geometric` has not moved yet and still assembles its own in Polars.
         """
         return (
             register_plugin(f"{function_name}_scalar", (value,), kwargs=self._scalar_kwargs)

--- a/polars_stats/distributions/_uniform.py
+++ b/polars_stats/distributions/_uniform.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING, ClassVar
 
-import polars as pl
-
 from polars_stats.distributions._base import (
     ContinuousDistribution,
     coerce_param,
@@ -13,10 +11,9 @@ from polars_stats.distributions._base import (
 )
 
 if TYPE_CHECKING:
-    from polars_stats._typing import IntoExprColumn
+    import polars as pl
 
-_MEDIAN_QUANTILE = 0.5
-"""Where `Uniform._inverse` switches which bound it interpolates from; see that method."""
+    from polars_stats._typing import IntoExprColumn
 
 
 class Uniform(ContinuousDistribution):
@@ -34,8 +31,12 @@ class Uniform(ContinuousDistribution):
 
     An invalid parameterisation (``max <= min``, a non-finite bound, or a width ``max - min``
     overflowing ``float64``) is not checked at construction; matching every other distribution, it
-    raises ``InvalidOperation`` (a ``ComputeError``) when any method is evaluated. Null bounds
-    propagate to null.
+    raises ``InvalidOperation`` (a ``ComputeError``) when any method is evaluated.
+
+    A null bound propagates to null wherever the result depends on it. Where the *other*, known
+    bound already places the evaluation point outside the support, the bound-free constant survives
+    instead (``pdf`` ``0``, ``log_pdf`` ``-inf``, and the saturated end of ``cdf`` / ``log_cdf`` /
+    ``sf`` / ``log_sf``). Both inverses null at every quantile under either null bound.
     """
 
     _min: pl.Expr
@@ -57,130 +58,48 @@ class Uniform(ContinuousDistribution):
 
         Validated in Rust so an invalid parameterisation (``max <= min``, a non-finite bound, or a
         width overflowing ``float64``) raises rather than silently yielding a non-positive or
-        infinite width. Every closed-form method (moments and pdf/cdf/ppf) derives from this, so they
-        all validate consistently; null bounds propagate. See ``_checked`` for the scalar-vs-column
-        routing.
+        infinite width. The moments derive from this; the value-keyed methods validate inside their own
+        plugin, through the same Rust check. Null bounds propagate. See ``_checked`` for the
+        scalar-vs-column routing.
         """
         return self._checked("uniform_range", self._max - self._min)
 
     def _pdf(self, value: pl.Expr) -> pl.Expr:
-        """``1 / (max - min)`` on ``[min, max]``, ``0`` outside, null where a bound is null.
-
-        The null branch is explicit because ``is_between`` yields null on a null bound, and a bare
-        ``when(in_range).then(...).otherwise(0.0)`` would take the ``otherwise``, reporting a confident
-        "outside the support" for a row whose support is unknown. ``_cdf`` and ``_sf`` need no such
-        branch, because their ``otherwise`` is the arithmetic and nulls on its own.
-        """
-        in_range = value.is_between(self._min, self._max, closed="both")
-        return (
-            pl.when(in_range.is_null())
-            .then(pl.lit(None, dtype=pl.Float64))
-            .when(in_range)
-            .then(1 / self.range)
-            .otherwise(0.0)
-        )
+        """``1 / (max - min)`` on the closed support ``[min, max]``, ``0`` outside."""
+        return self._value_plugin("uniform_pdf", value)
 
     def _log_pdf(self, value: pl.Expr) -> pl.Expr:
-        """``-log(max - min)`` on the support, ``-inf`` outside, null where a bound is null.
-
-        Same null branch as ``_pdf``, for the same reason.
-        """
-        in_range = value.is_between(self._min, self._max, closed="both")
-        return (
-            pl.when(in_range.is_null())
-            .then(pl.lit(None, dtype=pl.Float64))
-            .when(in_range)
-            .then(-self.range.log())
-            .otherwise(float("-inf"))
-        )
+        """``-log(max - min)`` on the closed support, ``-inf`` outside."""
+        return self._value_plugin("uniform_ln_pdf", value)
 
     def _cdf(self, value: pl.Expr) -> pl.Expr:
-        """``(value - min) / (max - min)`` clamped to ``[0, 1]``."""
-        return (
-            pl.when(value < self._min)
-            .then(0.0)
-            .when(value >= self._max)
-            .then(1.0)
-            .otherwise((value - self._min) / self.range)
-        )
+        """``(value - min) / (max - min)``, clamped to ``0`` below ``min`` and ``1`` from ``max`` up."""
+        return self._value_plugin("uniform_cdf", value)
 
     def _log_cdf(self, value: pl.Expr) -> pl.Expr:
-        """Log of the cdf ratio, through ``log1p`` of the survival ratio once past the midpoint.
+        """``log(cdf)`` below the midpoint, ``log1p(-sf)`` above it; ``-inf`` at/below ``min``, ``0`` from ``max`` up.
 
-        ``-inf`` at/below ``min``, ``0`` at/above ``max``. Overrides the base ``cdf().log()``, which
-        loses the whole near-certain half: approaching ``max`` the ratio rounds to exactly ``1`` and
-        its log to ``0``, where the truth is a small negative. Same branch ``normal.rs``'s
-        ``ln_half_erfc`` takes.
+        Overrides the base ``cdf().log()``, which loses the whole near-certain half: approaching
+        ``max`` the ratio rounds to exactly ``1`` and its log to ``0``, where the truth is a small
+        negative.
         """
-        upper = (-((self._max - value) / self.range)).log1p()
-        lower = ((value - self._min) / self.range).log()
-        return (
-            pl.when(value < self._min)
-            .then(float("-inf"))
-            .when(value >= self._max)
-            .then(0.0)
-            .when(value > self._min + self.range / 2)
-            .then(upper)
-            .otherwise(lower)
-        )
+        return self._value_plugin("uniform_ln_cdf", value)
 
     def _sf(self, value: pl.Expr) -> pl.Expr:
-        """``(max - value) / (max - min)`` clamped to ``[0, 1]`` (closed form, accurate in the upper tail)."""
-        return (
-            pl.when(value < self._min)
-            .then(1.0)
-            .when(value >= self._max)
-            .then(0.0)
-            .otherwise((self._max - value) / self.range)
-        )
+        """``(max - value) / (max - min)``, clamped to ``1`` below ``min`` and ``0`` from ``max`` up."""
+        return self._value_plugin("uniform_sf", value)
 
     def _log_sf(self, value: pl.Expr) -> pl.Expr:
-        """``0`` at/below ``min``, ``-inf`` at/above ``max``, and the mirror of ``_log_cdf`` between.
-
-        The near-certain half is the *lower* one here, so the ``log1p`` branch is on ``value`` below
-        the midpoint; the plain log of the ratio is exact on the other side.
-        """
-        upper = ((self._max - value) / self.range).log()
-        lower = (-((value - self._min) / self.range)).log1p()
-        return (
-            pl.when(value < self._min)
-            .then(0.0)
-            .when(value >= self._max)
-            .then(float("-inf"))
-            .when(value > self._min + self.range / 2)
-            .then(upper)
-            .otherwise(lower)
-        )
-
-    def _inverse(self, quantile: pl.Expr, *, ascending: bool) -> pl.Expr:
-        """Interpolate from whichever bound the answer is nearest; null outside ``[0, 1]``.
-
-        Both inverses are one multiply-add, and both lose the answer when they interpolate from the
-        *far* bound: ``min + quantile * range`` is a difference of nearly equal numbers once the
-        result lands near ``max``. Anchoring to the near bound makes the addition well conditioned,
-        and the ``1 - quantile`` it needs is only formed above the median, where Sterbenz makes it
-        exact.
-
-        ``ascending`` is ``True`` for ``ppf`` (small quantiles sit at ``min``) and ``False`` for
-        ``isf`` (small quantiles sit at ``max``).
-        """
-        lo, hi = (self._min, self._max) if ascending else (self._max, self._min)
-        step = self.range if ascending else -self.range
-        return (
-            pl.when(quantile.is_between(0, 1))
-            .then(
-                pl.when(quantile <= _MEDIAN_QUANTILE).then(lo + quantile * step).otherwise(hi - (1 - quantile) * step)
-            )
-            .otherwise(pl.lit(None, dtype=pl.Float64()))
-        )
+        """``0`` at/below ``min``, ``-inf`` from ``max`` up, and the mirror of ``_log_cdf`` between."""
+        return self._value_plugin("uniform_ln_sf", value)
 
     def _ppf(self, quantile: pl.Expr) -> pl.Expr:
         """``min + quantile * (max - min)``; null for ``quantile`` outside ``[0, 1]``.
 
         Evaluated as ``max - (1 - quantile) * range`` above the median, so a result near ``max`` on a
-        wide span keeps its relative precision. See ``_inverse``.
+        wide span keeps its relative precision.
         """
-        return self._inverse(quantile, ascending=True)
+        return self._value_plugin("uniform_ppf", quantile)
 
     def _isf(self, quantile: pl.Expr) -> pl.Expr:
         """``max - quantile * (max - min)``; null for ``quantile`` outside ``[0, 1]``.
@@ -188,9 +107,9 @@ class Uniform(ContinuousDistribution):
         The mirror of ``_ppf``, not the base-class ``ppf(1 - quantile)``: below
         ``quantile ~ 1.1e-16`` that complement rounds to exactly ``1.0`` and the whole tail
         collapses onto ``min + range``, which is total wherever ``max`` is near zero
-        (``Uniform(-1, 0).isf(1e-17)`` returned ``0.0`` against a true ``-1e-17``). See ``_inverse``.
+        (``Uniform(-1, 0).isf(1e-17)`` returned ``0.0`` against a true ``-1e-17``).
         """
-        return self._inverse(quantile, ascending=False)
+        return self._value_plugin("uniform_isf", quantile)
 
     def mean(self) -> pl.Expr:
         """Expected value, ``(min + max) / 2``."""

--- a/src/distributions/discrete_uniform.rs
+++ b/src/distributions/discrete_uniform.rs
@@ -334,8 +334,8 @@ fn coerce_points(value: &Series) -> PolarsResult<Points> {
 
 /// Apply a closed-form `f(support, point)` element-wise over `(value, min, max)`; shared by the
 /// six value-keyed plugins with an integer-exact path. Null and `NaN` contracts follow
-/// [`value_keyed_per_row`]: any null input nulls the row without building, an invalid
-/// parameterisation raises via [`build_support`] even on a `NaN` row.
+/// [`value_keyed_per_row`]: a null bound nulls the row without building, and an invalid
+/// parameterisation raises via [`build_support`] whatever the row's point is.
 fn du_value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
 where
     F: Fn(&Support, Point) -> Option<f64>,
@@ -359,8 +359,8 @@ where
     Ok(ca.with_name(name).into_series())
 }
 
-/// One row of [`du_value_keyed`]: build before the `NaN` short-circuit, so an invalid
-/// parameterisation still raises on a `NaN` row, exactly as [`value_keyed_per_row`] orders it.
+/// One row of [`du_value_keyed`]: build before the point is read, so an invalid parameterisation
+/// raises whatever the row's point is, exactly as [`value_keyed_per_row`] orders it.
 #[inline]
 fn per_row<F>(
     point: Option<Point>,
@@ -371,16 +371,17 @@ fn per_row<F>(
 where
     F: Fn(&Support, Point) -> Option<f64>,
 {
-    match (point, min, max) {
-        (Some(point), Some(min), Some(max)) => {
-            let support = build_support(min, max)?;
-            Ok(match point {
-                Point::Float(v) if v.is_nan() => Some(f64::NAN),
-                _ => f(&support, point),
-            })
-        },
-        _ => Ok(None),
-    }
+    let (Some(min), Some(max)) = (min, max) else {
+        return Ok(None);
+    };
+    let support = build_support(min, max)?;
+    let Some(point) = point else {
+        return Ok(None);
+    };
+    Ok(match point {
+        Point::Float(v) if v.is_nan() => Some(f64::NAN),
+        _ => f(&support, point),
+    })
 }
 
 /// Element-wise pmf: `1 / N` on the integer support, `0` off it, `NaN` for a `NaN` value.

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -5,6 +5,7 @@ use statrs::distribution::Exp;
 
 use crate::distributions::{
     align_inputs, validate_params_unary, value_keyed_derived_per_row, value_keyed_derived_scalar,
+    Domain,
 };
 use crate::rng::{
     binary_param_rows, sample_by_index, sample_per_row_binary, samples_by_index,
@@ -207,25 +208,6 @@ fn derive_ln_sf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
     Sides {
         below_support: 0.0,
         on_support: rate.map(|rate| move |x: f64| -rate * x),
-    }
-}
-
-/// `ppf` / `isf`: the arm inside the closed quantile domain, null outside it.
-///
-/// One slot rather than [`Sides`]' two, because no part of either inverse survives a null rate, at
-/// any quantile in range or out.
-struct Domain<Arm> {
-    inside: Option<Arm>,
-}
-
-impl<Arm: Fn(f64) -> f64> Domain<Arm> {
-    /// `None` (null) outside `[0, 1]`, matching the `quantile.is_between(0, 1)` this replaces.
-    /// `-0.0` is inside, since `-0.0 == 0.0`.
-    fn at(&self, quantile: f64) -> Option<f64> {
-        if !(0.0..=1.0).contains(&quantile) {
-            return None;
-        }
-        self.inside.as_ref().map(|arm| arm(quantile))
     }
 }
 

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -165,7 +165,7 @@ where
             };
             // Build before the value is read at all, so an invalid parameterisation raises whatever
             // the row's value is. Only a null or `NaN` *value* propagates. Pinned by
-            // `tests/distributions/plugin_nan_test.py` and `validation_contract_test.py`.
+            // `tests/distributions/plugin_nan_test.py` and `invalid_param_null_value_test.py`.
             let dist = build(p1, p2)?;
             let Some(value) = value_opt else {
                 return Ok(None);
@@ -228,7 +228,7 @@ where
         |value_opt, param_opt| -> PolarsResult<Option<f64>> {
             // Validate before the value is read at all, so an invalid parameter raises whatever the
             // row's value is. Only a null or `NaN` *value* propagates. Pinned by
-            // `tests/distributions/plugin_nan_test.py` and `validation_contract_test.py`.
+            // `tests/distributions/plugin_nan_test.py` and `invalid_param_null_value_test.py`.
             if let Some(param) = param_opt {
                 validate(param)?;
             }
@@ -246,15 +246,93 @@ where
     Ok(ca.with_name(name).into_series())
 }
 
+/// The closed quantile domain `[0, 1]`, for the inverses of a distribution that computes its own
+/// closed form rather than building a `statrs` one.
+///
+/// One slot rather than the two or three a support needs, because no part of either inverse
+/// survives a null parameter, at any quantile in range or out: `Exponential`'s and `Uniform`'s
+/// `null_param(s)_test.py` each pin it.
+pub(crate) struct Domain<Arm> {
+    pub(crate) inside: Option<Arm>,
+}
+
+impl<Arm: Fn(f64) -> f64> Domain<Arm> {
+    /// `None` (null) outside `[0, 1]`; `-0.0` is inside, since `-0.0 == 0.0`.
+    ///
+    /// A `NaN` quantile never reaches here: every driver short-circuits it, which is what lets this
+    /// be a plain range check.
+    pub(crate) fn at(&self, quantile: f64) -> Option<f64> {
+        if !(0.0..=1.0).contains(&quantile) {
+            return None;
+        }
+        self.inside.as_ref().map(|arm| arm(quantile))
+    }
+}
+
+/// Two-parameter sibling of [`value_keyed_derived_per_row`], over `try_ternary_elementwise`.
+///
+/// "Pair" counts the *distribution parameters* (`Uniform`'s two bounds); the driver itself takes
+/// three `Series`. Kept beside the one-parameter version rather than generified over arity, because
+/// `derive` needs both `Option`s in scope to answer from one bound while the other is null.
+///
+/// Null contract: as in [`value_keyed_derived_per_row`], with the parameter half now two-sided. A
+/// null **value** nulls the row without validating. A null parameter reaches `derive` as `None`, so
+/// the branches a single known parameter already settles still answer. Nothing is validated there,
+/// since a half-specified parameterisation is not one to reject.
+///
+/// `NaN` contract: a `NaN` value short-circuits to `NaN`, but only after `validate` has run, so an
+/// invalid parameterisation still raises on a `NaN` row.
+pub(crate) fn value_keyed_derived_pair_per_row<Dist, Branches, Validate, Derive, Select>(
+    inputs: &[Series],
+    validate: Validate,
+    derive: Derive,
+    select: Select,
+) -> PolarsResult<Series>
+where
+    Validate: Fn(f64, f64) -> PolarsResult<Dist>,
+    Derive: Fn(Option<f64>, Option<f64>) -> Branches,
+    Select: Fn(&Branches, f64) -> Option<f64>,
+{
+    let inputs = align_inputs(inputs)?;
+    let value = inputs[0].cast(&DataType::Float64)?;
+    let param_a = inputs[1].cast(&DataType::Float64)?;
+    let param_b = inputs[2].cast(&DataType::Float64)?;
+    let name = inputs[0].name().clone();
+
+    let ca: Float64Chunked = try_ternary_elementwise(
+        value.f64()?,
+        param_a.f64()?,
+        param_b.f64()?,
+        |value_opt, a_opt, b_opt| -> PolarsResult<Option<f64>> {
+            // Validate before the value is read at all, so an invalid parameterisation raises
+            // whatever the row's value is. Only a null or `NaN` *value* propagates. Pinned by
+            // `tests/distributions/plugin_nan_test.py` and `invalid_param_null_value_test.py`.
+            if let (Some(a), Some(b)) = (a_opt, b_opt) {
+                validate(a, b)?;
+            }
+            let Some(value) = value_opt else {
+                return Ok(None);
+            };
+            Ok(if value.is_nan() {
+                Some(f64::NAN)
+            } else {
+                select(&derive(a_opt, b_opt), value)
+            })
+        },
+    )?;
+
+    Ok(ca.with_name(name).into_series())
+}
+
 /// Shared driver for the two-parameter validation plugins: `validate` builds the distribution per
 /// row and returns the `Float64` to emit, either a parameter itself (`sigma`) or a quantity derived
 /// from both (Uniform's `max - min`), `?`-propagating the `InvalidOperation` out of `build_dist`.
 /// Any null input nulls the row without calling `validate`, matching the samplers.
 ///
 /// These plugins are what let the closed-form moments, and the value-keyed methods still assembled
-/// in Polars (`Geometric`, `Uniform`), report an invalid parameterisation through the same Rust
-/// `build_dist`. The constant-parameter fast path calls the same plugin on length-1
-/// `pl.lit` inputs, so it is built once instead of per row.
+/// in Polars (`Geometric`), report an invalid parameterisation through the same Rust `build_dist`.
+/// The constant-parameter fast path calls the same plugin on length-1 `pl.lit` inputs, so it is
+/// built once instead of per row.
 ///
 /// The two parameter dtypes are independent, so a mixed `(u64, f64)` parameterisation (Binomial)
 /// fits, as in [`ternary_param_rows`](crate::rng::ternary_param_rows): the caller does the cast and

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -160,19 +160,21 @@ where
         p1,
         p2,
         |value_opt, p1_opt, p2_opt| -> PolarsResult<Option<f64>> {
-            match (value_opt, p1_opt, p2_opt) {
-                (Some(value), Some(p1), Some(p2)) => {
-                    // Build before the `NaN` short-circuit, so an invalid parameterisation still
-                    // raises on a `NaN` row. Pinned by `tests/distributions/plugin_nan_test.py`.
-                    let dist = build(p1, p2)?;
-                    Ok(if value.is_nan() {
-                        Some(f64::NAN)
-                    } else {
-                        f(&dist, value)
-                    })
-                },
-                _ => Ok(None),
-            }
+            let (Some(p1), Some(p2)) = (p1_opt, p2_opt) else {
+                return Ok(None);
+            };
+            // Build before the value is read at all, so an invalid parameterisation raises whatever
+            // the row's value is. Only a null or `NaN` *value* propagates. Pinned by
+            // `tests/distributions/plugin_nan_test.py` and `validation_contract_test.py`.
+            let dist = build(p1, p2)?;
+            let Some(value) = value_opt else {
+                return Ok(None);
+            };
+            Ok(if value.is_nan() {
+                Some(f64::NAN)
+            } else {
+                f(&dist, value)
+            })
         },
     )?;
 
@@ -224,14 +226,15 @@ where
         value.f64()?,
         param.f64()?,
         |value_opt, param_opt| -> PolarsResult<Option<f64>> {
-            let Some(value) = value_opt else {
-                return Ok(None);
-            };
-            // Validate before the `NaN` short-circuit, so an invalid parameter still raises on a
-            // `NaN` row. Pinned by `tests/distributions/plugin_nan_test.py`.
+            // Validate before the value is read at all, so an invalid parameter raises whatever the
+            // row's value is. Only a null or `NaN` *value* propagates. Pinned by
+            // `tests/distributions/plugin_nan_test.py` and `validation_contract_test.py`.
             if let Some(param) = param_opt {
                 validate(param)?;
             }
+            let Some(value) = value_opt else {
+                return Ok(None);
+            };
             Ok(if value.is_nan() {
                 Some(f64::NAN)
             } else {

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -3,21 +3,22 @@ use pyo3_polars::derive::polars_expr;
 use rand::distr::{Distribution, StandardUniform};
 use statrs::distribution::Uniform;
 
-use crate::distributions::{align_inputs, validate_params_binary};
+use crate::distributions::{
+    align_inputs, validate_params_binary, value_keyed_derived_pair_per_row, value_keyed_scalar,
+    Domain,
+};
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
-fn build_dist(min: f64, max: f64) -> PolarsResult<Uniform> {
+fn build_dist(min: f64, max: f64) -> PolarsResult<(f64, f64)> {
     // `statrs` accepts any finite `min < max`, but a support wider than `f64::MAX` (e.g.
     // `min=-1e308, max=1e308`) makes `max - min` overflow to `inf`, and with it every derived
     // quantity: `range`, the moments, and the draw itself would all silently emit `inf` instead
     // of erroring. Reject it here so all uniform plugins report it as an invalid
     // parameterisation.
     if !(max - min).is_finite() {
-        // Scientific notation: this only fires for enormous bounds, whose plain `Display` is a
-        // 300-digit decimal expansion.
         return Err(PolarsError::InvalidOperation(
             format!("max - min must be finite, got min={min:e}, max={max:e}").into(),
         ));
@@ -26,13 +27,11 @@ fn build_dist(min: f64, max: f64) -> PolarsResult<Uniform> {
         PolarsError::InvalidOperation(
             format!("max must be strictly greater than min, got min={min}, max={max}: {e}").into(),
         )
-    })
+    })?;
+    Ok((min, max))
 }
 
 /// Uniform's constant bounds, deserialised once per call.
-///
-/// The one place this file spells `(min, max)`: both samplers validate through
-/// [`Self::validated_bounds`], so the order cannot drift between them.
 #[derive(serde::Deserialize)]
 struct UniformParamsKwargs {
     min: f64,
@@ -40,14 +39,338 @@ struct UniformParamsKwargs {
 }
 
 impl UniformParamsKwargs {
-    /// Validate the constant bounds once per call and return them raw.
+    /// Constant-bounds twin of [`value_keyed_derived_pair_per_row`]: validates and derives once per
+    /// call, then maps `select` over the evaluation-point column.
     ///
-    /// The built distribution is discarded on purpose: [`draw_half_open`] wants the `(lo, hi)` pair,
-    /// not a `statrs::Uniform`.
-    fn validated_bounds(&self) -> PolarsResult<(f64, f64)> {
+    /// The Python side routes here only once both bounds are Python scalars, so `derive` always sees
+    /// `Some` and the bound-only terms it hoists (`1 / range`, `-ln(range)`) are computed once
+    /// instead of per row.
+    fn value_keyed<Branches>(
+        &self,
+        value: &Series,
+        derive: impl Fn(Option<f64>, Option<f64>) -> Branches,
+        select: impl Fn(&Branches, f64) -> Option<f64>,
+    ) -> PolarsResult<Series> {
         build_dist(self.min, self.max)?;
-        Ok((self.min, self.max))
+        let branches = derive(Some(self.min), Some(self.max));
+        value_keyed_scalar(value, |v| select(&branches, v))
     }
+}
+
+/// Where both inverses switch which bound they interpolate from; see [`derive_inverse`].
+const MEDIAN_QUANTILE: f64 = 0.5;
+
+/// A validated `(min, max)` pair and its width, which every branch table below reads.
+#[derive(Clone, Copy)]
+struct Span {
+    min: f64,
+    max: f64,
+    range: f64,
+}
+
+/// `None` when either bound is null, leaving the `interior` / `on_support` slots below `None` on
+/// exactly the rows whose answer needs both bounds.
+fn span(min: Option<f64>, max: Option<f64>) -> Option<Span> {
+    let (min, max) = (min?, max?);
+    Some(Span {
+        min,
+        max,
+        range: max - min,
+    })
+}
+
+impl Span {
+    /// Where the two log methods swap conditioning, as `min + range / 2` rather than
+    /// `(min + max) / 2`.
+    ///
+    /// The two round differently on a span that straddles zero, and `min + max` can overflow where
+    /// `range / 2` cannot: `range` is already known finite.
+    fn midpoint(self) -> f64 {
+        self.min + self.range / 2.0
+    }
+}
+
+/// `pdf` / `log_pdf`: the answer on the closed support `[min, max]`, and off it.
+///
+/// The bounds are `Option`s and the off-support answer a plain `f64`, so a slot answers whenever the
+/// bound that places the point is known, whatever the other one is.
+struct Density {
+    min: Option<f64>,
+    max: Option<f64>,
+    off_support: f64,
+    on_support: Option<f64>,
+}
+
+impl Density {
+    /// `1 / range` on the support, `0` off it.
+    fn pdf(min: Option<f64>, max: Option<f64>) -> Self {
+        Density {
+            min,
+            max,
+            off_support: 0.0,
+            on_support: span(min, max).map(|s| 1.0 / s.range),
+        }
+    }
+
+    /// `-ln(range)` on the support, `-inf` off it. From the width rather than as `ln(pdf)`, so it
+    /// stays exact where the density itself has underflowed or overflowed.
+    fn ln_pdf(min: Option<f64>, max: Option<f64>) -> Self {
+        Density {
+            min,
+            max,
+            off_support: f64::NEG_INFINITY,
+            on_support: span(min, max).map(|s| -s.range.ln()),
+        }
+    }
+
+    /// The support is closed at both ends, so `max` is on it (`pdf(max) == 1 / range`) and only
+    /// `value > max` is outside. scipy's convention, and the one asymmetry with `uniform_sample`,
+    /// which draws on the half-open `[min, max)`.
+    ///
+    /// A `NaN` point never reaches here: both drivers short-circuit it.
+    fn at(&self, value: f64) -> Option<f64> {
+        if self.min.is_some_and(|min| value < min) || self.max.is_some_and(|max| value > max) {
+            return Some(self.off_support);
+        }
+        self.on_support
+    }
+}
+
+/// `cdf` / `log_cdf` / `sf` / `log_sf`: the three places an evaluation point lands, and the answer
+/// at each.
+///
+/// These saturate from `max` up, so `max` takes `at_or_above_max` rather than the interior.
+struct Regions<Arm> {
+    min: Option<f64>,
+    max: Option<f64>,
+    below_min: f64,
+    at_or_above_max: f64,
+    interior: Option<Arm>,
+}
+
+impl<Arm: Fn(f64) -> f64> Regions<Arm> {
+    fn at(&self, value: f64) -> Option<f64> {
+        if self.min.is_some_and(|min| value < min) {
+            return Some(self.below_min);
+        }
+        if self.max.is_some_and(|max| value >= max) {
+            return Some(self.at_or_above_max);
+        }
+        self.interior.as_ref().map(|arm| arm(value))
+    }
+}
+
+/// `(value - min) / range` on the support, clamped to `0` below and `1` from `max` up.
+fn derive_cdf(min: Option<f64>, max: Option<f64>) -> Regions<impl Fn(f64) -> f64> {
+    Regions {
+        min,
+        max,
+        below_min: 0.0,
+        at_or_above_max: 1.0,
+        interior: span(min, max).map(|s| move |value: f64| (value - s.min) / s.range),
+    }
+}
+
+/// `ln(cdf)` below the midpoint, `ln_1p(-sf)` above it; `-inf` below `min`, `0` from `max` up.
+///
+/// Approaching `max` the cdf ratio rounds to exactly `1` and its log to `0`, where the truth is a
+/// small negative, so the near-certain half reads the *survival* fraction through `ln_1p` instead.
+/// The other half is well conditioned and takes the plain log, the same branch `normal.rs`'s
+/// `ln_half_erfc` takes.
+fn derive_ln_cdf(min: Option<f64>, max: Option<f64>) -> Regions<impl Fn(f64) -> f64> {
+    Regions {
+        min,
+        max,
+        below_min: f64::NEG_INFINITY,
+        at_or_above_max: 0.0,
+        interior: span(min, max).map(|s| {
+            let midpoint = s.midpoint();
+            move |value: f64| {
+                if value > midpoint {
+                    (-((s.max - value) / s.range)).ln_1p()
+                } else {
+                    ((value - s.min) / s.range).ln()
+                }
+            }
+        }),
+    }
+}
+
+/// `(max - value) / range` on the support, `1` below `min` and `0` from `max` up.
+///
+/// The closed form, never `1 - cdf`: the complement quantises the upper tail to the `1.1e-16`
+/// spacing of `1.0` and reaches `0.0` below that.
+fn derive_sf(min: Option<f64>, max: Option<f64>) -> Regions<impl Fn(f64) -> f64> {
+    Regions {
+        min,
+        max,
+        below_min: 1.0,
+        at_or_above_max: 0.0,
+        interior: span(min, max).map(|s| move |value: f64| (s.max - value) / s.range),
+    }
+}
+
+/// The mirror of [`derive_ln_cdf`]: `0` below `min`, `-inf` from `max` up, and the `ln_1p` branch on
+/// the **lower** half, which is where the survival function is the near-certain one.
+fn derive_ln_sf(min: Option<f64>, max: Option<f64>) -> Regions<impl Fn(f64) -> f64> {
+    Regions {
+        min,
+        max,
+        below_min: 0.0,
+        at_or_above_max: f64::NEG_INFINITY,
+        interior: span(min, max).map(|s| {
+            let midpoint = s.midpoint();
+            move |value: f64| {
+                if value > midpoint {
+                    ((s.max - value) / s.range).ln()
+                } else {
+                    (-((value - s.min) / s.range)).ln_1p()
+                }
+            }
+        }),
+    }
+}
+
+/// `ppf` and `isf`, interpolating from whichever bound the answer is nearest.
+///
+/// Both inverses are one multiply-add, and both lose the answer when they interpolate from the
+/// *far* bound: `min + quantile * range` is a difference of nearly equal numbers once the result
+/// lands near `max`. Anchoring to the near bound makes the addition well conditioned, and the
+/// `1 - quantile` it needs is formed only above [`MEDIAN_QUANTILE`], where Sterbenz makes it
+/// exact.
+///
+/// `ascending` is `true` for `ppf`, whose quantile `0` sits at `min`, and `false` for `isf`, whose
+/// sits at `max`. Mirroring rather than `ppf(1 - q)`: below `q ~ 1.1e-16` that complement rounds to
+/// `1.0` and the whole tail collapses onto one bound.
+fn derive_inverse(
+    min: Option<f64>,
+    max: Option<f64>,
+    ascending: bool,
+) -> Domain<impl Fn(f64) -> f64> {
+    Domain {
+        inside: span(min, max).map(move |s| {
+            let (at_zero, at_one, step) = if ascending {
+                (s.min, s.max, s.range)
+            } else {
+                (s.max, s.min, -s.range)
+            };
+            move |quantile: f64| {
+                if quantile <= MEDIAN_QUANTILE {
+                    at_zero + quantile * step
+                } else {
+                    at_one - (1.0 - quantile) * step
+                }
+            }
+        }),
+    }
+}
+
+/// `min + quantile * range`, from `max` down above the median; null outside `[0, 1]`.
+fn derive_ppf(min: Option<f64>, max: Option<f64>) -> Domain<impl Fn(f64) -> f64> {
+    derive_inverse(min, max, true)
+}
+
+/// `max - quantile * range`, from `min` up above the median; null outside `[0, 1]`.
+fn derive_isf(min: Option<f64>, max: Option<f64>) -> Domain<impl Fn(f64) -> f64> {
+    derive_inverse(min, max, false)
+}
+
+/// Element-wise pdf; see [`Density::at`] for why the support is closed at `max`.
+/// See [`value_keyed_derived_pair_per_row`] for the null/error contract.
+#[polars_expr(output_type=Float64)]
+fn uniform_pdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_pair_per_row(inputs, build_dist, Density::pdf, Density::at)
+}
+
+/// Element-wise log-pdf; see [`Density::ln_pdf`].
+#[polars_expr(output_type=Float64)]
+fn uniform_ln_pdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_pair_per_row(inputs, build_dist, Density::ln_pdf, Density::at)
+}
+
+/// Element-wise cdf `P(X <= value)`; see [`derive_cdf`].
+#[polars_expr(output_type=Float64)]
+fn uniform_cdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_pair_per_row(inputs, build_dist, derive_cdf, Regions::at)
+}
+
+/// Element-wise log-cdf; see [`derive_ln_cdf`].
+#[polars_expr(output_type=Float64)]
+fn uniform_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_pair_per_row(inputs, build_dist, derive_ln_cdf, Regions::at)
+}
+
+/// Element-wise survival function `P(X > value)`; see [`derive_sf`] for why it is not `1 - cdf`.
+#[polars_expr(output_type=Float64)]
+fn uniform_sf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_pair_per_row(inputs, build_dist, derive_sf, Regions::at)
+}
+
+/// Element-wise log-sf; see [`derive_ln_sf`].
+#[polars_expr(output_type=Float64)]
+fn uniform_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_pair_per_row(inputs, build_dist, derive_ln_sf, Regions::at)
+}
+
+/// Element-wise ppf (inverse cdf); see [`derive_inverse`].
+#[polars_expr(output_type=Float64)]
+fn uniform_ppf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_pair_per_row(inputs, build_dist, derive_ppf, Domain::at)
+}
+
+/// Element-wise inverse survival function; see [`derive_inverse`] for why it never forms a
+/// complement.
+#[polars_expr(output_type=Float64)]
+fn uniform_isf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_pair_per_row(inputs, build_dist, derive_isf, Domain::at)
+}
+
+/// Constant-bounds fast path for [`uniform_pdf`].
+#[polars_expr(output_type=Float64)]
+fn uniform_pdf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], Density::pdf, Density::at)
+}
+
+/// Constant-bounds fast path for [`uniform_ln_pdf`].
+#[polars_expr(output_type=Float64)]
+fn uniform_ln_pdf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], Density::ln_pdf, Density::at)
+}
+
+/// Constant-bounds fast path for [`uniform_cdf`].
+#[polars_expr(output_type=Float64)]
+fn uniform_cdf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_cdf, Regions::at)
+}
+
+/// Constant-bounds fast path for [`uniform_ln_cdf`].
+#[polars_expr(output_type=Float64)]
+fn uniform_ln_cdf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_ln_cdf, Regions::at)
+}
+
+/// Constant-bounds fast path for [`uniform_sf`].
+#[polars_expr(output_type=Float64)]
+fn uniform_sf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_sf, Regions::at)
+}
+
+/// Constant-bounds fast path for [`uniform_ln_sf`].
+#[polars_expr(output_type=Float64)]
+fn uniform_ln_sf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_ln_sf, Regions::at)
+}
+
+/// Constant-bounds fast path for [`uniform_ppf`].
+#[polars_expr(output_type=Float64)]
+fn uniform_ppf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_ppf, Domain::at)
+}
+
+/// Constant-bounds fast path for [`uniform_isf`].
+#[polars_expr(output_type=Float64)]
+fn uniform_isf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_isf, Domain::at)
 }
 
 /// One half-open `[lo, hi)` draw: `lo + (hi - lo) * U[0, 1)`, matching scipy's
@@ -83,9 +406,6 @@ fn draw_half_open(lo: f64, hi: f64, rng: &mut impl rand::Rng) -> f64 {
 /// Per row, `null` propagates and an invalid parameterisation (`max <= min`, non-finite bounds, or
 /// a width overflowing `f64`) raises via [`build_dist`]. Seeding and chunk-invariance follow
 /// [`sample_per_row_ternary`].
-///
-/// The built distribution is discarded on purpose: the row state is the raw `(min, max)` pair
-/// [`draw_half_open`] draws from.
 #[polars_expr(output_type=Float64)]
 fn uniform_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
@@ -100,22 +420,18 @@ fn uniform_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Serie
         max.f64()?,
         index.u64()?,
         kwargs.seed,
-        |lo, hi| {
-            build_dist(lo, hi)?;
-            Ok((lo, hi))
-        },
+        build_dist,
         |&(lo, hi), rng| draw_half_open(lo, hi, rng),
     )
 }
 
-/// Constant-bounds fast path for [`uniform_sample`]. The built distribution is intentionally
-/// unused; the draw is [`draw_half_open`] over the raw bounds.
+/// Constant-bounds fast path for [`uniform_sample`].
 #[polars_expr(output_type=Float64)]
 fn uniform_sample_scalar(
     inputs: &[Series],
     kwargs: SampleScalarKwargs<UniformParamsKwargs>,
 ) -> PolarsResult<Series> {
-    let (lo, hi) = kwargs.params.validated_bounds()?;
+    let (lo, hi) = build_dist(kwargs.params.min, kwargs.params.max)?;
     let name = inputs[0].name().clone();
 
     sample_by_index(name, &inputs[0], kwargs.seed, |rng| {
@@ -132,7 +448,7 @@ fn uniform_samples_scalar(
     inputs: &[Series],
     kwargs: SamplesScalarKwargs<UniformParamsKwargs>,
 ) -> PolarsResult<Series> {
-    let (lo, hi) = kwargs.params.validated_bounds()?;
+    let (lo, hi) = build_dist(kwargs.params.min, kwargs.params.max)?;
     let name = inputs[0].name().clone();
 
     samples_by_index(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
@@ -153,12 +469,7 @@ fn uniform_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Ser
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
 
-    // The built distribution is validated then dropped; the row state keeps the raw bounds, as
-    // [`draw_half_open`] needs (mirrors the `uniform_sample_scalar` `build`).
-    let rows = ternary_param_rows(min.f64()?, max.f64()?, index.u64()?, |lo, hi| {
-        build_dist(lo, hi)?;
-        Ok((lo, hi))
-    });
+    let rows = ternary_param_rows(min.f64()?, max.f64()?, index.u64()?, build_dist);
 
     samples_per_row(name, rows, kwargs.seed, kwargs.size, |&(lo, hi), rng| {
         draw_half_open(lo, hi, rng)
@@ -181,7 +492,6 @@ fn uniform_range(inputs: &[Series]) -> PolarsResult<Series> {
     let max = inputs[1].cast(&DataType::Float64)?;
 
     validate_params_binary(min.f64()?, max.f64()?, |lo, hi| {
-        build_dist(lo, hi)?;
-        Ok(hi - lo)
+        build_dist(lo, hi).map(|(lo, hi)| hi - lo)
     })
 }

--- a/tests/distributions/plugin_nan_test.py
+++ b/tests/distributions/plugin_nan_test.py
@@ -14,9 +14,10 @@ in two places:
 * `Binomial`: `NaN < 0.0` is false and `NaN.floor() as u64` saturates to `0`, so unguarded bodies
   would return a confident `P(X <= 0)` (and a `pmf` of `0.0`).
 
-`Bernoulli` and `Exponential` take a third driver (`value_keyed_derived_per_row`), which repeats the
-short-circuit: the shared per-row one nulls a row on any null parameter, and their off-support
-answers are contracted to survive one. Covered here so the drivers cannot drift.
+`Bernoulli` and `Exponential` take a third driver (`value_keyed_derived_per_row`) and `Uniform` its
+two-parameter sibling, both of which repeat the short-circuit: the shared per-row one nulls a row on
+any null parameter, and their off-support answers are contracted to survive one. Covered here so the
+drivers cannot drift.
 
 Both plugin shapes are covered: scalar-parameter instances route to the `<method>_scalar` twins,
 column-parameter instances to the per-row plugins.
@@ -30,7 +31,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
-from polars_stats import Bernoulli, Beta, Binomial, DiscreteUniform, Exponential, LogNormal, Normal
+from polars_stats import Bernoulli, Beta, Binomial, DiscreteUniform, Exponential, LogNormal, Normal, Uniform
 from polars_stats.distributions._base import DiscreteDistribution
 
 if TYPE_CHECKING:
@@ -58,6 +59,8 @@ _CASES = [
     ("exponential-columns", Exponential(rate=_col(1.5))),
     ("discreteuniform-scalar", DiscreteUniform(min=-2, max=9)),
     ("discreteuniform-columns", DiscreteUniform(min=_col(-2, pl.Int64()), max=_col(9, pl.Int64()))),
+    ("uniform-scalar", Uniform(min=-2.0, max=9.0)),
+    ("uniform-columns", Uniform(min=_col(-2.0), max=_col(9.0))),
 ]
 
 

--- a/tests/distributions/uniform/null_params_test.py
+++ b/tests/distributions/uniform/null_params_test.py
@@ -1,5 +1,12 @@
+"""Null-bound contract: every method, both bounds, on and off the support.
+
+An answer survives a null bound exactly when the other, known bound decides it. That is a rule about
+bounds rather than about methods, so the table below is keyed on `(bounds, value)`.
+"""
+
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -31,6 +38,8 @@ _METHODS: dict[str, Callable[[Uniform], pl.Expr]] = {
     "samples": lambda u: u.samples(size=2, seed=0),
 }
 
+_SCHEMA = {"lo": pl.Float64, "hi": pl.Float64}
+
 
 def _column_bounds() -> Uniform:
     return Uniform(min=pl.col("lo"), max=pl.col("hi"))
@@ -38,7 +47,7 @@ def _column_bounds() -> Uniform:
 
 @pytest.mark.parametrize("expr_fn", _METHODS.values(), ids=list(_METHODS))
 def test_method_propagates_null_in_min(expr_fn: Callable[[Uniform], pl.Expr]) -> None:
-    df = pl.DataFrame({"lo": [0.0, None, 0.0], "hi": [1.0, 1.0, 1.0]}, schema={"lo": pl.Float64, "hi": pl.Float64})
+    df = pl.DataFrame({"lo": [0.0, None, 0.0], "hi": [1.0, 1.0, 1.0]}, schema=_SCHEMA)
     result = df.select(r=expr_fn(_column_bounds()))["r"]
     assert result.is_null().to_list() == [False, True, False]
 
@@ -47,41 +56,98 @@ def test_method_propagates_null_in_min(expr_fn: Callable[[Uniform], pl.Expr]) ->
 def test_method_propagates_null_in_max(expr_fn: Callable[[Uniform], pl.Expr]) -> None:
     # `max` is the *second* plugin input, so a guard written against the first only would pass the
     # test above and fail here.
-    df = pl.DataFrame({"lo": [0.0, 0.0, 0.0], "hi": [1.0, None, 1.0]}, schema={"lo": pl.Float64, "hi": pl.Float64})
+    df = pl.DataFrame({"lo": [0.0, 0.0, 0.0], "hi": [1.0, None, 1.0]}, schema=_SCHEMA)
     result = df.select(r=expr_fn(_column_bounds()))["r"]
     assert result.is_null().to_list() == [False, True, False]
 
 
-def test_density_nulls_where_the_null_bound_decides_the_support() -> None:
-    # `is_between` yields null on a null bound and `pl.when(null)` takes the `otherwise`, so without an
-    # explicit null branch the density reports a confident `0.0` (`-inf` for the log) for a row whose
-    # support is unknown. `cdf` and `sf` need no such branch, because their `otherwise` is the
-    # arithmetic and nulls on its own.
-    df = pl.DataFrame({"lo": [0.0, None], "hi": [1.0, 1.0]}, schema={"lo": pl.Float64, "hi": pl.Float64})
+_VALUE_METHODS = ("pdf", "log_pdf", "cdf", "log_cdf", "sf", "log_sf")
+
+_BELOW_MIN: dict[str, float | None] = {
+    "pdf": 0.0,
+    "log_pdf": -math.inf,
+    "cdf": 0.0,
+    "log_cdf": -math.inf,
+    "sf": 1.0,
+    "log_sf": 0.0,
+}
+"""What the six value-keyed methods answer strictly below `min`, for every admissible `max`."""
+
+_ABOVE_MAX: dict[str, float | None] = {
+    "pdf": 0.0,
+    "log_pdf": -math.inf,
+    "cdf": 1.0,
+    "log_cdf": 0.0,
+    "sf": 0.0,
+    "log_sf": -math.inf,
+}
+"""What they answer strictly above `max`, for every admissible `min`."""
+
+_NULL: dict[str, float | None] = dict.fromkeys(_VALUE_METHODS)
+"""Nothing survives: the null bound is the one that would have placed the point."""
+
+# The `value == 1.0` row is where the two support conventions diverge: the densities treat the
+# support as the closed `[min, max]`, so a point at `max` is inside it and still needs `min`, while
+# `cdf` / `sf` and their logs are already saturated from `max` up. There is no lower-bound
+# counterpart: every method leaves `min` itself to the interior, so `value == min` under a null
+# `max` nulls throughout.
+_NULL_BOUND_CASES: tuple[tuple[tuple[float | None, float | None], float, dict[str, float | None]], ...] = (
+    ((None, 1.0), -5.0, _NULL),
+    ((None, 1.0), 0.5, _NULL),
+    ((None, 1.0), 1.0, {**_ABOVE_MAX, "pdf": None, "log_pdf": None}),
+    ((None, 1.0), 5.0, _ABOVE_MAX),
+    ((0.0, None), -5.0, _BELOW_MIN),
+    ((0.0, None), 0.0, _NULL),
+    ((0.0, None), 0.5, _NULL),
+    ((0.0, None), 5.0, _NULL),
+    ((None, None), -5.0, _NULL),
+    ((None, None), 0.5, _NULL),
+    ((None, None), 5.0, _NULL),
+)
+
+
+@pytest.mark.parametrize(
+    ("bounds", "value", "expected"),
+    _NULL_BOUND_CASES,
+    ids=[f"min={lo},max={hi},v={v}" for (lo, hi), v, _ in _NULL_BOUND_CASES],
+)
+def test_value_keyed_answer_survives_only_when_the_known_bound_decides_it(
+    bounds: tuple[float | None, float | None], value: float, expected: dict[str, float | None]
+) -> None:
+    # Row 0 carries known bounds so the null bound shares a chunk with a fully specified one: a
+    # driver that answered per chunk rather than per row would still pass a one-row frame.
+    lo, hi = bounds
+    df = pl.DataFrame({"lo": [0.0, lo], "hi": [1.0, hi]}, schema=_SCHEMA)
     dist = _column_bounds()
-
-    on_support = df.select(pdf=dist.pdf(pl.lit(0.5)), log_pdf=dist.log_pdf(pl.lit(0.5)))
-    below = df.select(pdf=dist.pdf(pl.lit(-1.0)), log_pdf=dist.log_pdf(pl.lit(-1.0)))
-
-    assert on_support["pdf"].to_list() == [1.0, None]
-    assert on_support["log_pdf"].to_list() == [0.0, None]
-    assert below["pdf"].to_list() == [0.0, None]
-    assert below["log_pdf"].to_list() == [float("-inf"), None]
+    got = df.select(**{name: getattr(dist, name)(pl.lit(value)) for name in _VALUE_METHODS})
+    assert {name: got[name][1] for name in _VALUE_METHODS} == expected
+    assert all(got[name][0] is not None for name in _VALUE_METHODS), "the known-bounds row nulled"
 
 
-def test_density_stays_confident_when_the_known_bound_settles_it() -> None:
-    # A null bound does not null the row where the *other* bound already places the point outside the
-    # support. `is_between` is `False` there rather than null (Kleene `False & null` is `False`), and
-    # the density is `0` for every admissible value of the missing bound, so a guard that nulled these
-    # rows would be too blunt.
-    schema = {"lo": pl.Float64, "hi": pl.Float64}
-    null_min = pl.DataFrame({"lo": [None], "hi": [1.0]}, schema=schema)
-    null_max = pl.DataFrame({"lo": [0.0], "hi": [None]}, schema=schema)
-    dist = _column_bounds()
+@pytest.mark.parametrize("method", ["ppf", "isf"])
+@pytest.mark.parametrize("quantile", [0.0, 0.25, 0.5, 0.75, 1.0, -0.5, 1.5])
+@pytest.mark.parametrize("bounds", [(None, 1.0), (0.0, None), (None, None)], ids=str)
+def test_inverse_nulls_under_a_null_bound(
+    method: str, quantile: float, bounds: tuple[float | None, float | None]
+) -> None:
+    """Endpoints and out-of-range quantiles as well as interior ones: neither inverse has a
+    bound-free branch anywhere in its domain, under either null bound."""
+    lo, hi = bounds
+    df = pl.DataFrame({"lo": [0.0, lo], "hi": [1.0, hi]}, schema=_SCHEMA)
+    result = df.select(r=getattr(_column_bounds(), method)(quantile))["r"]
+    assert result[1] is None
+    assert (result[0] is not None) == (0.0 <= quantile <= 1.0), "the known-bounds row disagreed"
 
-    above_known_max = null_min.select(pdf=dist.pdf(pl.lit(2.0)), log_pdf=dist.log_pdf(pl.lit(2.0)))
-    below_known_min = null_max.select(pdf=dist.pdf(pl.lit(-1.0)), log_pdf=dist.log_pdf(pl.lit(-1.0)))
 
-    for got in (above_known_max, below_known_min):
-        assert got["pdf"].to_list() == [0.0]
-        assert got["log_pdf"].to_list() == [float("-inf")]
+@pytest.mark.parametrize("hook", ["_pdf", "_log_pdf", "_cdf", "_log_cdf", "_sf", "_log_sf", "_ppf", "_isf"])
+@pytest.mark.parametrize("bounds", [(None, 1.0), (0.0, None), (None, None)], ids=str)
+def test_nan_value_stays_nan_under_a_null_bound(hook: str, bounds: tuple[float | None, float | None]) -> None:
+    """A `NaN` evaluation point short-circuits before the branches, so a null bound does not null it.
+
+    Reached through the private hook, since the public wrapper answers `NaN` on its own. Without the
+    short-circuit `NaN` would be placed by whichever bound is known and answer that bound's constant.
+    """
+    lo, hi = bounds
+    df = pl.DataFrame({"lo": [0.0, lo], "hi": [1.0, hi]}, schema=_SCHEMA)
+    result = df.select(r=getattr(_column_bounds(), hook)(pl.lit(math.nan)))["r"].to_list()
+    assert all(v is not None and math.isnan(v) for v in result), "a NaN evaluation point nulled"

--- a/tests/distributions/uniform/validation_test.py
+++ b/tests/distributions/uniform/validation_test.py
@@ -6,7 +6,6 @@ import polars as pl
 import pytest
 
 from polars_stats import Uniform
-from tests._polars_compat import ARM_MASKING_HIDES_VALIDATION
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -34,16 +33,8 @@ _METHODS: dict[str, Callable[[Uniform], pl.Expr]] = {
 }
 
 
-_ARM_MASKED_METHODS = frozenset({"pdf", "log_pdf", "cdf", "log_cdf", "sf", "log_sf"})
-"""The methods `ARM_MASKING_HIDES_VALIDATION` breaks here, measured on polars 1.44.1."""
-
-
-@pytest.mark.parametrize(("name", "expr_fn"), _METHODS.items(), ids=list(_METHODS))
-def test_method_raises_on_max_le_min_column(
-    name: str, expr_fn: Callable[[Uniform], pl.Expr], request: pytest.FixtureRequest
-) -> None:
-    if ARM_MASKING_HIDES_VALIDATION and name in _ARM_MASKED_METHODS:
-        request.applymarker(pytest.mark.xfail(reason="pola-rs/polars#29005"))
+@pytest.mark.parametrize("expr_fn", _METHODS.values(), ids=list(_METHODS))
+def test_method_raises_on_max_le_min_column(expr_fn: Callable[[Uniform], pl.Expr]) -> None:
     df = pl.DataFrame({"lo": [0.0, 5.0], "hi": [1.0, 2.0], "x": [0.5, 0.5], "q": [0.5, 0.5]})
     u = Uniform(min=pl.col("lo"), max=pl.col("hi"))  # row 1: hi (2.0) <= lo (5.0)
     with pytest.raises(pl.exceptions.ComputeError, match="max must be strictly greater than min"):

--- a/tests/distributions/validation_contract_test.py
+++ b/tests/distributions/validation_contract_test.py
@@ -87,12 +87,11 @@ it gets its own test below, alongside the `NaN` point that leaks through the sam
 
 _LEAKING_METHODS: dict[str, frozenset[str]] = {
     "Geometric": frozenset({"pmf", "log_pmf", "cdf", "log_cdf", "sf", "log_sf", "ppf", "isf"}),
-    "Uniform": frozenset({"pdf", "log_pdf", "cdf", "log_cdf", "sf", "log_sf", "ppf", "isf"}),
 }
 """The (distribution, method) pairs that `ARM_MASKING_HIDES_VALIDATION` is expected to break.
 
 Measured, not assumed: these are exactly the pairs that fail on polars 1.44.1 and pass on 1.43.2.
-Every value-keyed method of the two remaining distributions leaks. Porting a distribution's closed
+Every value-keyed method of the one remaining distribution leaks. Porting a distribution's closed
 forms to Rust deletes its entry here; the last one to go deletes the dict.
 """
 

--- a/tests/distributions/validation_contract_test.py
+++ b/tests/distributions/validation_contract_test.py
@@ -80,11 +80,8 @@ _SUPPORT_POINTS = (-3.0, -1.0, 0.0, 0.5, 1.0, 3.0, 100.0)
 _QUANTILES = (-0.5, 0.001, 0.5, 0.999, 1.5)
 """In-range quantiles plus the two out-of-range values, which take the guard branch instead of computing.
 
-A `None` quantile is deliberately *not* probed. Polars masks null rows out of an elementwise plugin's
-input on every supported version, so the parameters on a null row never reach the validator and no
-distribution raises, `DiscreteUniform` and the other Rust-backed ones included. That is a property of
-plugin dispatch, not of the branch the value selects, and removing `propagate_null_and_nan` would not
-change it, which is what separates it from the `NaN` point the second test does probe.
+A `None` quantile is not probed here. It is not a statement about which branch the value selects, so
+it gets its own test below, alongside the `NaN` point that leaks through the same wrapper.
 """
 
 
@@ -110,7 +107,7 @@ def _ids(case: _Case) -> str:
     return case.name
 
 
-def _report(case: _Case, method_fn: Callable[[pl.Expr], pl.Expr], value: float) -> str | None:
+def _report(case: _Case, method_fn: Callable[[pl.Expr], pl.Expr], value: float | None) -> str | None:
     """The `ComputeError` message the method raised at `value`, or `None` if it returned a result."""
     frame = pl.DataFrame({**case.columns, "v": pl.Series([value, value], dtype=pl.Float64)})
     try:
@@ -180,3 +177,31 @@ def test_invalid_parameter_raises_at_a_nan_evaluation_point(case: _Case, request
     # supported polars ever reaches.
     unreported = [method for method, report in reports if report is None or case.fragment not in report]
     assert not unreported, f"{case.name} did not report the invalid `{case.fragment}` at a NaN point in {unreported}"
+
+
+_RUST_CASES = tuple(case for case in _CASES if case.name not in _LEAKING_METHODS)
+"""The cases whose value-keyed methods compute in Rust, derived rather than listed again.
+
+A distribution leaves `_LEAKING_METHODS` exactly when its closed forms move into Rust, so this set
+grows on its own as the port series lands.
+"""
+
+
+@pytest.mark.parametrize("case", _RUST_CASES, ids=_ids)
+def test_invalid_parameter_raises_at_a_null_evaluation_point(case: _Case) -> None:
+    """The null sibling of the test above: an invalid parameterisation raises whatever the value is.
+
+    A null *value* propagates to null, but it never downgrades an invalid parameterisation to one.
+    That is what separates it from a null *parameter*, where there is nothing to reject and the row
+    nulls. Every per-row driver validates before it reads the value, so this holds on every supported
+    polars, which is why it needs no gate where the two tests above do.
+
+    Probed through the private hooks: `propagate_null_and_nan` spells the null overlay as the same
+    `when(...).then(...).otherwise(result)` the `NaN` test above indicts, so the public wrappers still
+    mask this from polars 1.44. Deleting the wrapper is what closes that half.
+    """
+    probed = [(method, fn) for method in _NAN_METHODS if (fn := getattr(case.dist, f"_{method}", None)) is not None]
+    assert len(probed) == len(_NAN_METHODS) - 2
+    reports = [(method, _report(case, fn, None)) for method, fn in probed]
+    unreported = [method for method, report in reports if report is None or case.fragment not in report]
+    assert not unreported, f"{case.name} did not report the invalid `{case.fragment}` at a null point in {unreported}"

--- a/tests/distributions/value_keyed_fast_path_test.py
+++ b/tests/distributions/value_keyed_fast_path_test.py
@@ -1,6 +1,6 @@
 """Validation contract of the constant-parameter value-keyed fast path.
 
-Covers Normal, LogNormal, Binomial, Beta, DiscreteUniform, Bernoulli and Exponential: the
+Covers Normal, LogNormal, Binomial, Beta, DiscreteUniform, Bernoulli, Exponential and Uniform: the
 distributions with per-method Rust plugins.
 
 `pdf` / `pmf` / `cdf` / `sf` / `ppf` with all-scalar parameters route through a dedicated ``<name>_<method>_scalar``
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
-from polars_stats import Bernoulli, Beta, Binomial, DiscreteUniform, Exponential, LogNormal, Normal
+from polars_stats import Bernoulli, Beta, Binomial, DiscreteUniform, Exponential, LogNormal, Normal, Uniform
 from polars_stats.distributions._base import ContinuousDistribution
 from tests._polars_compat import assert_series_equal
 
@@ -100,6 +100,14 @@ _CASES: dict[str, tuple[Callable[[], _UnivariateDistribution], Callable[[], _Uni
         lambda: DiscreteUniform(_col(3, pl.Int64()), _col(3, pl.Int64())),
         False,
     ),
+    "uniform max<min": (lambda: Uniform(5.0, 2.0), lambda: Uniform(_col(5.0), _col(2.0)), True),
+    # `min == max` is an empty support for a *continuous* uniform, unlike the discrete one above, so
+    # here the two distributions disagree and both uniform paths must reject it.
+    "uniform max=min": (lambda: Uniform(3.0, 3.0), lambda: Uniform(_col(3.0), _col(3.0)), True),
+    "uniform max=nan": (lambda: Uniform(0.0, _NAN), lambda: Uniform(_col(0.0), _col(_NAN)), True),
+    # Individually finite bounds whose width overflows `f64`: rejected by uniform's own guard rather
+    # than by statrs, and the fast path must apply it as the per-row path does.
+    "uniform width overflows": (lambda: Uniform(-1e308, 1e308), lambda: Uniform(_col(-1e308), _col(1e308)), True),
 }
 
 

--- a/tests/property/_specs.py
+++ b/tests/property/_specs.py
@@ -293,14 +293,13 @@ ALL_SPECS = [
 CONTINUOUS_SPECS = [s for s in ALL_SPECS if s.continuous]
 DISCRETE_SPECS = [s for s in ALL_SPECS if not s.continuous]
 
-# These specs compute in Polars, not in a Rust body, so with constant parameters their operands are
-# length-1 literals that polars may fold differently from the column kernel. Every IEEE operation is
-# exactly rounded, so the measured 1-ULP gap (Uniform's `variance` / `std`) is a different operation
-# *order*, not a different formula. Extend from a failing assertion, never by widening the tolerance.
-# A spec whose closed forms move into Rust leaves this set: one body then feeds both paths.
-ULP_TOLERANT_VALUE_SPECS = frozenset({"uniform"})
-"""Specs whose value-keyed methods compare to `ULP_REL_TOL` instead of bit-exactly."""
-
+# These specs compute a moment in Polars, not in a Rust body, so with constant parameters their
+# operands are length-1 literals that polars may fold differently from the column kernel. Every IEEE
+# operation is exactly rounded, so the measured 1-ULP gap (Uniform's `variance` / `std`) is a
+# different operation *order*, not a different formula. Extend from a failing assertion, never by
+# widening the tolerance. There is no value-keyed counterpart: every spec whose value-keyed methods
+# run in Rust is bit-exact on both routings by construction, and `geometric`, the last one still
+# assembling them in Polars, measures bit-exact too.
 ULP_TOLERANT_MOMENT_SPECS = frozenset({"uniform", "geometric"})
 """Specs whose moments compare to `ULP_REL_TOL` instead of bit-exactly.
 

--- a/tests/property/fast_path_context_test.py
+++ b/tests/property/fast_path_context_test.py
@@ -35,7 +35,6 @@ from tests.property._specs import (
     ULP_ABS_TOL,
     ULP_REL_TOL,
     ULP_TOLERANT_MOMENT_SPECS,
-    ULP_TOLERANT_VALUE_SPECS,
 )
 
 if TYPE_CHECKING:
@@ -76,7 +75,7 @@ def _assert_matches_across_contexts(
     `fast_height` is the fast path's own height under a plain `select`: 1 when every input is constant
     (a moment), the frame height when a column-valued `value` sets the length. Asserting it is what
     keeps this test pinning a *shape* and not only values. `exact` is the default because both paths
-    compute the identical value; the caller relaxes it only for the `ULP_TOLERANT_*` specs.
+    compute the identical value; the caller relaxes it only for `ULP_TOLERANT_MOMENT_SPECS`.
     """
     # `select`: the fast path holds its own height, and broadcasts against the per-row column beside it.
     assert frame.select(r=fast).height == fast_height
@@ -139,9 +138,9 @@ def test_moment_fast_path_matches_per_row_across_contexts(spec: DistSpec, moment
 def test_value_keyed_fast_path_matches_per_row_across_contexts(spec: DistSpec, data: st.DataObject) -> None:
     """Density / log-density / cdf / sf / ppf scalar fast paths equal the per-row path under every context.
 
-    This is where the `Geometric` / `Uniform` closed forms get their cross-context coverage: their
-    value-keyed methods are pure Polars, routing validation through the same `_checked` gate as the
-    moments, so a broadcast bug in that gate is the only way they diverge.
+    This is where the `Geometric` closed forms get their cross-context coverage: its value-keyed
+    methods are pure Polars, routing validation through the same `_checked` gate as the moments, so a
+    broadcast bug in that gate is the only way they diverge.
     """
     params = data.draw(spec.params)
     scalar = spec.make(params)
@@ -165,6 +164,4 @@ def test_value_keyed_fast_path_matches_per_row_across_contexts(spec: DistSpec, d
     )
     for fast, slow in cases:
         # The `value` argument is a column, so it sets the length on both paths.
-        _assert_matches_across_contexts(
-            frame, fast, slow, fast_height=_N_ROWS, exact=spec.name not in ULP_TOLERANT_VALUE_SPECS
-        )
+        _assert_matches_across_contexts(frame, fast, slow, fast_height=_N_ROWS)

--- a/tests/property/value_keyed_test.py
+++ b/tests/property/value_keyed_test.py
@@ -7,10 +7,9 @@ In Rust both plugins call the same named per-method body, so for any parameteris
 must agree bit for bit, including null propagation and ppf's null-outside-``[0, 1]`` contract. A
 divergence (e.g. a parameter-order swap in a scalar kwargs struct) must fail here.
 
-Bit-equality holds wherever a single Rust body feeds both paths. ``uniform`` and ``geometric`` have
-no Rust value-keyed plugin: both evaluate the same Polars expression, and the scalar path does it on
-length-1 operands, so polars may fold it differently. Where that moves the last bit
-(``ULP_TOLERANT_VALUE_SPECS``) the comparison is 1 ULP; the rest stay exact.
+The comparison is bit-exact for every spec. ``geometric`` still evaluates a Polars expression on both
+paths, on length-1 operands under a constant parameterisation, which polars is free to fold
+differently; measured, it does not.
 """
 
 from __future__ import annotations
@@ -24,7 +23,7 @@ from hypothesis import strategies as st
 
 from polars_stats.distributions._base import ContinuousDistribution, DiscreteDistribution
 from tests._polars_compat import assert_series_equal, linear_space
-from tests.property._specs import ALL_SPECS, ULP_ABS_TOL, ULP_REL_TOL, ULP_TOLERANT_VALUE_SPECS
+from tests.property._specs import ALL_SPECS
 
 if TYPE_CHECKING:
     from polars_stats.distributions._base import _UnivariateDistribution
@@ -75,8 +74,7 @@ def test_value_keyed_scalar_fast_path_matches_per_row(spec: DistSpec, data: st.D
         (quantiles, scalar.ppf(q), per_row.ppf(q)),
         (quantiles, scalar.isf(q), per_row.isf(q)),
     ]
-    exact = spec.name not in ULP_TOLERANT_VALUE_SPECS
     for frame, fast_expr, per_row_expr in cases:
         fast = frame.select(r=fast_expr)["r"]
         slow = frame.select(r=per_row_expr)["r"]
-        assert_series_equal(fast, slow, check_exact=exact, rel_tol=ULP_REL_TOL, abs_tol=ULP_ABS_TOL)
+        assert_series_equal(fast, slow, check_exact=True)

--- a/tests/scipy_parity/uniform_test.py
+++ b/tests/scipy_parity/uniform_test.py
@@ -69,9 +69,9 @@ def test_log_methods_keep_the_near_certain_side(lo: float, hi: float, offset: fl
 
     Both inherited a plain `log` of a ratio that rounds to exactly `1` as the argument approaches
     the far support edge, so the result collapsed to `0.0` where the truth is a small negative
-    (`-8.9e-17` one ulp below `max` on `[-3, 7]`). The fix is the `log1p` branch `normal.rs`'s
-    `ln_half_erfc` already takes; the oracle is `log1p(-offset)`, exact because the ratio is the
-    fraction of the span and `offset` is it exactly.
+    (`-8.9e-17` one ulp below `max` on `[-3, 7]`). `uniform.rs`'s `derive_ln_cdf` and `derive_ln_sf`
+    take the `log1p` branch `normal.rs`'s `ln_half_erfc` already takes; the oracle is
+    `log1p(-offset)`, exact because the ratio is the fraction of the span and `offset` is it exactly.
     """
     width = hi - lo
     frame = pl.DataFrame({"upper": [hi - width * offset], "lower": [lo + width * offset]})
@@ -87,7 +87,7 @@ def test_log_methods_keep_the_near_certain_side(lo: float, hi: float, offset: fl
 # The `isf` regression. `isf` was the base-class `ppf(1 - quantile)`, which forms
 # `min + (1 - quantile) * range`; below `quantile ~ 1.1e-16` the complement rounds to exactly `1.0`
 # and the whole tail collapses onto `min + range`. Invisible wherever `max` is far from zero, total
-# wherever it is not. `_isf` now subtracts from `max`.
+# wherever it is not. `uniform.rs`'s `derive_inverse` subtracts from `max` instead.
 #
 # Oracled by the exact closed form `max - quantile * range` in `Fraction` arithmetic, not by scipy:
 # `scipy.stats.uniform.isf` composes the same way and reproduces the defect.
@@ -112,9 +112,10 @@ def test_isf_keeps_relative_precision_where_the_answer_approaches_zero(lo: float
 
 # The `ppf` half of the same reassociation, which shipped without a test while its `isf` twin above
 # got one. `min + quantile * range` is a difference of nearly equal numbers once the result lands
-# near `max`, so `Uniform(-1e10, 1).ppf(1 - 1.1e-10)` was relatively wrong by `3.0e-06`; `_ppf` now
-# interpolates from `max` above the median. Every quantile below is above `0.5`, the only side the
-# rewrite changed, and the spans are wide enough that `min` and the answer differ by many decades.
+# near `max`, so `Uniform(-1e10, 1).ppf(1 - 1.1e-10)` was relatively wrong by `3.0e-06`; the shared
+# `derive_inverse` interpolates from `max` above the median. Every quantile below is above `0.5`, the
+# only side the rewrite changed, and the spans are wide enough that `min` and the answer differ by
+# many decades.
 #
 # Same `Fraction` oracle as the `isf` test and for the same reason: `scipy.stats.uniform.ppf` is
 # `loc + q * scale`, the spelling under test, so it agrees with the defect.


### PR DESCRIPTION
Two commits

### `fix(validation): raise on an invalid parameterisation whatever the row's value is` (cec89e2)

Found while reviewing the port, fixed first because it stands alone and predates it.

Every per-row driver returned early on a null evaluation point **before** validating the parameters, so an invalid parameterisation beside a null value silently nulled the row, while the constant-parameter twin raised on the same data. The documented contract is that an invalid parameter value "fails the whole evaluation, never silently nulls"; only null and NaN *values* propagate.

### `refactor(uniform): compute the value-keyed closed forms in Rust` (6fde915)

Moves Uniform's eight value-keyed methods from branching Polars expressions into Rust plugins, so an invalid parameterisation raises whichever branch the evaluation point selects instead of being masked by polars 1.44's `when`/`then` arm nulling.
