### PR TITLE
refactor(geometric): compute the value-keyed closed forms in Rust

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -170,14 +170,15 @@ code rather than halfway through, write the scipy-parity test first, and keep a 
           ([pola-rs/polars#29005](https://github.com/pola-rs/polars/issues/29005)), and no Polars expression can
           spell a guard that survives the optimiser. In practice this is the value-keyed set: `pdf` / `pmf`,
           `log_pdf` / `log_pmf`, `cdf`, `log_cdf`, `sf`, `log_sf`, `ppf`, `isf`. `DiscreteUniform`, `Bernoulli`,
-          `Exponential` and `Uniform` are the worked examples: every value-keyed method is a one-line
+          `Exponential`, `Geometric` and `Uniform` are the worked examples: every value-keyed method is a one-line
           `_value_plugin` hook over a Rust body, and only the moments stay in `_<name>.py`.
         * Split such a body into a `derive` that turns the parameters into their branch answers and a `select` that
           picks one by the evaluation value. Where the branch answers are fixed once the parameters are, the table is
           non-generic and `derive` is an associated constructor (`bernoulli.rs`'s `Mass::pmf` / `Mass::at`,
           `uniform.rs`'s `Density::pdf`); where a branch still depends on the evaluation point, the table carries an
-          `Arm` type parameter and `derive` is a free function (`exponential.rs`'s `derive_cdf` / `Sides::at`,
-          `uniform.rs`'s `derive_cdf` / `Regions::at`). The Polars expression it replaces computed `1 - p` once on a
+          `Arm` type parameter and `derive` is a free function (`exponential.rs`'s and `geometric.rs`'s `derive_cdf`
+          over the shared `Sides<Arm, FLOOR>` in `mod.rs`, `uniform.rs`'s `derive_cdf` / `Regions::at`). The Polars
+          expression it replaces computed `1 - p` once on a
           length-1 literal and broadcast it; a body that recomputes per row regressed the constant-parameter path by
           up to 195% at 10M rows. `derive` runs once per call on the constant path and once per row when a parameter
           is a column.
@@ -304,9 +305,10 @@ probe aimed at it.
 
 **Where the recipes live.** `exponential.rs`'s `derive_ln_sf` (an exact closed form), its `derive_cdf` and
 `LogNormal.variance` (the `sinh` identity standing in for the `expm1` Polars does not expose), its `derive_ln_cdf` and
-`uniform.rs`'s `derive_ln_cdf` (`log1p` on the near-certain side), `normal.rs`'s `ln_erfc` (a special function ported
-to log space, the pattern for the hard cases), and the `isf_value` bodies in `normal.rs` (a symmetry) and
-`lognormal.rs` (composing one).
+`uniform.rs`'s `derive_ln_cdf` (`log1p` on the near-certain side), `geometric.rs`'s `smallest_support_point` (the
+one-ulp tie rule of a discrete inverse, decided in the log domain both sides entered through), `normal.rs`'s `ln_erfc`
+(a special function ported to log space, the pattern for the hard cases), and the `isf_value` bodies in `normal.rs` (a
+symmetry) and `lognormal.rs` (composing one).
 
 ## Conventions
 

--- a/docs/explanation/accuracy.md
+++ b/docs/explanation/accuracy.md
@@ -52,9 +52,9 @@ magnitudes are in the inherited limits below.
 * **Discrete `ppf` / `isf` at a step boundary.** `Binomial.ppf` is a binary search resolved to the
   cdf's own precision, so a quantile within `1e-12` *relative* of a cdf step may return the
   neighbouring support point. `Geometric.ppf` / `isf` decide the same tie in the log domain, testing
-  `k * log1p(-p)` against `log1p(-q)` rather than re-deriving `cdf(k)`. That is deliberate and it is
-  the more accurate rule: across 1997 probes sitting on and either side of exact step boundaries it
-  disagrees with exact rational arithmetic 357 times, against 490 for the alternative. The price is
+  `k * log1p(-p)` against `log1p(-q)` rather than re-deriving `cdf(k)`. That is deliberate: across
+  1997 probes sitting on and either side of exact step boundaries it disagrees with exact rational
+  arithmetic 357 times, against 490 for the alternative. The price is
   that `ppf` and `cdf` are not exact mutual inverses there, and the miss goes both ways, by at most
   one support point: at `p = 1e-8` with `q = sf(1)`, `isf(q)` is `2` where `1` is the answer. On a
   step the two roundings decide the last bit, so which side a given quantile falls on is also the
@@ -65,8 +65,16 @@ magnitudes are in the inherited limits below.
   [the error glibc documents](https://www.gnu.org/software/libc/manual/html_node/Errors-in-Math-Functions.html)
   for it. Only the one-support-point bound is portable, so it is the only thing pinned. `scipy`'s
   [`geom._ppf`](https://github.com/scipy/scipy/blob/main/scipy/stats/_discrete_distns.py) made the
-  opposite trade (it tests against its own `_cdf`, so it is self-consistent and less accurate). Parity
-  is gated at integer equality rather than at a float tolerance.
+  opposite trade: it tests against its own `_cdf`, so `ppf(cdf(k))` round-trips to `k` there.
+  `Geometric(0.3).ppf(0.51)` shows the two rules part. The double nearest `0.51` sits `8.9e-18`
+  above the exact `cdf(2) = 0.51`, so the two readings of the input have different answers: `2` for
+  the decimal `0.51`, `3` for the stored double. Both libraries form the same ratio,
+  `log1p(-0.51) / log1p(-0.3) = 2.0000000000000004`, and ceil it to `3`; the step-back decides. scipy
+  re-derives `cdf(2)` in the linear domain, where its `expm1` lands exactly on `0.51`, so
+  `cdf(2) >= q` reads true and it steps back to `2`. This library compares `2 * log1p(-0.3)` against
+  `log1p(-0.51)`, where the two sides differ by one ulp, and answers `3`. `isf(0.49)` mirrors it (`3`
+  here, `2` in scipy, whose `isf` is `ppf(1 - q)`). Parity is gated at integer equality rather than
+  at a float tolerance.
 
     `DiscreteUniform.ppf` / `isf` are closed forms rather than searches, and `ppf` carries scipy's
     own rounding, bit for bit: in a one-ulp quantile window above each cdf step edge, `q * N` rounds

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -68,17 +68,14 @@ the expression engine. Methods that go through `statrs` (sampling, transcendenta
 native `ln_pdf`/`ln_pmf`, native `sf`) get a Rust plugin function, and so do the elementary value-keyed closed forms:
 they branch on the evaluation value, which puts the validator inside a `when` arm where polars can mask it away
 (see [Design notes](design.md#one-rust-file-per-distribution-one-plugin-function-per-method-that-needs-rust)).
-`Geometric` is the one that has not moved yet.
 
 **Parameter validation needs Rust.** A bare `pl.Expr` cannot raise per row, so any method computed in Python routes its
-parameters through one small validating plugin that raises on a bad row and returns a reused quantity. For
-`Geometric`, the last distribution assembling its value-keyed methods in Polars, that covers the whole surface.
-Everywhere else it covers the closed-form moments only, since the value-keyed methods already validate
-inside their own plugin: `normal_sigma` validates `sigma > 0`, so `Normal.mean()` raises exactly as `Normal.pdf()`
-does, and `uniform_range` returns `max - min` and raises on `max <= min` for `Uniform`'s five moments, as
-`bernoulli_proba` and `exponential_rate` do for `Bernoulli`'s and `Exponential`'s. Either
-way a pure-math `mean` makes one FFI round-trip and reports an invalid parameterisation consistently, trading a little
-throughput for a uniform error surface.
+parameters through one small validating plugin that raises on a bad row and returns a reused quantity. That covers the
+closed-form moments, since the value-keyed methods already validate inside their own plugin: `normal_sigma` validates
+`sigma > 0`, so `Normal.mean()` raises exactly as `Normal.pdf()` does, and `uniform_range` returns `max - min` and
+raises on `max <= min` for `Uniform`'s five moments, as `bernoulli_proba`, `exponential_rate` and `geometric_p` do for
+`Bernoulli`'s, `Exponential`'s and `Geometric`'s. Either way a pure-math `mean` makes one FFI round-trip and reports an
+invalid parameterisation consistently, trading a little throughput for a uniform error surface.
 
 ## Sampling
 

--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -40,9 +40,7 @@ unbranched expression has nothing to mask. So a closed form stays in Python when
 unconditionally or named in a `when(...)` condition, and moves to Rust when it is read only inside an arm, which is
 what branching on the evaluation value always looks like.
 
-The table below is the rule, which every new distribution follows. It is not yet a description of the tree:
-`Geometric` still assembles its value-keyed methods in Polars and is the last one left to port; the
-[reference index](../reference/index.md) carries the resulting known limitation. Method by method:
+The table below is the rule, which every distribution follows. Method by method:
 
 | Method | In Rust? | Notes |
 |---|---|---|
@@ -103,12 +101,12 @@ path is selected only when the parameters are known scalars, so nothing column-v
 
 ### Constant parameters validate once, not per row
 
-The moments (`mean`, `variance`, `std`, `entropy`) and the value-keyed closed forms still assembled in Polars
-(`Geometric`) do not build a distribution; they compute a Polars expression. But they still route their
-*validation* through a small Rust plugin (`normal_sigma`, `uniform_range`, `bernoulli_proba`,
-`binomial_params`, `lognormal_sigma`, `exponential_rate`, `beta_params`) so an invalid parameterisation raises the same
-`ComputeError` as the sampler and value-keyed methods rather than silently producing a nonsense moment (see "Invalid
-parameters raise"). With column parameters that plugin runs over the parameter columns, validating each row.
+The moments (`mean`, `variance`, `std`, `entropy`) do not build a distribution; they compute a Polars expression. But
+they still route their *validation* through a small Rust plugin (`normal_sigma`, `uniform_range`, `bernoulli_proba`,
+`binomial_params`, `lognormal_sigma`, `exponential_rate`, `geometric_p`, `beta_params`) so an invalid parameterisation
+raises the same `ComputeError` as the sampler and value-keyed methods rather than silently producing a nonsense moment
+(see "Invalid parameters raise"). With column parameters that plugin runs over the parameter columns, validating each
+row.
 
 For all-scalar parameters the same plugin is called on length-1 `pl.lit` inputs, so its elementwise closure runs once.
 The validated quantity (or, for `Beta.entropy` and `Binomial.entropy`, the entropy itself) is returned behind a

--- a/docs/how-to/migrate-from-scipy.md
+++ b/docs/how-to/migrate-from-scipy.md
@@ -137,7 +137,8 @@ Polars defaults to `ddof=1`.
 | Randomness | `random_state` / global NumPy state | per-call `seed` only, no global state |
 | Accuracy | reference implementation | matched to `1e-12` absolute in the parity suite, relaxed to `1e-9` / `1e-6` for erf-based and search-based `ppf` methods |
 | `DiscreteUniform.median()` | `randint.median()` is `ppf(0.5)`, a support point | the midpoint `(min + max) / 2`, which for an even support size is not a support point |
-| Discrete `ppf(0)` / `isf(1)` | the below-support sentinel `low - 1` | clamped to the support, so `ppf(0)` is `min` and `isf(1)` is `min` |
+| Discrete `ppf(0)` / `isf(1)` | the point below the support, `a - 1` (`geom.ppf(0)` is `0`, `binom.ppf(0)` is `-1`); continuous families answer the support bound | the smallest support point for every family (`Geometric.ppf(0)` is `1`), the value `ppf(q)` gives for every `q > 0` |
+| Discrete `ppf` / `isf` exactly on a cdf step | `geom(0.3).ppf(0.51)` is `2`, the answer for the decimal `0.51` | `3`, the answer for the stored double; on a step the two can differ by one support point, see [Numerical accuracy](../explanation/accuracy.md#structural) |
 
 ## What has no equivalent
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -68,29 +68,20 @@ mean of a different distribution on every row.
 
 !!! warning "Known limitation on polars >= 1.44"
 
-    On polars 1.44.0 and newer, `Geometric` may **return a value instead of raising
-    `ComputeError`** when a *column-valued* parameter is invalid on a row the selected branch does
-    not cover.
+    On polars 1.44.0 and newer, an invalid parameter goes unreported on a row whose **evaluation point
+    is null or `NaN`**, for every distribution and both parameter spellings, scalar included.
 
     Polars 1.44.0 ([pola-rs/polars#28498](https://github.com/pola-rs/polars/pull/28498)) masks the arms
-    of a `when/then/otherwise` to null on the rows an arm does not select, so a validator reached only
-    from inside an arm never sees the offending row. `Geometric` assembles its value-keyed closed
-    forms (`pmf`, `log_pmf`, `cdf`, `log_cdf`, `sf`, `log_sf`, `ppf`, `isf`) as branching Polars
-    expressions, so it is affected.
-
-    **Not affected:** every other distribution (they compute in Rust and validate unconditionally),
-    `Geometric`'s own moments (`mean`, `variance`, `std`, `median`, `entropy`), and every *valid*
-    computation, whose results are unchanged. `Bernoulli`, `Exponential` and `Uniform` were affected
-    up to and including v0.0.2 and no longer are: their closed forms now compute in Rust.
-
-    One narrower case survives for *every* distribution and *both* parameter spellings, scalar
-    included: a **null or `NaN` evaluation point** is masked out of the plugin's input by the wrapper
-    that gives you `null -> null` and `NaN -> NaN`, so an invalid parameter goes unreported on those
-    rows. With a column parameter that is per row; with a scalar one it takes the whole batch, so
+    of a `when/then/otherwise` to null on the rows an arm does not select. Every value-keyed method
+    validates inside the Rust plugin that computes it, but the wrapper that gives you `null -> null` and
+    `NaN -> NaN` sits one level above, and it masks those rows out of the plugin's input before it can
+    validate. With a column parameter that is per row; with a scalar one it takes the whole batch, so
     `Bernoulli(p=1.5).pmf(col)` returns `[nan, nan]` over an all-`NaN` column but still raises as soon
     as one evaluation point is finite.
 
+    **Not affected:** every finite evaluation point, on every method of every distribution, and every
+    *valid* computation, whose results are unchanged.
+
     **Workarounds:** pin `polars<1.44` yourself, or validate column parameters before passing them.
 
-    Tracked as [pola-rs/polars#29005](https://github.com/pola-rs/polars/issues/29005). The limitation
-    goes away once `Geometric` moves its closed forms into Rust, which is in progress.
+    Tracked as [pola-rs/polars#29005](https://github.com/pola-rs/polars/issues/29005).

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -462,7 +462,6 @@ class _UnivariateDistribution(ABC):
 
         A value-keyed method belongs here even where its closed form is elementary: a branching Polars
         expression cannot be trusted to reach its validator on every row (see docs/explanation/design.md).
-        `Geometric` has not moved yet and still assembles its own in Polars.
         """
         return (
             register_plugin(f"{function_name}_scalar", (value,), kwargs=self._scalar_kwargs)

--- a/polars_stats/distributions/_geometric.py
+++ b/polars_stats/distributions/_geometric.py
@@ -7,44 +7,12 @@ import polars as pl
 from polars_stats.distributions._base import (
     DiscreteDistribution,
     coerce_param,
-    expm1,
-    log_abs_expm1,
     scalar_float,
     scalar_kwargs,
 )
 
 if TYPE_CHECKING:
     from polars_stats._typing import IntoExprColumn
-
-_CDF_DIRECT_COMPLEMENT_MAX = -20.0
-"""Crossover of `Geometric._cdf`, in units of `log(sf)`.
-
-Below it `exp(log_tail)` is small enough that the direct `1 - exp(log_tail)` rounds no worse than the
-`sinh` identity and cannot round above `1`. The identity itself only breaks past `log_tail ~ -1455`,
-where `sinh` overflows, far inside this branch.
-"""
-
-_LOG_CDF_LOG1P_MAX = -1.0
-"""Crossover of `Geometric._log_cdf`, in units of `log(sf)`.
-
-Below it the cdf sits within `0.63` of `1` and `log1p(-exp(log_tail))` carries that difference
-exactly, down through the `cdf ~ 1 - 1e-16` zone where `cdf().log()` reads the tail mass as `0`.
-"""
-
-
-def _smallest_support_point(log_target: pl.Expr, log_failure: pl.Expr) -> pl.Expr:
-    """Smallest ``k >= 1`` with ``k * log_failure <= log_target``, the shape both inverses share.
-
-    ``ppf`` and ``isf`` differ only in what they take the log of (``1 - q`` against ``q``); the
-    ceiling, the one-ulp correction and the clip to the support floor are common. Every answer is a
-    positive integer, so the ceiling is clipped up to ``1.0``, which is also where ``-0.0`` lands at
-    the degenerate endpoint of either inverse. A ratio sitting an ulp above an exact integer
-    overshoots by one support point, so it steps back down whenever ``k - 1`` already satisfies the
-    inequality, compared in the same log domain both sides entered through.
-    """
-    ceiling = (log_target / log_failure).ceil()
-    overshot = (ceiling - 1.0) * log_failure <= log_target
-    return pl.when(overshot).then(ceiling - 1.0).otherwise(ceiling).clip(1.0)
 
 
 class Geometric(DiscreteDistribution):
@@ -63,9 +31,12 @@ class Geometric(DiscreteDistribution):
     An invalid ``p`` (``p <= 0``, ``p > 1`` or ``NaN``) is not checked at construction; matching every
     other distribution, it raises ``InvalidOperation`` (a ``ComputeError``) when any method is
     evaluated. A null ``p`` propagates to null wherever the result depends on ``p``; the off-support
-    constants (``pmf(0) = 0``, ``cdf(0) = 0``, ``sf(0) = 1``) do not, as in ``Bernoulli``. Samples are
-    ``UInt64`` trial counts, so unlike ``Bernoulli`` the degenerate ``p = 0`` point mass is not
-    representable.
+    constants (``pmf(0) = 0``, ``cdf(0) = 0``, ``sf(0) = 1``, and ``pmf`` at any non-integral point)
+    do not, as in ``Bernoulli``. Samples are ``UInt64`` trial counts, so unlike ``Bernoulli`` the
+    degenerate ``p = 0`` point mass is not representable.
+
+    The value-keyed methods compute in Rust, so an invalid ``p`` is reported whichever branch the
+    value selects. The moments stay in Polars, reading ``p`` through the same Rust validator.
     """
 
     _p: pl.Expr
@@ -83,141 +54,58 @@ class Geometric(DiscreteDistribution):
     def _checked_p(self) -> pl.Expr:
         """``p`` validated in Rust to lie in ``(0, 1]`` (raises otherwise), null when ``p`` is null.
 
-        Validated in Rust so the closed-form methods report an invalid ``p`` consistently with
-        ``sample`` rather than silently computing with a non-positive probability. `_checked`
-        validates once for a scalar ``p`` (length-1 input) and per-row for a column.
+        Read only by the moments; the value-keyed methods validate inside their own plugin.
         """
         return self._checked("geometric_p", self._p)
 
     @property
     def _raw_p(self) -> pl.Expr:
-        """``p`` as ``Float64``, without the validating round trip: the operand every formula reads.
+        """``p`` as ``Float64`` without the validating round trip, so a moment can name it repeatedly.
 
-        Free to name repeatedly, unlike `_checked_p`. The cast is the one `geometric_p` performs on
-        the way in, so a ``Float32`` parameter column still yields ``Float64`` results.
+        The cast is the one `geometric_p` performs on the way in, so a ``Float32`` parameter column
+        still yields ``Float64`` results.
         """
         return self._p.cast(pl.Float64())
 
     def _when_p_valid(self, formula: pl.Expr) -> pl.Expr:
-        """``formula``, read off `_raw_p`, behind a single validation of ``p``.
+        """``formula`` behind a single validation of ``p``: raises on an invalid ``p``, null on a null one.
 
-        `_UnivariateDistribution._moment`'s gate, extended to the value-keyed formulas: every
-        Geometric formula but ``mean`` names ``p`` two to six times, and polars folds neither a
-        repeated subexpression nor a plugin call, so naming `_checked_p` inline would cross FFI once
-        per mention. Over a column ``p`` that is 10x one validation on ``ppf`` and 6x on ``entropy``.
-
-        The gate wraps the ``p``-dependent branch only, never a whole method: the off-support
-        constants in `_pmf`, `_cdf` and `_log_sf` do not depend on ``p`` and must survive a null one.
-        An invalid ``p`` still raises from either branch, since polars evaluates both.
+        Polars folds neither a repeated subexpression nor a plugin call, so a moment naming
+        `_checked_p` inline would cross FFI once per mention (6x on ``entropy`` over a column ``p``).
         """
         return pl.when(self._checked_p.is_not_null()).then(formula)
 
-    def _log_tail(self, value: pl.Expr) -> pl.Expr:
-        """``floor(value) * log1p(-p)``, the log survival mass every tail method enters through.
-
-        ``log1p(-p)`` rather than the literal ``log(1 - p)``, which inherits the rounding of ``1 - p``
-        (a few parts in ``1e9`` at ``p = 1e-8``) and collapses to ``0.0`` below ``p ~ 1.1e-16``. See
-        docs/contributing.md, "Numerical stability".
-        """
-        return value.floor() * (-self._raw_p).log1p()
-
     def _pmf(self, value: pl.Expr) -> pl.Expr:
         """``(1 - p)**(k - 1) * p`` on the positive integers, ``0`` elsewhere."""
-        p = self._raw_p
-        k = value.floor()
-        # `k = 1` short-circuits the power term, which is `0 * -inf = nan` at `p = 1`.
-        mass = pl.when(k == 1).then(p).otherwise(p * ((k - 1) * (-p).log1p()).exp())
-        return pl.when((value >= 1) & (k == value)).then(self._when_p_valid(mass)).otherwise(0.0)
+        return self._value_plugin("geometric_pmf", value)
 
     def _log_pmf(self, value: pl.Expr) -> pl.Expr:
-        """``(k - 1) * log1p(-p) + log(p)`` on the positive integers, ``-inf`` elsewhere.
-
-        Overrides the base ``pmf().log()``, whose ``log(1 - p)`` collapses to ``0.0`` below
-        ``p ~ 1.1e-16``. ``k = 1`` reads ``log(p)`` directly, because ``(k - 1) * log1p(-p)`` is
-        ``0 * -inf = nan`` at ``p = 1``.
-        """
-        p = self._raw_p
-        k = value.floor()
-        log_mass = pl.when(k == 1).then(p.log()).otherwise((k - 1) * (-p).log1p() + p.log())
-        return pl.when((value >= 1) & (k == value)).then(self._when_p_valid(log_mass)).otherwise(float("-inf"))
+        """``(k - 1) * log1p(-p) + log(p)`` on the positive integers, ``-inf`` elsewhere."""
+        return self._value_plugin("geometric_ln_pmf", value)
 
     def _cdf(self, value: pl.Expr) -> pl.Expr:
-        """``0`` below the support, else ``-expm1(log_tail)``.
-
-        Below `_CDF_DIRECT_COMPLEMENT_MAX` it is read directly as ``1 - exp(log_tail)``. The literal
-        ``1 - (1 - p)**k`` would instead inherit the rounding of both ``1 - p`` and the subtraction
-        against ``1``.
-        """
-        log_tail = self._log_tail(value)
-        complement = (
-            pl.when(log_tail <= _CDF_DIRECT_COMPLEMENT_MAX).then(1.0 - log_tail.exp()).otherwise(-expm1(log_tail))
-        )
-        return pl.when(value < 1).then(0.0).otherwise(self._when_p_valid(complement))
+        """``1 - (1 - p)**floor(k)`` from ``1`` up, ``0`` below."""
+        return self._value_plugin("geometric_cdf", value)
 
     def _log_cdf(self, value: pl.Expr) -> pl.Expr:
-        """``-inf`` below the support, else ``log(1 - exp(log_tail))``.
-
-        Two regimes, split at `_LOG_CDF_LOG1P_MAX` where the answer's own magnitude stops dwarfing
-        the absolute granularity of the pieces. Below it ``log1p`` carries the difference from ``1``
-        exactly; above it `log_abs_expm1` assembles the answer on the log scale, keeping the rounding
-        relative.
-        """
-        log_tail = self._log_tail(value)
-        log_complement = (
-            pl.when(log_tail <= _LOG_CDF_LOG1P_MAX).then((-log_tail.exp()).log1p()).otherwise(log_abs_expm1(log_tail))
-        )
-        return pl.when(value < 1).then(float("-inf")).otherwise(self._when_p_valid(log_complement))
+        """``log(1 - (1 - p)**floor(k))`` from ``1`` up, ``-inf`` below."""
+        return self._value_plugin("geometric_ln_cdf", value)
 
     def _sf(self, value: pl.Expr) -> pl.Expr:
-        """``exp(log_sf)``, which is exactly ``1`` below the support.
-
-        Overrides the base ``1 - cdf``, which recomputes ``p`` as ``1 - (1 - p)`` and so quantises it
-        to the ``1.1e-16`` spacing of ``1.0``, reaching ``0.0`` below that.
-        """
-        return self._log_sf(value).exp()
+        """``(1 - p)**floor(k)`` from ``1`` up, ``1`` below."""
+        return self._value_plugin("geometric_sf", value)
 
     def _log_sf(self, value: pl.Expr) -> pl.Expr:
-        """``0`` below the support, else `_log_tail`."""
-        return pl.when(value < 1).then(0.0).otherwise(self._when_p_valid(self._log_tail(value)))
+        """``floor(k) * log1p(-p)`` from ``1`` up, ``0`` below."""
+        return self._value_plugin("geometric_ln_sf", value)
 
     def _ppf(self, quantile: pl.Expr) -> pl.Expr:
-        """Smallest ``k`` with ``cdf(k) >= quantile``: ``ceil(log1p(-q) / log1p(-p))``, clipped to the support floor.
-
-        Null for ``q`` outside ``[0, 1]``. The numerator goes through ``log1p`` as well: the literal
-        ``log(1 - q)`` collapses to ``0.0`` below ``q ~ 1.1e-16`` and answers ``0`` where the smallest
-        support point ``1`` is the only correct answer. Its negation is written ``0.0 - q`` so an
-        unsigned quantile column promotes to ``Float64`` (polars rejects ``neg`` on an unsigned dtype).
-
-        ``q = 1`` runs the ratio off to ``+inf``, the right answer for an unbounded support.
-        ``p = 1`` short-circuits before `_smallest_support_point`, where the ratio would be
-        ``-inf / -inf = nan`` and the whole mass sits on ``k = 1``.
-        """
-        p = self._raw_p
-        support_point = _smallest_support_point((0.0 - quantile).log1p(), (-p).log1p())
-        answer = pl.when(p == 1).then(1.0).otherwise(support_point)
-        return (
-            pl.when(quantile.is_between(0, 1))
-            .then(self._when_p_valid(answer))
-            .otherwise(pl.lit(None, dtype=pl.Float64()))
-        )
+        """Smallest ``k`` with ``cdf(k) >= quantile``; null for ``quantile`` outside ``[0, 1]``."""
+        return self._value_plugin("geometric_ppf", quantile)
 
     def _isf(self, quantile: pl.Expr) -> pl.Expr:
-        """Smallest ``k`` with ``sf(k) <= quantile``: ``ceil(log(q) / log1p(-p))``, clipped to the support floor.
-
-        The exact inverse of `_sf`, entered against ``quantile`` itself rather than through the base
-        ``ppf(1 - quantile)``, whose complement throws the tail mass away before the inverse runs.
-        Here ``q = 1`` degenerates to ``-0.0`` and ``q = 0`` flows through as ``+inf``. At ``p = 1``
-        every survival quantile inverts to ``k = 1``, including ``q = 0``, where ``sf(1) = 0``
-        already satisfies the inequality.
-        """
-        p = self._raw_p
-        support_point = _smallest_support_point(quantile.log(), (-p).log1p())
-        answer = pl.when(p == 1).then(1.0).otherwise(support_point)
-        return (
-            pl.when(quantile.is_between(0, 1))
-            .then(self._when_p_valid(answer))
-            .otherwise(pl.lit(None, dtype=pl.Float64()))
-        )
+        """Smallest ``k`` with ``sf(k) <= quantile``; null for ``quantile`` outside ``[0, 1]``."""
+        return self._value_plugin("geometric_isf", quantile)
 
     def mean(self) -> pl.Expr:
         """Expected value, ``1 / p``. The one formula naming ``p`` once, so it reads `_checked_p` directly."""

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -4,8 +4,8 @@ use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::Exp;
 
 use crate::distributions::{
-    align_inputs, validate_params_unary, value_keyed_derived_per_row, value_keyed_derived_scalar,
-    Domain,
+    align_inputs, expm1, validate_params_unary, value_keyed_derived_per_row,
+    value_keyed_derived_scalar, Domain, Sides,
 };
 use crate::rng::{
     binary_param_rows, sample_by_index, sample_per_row_binary, samples_by_index,
@@ -71,50 +71,6 @@ fn exponential_rate(inputs: &[Series]) -> PolarsResult<Series> {
 /// it below would overflow past `t ~ 1420`. The two branches agree to `1e-16` here.
 const CDF_SINH_MAX: f64 = 1.0;
 
-/// `exp(t) - 1` through the identity `2 exp(t / 2) sinh(t / 2)`, which has no subtraction to cancel.
-///
-/// Not `f64::exp_m1`, which differs from this identity by one ulp on roughly a fifth of the left
-/// tail. Every expected value in `tests/distributions/exponential/` is this identity's rounding, and
-/// `_base.expm1` spells it the same way for the distributions still assembled in Polars.
-///
-/// `sinh(t / 2)` overflows above `|t| ~ 1420`; the only caller crosses over at [`CDF_SINH_MAX`],
-/// long before that.
-#[inline]
-fn expm1(t: f64) -> f64 {
-    let half = t / 2.0;
-    2.0 * half.exp() * half.sinh()
-}
-
-// Exponential hoists less than Bernoulli: every on-support answer is a function of the rate *and*
-// the evaluation point, so a `derive_*` captures the rate-only terms and the rest stays in the arm.
-// Free functions rather than associated ones, because each returns a distinct opaque arm type.
-
-/// The two sides of the support, for the six value-keyed methods.
-///
-/// Below `x = 0` every answer is the rate-free support constant, so a null rate must not null it.
-/// `below_support` is an `f64` rather than an `Option<f64>`, leaving nothing to thread a rate
-/// through by accident; all six constants are pinned by
-/// `tests/distributions/exponential/null_params_test.py`. `on_support` is `None` exactly when the
-/// rate is null.
-struct Sides<Arm> {
-    below_support: f64,
-    on_support: Option<Arm>,
-}
-
-impl<Arm: Fn(f64) -> f64> Sides<Arm> {
-    /// `x < 0` takes the support constant, everything else the arm, so `-0.0` is on the support.
-    ///
-    /// A `NaN` point never reaches here: both drivers short-circuit it. That is what lets this be a
-    /// bare `<`; the `!(x >= 0)` a negated predicate would spell puts `NaN` below the support.
-    fn at(&self, value: f64) -> Option<f64> {
-        if value < 0.0 {
-            Some(self.below_support)
-        } else {
-            self.on_support.as_ref().map(|arm| arm(value))
-        }
-    }
-}
-
 /// `rate * exp(-rate * x)` on `x >= 0`, `0` below, keeping the subnormal range exact.
 ///
 /// Reassociated as `(rate * exp(-rate * x / 2)) * exp(-rate * x / 2)`: the same product with the
@@ -122,7 +78,7 @@ impl<Arm: Fn(f64) -> f64> Sides<Arm> {
 /// range while the scale is still to be applied, and the final multiply then magnifies what the
 /// subnormal threw away. Halving the exponent keeps the intermediate normal, at the cost of one
 /// multiply and no branch.
-fn derive_pdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
+fn derive_pdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64, 0> {
     Sides {
         below_support: 0.0,
         on_support: rate.map(|rate| {
@@ -136,7 +92,7 @@ fn derive_pdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
 
 /// `ln(rate) - rate * x` on `x >= 0`, `-inf` below. `ln(rate)` is the only term the rate alone fixes,
 /// so it is the only one [`value_keyed_derived_scalar`] can lift out of the loop.
-fn derive_ln_pdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
+fn derive_ln_pdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64, 0> {
     Sides {
         below_support: f64::NEG_INFINITY,
         on_support: rate.map(|rate| {
@@ -150,7 +106,7 @@ fn derive_ln_pdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
 ///
 /// `1 - exp(-t)` cancels to `0` below `t ~ 1.1e-16`, so the small branch reads it as `-expm1(-t)`;
 /// see [`CDF_SINH_MAX`] for why the crossover is where it is.
-fn derive_cdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
+fn derive_cdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64, 0> {
     Sides {
         below_support: 0.0,
         on_support: rate.map(|rate| {
@@ -176,7 +132,7 @@ fn derive_cdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
 /// against the computed cdf. It coincides with [`CDF_SINH_MAX`] rather than deriving from it, which
 /// is what lets the left arm inline [`derive_cdf`]'s `expm1` branch: on the support and below
 /// `t = 1` that is the only branch it would take.
-fn derive_ln_cdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
+fn derive_ln_cdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64, 0> {
     Sides {
         below_support: f64::NEG_INFINITY,
         on_support: rate.map(|rate| {
@@ -196,7 +152,7 @@ fn derive_ln_cdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
 ///
 /// The closed form, never `1 - cdf`: the complement quantises the upper tail to the `1.1e-16`
 /// spacing of `1.0` and reaches `0.0` below that.
-fn derive_sf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
+fn derive_sf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64, 0> {
     Sides {
         below_support: 1.0,
         on_support: rate.map(|rate| move |x: f64| (-rate * x).exp()),
@@ -204,7 +160,7 @@ fn derive_sf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
 }
 
 /// `-rate * x` on `x >= 0`, `0` below: the plain log of [`derive_sf`].
-fn derive_ln_sf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64> {
+fn derive_ln_sf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64, 0> {
     Sides {
         below_support: 0.0,
         on_support: rate.map(|rate| move |x: f64| -rate * x),

--- a/src/distributions/geometric.rs
+++ b/src/distributions/geometric.rs
@@ -3,7 +3,10 @@ use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::Geometric;
 
-use crate::distributions::{align_inputs, validate_params_unary};
+use crate::distributions::{
+    align_inputs, expm1, ln_abs_expm1, validate_params_unary, value_keyed_derived_per_row,
+    value_keyed_derived_scalar, Domain, Sides,
+};
 use crate::rng::{
     binary_param_rows, sample_by_index, sample_per_row_binary, samples_by_index, samples_per_row,
     samples_u64_output, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
@@ -17,13 +20,19 @@ fn build_dist(proba: f64) -> PolarsResult<Geometric> {
     })
 }
 
-/// The samplers' per-row state: `ln(1 - p)`, the log base [`draw`]'s inverse transform divides by.
-///
-/// Validated through [`build_dist`], so an invalid `p` raises identically either way. Built once per
-/// row, not once per draw: the multi-draw and constant-parameter paths take many draws per state.
+/// `ln(1 - p)` as `ln_1p(-p)`: the literal `ln(1.0 - p)` inherits the rounding of `1 - p` (a few
+/// parts in `1e9` at `p = 1e-8`) and collapses to `0.0` below `p ~ 1.1e-16`. `-inf` at `p = 1`.
+#[inline]
+fn ln_failure(proba: f64) -> f64 {
+    (-proba).ln_1p()
+}
+
+/// The samplers' per-row state: [`ln_failure`], validated through [`build_dist`] so an invalid `p`
+/// raises identically either way. Built once per row, not once per draw: the multi-draw and
+/// constant-parameter paths take many draws per state.
 fn build_sampler(proba: f64) -> PolarsResult<f64> {
     build_dist(proba)?;
-    Ok((-proba).ln_1p())
+    Ok(ln_failure(proba))
 }
 
 /// Geometric's constant success probability, deserialised once per call.
@@ -36,13 +45,25 @@ impl GeometricParamsKwargs {
     fn build_sampler(&self) -> PolarsResult<f64> {
         build_sampler(self.p)
     }
+
+    /// Binds the constant `p` and `build_dist` into [`value_keyed_derived_scalar`], which validates
+    /// and derives once per call rather than per row.
+    fn value_keyed<Branches>(
+        &self,
+        value: &Series,
+        derive: impl Fn(Option<f64>) -> Branches,
+        select: impl Fn(&Branches, f64) -> Option<f64>,
+    ) -> PolarsResult<Series> {
+        value_keyed_derived_scalar(value, self.p, build_dist, derive, select)
+    }
 }
 
 /// Element-wise validation of the success probability: returns `p` unchanged, raising
 /// `InvalidOperation` if `p` is outside `(0, 1]`. `null` propagates.
 ///
-/// The closed-form Python methods derive from this so they report an invalid `p` consistently
-/// with `geometric_sample`, instead of silently computing with a non-positive probability.
+/// The moments derive from this so they report an invalid `p` consistently with `geometric_sample`,
+/// instead of silently computing with a non-positive probability. The value-keyed methods validate
+/// inside their own plugin instead.
 #[polars_expr(output_type=Float64)]
 fn geometric_p(inputs: &[Series]) -> PolarsResult<Series> {
     let proba = inputs[0].cast(&DataType::Float64)?;
@@ -53,23 +74,337 @@ fn geometric_p(inputs: &[Series]) -> PolarsResult<Series> {
     })
 }
 
+/// Crossover of [`derive_cdf`], in units of `ln(sf)`.
+///
+/// Below it `exp(ln_sf)` is small enough that the direct `1 - exp(ln_sf)` rounds no worse than the
+/// `sinh` identity and cannot round above `1`. The identity itself only breaks past `ln_sf ~ -1455`,
+/// where `sinh` overflows, far inside this branch.
+const CDF_DIRECT_COMPLEMENT_MAX: f64 = -20.0;
+
+/// Crossover of [`derive_ln_cdf`], in units of `ln(sf)`.
+///
+/// Below it the cdf sits within `0.63` of `1` and `ln_1p(-exp(ln_sf))` carries that difference
+/// exactly, down through the `cdf ~ 1 - 1e-16` zone where `cdf.ln()` reads the tail mass as `0`.
+const LN_CDF_LN_1P_MAX: f64 = -1.0;
+
+/// `pmf` / `log_pmf`: `off_support` is a plain `f64` because a point below `1` or a non-integral one
+/// carries no mass whatever `p` is, so a null `p` must not null it; `on_support` is `None` exactly
+/// when `p` is null. Pinned by `tests/distributions/geometric/null_param_test.py`.
+struct Mass<Arm> {
+    off_support: f64,
+    on_support: Option<Arm>,
+}
+
+impl<Arm: Fn(f64) -> f64> Mass<Arm> {
+    /// Only a positive integer takes the arm, so `pmf(2.5)` is `0`, not the mass at `2`.
+    /// `floor(k) == k` rather than an integer cast keeps `1e300` and `+inf` on the support, answering
+    /// `0` through the arm instead of saturating. A `NaN` point never reaches here: both drivers
+    /// short-circuit it.
+    fn at(&self, value: f64) -> Option<f64> {
+        if value >= 1.0 && value.floor() == value {
+            self.on_support.as_ref().map(|arm| arm(value))
+        } else {
+            Some(self.off_support)
+        }
+    }
+}
+
+/// `cdf` / `log_cdf` / `sf` / `log_sf`: the tail methods floor a non-integral point onto the support,
+/// so `cdf(2.5)` is `cdf(2)` and needs `p` where [`Mass`] answers its constant; the two cannot share
+/// a table.
+type Tail<Arm> = Sides<Arm, 1>;
+
+/// `(1 - p)^(k - 1) * p` on the positive integers, `0` elsewhere.
+///
+/// `k = 1` short-circuits the power: its exponent `(k - 1) * ln(1 - p)` is `0 * -inf = NaN` at
+/// `p = 1`, where the whole mass sits on `k = 1`.
+fn derive_pmf(p: Option<f64>) -> Mass<impl Fn(f64) -> f64> {
+    Mass {
+        off_support: 0.0,
+        on_support: p.map(|p| {
+            let ln_failure = ln_failure(p);
+            move |k: f64| {
+                if k == 1.0 {
+                    p
+                } else {
+                    p * ((k - 1.0) * ln_failure).exp()
+                }
+            }
+        }),
+    }
+}
+
+/// `(k - 1) * ln(1 - p) + ln(p)` on the positive integers, `-inf` elsewhere.
+///
+/// Not `ln(pmf)`, whose `ln(1 - p)` collapses to `0.0` below `p ~ 1.1e-16`. `k = 1` reads `ln(p)`
+/// alone, for the same `0 * -inf` reason as [`derive_pmf`].
+fn derive_ln_pmf(p: Option<f64>) -> Mass<impl Fn(f64) -> f64> {
+    Mass {
+        off_support: f64::NEG_INFINITY,
+        on_support: p.map(|p| {
+            let (ln_failure, ln_p) = (ln_failure(p), p.ln());
+            move |k: f64| {
+                if k == 1.0 {
+                    ln_p
+                } else {
+                    (k - 1.0) * ln_failure + ln_p
+                }
+            }
+        }),
+    }
+}
+
+/// `1 - (1 - p)^floor(k)` from `1` up, `0` below, read as `-expm1(ln_sf)`.
+///
+/// Below [`CDF_DIRECT_COMPLEMENT_MAX`] it is the direct `1 - exp(ln_sf)` instead. The literal
+/// `1 - (1 - p)^k` would inherit the rounding of both `1 - p` and the subtraction against `1`.
+fn derive_cdf(p: Option<f64>) -> Tail<impl Fn(f64) -> f64> {
+    Tail {
+        below_support: 0.0,
+        on_support: p.map(|p| {
+            let ln_failure = ln_failure(p);
+            move |k: f64| {
+                let ln_sf = k.floor() * ln_failure;
+                if ln_sf <= CDF_DIRECT_COMPLEMENT_MAX {
+                    1.0 - ln_sf.exp()
+                } else {
+                    -expm1(ln_sf)
+                }
+            }
+        }),
+    }
+}
+
+/// `ln(1 - exp(ln_sf))` from `1` up, `-inf` below.
+///
+/// Split at [`LN_CDF_LN_1P_MAX`], where the answer's own magnitude stops dwarfing the absolute
+/// granularity of the pieces: below it `ln_1p` carries the difference from `1` exactly, above it
+/// [`ln_abs_expm1`] assembles the answer on the log scale so the rounding stays relative.
+fn derive_ln_cdf(p: Option<f64>) -> Tail<impl Fn(f64) -> f64> {
+    Tail {
+        below_support: f64::NEG_INFINITY,
+        on_support: p.map(|p| {
+            let ln_failure = ln_failure(p);
+            move |k: f64| {
+                let ln_sf = k.floor() * ln_failure;
+                if ln_sf <= LN_CDF_LN_1P_MAX {
+                    (-ln_sf.exp()).ln_1p()
+                } else {
+                    ln_abs_expm1(ln_sf)
+                }
+            }
+        }),
+    }
+}
+
+/// `exp(ln_sf)` from `1` up, exactly `1` below.
+///
+/// Never `1 - cdf`, which recomputes `p` as `1 - (1 - p)` and so quantises it to the `1.1e-16`
+/// spacing of `1.0`, reaching `0.0` below that.
+fn derive_sf(p: Option<f64>) -> Tail<impl Fn(f64) -> f64> {
+    Tail {
+        below_support: 1.0,
+        on_support: p.map(|p| {
+            let ln_failure = ln_failure(p);
+            move |k: f64| (k.floor() * ln_failure).exp()
+        }),
+    }
+}
+
+/// `ln(sf) = floor(k) * ln(1 - p)` from `1` up, `0` below.
+fn derive_ln_sf(p: Option<f64>) -> Tail<impl Fn(f64) -> f64> {
+    Tail {
+        below_support: 0.0,
+        on_support: p.map(|p| {
+            let ln_failure = ln_failure(p);
+            move |k: f64| k.floor() * ln_failure
+        }),
+    }
+}
+
+/// Smallest `k >= 1` with `k * ln_failure <= log_target`, the shape both inverses share: they differ
+/// only in what they take the log of (`1 - q` against `q`).
+///
+/// A ratio sitting an ulp above an exact integer overshoots by one support point, so the ceiling
+/// steps back down whenever `k - 1` already satisfies the inequality, compared in the same log domain
+/// both sides entered through. The clip to `1.0` is also where `-0.0` lands at the degenerate
+/// endpoint of either inverse.
+///
+/// `ln_failure` is divided by, never reciprocated: `x * (1 / d)` rounds twice where `x / d` rounds
+/// once, and at a subnormal `ln(1 - p)` the reciprocal overflows to `inf`, turning `q = 0` into `NaN`
+/// and every other quantile into `inf`. So neither inverse hoists it into its `derive`.
+fn smallest_support_point(log_target: f64, ln_failure: f64) -> f64 {
+    let ceiling = (log_target / ln_failure).ceil();
+    let overshot = (ceiling - 1.0) * ln_failure <= log_target;
+    let k = if overshot { ceiling - 1.0 } else { ceiling };
+    k.max(1.0)
+}
+
+/// `ceil(ln_1p(-q) / ln(1 - p))`, the smallest `k` with `cdf(k) >= q`; null outside `[0, 1]`.
+///
+/// `ln_1p(-q)`, not `ln(1 - q)`, which collapses to `0.0` below `q ~ 1.1e-16` and answers `0` where
+/// `1` is the only correct answer. `q = 1` runs the ratio off to `+inf`, right for an unbounded
+/// support. `p = 1` short-circuits before [`smallest_support_point`], where the ratio would be
+/// `-inf / -inf = NaN`.
+fn derive_ppf(p: Option<f64>) -> Domain<impl Fn(f64) -> f64> {
+    Domain {
+        inside: p.map(|p| {
+            let ln_failure = ln_failure(p);
+            move |quantile: f64| {
+                if p == 1.0 {
+                    1.0
+                } else {
+                    smallest_support_point((-quantile).ln_1p(), ln_failure)
+                }
+            }
+        }),
+    }
+}
+
+/// `ceil(ln(q) / ln(1 - p))`, the smallest `k` with `sf(k) <= q`; null outside `[0, 1]`.
+///
+/// Entered against `q` itself, never as `ppf(1 - q)`, whose complement throws the tail mass away
+/// before the inverse runs. `q = 1` degenerates to `-0.0` and `q = 0` flows through as `+inf`. At
+/// `p = 1` every survival quantile inverts to `k = 1`, `q = 0` included, since `sf(1) = 0` already
+/// satisfies the inequality.
+fn derive_isf(p: Option<f64>) -> Domain<impl Fn(f64) -> f64> {
+    Domain {
+        inside: p.map(|p| {
+            let ln_failure = ln_failure(p);
+            move |quantile: f64| {
+                if p == 1.0 {
+                    1.0
+                } else {
+                    smallest_support_point(quantile.ln(), ln_failure)
+                }
+            }
+        }),
+    }
+}
+
+/// Element-wise pmf; see [`derive_pmf`], and [`Mass::at`] for the support rule.
+/// See [`value_keyed_derived_per_row`] for the null/error contract.
+#[polars_expr(output_type=Float64)]
+fn geometric_pmf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_per_row(inputs, build_dist, derive_pmf, Mass::at)
+}
+
+/// Element-wise log-pmf; see [`derive_ln_pmf`].
+#[polars_expr(output_type=Float64)]
+fn geometric_ln_pmf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_per_row(inputs, build_dist, derive_ln_pmf, Mass::at)
+}
+
+/// Element-wise cdf `P(X <= value)`; see [`derive_cdf`] and [`CDF_DIRECT_COMPLEMENT_MAX`].
+#[polars_expr(output_type=Float64)]
+fn geometric_cdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_per_row(inputs, build_dist, derive_cdf, Tail::at)
+}
+
+/// Element-wise log-cdf; see [`derive_ln_cdf`] and [`LN_CDF_LN_1P_MAX`].
+#[polars_expr(output_type=Float64)]
+fn geometric_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_per_row(inputs, build_dist, derive_ln_cdf, Tail::at)
+}
+
+/// Element-wise survival function `P(X > value)`; see [`derive_sf`] for why it is not `1 - cdf`.
+#[polars_expr(output_type=Float64)]
+fn geometric_sf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_per_row(inputs, build_dist, derive_sf, Tail::at)
+}
+
+/// Element-wise log-sf; see [`derive_ln_sf`].
+#[polars_expr(output_type=Float64)]
+fn geometric_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_per_row(inputs, build_dist, derive_ln_sf, Tail::at)
+}
+
+/// Element-wise ppf (inverse cdf); see [`derive_ppf`] and [`smallest_support_point`].
+#[polars_expr(output_type=Float64)]
+fn geometric_ppf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_per_row(inputs, build_dist, derive_ppf, Domain::at)
+}
+
+/// Element-wise inverse survival function; see [`derive_isf`] for why it never forms a complement.
+#[polars_expr(output_type=Float64)]
+fn geometric_isf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed_derived_per_row(inputs, build_dist, derive_isf, Domain::at)
+}
+
+/// Constant-`p` fast path for [`geometric_pmf`].
+#[polars_expr(output_type=Float64)]
+fn geometric_pmf_scalar(inputs: &[Series], kwargs: GeometricParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_pmf, Mass::at)
+}
+
+/// Constant-`p` fast path for [`geometric_ln_pmf`].
+#[polars_expr(output_type=Float64)]
+fn geometric_ln_pmf_scalar(
+    inputs: &[Series],
+    kwargs: GeometricParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_ln_pmf, Mass::at)
+}
+
+/// Constant-`p` fast path for [`geometric_cdf`].
+#[polars_expr(output_type=Float64)]
+fn geometric_cdf_scalar(inputs: &[Series], kwargs: GeometricParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_cdf, Tail::at)
+}
+
+/// Constant-`p` fast path for [`geometric_ln_cdf`].
+#[polars_expr(output_type=Float64)]
+fn geometric_ln_cdf_scalar(
+    inputs: &[Series],
+    kwargs: GeometricParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_ln_cdf, Tail::at)
+}
+
+/// Constant-`p` fast path for [`geometric_sf`].
+#[polars_expr(output_type=Float64)]
+fn geometric_sf_scalar(inputs: &[Series], kwargs: GeometricParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_sf, Tail::at)
+}
+
+/// Constant-`p` fast path for [`geometric_ln_sf`].
+#[polars_expr(output_type=Float64)]
+fn geometric_ln_sf_scalar(
+    inputs: &[Series],
+    kwargs: GeometricParamsKwargs,
+) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_ln_sf, Tail::at)
+}
+
+/// Constant-`p` fast path for [`geometric_ppf`].
+#[polars_expr(output_type=Float64)]
+fn geometric_ppf_scalar(inputs: &[Series], kwargs: GeometricParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_ppf, Domain::at)
+}
+
+/// Constant-`p` fast path for [`geometric_isf`].
+#[polars_expr(output_type=Float64)]
+fn geometric_isf_scalar(inputs: &[Series], kwargs: GeometricParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], derive_isf, Domain::at)
+}
+
 /// One Geometric draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
 ///
 /// Every Geometric sampler draws through here, per-row and fast path alike, so their bit-equality is
 /// structural rather than only sampled by `sample_test.py`.
 ///
-/// The inverse transform `ceil(ln u / ln(1 - p))` takes its log base from [`build_sampler`]'s
-/// `ln_1p`, not from `statrs`' `Distribution<u64>`, which forms the literal `1.0 - p`: that rounds
-/// to `1.0` at `p <= 2^-54`, so the base is `0.0`, the ratio `-inf`, and every draw below the
-/// threshold casts to `0` where the true draws are around `1 / p`.
+/// The inverse transform `ceil(ln u / ln(1 - p))` takes its log base from [`ln_failure`], not from
+/// `statrs`' `Distribution<u64>`, which forms the literal `1.0 - p`: that rounds to `1.0` at
+/// `p <= 2^-54`, so the base is `0.0`, the ratio `-inf`, and every draw below the threshold casts to
+/// `0` where the true draws are around `1 / p`.
 ///
 /// `u` comes from `(0, 1]`, so `u = 1` gives a raw draw of `0`; `.max(1)` lifts it to the support
 /// floor, where that endpoint's mass belongs in the limit. At the other end the cast saturates once
 /// `-ln u` outgrows `u64::MAX * p`, from around `p ~ 2e-18`: a dtype limit, not an algorithm one.
 #[inline]
-fn draw(log_failure: &f64, rng: &mut impl rand::Rng) -> u64 {
+fn draw(ln_failure: &f64, rng: &mut impl rand::Rng) -> u64 {
     let uniform: f64 = RandDistribution::sample(&rand::distr::OpenClosed01, rng);
-    ((uniform.ln() / log_failure).ceil() as u64).max(1)
+    ((uniform.ln() / ln_failure).ceil() as u64).max(1)
 }
 
 /// Element-wise Geometric sampler over `(p, row_index)`, returning `UInt64`.
@@ -99,10 +434,10 @@ fn geometric_sample_scalar(
     inputs: &[Series],
     kwargs: SampleScalarKwargs<GeometricParamsKwargs>,
 ) -> PolarsResult<Series> {
-    let log_failure = kwargs.params.build_sampler()?;
+    let ln_failure = kwargs.params.build_sampler()?;
     let name = inputs[0].name().clone();
 
-    sample_by_index(name, &inputs[0], kwargs.seed, |rng| draw(&log_failure, rng))
+    sample_by_index(name, &inputs[0], kwargs.seed, |rng| draw(&ln_failure, rng))
 }
 
 /// Constant-parameter multi-draw fast path: the `samples` twin of [`geometric_sample_scalar`].
@@ -114,11 +449,11 @@ fn geometric_samples_scalar(
     inputs: &[Series],
     kwargs: SamplesScalarKwargs<GeometricParamsKwargs>,
 ) -> PolarsResult<Series> {
-    let log_failure = kwargs.params.build_sampler()?;
+    let ln_failure = kwargs.params.build_sampler()?;
     let name = inputs[0].name().clone();
 
     samples_by_index(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
-        draw(&log_failure, rng)
+        draw(&ln_failure, rng)
     })
 }
 

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -246,12 +246,65 @@ where
     Ok(ca.with_name(name).into_series())
 }
 
+/// `exp(t) - 1` through the identity `2 exp(t / 2) sinh(t / 2)`, which has no subtraction to cancel.
+///
+/// Not `f64::exp_m1`, which differs from this identity by one ulp on roughly a fifth of the left
+/// tail. Every expected value in `tests/distributions/exponential/` is this identity's rounding, and
+/// `_base.expm1` spells it the same way for the moments still assembled in Polars.
+///
+/// `sinh(t / 2)` overflows above `|t| ~ 1420`; every caller crosses over to a direct form long before
+/// that (`exponential::CDF_SINH_MAX`, `geometric::CDF_DIRECT_COMPLEMENT_MAX`).
+#[inline]
+pub(crate) fn expm1(t: f64) -> f64 {
+    let half = t / 2.0;
+    2.0 * half.exp() * half.sinh()
+}
+
+/// `ln|exp(t) - 1|` as `ln(2) + t / 2 + ln|sinh(t / 2)|`: [`expm1`]'s identity read term by term on
+/// the log scale, so each term is large exactly where the answer is and the rounding stays relative;
+/// `expm1(t).ln()` would round the answer's own magnitude away.
+///
+/// The absolute value carries both signs of `t`: a no-op for `t > 0`, and for `t < 0` the log of the
+/// complement `1 - exp(t)`. Same overflow limit as [`expm1`]; `_base.log_abs_expm1` spells it the same
+/// way for `LogNormal.entropy`.
+#[inline]
+pub(crate) fn ln_abs_expm1(t: f64) -> f64 {
+    let half = t / 2.0;
+    std::f64::consts::LN_2 + half + half.sinh().abs().ln()
+}
+
+/// The two sides of a support whose floor is the integer `FLOOR`, for the value-keyed methods of a
+/// distribution that computes its own closed form.
+///
+/// Below the floor every answer is a parameter-free constant, so a null parameter must not null it:
+/// `below_support` is a plain `f64`, leaving nothing to thread the parameter through by accident.
+/// `on_support` is `None` exactly when the parameter is null. Each distribution's
+/// `null_param(s)_test.py` pins its constants.
+pub(crate) struct Sides<Arm, const FLOOR: i8> {
+    pub(crate) below_support: f64,
+    pub(crate) on_support: Option<Arm>,
+}
+
+impl<Arm: Fn(f64) -> f64, const FLOOR: i8> Sides<Arm, FLOOR> {
+    /// `value < FLOOR` takes the constant, everything else the arm, so `-0.0` sits where `0.0` does.
+    ///
+    /// A `NaN` value never reaches here: every driver short-circuits it. That is what lets this be a
+    /// bare `<`; the `!(value >= FLOOR)` a negated predicate would spell puts `NaN` below the support.
+    pub(crate) fn at(&self, value: f64) -> Option<f64> {
+        if value < f64::from(FLOOR) {
+            Some(self.below_support)
+        } else {
+            self.on_support.as_ref().map(|arm| arm(value))
+        }
+    }
+}
+
 /// The closed quantile domain `[0, 1]`, for the inverses of a distribution that computes its own
 /// closed form rather than building a `statrs` one.
 ///
-/// One slot rather than the two or three a support needs, because no part of either inverse
-/// survives a null parameter, at any quantile in range or out: `Exponential`'s and `Uniform`'s
-/// `null_param(s)_test.py` each pin it.
+/// One slot rather than the two a support needs, because no part of either inverse survives a
+/// null parameter, at any quantile in range or out; each distribution's `null_param(s)_test.py` pins
+/// it.
 pub(crate) struct Domain<Arm> {
     pub(crate) inside: Option<Arm>,
 }
@@ -329,10 +382,10 @@ where
 /// from both (Uniform's `max - min`), `?`-propagating the `InvalidOperation` out of `build_dist`.
 /// Any null input nulls the row without calling `validate`, matching the samplers.
 ///
-/// These plugins are what let the closed-form moments, and the value-keyed methods still assembled
-/// in Polars (`Geometric`), report an invalid parameterisation through the same Rust `build_dist`.
-/// The constant-parameter fast path calls the same plugin on length-1 `pl.lit` inputs, so it is
-/// built once instead of per row.
+/// These plugins are what let the closed-form moments report an invalid parameterisation through
+/// the same Rust `build_dist` as the value-keyed methods and the samplers. The constant-parameter
+/// fast path calls the same plugin on length-1 `pl.lit` inputs, so it is built once instead of per
+/// row.
 ///
 /// The two parameter dtypes are independent, so a mixed `(u64, f64)` parameterisation (Binomial)
 /// fits, as in [`ternary_param_rows`](crate::rng::ternary_param_rows): the caller does the cast and

--- a/tests/_polars_compat.py
+++ b/tests/_polars_compat.py
@@ -11,8 +11,8 @@ forwarded untouched.
 `linear_space` backfills `polars.linear_space`, which is missing on older supported polars; the implementation here
 reproduces its evenly spaced, inclusive-endpoint grid on every supported version.
 
-`ARM_MASKING_HIDES_VALIDATION` gates the validation contract, which polars 1.44 breaks for the
-distributions that assemble their closed forms in Python.
+`ARM_MASKING_HIDES_VALIDATION` gates the validation contract at a null or `NaN` evaluation point, which
+polars 1.44 breaks by masking the `propagate_null_and_nan` wrapper's arms before the plugin can validate.
 
 `arr_explode` wraps `Series.arr.explode`: polars 1.36 added the `empty_as_null` flag and 1.42 deprecated its
 default (a warning `filterwarnings = ["error"]` escalates), so newer polars needs the explicit kwarg while older

--- a/tests/distributions/geometric/degenerate_test.py
+++ b/tests/distributions/geometric/degenerate_test.py
@@ -5,7 +5,7 @@ At `p = 1` the shared entry `log1p(-p)` is `-inf`, so `floor(value) * log1p(-p)`
 below-support constant *before* forming that product, and each inverse short-circuits on `p == 1`
 before dividing `-inf` by `-inf`. Nothing else pins that ordering: the scipy parity grid excludes
 `p = 1` (scipy's generic discrete `ppf`, `isf`, `median` and `entropy` do not answer there) and the
-per-method grids stop at `p = 0.8`, so a reordered `when` chain would leak `NaN` and still ship green.
+per-method grids stop at `p = 0.8`, so a reordered branch would leak `NaN` and still ship green.
 """
 
 from __future__ import annotations
@@ -67,12 +67,23 @@ def test_value_keyed_method_at_p_one_from_a_column(
     assert got == [e for _, e in cases]
 
 
-@pytest.mark.parametrize("quantile", [0.0, 1e-300, 0.25, 0.5, 0.75, 1.0])
+_QUANTILES = [0.0, 1e-300, 0.25, 0.5, 0.75, 1.0]
+
+
+@pytest.mark.parametrize("quantile", _QUANTILES)
 def test_both_inverses_collapse_to_the_mass_point(quantile: float, unit_frame: pl.DataFrame) -> None:
     """Every quantile inverts to `k = 1`, including the endpoints where the ratio would be `NaN`."""
     frame = unit_frame.select(ppf=Geometric(p=1.0).ppf(quantile), isf=Geometric(p=1.0).isf(quantile))
     assert frame.item(0, "ppf") == 1.0
     assert frame.item(0, "isf") == 1.0
+
+
+@pytest.mark.parametrize("method", ["ppf", "isf"])
+def test_both_inverses_collapse_to_the_mass_point_from_a_column(method: str) -> None:
+    """The per-row path short-circuits on `p == 1` too: `p = 1` is a value, not a constant-folding artefact."""
+    frame = pl.DataFrame({"p": [1.0] * len(_QUANTILES), "q": _QUANTILES})
+    got = frame.select(r=getattr(Geometric(p=pl.col("p")), method)(pl.col("q")))["r"].to_list()
+    assert got == [1.0] * len(_QUANTILES)
 
 
 def test_moments_at_p_one(unit_frame: pl.DataFrame) -> None:

--- a/tests/distributions/geometric/isf_test.py
+++ b/tests/distributions/geometric/isf_test.py
@@ -63,6 +63,18 @@ def test_isf_overshoots_by_one_at_an_exact_step_boundary(unit_frame: pl.DataFram
     assert unit_frame.select(v=Geometric(p=p).isf(math.nextafter(sf_at_floor, 1.0))).item(0, "v") == support_floor
 
 
+def test_isf_step_boundary_agrees_across_routings(unit_frame: pl.DataFrame) -> None:
+    """A column `p` takes the same tie-break as a Python-float `p`, on a frame longer than one row."""
+    p = 1e-8
+    sf_at_floor = unit_frame.select(v=Geometric(p=p).sf(1.0)).item(0, "v")
+    quantiles = [sf_at_floor, math.nextafter(sf_at_floor, 0.0), math.nextafter(sf_at_floor, 1.0)]
+    frame = pl.DataFrame({"q": quantiles, "p": [p] * len(quantiles)})
+
+    got = frame.select(scalar=Geometric(p=p).isf(pl.col("q")), column=Geometric(p=pl.col("p")).isf(pl.col("q")))
+    assert got["scalar"].to_list() == [2.0, 2.0, 1.0]
+    assert got["column"].to_list() == [2.0, 2.0, 1.0]
+
+
 @pytest.mark.parametrize("quantile", [-0.1, 1.5])
 def test_isf_out_of_range_quantile_is_null(quantile: float, unit_frame: pl.DataFrame) -> None:
     result = unit_frame.select(v=Geometric(p=0.3).isf(quantile)).item(0, "v")

--- a/tests/distributions/geometric/null_param_test.py
+++ b/tests/distributions/geometric/null_param_test.py
@@ -1,15 +1,16 @@
 """A null `p` nulls every answer that depends on it, and only those.
 
 `pmf(0) = 0`, `cdf(0) = 0` and `sf(0) = 1` are off-support constants with no `p` in them, so they
-survive a null one; the class docstring promises it and `Bernoulli` behaves the same way.
+survive a null one; the class docstring promises it and `Bernoulli` behaves the same way. The split is
+per method: a non-integral point in range carries no mass, so `pmf(2.5) = 0` survives, but `cdf(2.5)`
+is `cdf(2)`, needs `p`, and nulls.
 
-It is a placement contract on a single gate. Every closed-form method reads `p` through one
-validating round trip (`Geometric._when_p_valid`) rather than naming the validated `p` inline, and
-widening that gate from the `p`-dependent branch to the whole method would null these constants and
-still leave the suite green: the per-method null tests all evaluate on the support.
+Nothing else pins the constants: the per-method null tests all evaluate on the support.
 """
 
 from __future__ import annotations
+
+import math
 
 import polars as pl
 import pytest
@@ -18,49 +19,85 @@ from polars_stats import Geometric
 
 _NEG_INF = float("-inf")
 
-# (id, expr builder, expected) for the answers that hold with no `p` at all.
-_OFF_SUPPORT: list[tuple[str, str, float, float]] = [
-    ("pmf", "pmf", -1.0, 0.0),
-    ("pmf", "pmf", 0.0, 0.0),
-    ("pmf", "pmf", 0.5, 0.0),
-    ("log_pmf", "log_pmf", 0.0, _NEG_INF),
-    ("cdf", "cdf", 0.0, 0.0),
-    ("log_cdf", "log_cdf", 0.0, _NEG_INF),
-    ("sf", "sf", 0.0, 1.0),
-    ("log_sf", "log_sf", 0.0, 0.0),
+# (method, value, expected) for the answers that hold with no `p` at all: below the support for every
+# method, and at a non-integral point in range for the two mass methods.
+_OFF_SUPPORT: list[tuple[str, float, float]] = [
+    ("pmf", -1.0, 0.0),
+    ("pmf", 0.0, 0.0),
+    ("pmf", 0.5, 0.0),
+    ("pmf", 2.5, 0.0),
+    ("log_pmf", -1.0, _NEG_INF),
+    ("log_pmf", 0.0, _NEG_INF),
+    ("log_pmf", 0.5, _NEG_INF),
+    ("log_pmf", 2.5, _NEG_INF),
+    ("cdf", -1.0, 0.0),
+    ("cdf", 0.0, 0.0),
+    ("cdf", 0.5, 0.0),
+    ("log_cdf", -1.0, _NEG_INF),
+    ("log_cdf", 0.0, _NEG_INF),
+    ("log_cdf", 0.5, _NEG_INF),
+    ("sf", -1.0, 1.0),
+    ("sf", 0.0, 1.0),
+    ("sf", 0.5, 1.0),
+    ("log_sf", -1.0, 0.0),
+    ("log_sf", 0.0, 0.0),
+    ("log_sf", 0.5, 0.0),
 ]
 
-_ON_SUPPORT = ["pmf", "log_pmf", "cdf", "log_cdf", "sf", "log_sf"]
+# (method, value) pairs whose answer reads `p`, so a null one must reach the result.
+_ON_SUPPORT: list[tuple[str, float]] = [
+    ("pmf", 1.0),
+    ("pmf", 3.0),
+    ("log_pmf", 1.0),
+    ("log_pmf", 3.0),
+    ("cdf", 1.0),
+    ("cdf", 2.5),
+    ("log_cdf", 1.0),
+    ("log_cdf", 2.5),
+    ("sf", 1.0),
+    ("sf", 2.5),
+    ("log_sf", 1.0),
+    ("log_sf", 2.5),
+]
 
 _PARAMETER_ONLY = ["mean", "variance", "std", "median", "entropy"]
 
 
+def _null_p() -> pl.DataFrame:
+    return pl.DataFrame({"p": [None]}, schema={"p": pl.Float64})
+
+
 @pytest.mark.parametrize(
     ("method", "value", "expected"),
-    [(m, v, e) for _, m, v, e in _OFF_SUPPORT],
-    ids=[f"{name}({value})" for name, _, value, _ in _OFF_SUPPORT],
+    _OFF_SUPPORT,
+    ids=[f"{method}({value})" for method, value, _ in _OFF_SUPPORT],
 )
 def test_off_support_constant_survives_a_null_p(method: str, value: float, expected: float) -> None:
-    frame = pl.DataFrame({"p": [None]}, schema={"p": pl.Float64})
-    result = frame.select(r=getattr(Geometric(p=pl.col("p")), method)(value))["r"].item()
+    result = _null_p().select(r=getattr(Geometric(p=pl.col("p")), method)(value))["r"].item()
     assert result == expected
 
 
-@pytest.mark.parametrize("method", _ON_SUPPORT)
-def test_on_support_value_nulls_under_a_null_p(method: str) -> None:
-    frame = pl.DataFrame({"p": [None]}, schema={"p": pl.Float64})
-    assert frame.select(r=getattr(Geometric(p=pl.col("p")), method)(1.0))["r"].item() is None
+@pytest.mark.parametrize(("method", "value"), _ON_SUPPORT, ids=[f"{method}({value})" for method, value in _ON_SUPPORT])
+def test_on_support_value_nulls_under_a_null_p(method: str, value: float) -> None:
+    assert _null_p().select(r=getattr(Geometric(p=pl.col("p")), method)(value))["r"].item() is None
 
 
 @pytest.mark.parametrize("method", _PARAMETER_ONLY)
 def test_moment_nulls_under_a_null_p(method: str) -> None:
-    frame = pl.DataFrame({"p": [None]}, schema={"p": pl.Float64})
-    assert frame.select(r=getattr(Geometric(p=pl.col("p")), method)())["r"].item() is None
+    assert _null_p().select(r=getattr(Geometric(p=pl.col("p")), method)())["r"].item() is None
 
 
 @pytest.mark.parametrize("method", ["ppf", "isf"])
-@pytest.mark.parametrize("quantile", [0.5, 2.0])
+@pytest.mark.parametrize("quantile", [0.0, 0.5, 1.0, 2.0])
 def test_inverse_nulls_under_a_null_p(method: str, quantile: float) -> None:
     """Null inside `[0, 1]` because the answer needs `p`, and null outside it by the domain contract."""
-    frame = pl.DataFrame({"p": [None]}, schema={"p": pl.Float64})
-    assert frame.select(r=getattr(Geometric(p=pl.col("p")), method)(quantile))["r"].item() is None
+    assert _null_p().select(r=getattr(Geometric(p=pl.col("p")), method)(quantile))["r"].item() is None
+
+
+def test_nan_value_stays_nan_under_a_null_p() -> None:
+    """A `NaN` point short-circuits before the branches, so a null `p` does not null it.
+
+    Probed through the private hook, since the public wrapper answers `NaN` on its own.
+    """
+    result = _null_p().select(r=Geometric(p=pl.col("p"))._pmf(pl.lit(math.nan)))["r"].item()
+    assert math.isnan(result)

--- a/tests/distributions/geometric/ppf_test.py
+++ b/tests/distributions/geometric/ppf_test.py
@@ -64,8 +64,8 @@ def test_ppf_at_an_exact_step_boundary_can_miss_by_one(
     """On a step the answer is the definition's support point or a neighbour, and no further.
 
     The tie-break compares `k * log1p(-p)` against `log1p(-q)` rather than re-deriving `cdf(k)`.
-    That is deliberate and the more accurate rule (1997 boundary probes: 357 disagreements with
-    exact arithmetic against 490 for the alternative), and the price is that `ppf` and `cdf` are not
+    That is deliberate (1997 boundary probes: 357 disagreements with exact arithmetic against 490 for
+    the alternative), and the price is that `ppf` and `cdf` are not
     exact mutual inverses on a step: the two roundings decide the last bit there. Which side they
     fall on is the platform's `exp` and `log1p`, not the rule, so only the bound is portable and
     only the bound is pinned. At `p = 0.1` one ulp above `cdf(10)`, Apple's libm answers `10` and
@@ -79,6 +79,23 @@ def test_ppf_at_an_exact_step_boundary_can_miss_by_one(
 
     got = unit_frame.select(v=Geometric(p=p).ppf(quantile)).item(0, "v")
     assert abs(got - _smallest_support_point_exact(p, quantile)) <= 1
+
+
+@pytest.mark.parametrize(("p", "step"), [(0.1, 10), (0.3, 4), (0.5, 20), (0.05, 13)])
+def test_ppf_at_an_exact_step_boundary_agrees_across_routings(p: float, step: int, unit_frame: pl.DataFrame) -> None:
+    """A column `p` takes the same tie-break as a Python-float `p`, on a frame longer than one row.
+
+    `unit_frame` is the one length at which a Polars expression on a literal `p` folds like a column
+    one, so the scalar tests above cannot see the two routings drift apart at a step.
+    """
+    cdf_at_step = unit_frame.select(v=Geometric(p=p).cdf(float(step))).item(0, "v")
+    quantiles = [math.nextafter(cdf_at_step, 0.0), cdf_at_step, math.nextafter(cdf_at_step, 1.0)]
+    frame = pl.DataFrame({"q": quantiles, "p": [p] * len(quantiles)})
+
+    got = frame.select(scalar=Geometric(p=p).ppf(pl.col("q")), column=Geometric(p=pl.col("p")).ppf(pl.col("q")))
+    assert got["scalar"].to_list() == got["column"].to_list()
+    for quantile, k in zip(quantiles, got["scalar"].to_list(), strict=True):
+        assert abs(k - _smallest_support_point_exact(p, quantile)) <= 1
 
 
 @pytest.mark.parametrize("quantile", [-0.1, 1.5])

--- a/tests/distributions/geometric/validation_test.py
+++ b/tests/distributions/geometric/validation_test.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 # Every public method must report an out-of-range `p` as a ComputeError, not silently compute.
 # The support is `0 < p <= 1`, so unlike Bernoulli the degenerate `p = 0` is invalid too. The
-# deterministic methods all derive from the Rust-validated `_checked_p`; the samplers validate in
+# moments read the Rust-validated `_checked_p`; the value-keyed methods and the samplers validate in
 # their own plugin.
 _METHODS: dict[str, Callable[[Geometric], pl.Expr]] = {
     "pmf": lambda g: g.pmf(pl.col("k")),

--- a/tests/distributions/plugin_nan_test.py
+++ b/tests/distributions/plugin_nan_test.py
@@ -14,10 +14,10 @@ in two places:
 * `Binomial`: `NaN < 0.0` is false and `NaN.floor() as u64` saturates to `0`, so unguarded bodies
   would return a confident `P(X <= 0)` (and a `pmf` of `0.0`).
 
-`Bernoulli` and `Exponential` take a third driver (`value_keyed_derived_per_row`) and `Uniform` its
-two-parameter sibling, both of which repeat the short-circuit: the shared per-row one nulls a row on
-any null parameter, and their off-support answers are contracted to survive one. Covered here so the
-drivers cannot drift.
+`Bernoulli`, `Exponential` and `Geometric` take a third driver (`value_keyed_derived_per_row`) and
+`Uniform` its two-parameter sibling, both of which repeat the short-circuit: the shared per-row one
+nulls a row on any null parameter, and their off-support answers are contracted to survive one.
+Covered here so the drivers cannot drift.
 
 Both plugin shapes are covered: scalar-parameter instances route to the `<method>_scalar` twins,
 column-parameter instances to the per-row plugins.
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
-from polars_stats import Bernoulli, Beta, Binomial, DiscreteUniform, Exponential, LogNormal, Normal, Uniform
+from polars_stats import Bernoulli, Beta, Binomial, DiscreteUniform, Exponential, Geometric, LogNormal, Normal, Uniform
 from polars_stats.distributions._base import DiscreteDistribution
 
 if TYPE_CHECKING:
@@ -57,6 +57,8 @@ _CASES = [
     ("binomial-columns", Binomial(n=_col(5, pl.Int64()), p=_col(0.4))),
     ("exponential-scalar", Exponential(rate=1.5)),
     ("exponential-columns", Exponential(rate=_col(1.5))),
+    ("geometric-scalar", Geometric(p=0.3)),
+    ("geometric-columns", Geometric(p=_col(0.3))),
     ("discreteuniform-scalar", DiscreteUniform(min=-2, max=9)),
     ("discreteuniform-columns", DiscreteUniform(min=_col(-2, pl.Int64()), max=_col(9, pl.Int64()))),
     ("uniform-scalar", Uniform(min=-2.0, max=9.0)),

--- a/tests/distributions/validation_contract_test.py
+++ b/tests/distributions/validation_contract_test.py
@@ -1,10 +1,10 @@
 """Every value-keyed method reports an invalid parameterisation, whichever branch the value selects.
 
 Two axes, one contract. The first test sweeps the *evaluation value* across every branch of every
-method, and is what the Rust ports exist to make green. The second holds the value at `NaN` and
-targets `propagate_null_and_nan` instead, a `when/then/otherwise` wrapped around every public
-value-keyed method: a second place the validator can sit inside an arm, one level above the
-distribution.
+method, which holds because every value-keyed method validates inside the Rust plugin that computes
+it. The second holds the value at `NaN` and targets `propagate_null_and_nan` instead, a
+`when/then/otherwise` wrapped around every public value-keyed method: a second place the validator
+can sit inside an arm, one level above the distribution.
 """
 
 from __future__ import annotations
@@ -85,16 +85,6 @@ it gets its own test below, alongside the `NaN` point that leaks through the sam
 """
 
 
-_LEAKING_METHODS: dict[str, frozenset[str]] = {
-    "Geometric": frozenset({"pmf", "log_pmf", "cdf", "log_cdf", "sf", "log_sf", "ppf", "isf"}),
-}
-"""The (distribution, method) pairs that `ARM_MASKING_HIDES_VALIDATION` is expected to break.
-
-Measured, not assumed: these are exactly the pairs that fail on polars 1.44.1 and pass on 1.43.2.
-Every value-keyed method of the one remaining distribution leaks. Porting a distribution's closed
-forms to Rust deletes its entry here; the last one to go deletes the dict.
-"""
-
 _METHOD_VALUES: tuple[tuple[str, tuple[float, ...]], ...] = (
     *((method, _SUPPORT_POINTS) for method in _VALUE_METHODS),
     *((method, _QUANTILES) for method in _QUANTILE_METHODS),
@@ -119,20 +109,17 @@ def _report(case: _Case, method_fn: Callable[[pl.Expr], pl.Expr], value: float |
 @pytest.mark.parametrize("case", _CASES, ids=_ids)
 @pytest.mark.parametrize(("method", "values"), _METHOD_VALUES, ids=[method for method, _ in _METHOD_VALUES])
 def test_invalid_parameter_raises_whichever_branch_the_value_selects(
-    case: _Case, method: str, values: tuple[float, ...], request: pytest.FixtureRequest
+    case: _Case, method: str, values: tuple[float, ...]
 ) -> None:
     """One assertion per (distribution, method), over the whole value sweep.
 
     Which branch a value selects is an implementation detail of the method, so splitting the sweep
     into one test per value would make the pass/fail pattern an artifact of that detail rather than a
-    statement about the contract. It would also make the `polars>=1.44` gate below inexact: leakage
-    is not uniform across values within a method.
+    statement about the contract.
     """
     method_fn: Callable[[pl.Expr], pl.Expr] | None = getattr(case.dist, method, None)
     if method_fn is None:
         pytest.skip(f"{case.name} has no {method} (wrong family)")
-    if ARM_MASKING_HIDES_VALIDATION and method in _LEAKING_METHODS.get(case.name, frozenset()):
-        request.applymarker(pytest.mark.xfail(reason="pola-rs/polars#29005"))
 
     reports = [(value, _report(case, method_fn, value)) for value in values]
     # A `None` report means the invalid row in `columns` was silently computed rather than reported.
@@ -178,15 +165,7 @@ def test_invalid_parameter_raises_at_a_nan_evaluation_point(case: _Case, request
     assert not unreported, f"{case.name} did not report the invalid `{case.fragment}` at a NaN point in {unreported}"
 
 
-_RUST_CASES = tuple(case for case in _CASES if case.name not in _LEAKING_METHODS)
-"""The cases whose value-keyed methods compute in Rust, derived rather than listed again.
-
-A distribution leaves `_LEAKING_METHODS` exactly when its closed forms move into Rust, so this set
-grows on its own as the port series lands.
-"""
-
-
-@pytest.mark.parametrize("case", _RUST_CASES, ids=_ids)
+@pytest.mark.parametrize("case", _CASES, ids=_ids)
 def test_invalid_parameter_raises_at_a_null_evaluation_point(case: _Case) -> None:
     """The null sibling of the test above: an invalid parameterisation raises whatever the value is.
 

--- a/tests/distributions/value_keyed_fast_path_test.py
+++ b/tests/distributions/value_keyed_fast_path_test.py
@@ -1,7 +1,6 @@
 """Validation contract of the constant-parameter value-keyed fast path.
 
-Covers Normal, LogNormal, Binomial, Beta, DiscreteUniform, Bernoulli, Exponential and Uniform: the
-distributions with per-method Rust plugins.
+Covers every distribution: each has per-method Rust plugins.
 
 `pdf` / `pmf` / `cdf` / `sf` / `ppf` with all-scalar parameters route through a dedicated ``<name>_<method>_scalar``
 plugin that validates and builds the `statrs` distribution once (via the shared `build_dist`), instead of rebuilding it
@@ -31,7 +30,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
-from polars_stats import Bernoulli, Beta, Binomial, DiscreteUniform, Exponential, LogNormal, Normal, Uniform
+from polars_stats import Bernoulli, Beta, Binomial, DiscreteUniform, Exponential, Geometric, LogNormal, Normal, Uniform
 from polars_stats.distributions._base import ContinuousDistribution
 from tests._polars_compat import assert_series_equal
 
@@ -89,6 +88,12 @@ _CASES: dict[str, tuple[Callable[[], _UnivariateDistribution], Callable[[], _Uni
     # An infinite rate is accepted by statrs as the degenerate point mass at 0, like the Normal
     # scale and unlike the Beta shape; both paths must accept it identically.
     "exponential rate=inf (accepted)": (lambda: Exponential(_INF), lambda: Exponential(_col(_INF)), False),
+    "geometric p=nan": (lambda: Geometric(_NAN), lambda: Geometric(_col(_NAN)), True),
+    "geometric p=1.5": (lambda: Geometric(1.5), lambda: Geometric(_col(1.5)), True),
+    # `p = 0` is the one endpoint Geometric rejects where Bernoulli accepts it: the trial count of a
+    # never-succeeding trial is not representable.
+    "geometric p=0": (lambda: Geometric(0.0), lambda: Geometric(_col(0.0)), True),
+    "geometric p=1 (accepted)": (lambda: Geometric(1.0), lambda: Geometric(_col(1.0)), False),
     "discreteuniform min>max": (
         lambda: DiscreteUniform(6, 1),
         lambda: DiscreteUniform(_col(6, pl.Int64()), _col(1, pl.Int64())),

--- a/tests/property/_specs.py
+++ b/tests/property/_specs.py
@@ -297,9 +297,8 @@ DISCRETE_SPECS = [s for s in ALL_SPECS if not s.continuous]
 # operands are length-1 literals that polars may fold differently from the column kernel. Every IEEE
 # operation is exactly rounded, so the measured 1-ULP gap (Uniform's `variance` / `std`) is a
 # different operation *order*, not a different formula. Extend from a failing assertion, never by
-# widening the tolerance. There is no value-keyed counterpart: every spec whose value-keyed methods
-# run in Rust is bit-exact on both routings by construction, and `geometric`, the last one still
-# assembling them in Polars, measures bit-exact too.
+# widening the tolerance. There is no value-keyed counterpart: every value-keyed method runs in Rust,
+# so one body feeds both routings and they are bit-exact by construction.
 ULP_TOLERANT_MOMENT_SPECS = frozenset({"uniform", "geometric"})
 """Specs whose moments compare to `ULP_REL_TOL` instead of bit-exactly.
 

--- a/tests/property/fast_path_context_test.py
+++ b/tests/property/fast_path_context_test.py
@@ -136,12 +136,7 @@ def test_moment_fast_path_matches_per_row_across_contexts(spec: DistSpec, moment
 @pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
 @given(data=st.data())
 def test_value_keyed_fast_path_matches_per_row_across_contexts(spec: DistSpec, data: st.DataObject) -> None:
-    """Density / log-density / cdf / sf / ppf scalar fast paths equal the per-row path under every context.
-
-    This is where the `Geometric` closed forms get their cross-context coverage: its value-keyed
-    methods are pure Polars, routing validation through the same `_checked` gate as the moments, so a
-    broadcast bug in that gate is the only way they diverge.
-    """
+    """Density / log-density / cdf / sf / ppf scalar fast paths equal the per-row path under every context."""
     params = data.draw(spec.params)
     scalar = spec.make(params)
     per_row = spec.make_columns(params)

--- a/tests/property/value_keyed_test.py
+++ b/tests/property/value_keyed_test.py
@@ -7,9 +7,7 @@ In Rust both plugins call the same named per-method body, so for any parameteris
 must agree bit for bit, including null propagation and ppf's null-outside-``[0, 1]`` contract. A
 divergence (e.g. a parameter-order swap in a scalar kwargs struct) must fail here.
 
-The comparison is bit-exact for every spec. ``geometric`` still evaluates a Polars expression on both
-paths, on length-1 operands under a constant parameterisation, which polars is free to fold
-differently; measured, it does not.
+The comparison is bit-exact for every spec.
 """
 
 from __future__ import annotations

--- a/tests/scipy_parity/geometric_test.py
+++ b/tests/scipy_parity/geometric_test.py
@@ -16,8 +16,8 @@ from tests.scipy_parity._harness import Case, assert_case_matches_scipy
 # so the grid holds only valid parameters. `p = 1` is excluded because scipy's generic discrete
 # entropy does not answer there (see the divergence note below).
 _PS = [0.05, 0.1, 0.25, 0.5, 0.75, 0.9]
-# Interior quantiles only: scipy's discrete ppf/isf return the below-support sentinel -1 at the
-# exact endpoints q in {0, 1}, which this support-clamped ppf/isf does not reproduce.
+# Interior quantiles only: scipy's discrete ppf/isf return the point below the support, `a - 1 = 0`,
+# at the exact endpoints q in {0, 1}, which this support-clamped ppf/isf does not reproduce.
 _QUANTILES = [0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95]
 # Spans below the support, several integer points, a non-integer, and well into the upper tail.
 _VALUE_GRID = [-1.0, 0.0, 1.0, 2.0, 3.7, 10.0, 50.0]
@@ -46,7 +46,7 @@ def test_method_matches_scipy(case: Case[Geometric], p: float) -> None:
     """Every closed-form method matches `scipy.stats.geom(p)` across `_PS` x grids.
 
     Table-driven: adding a method is one row in `_CASES`. `ppf`/`isf` use interior quantiles only,
-    since scipy's discrete inverse returns the below-support sentinel -1 at `q` in `{0, 1}`, which
+    since scipy's discrete inverse returns the point below the support (`0`) at `q` in `{0, 1}`, which
     the support-clamped inverses here do not reproduce. Method-specific behaviour (support handling,
     null propagation) is asserted in the per-method test files.
     """
@@ -129,9 +129,10 @@ def test_memorylessness_of_sf() -> None:
 
 # NOTE: Deliberate divergences from scipy, recorded here rather than rediscovered as surprises.
 #
-# * Endpoints of the inverse: scipy's discrete `ppf(0)` returns its below-support sentinel `-1`,
-#   while the smallest support point here (`k = 1`) is the only meaningful answer; `ppf(1)` is `inf`
-#   on both sides. Interior-quantile parity covers everything else.
+# * Endpoints of the inverse: scipy's discrete `ppf(0)` and `isf(1)` return the point below the
+#   support, `a - 1 = 0`; this library answers the smallest support point, `1`, the value every
+#   `q > 0` already inverts to on both sides. `ppf(1)` is `inf` on both sides. Interior-quantile
+#   parity covers everything else.
 # * `p = 0`: scipy accepts it and returns degenerate values; this crate raises, as the geometric
 #   law degenerates to "never succeeds" and has no finite moments.
 # * `entropy` at `p = 1`: this crate answers `0.0` by the `0 * log 0 = 0` convention; scipy's


### PR DESCRIPTION
Ports Geometric's eight value-keyed methods to Rust bodies on the shared derive/select drivers, the last of the lift-polars-pin series: an invalid p now raises on polars >= 1.44 whichever branch the value selects, and `_LEAKING_METHODS` is gone.

Bit-exact with the pre-port column routing; a Python-float p on frames of two or more rows now agrees with it on ppf / isf, where v0.0.2 could answer one support point apart at a cdf step or inf at a subnormal p. 

And documents the scipy endpoint and step-boundary conventions.

