### PR TITLE
fix(build): enable dtype-full so an unsupported dtype raises instead of aborting the interpreter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +579,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +727,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -712,7 +746,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core",
  "wasm-bindgen",
 ]
@@ -781,6 +815,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "halfbrown"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ed2f2edad8a14c8186b847909a41fbb9c3eafa44f88bd891114ed5019da09"
+dependencies = [
+ "hashbrown 0.16.1",
+ "serde",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +833,17 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1537,6 +1592,7 @@ dependencies = [
  "polars-lazy",
  "polars-ops",
  "polars-plan",
+ "polars-sql",
  "polars-time",
  "polars-utils",
  "version_check",
@@ -1548,6 +1604,7 @@ version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5ab55460ca2553d1a2bbaf2046998cfbbb685bc18d1e168b4367b63301eb271"
 dependencies = [
+ "atoi_simd",
  "bitflags",
  "bytemuck",
  "bytes",
@@ -1560,6 +1617,7 @@ dependencies = [
  "getrandom 0.4.3",
  "half",
  "hashbrown 0.17.1",
+ "itoa",
  "lz4",
  "num-traits",
  "polars-arrow-format",
@@ -1629,6 +1687,7 @@ dependencies = [
  "chrono",
  "either",
  "fast-float2",
+ "half",
  "hashbrown 0.17.1",
  "itoa",
  "num-traits",
@@ -1664,6 +1723,7 @@ dependencies = [
  "boxcar",
  "bytemuck",
  "chrono",
+ "chrono-tz",
  "either",
  "getrandom 0.4.3",
  "hashbrown 0.17.1",
@@ -1740,10 +1800,12 @@ dependencies = [
  "polars-ops",
  "polars-plan",
  "polars-row",
+ "polars-time",
  "polars-utils",
  "rand",
  "rayon",
  "recursive",
+ "regex",
  "version_check",
 ]
 
@@ -1789,8 +1851,10 @@ dependencies = [
  "polars-config",
  "polars-core",
  "polars-error",
+ "polars-json",
  "polars-parquet",
  "polars-schema",
+ "polars-time",
  "polars-utils",
  "rand",
  "rayon",
@@ -1800,6 +1864,27 @@ dependencies = [
  "serde_json",
  "simdutf8",
  "tokio",
+ "zmij",
+]
+
+[[package]]
+name = "polars-json"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495117c99362a05d4ea744c21f54d570991fd8ae3ec9dfb1f0e01f055747553f"
+dependencies = [
+ "chrono",
+ "fallible-streaming-iterator",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itoa",
+ "num-traits",
+ "polars-arrow",
+ "polars-compute",
+ "polars-error",
+ "polars-utils",
+ "simd-json",
+ "streaming-iterator",
  "zmij",
 ]
 
@@ -1824,6 +1909,7 @@ dependencies = [
  "polars-ops",
  "polars-plan",
  "polars-stream",
+ "polars-time",
  "polars-utils",
  "rayon",
  "version_check",
@@ -1843,6 +1929,7 @@ dependencies = [
  "polars-io",
  "polars-ops",
  "polars-plan",
+ "polars-time",
  "polars-utils",
  "rayon",
  "recursive",
@@ -1877,9 +1964,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3eeac77f1380bc8ba40ae9a9512911697952dfd3cfa48013f98a477e7ec6771"
 dependencies = [
  "argminmax",
+ "base64",
  "bytemuck",
+ "chrono",
+ "chrono-tz",
  "either",
  "hashbrown 0.17.1",
+ "hex",
  "indexmap",
  "libm",
  "memchr",
@@ -1896,6 +1987,8 @@ dependencies = [
  "regex-syntax",
  "serde",
  "strum_macros",
+ "unicode-normalization",
+ "unicode-reverse",
  "version_check",
 ]
 
@@ -1945,6 +2038,8 @@ dependencies = [
  "blake3",
  "bytemuck",
  "bytes",
+ "chrono",
+ "chrono-tz",
  "digest-io",
  "either",
  "futures",
@@ -1968,6 +2063,7 @@ dependencies = [
  "pyo3",
  "rayon",
  "recursive",
+ "regex",
  "serde",
  "sha2",
  "slotmap",
@@ -2003,6 +2099,26 @@ dependencies = [
  "polars-utils",
  "serde",
  "version_check",
+]
+
+[[package]]
+name = "polars-sql"
+version = "0.55.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae4b287917a1c50b9fab9618c32d3ac8c4b18ef1c61aded55d065c97c921c793"
+dependencies = [
+ "bitflags",
+ "hex",
+ "polars-core",
+ "polars-error",
+ "polars-lazy",
+ "polars-ops",
+ "polars-plan",
+ "polars-time",
+ "polars-utils",
+ "regex",
+ "serde",
+ "sqlparser",
 ]
 
 [[package]]
@@ -2073,6 +2189,7 @@ dependencies = [
  "atoi_simd",
  "bytemuck",
  "chrono",
+ "chrono-tz",
  "now",
  "num-traits",
  "polars-arrow",
@@ -2343,6 +2460,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -2445,6 +2568,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2820,6 +2963,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "simd-json"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e32d7ab2678282d21e53374fbead7119b7eacbede73685dcaac472870a29a11c"
+dependencies = [
+ "ahash",
+ "halfbrown",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2861,6 +3019,28 @@ checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
+dependencies = [
+ "log",
+ "recursive",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3201,6 +3381,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-reverse"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6f4888ebc23094adfb574fdca9fdc891826287a6397d2cd28802ffd6f20c76"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3243,6 +3447,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "value-trait"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f4b4a98dfe54bc9ed3641af7ffcb837240269627dbd5cb047d13daa39736cc"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3278,6 +3494,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -3599,6 +3824,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,11 @@ extension-module = ["pyo3/extension-module"]
 pyo3 = { version = "0.29.2", features = ["abi3-py310"] }
 pyo3-polars = { version = "0.28.0", features = ["derive", "dtype-array"] }
 serde = { version = "1", features = ["derive"] }
-# `dtype-full` is a correctness requirement, at ~3.4 MiB on the installed extension (~0.9 MiB of wheel). `pyo3-polars` rebuilds the `Series`
-# inside *this* polars build before our function body runs, and a dtype this build lacks is a `panic!`
-# in `DataType::from_arrow` that crosses the `extern "C"` entry point as a non-unwinding abort. No
-# Rust-side guard can help: the body never runs. Pinned by `tests/plugin_boundary_dtype_test.py`.
+# `dtype-full` is a correctness requirement (~3.4 MiB on the installed extension, ~0.9 MiB on the
+# wheel). `pyo3-polars` rebuilds the incoming `Series` inside *this* polars build before our function
+# body runs, and a dtype this build lacks is a `panic!` in `DataType::from_arrow` that crosses the
+# `extern "C"` entry point as a non-unwinding abort. No Rust-side guard can help: the body never
+# runs. Pinned by `tests/plugin_boundary_dtype_test.py`.
 #
 # Everything in `dtype-full` is supported-or-refused, nothing outside it is. `object` crosses as
 # `BinaryView` and refuses at the cast; `dtype-extension` needs `pyarrow`, which we do not depend on.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ extension-module = ["pyo3/extension-module"]
 pyo3 = { version = "0.29.2", features = ["abi3-py310"] }
 pyo3-polars = { version = "0.28.0", features = ["derive", "dtype-array"] }
 serde = { version = "1", features = ["derive"] }
-# The narrow integer dtypes are enabled for correctness, not reach: a parameter column whose dtype
-# this polars build lacks *panics* at the plugin boundary instead of raising.
-polars = { version = "0.55.2", default-features = false, features = [
-    "dtype-i8",
-    "dtype-i16",
-    "dtype-u8",
-    "dtype-u16",
-] }
+# `dtype-full` is a correctness requirement, at ~3.4 MiB on the installed extension (~0.9 MiB of wheel). `pyo3-polars` rebuilds the `Series`
+# inside *this* polars build before our function body runs, and a dtype this build lacks is a `panic!`
+# in `DataType::from_arrow` that crosses the `extern "C"` entry point as a non-unwinding abort. No
+# Rust-side guard can help: the body never runs. Pinned by `tests/plugin_boundary_dtype_test.py`.
+#
+# Everything in `dtype-full` is supported-or-refused, nothing outside it is. `object` crosses as
+# `BinaryView` and refuses at the cast; `dtype-extension` needs `pyarrow`, which we do not depend on.
+polars = { version = "0.55.2", default-features = false, features = ["dtype-full"] }
 polars-arrow = { version = "0.55.2", default-features = false }
 # Already in polars' tree; depended on directly for `runtime::RAYON` and its rayon re-export, so the
 # multi-draw samplers parallelise on the same thread pool polars itself uses.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -76,7 +76,7 @@ polars-stats/
 
 | Crate | Purpose |
 |---|---|
-| `polars` / `polars-arrow` | Series and expression types in Rust (pinned transitively by `pyo3-polars`) |
+| `polars` / `polars-arrow` | Series and expression types in Rust (pinned transitively by `pyo3-polars`; `dtype-full` adds ~3.4 MiB to the installed extension, ~0.9 MiB to the wheel, and stops an unknown dtype aborting the interpreter at the plugin boundary) |
 | `polars-core` | `POOL` and its `rayon` re-export, so the multi-draw fill runs on the thread pool Polars itself uses |
 | `pyo3-polars` | the `#[polars_expr]` macro and FFI glue (source of ABI churn) |
 | `pyo3` | Python FFI, abi3 for forward compatibility |

--- a/docs/reference/parameters-and-contracts.md
+++ b/docs/reference/parameters-and-contracts.md
@@ -60,13 +60,28 @@ A length-1 *expression* is accepted wherever a column is and broadcasts rather t
     Computing a parameter with `.over("g")` and using it in a plain `select` is fine too; it is only putting the
     distribution expression itself inside `over()` or `agg()` that is affected.
 
-Numeric columns of any width are cast to `Float64` at evaluation, so an integer column works wherever a float is
-expected. The integer parameters are the exception: the count `n` and `DiscreteUniform`'s bounds must already hold
+Numeric columns are cast to `Float64` at evaluation, so an integer column works wherever a float is expected. That
+covers every signed and unsigned integer width up to `Int128` / `UInt128`, and `Float16` / `Float32` / `Float64`.
+`Decimal` is the one numeric dtype the two positions treat differently: it works as a *parameter*, but as an
+evaluation point it raises `InvalidOperationError`, because the null/`NaN` guard applied to the value column has no
+`NaN` to test for on a decimal.
+
+The integer parameters are the exception to the cast: the count `n` and `DiscreteUniform`'s bounds must already hold
 integers, of any integer dtype, because casting a float one would silently truncate. `n` widens to `UInt64` and the
 bounds to `Int64`, so a `UInt64` bound *value* above `i64::MAX` raises rather than wrapping. The rule is judged on the
 dtype, so a float column raises even when every value in it is null; a `Null`-dtype column
-propagates nulls like any other parameter. A non-numeric column raises at
-evaluation: Polars fails the query with `InvalidOperationError` rather than returning nulls.
+propagates nulls like any other parameter.
+
+In **evaluation-point** position every non-numeric dtype is rejected: Polars fails the query with
+`InvalidOperationError`. That covers `Boolean`, `String`, `Categorical`, `Enum`, `Struct`, `Object` and the temporal
+dtypes, plus `Decimal`. Nothing silently parses and nothing silently nulls.
+
+**Parameter** position is weaker: past the integer rule above there is no dtype check, and the Rust cast decides.
+`Categorical`, `Enum`, `Struct` and `Object` fail it and raise `ComputeError`. The rest are accepted: a `String`
+parameter is *parsed*, so `Normal(mu="mu", sigma=1.0).sample(seed=0)` on a `mu` column holding `"0.5"` draws from a
+normal centred at `0.5`, and a `Boolean`, `String` or temporal parameter carries its own dtype back out of a moment
+(`Normal(mu="mu", sigma=1.0).mean()` on a `Date` column returns `Date`). Cast a parameter to `Float64` when you mean
+a number.
 
 ## Parameter validity
 
@@ -131,7 +146,8 @@ indistinguishable from a legitimately missing input, and would propagate wrong a
 | `null` value or quantile argument on a row | per row | `null` on that row |
 | `null` parameter on a row | per row | `null` on that row, no error, except where a branch that carries no parameter already settles the answer (see below) |
 | `NaN` value or quantile argument on a row | per row | `NaN` on that row (matches scipy) |
-| Non-numeric column as an argument or parameter | evaluation | Polars raises `InvalidOperationError` |
+| Non-numeric column as an *argument* | evaluation | Polars raises `InvalidOperationError` |
+| Non-numeric column as a *parameter* | Rust evaluation, if at all | `ComputeError` for `Categorical` / `Enum` / `Struct` / `Object`; `Boolean`, `String` and the temporal dtypes are **not** rejected and compute (see [Accepted inputs](#accepted-inputs)) |
 | `q` outside `[0, 1]` in `ppf` / `isf` | per row | `null`, guaranteed for every distribution and both parameter regimes (pinned by `tests/property/ppf_domain_test.py`). `q` exactly `0` or `1` is in range and maps to a support bound |
 | `x` outside the support (e.g. `pdf` below a `Uniform`'s `min`) | per row | `0.0` (matches scipy) |
 | `pmf(3.5)` for a discrete distribution | per row | `0.0` (matches scipy) |

--- a/docs/reference/parameters-and-contracts.md
+++ b/docs/reference/parameters-and-contracts.md
@@ -79,7 +79,8 @@ dtypes, plus `Decimal`. Nothing silently parses and nothing silently nulls.
 **Parameter** position is weaker: past the integer rule above there is no dtype check, and the Rust cast decides.
 `Categorical`, `Enum`, `Struct` and `Object` fail it and raise `ComputeError`. The rest are accepted: a `String`
 parameter is *parsed*, so `Normal(mu="mu", sigma=1.0).sample(seed=0)` on a `mu` column holding `"0.5"` draws from a
-normal centred at `0.5`, and a `Boolean`, `String` or temporal parameter carries its own dtype back out of a moment
+normal centred at `0.5`, while a string that does not parse becomes a null parameter on its row and the row nulls
+with no error. A `Boolean`, `String` or temporal parameter carries its own dtype back out of a moment
 (`Normal(mu="mu", sigma=1.0).mean()` on a `Date` column returns `Date`). Cast a parameter to `Float64` when you mean
 a number.
 
@@ -147,7 +148,7 @@ indistinguishable from a legitimately missing input, and would propagate wrong a
 | `null` parameter on a row | per row | `null` on that row, no error, except where a branch that carries no parameter already settles the answer (see below) |
 | `NaN` value or quantile argument on a row | per row | `NaN` on that row (matches scipy) |
 | Non-numeric column as an *argument* | evaluation | Polars raises `InvalidOperationError` |
-| Non-numeric column as a *parameter* | Rust evaluation, if at all | `ComputeError` for `Categorical` / `Enum` / `Struct` / `Object`; `Boolean`, `String` and the temporal dtypes are **not** rejected and compute (see [Accepted inputs](#accepted-inputs)) |
+| Non-numeric column as a *parameter* | Rust evaluation, if at all | `ComputeError` for `Categorical` / `Enum` / `Struct` / `Object`; `Boolean`, `String` and the temporal dtypes are **not** rejected and compute, an unparsable `String` nulling its row (see [Accepted inputs](#accepted-inputs)) |
 | `q` outside `[0, 1]` in `ppf` / `isf` | per row | `null`, guaranteed for every distribution and both parameter regimes (pinned by `tests/property/ppf_domain_test.py`). `q` exactly `0` or `1` is in range and maps to a support bound |
 | `x` outside the support (e.g. `pdf` below a `Uniform`'s `min`) | per row | `0.0` (matches scipy) |
 | `pmf(3.5)` for a discrete distribution | per row | `0.0` (matches scipy) |

--- a/docs/reference/parameters-and-contracts.md
+++ b/docs/reference/parameters-and-contracts.md
@@ -74,7 +74,8 @@ propagates nulls like any other parameter.
 
 In **evaluation-point** position every non-numeric dtype is rejected: Polars fails the query with
 `InvalidOperationError`. That covers `Boolean`, `String`, `Categorical`, `Enum`, `Struct`, `Object` and the temporal
-dtypes, plus `Decimal`. Nothing silently parses and nothing silently nulls.
+dtypes, plus `Decimal`. Nothing silently parses and nothing silently nulls. (On polars older than 1.25, an `Object`
+column in either position raises `PanicException` from polars' own arrow export instead.)
 
 **Parameter** position is weaker: past the integer rule above there is no dtype check, and the Rust cast decides.
 `Categorical`, `Enum`, `Struct` and `Object` fail it and raise `ComputeError`. The rest are accepted: a `String`

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,6 +3,10 @@
 Tests for the distribution surface live in three places, split by what they assert.
 A new distribution adds tests by following the existing files, not by writing fixtures from scratch.
 
+One module sits outside that split: `plugin_boundary_dtype_test.py` asserts only that a dtype
+crossing the FFI boundary leaves the interpreter alive, in a subprocess per case because the abort it
+guards against would take pytest down with it. A new distribution adds nothing there.
+
 ## 1. Per-method behavioural tests: `tests/distributions/<name>/`
 
 One directory per distribution, mirroring [`distributions/bernoulli/`](distributions/bernoulli),

--- a/tests/_polars_compat.py
+++ b/tests/_polars_compat.py
@@ -14,6 +14,8 @@ reproduces its evenly spaced, inclusive-endpoint grid on every supported version
 `ARM_MASKING_HIDES_VALIDATION` gates the validation contract at a null or `NaN` evaluation point, which
 polars 1.44 breaks by masking the `propagate_null_and_nan` wrapper's arms before the plugin can validate.
 
+`available_dtypes` drops the dtypes an older supported polars has no name for.
+
 `arr_explode` wraps `Series.arr.explode`: polars 1.36 added the `empty_as_null` flag and 1.42 deprecated its
 default (a warning `filterwarnings = ["error"]` escalates), so newer polars needs the explicit kwarg while older
 supported polars does not accept it.
@@ -36,6 +38,7 @@ __all__ = (
     "PARTITIONED_BROADCAST_AVAILABLE",
     "arr_explode",
     "assert_series_equal",
+    "available_dtypes",
     "linear_space",
 )
 
@@ -86,6 +89,11 @@ the arm does not select. It does not mask the **condition**. So a validator reac
 `when(...)` condition, or one called unconditionally from inside the plugin that computes the answer,
 still does.
 """
+
+
+def available_dtypes(*names: str) -> tuple[pl.DataType, ...]:
+    """Instantiate each named dtype the installed polars has; `Int128`, `UInt128` and `Float16` postdate the floor."""
+    return tuple(dtype() for name in names if (dtype := getattr(pl, name, None)) is not None)
 
 
 def arr_explode(series: Series) -> Series:

--- a/tests/plugin_boundary_dtype_test.py
+++ b/tests/plugin_boundary_dtype_test.py
@@ -46,14 +46,19 @@ filter drops the rest.
 """
 
 _SHAPES = ("value", "parameter", "sampler")
-_REACHED_RUST = frozenset({"computed", "ComputeError"})
+_REACHED_RUST = frozenset({"computed", "ComputeError", "PanicException"})
+"""Outcomes only Rust can produce. A `PanicException` is a panic that unwound through polars' own entry
+point (polars before 1.25 raises one from its arrow export for `Object`): catchable, so not the abort we guard."""
 
 
 def _outcome(frame: pl.DataFrame, expr: pl.Expr) -> str:  # pragma: no cover
-    """`"computed"` or the exception name; any catchable error passes, an abort never returns."""
+    """`"computed"` or the exception name; any catchable error passes, an abort never returns.
+
+    `PanicException` subclasses `BaseException`, so `Exception` alone would let it end the child with exit 1.
+    """
     try:
         frame.select(r=expr)
-    except Exception as err:  # noqa: BLE001
+    except (Exception, pl.exceptions.PanicException) as err:  # noqa: BLE001
         return type(err).__name__
     return "computed"
 

--- a/tests/plugin_boundary_dtype_test.py
+++ b/tests/plugin_boundary_dtype_test.py
@@ -1,0 +1,91 @@
+"""No dtype crossing the plugin boundary may kill the interpreter.
+
+`pyo3-polars` rebuilds the incoming `Series` inside this crate's polars build before any of our Rust
+runs; a dtype that build lacks panics there, and the panic crosses an `extern "C"` entry point and
+becomes a non-unwinding abort that nothing in Python can catch. The `dtype-full` feature on the
+`polars` dependency prevents it, and this module guards that feature.
+
+Each case runs in a subprocess, because an abort would take pytest with it. The parent asserts the
+child survived, reported all three shapes, and reached Rust in at least one of them: without the
+last check a Python-side dtype guard could short-circuit every shape and pass vacuously.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from decimal import Decimal
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable
+
+import polars as pl
+import pytest
+
+import polars_stats as ps
+
+if TYPE_CHECKING:
+    from polars import Series
+
+_REPO_ROOT = Path(__file__).parent.parent
+
+_SERIES: dict[str, Callable[[], Series]] = {
+    "Int128": lambda: pl.Series("x", [1, 2], dtype=pl.Int128),
+    "UInt128": lambda: pl.Series("x", [1, 2], dtype=pl.UInt128),
+    "Float16": lambda: pl.Series("x", [1.0, 2.0], dtype=pl.Float16),
+    "Decimal": lambda: pl.Series("x", [Decimal("0.50"), Decimal("1.00")], dtype=pl.Decimal(10, 2)),
+    "Categorical": lambda: pl.Series("x", ["a", "b"], dtype=pl.Categorical),
+    "Enum": lambda: pl.Series("x", ["a", "b"], dtype=pl.Enum(["a", "b"])),
+    "Struct": lambda: pl.Series("x", [{"a": 1}, {"a": 2}], dtype=pl.Struct({"a": pl.Int64})),
+    "Date": lambda: pl.Series("x", [1, 2], dtype=pl.Int32).cast(pl.Date),
+    "Datetime": lambda: pl.Series("x", [1, 2], dtype=pl.Int64).cast(pl.Datetime("us")),
+    "Duration": lambda: pl.Series("x", [1, 2], dtype=pl.Int64).cast(pl.Duration("us")),
+    "Time": lambda: pl.Series("x", [1, 2], dtype=pl.Int64).cast(pl.Time),
+    "Object": lambda: pl.Series("x", [object(), object()], dtype=pl.Object),
+}
+"""The first seven abort without `dtype-full`; the temporal dtypes and `Object` are live on every build.
+
+Constructors are deferred so a dtype the installed polars predates costs a skip, not a collection error.
+"""
+
+_SHAPES = ("value", "parameter", "sampler")
+_REACHED_RUST = frozenset({"computed", "ComputeError"})
+
+
+def _outcome(frame: pl.DataFrame, expr: pl.Expr) -> str:
+    """`"computed"`, or the exception name: any catchable error is a pass, an abort is not catchable."""
+    try:
+        frame.select(r=expr)
+    except Exception as err:  # noqa: BLE001
+        return type(err).__name__
+    return "computed"
+
+
+def probe(dtype_name: str) -> None:
+    """Cross the boundary in all three shapes for one dtype, printing each outcome. Runs in the child."""
+    frame = _SERIES[dtype_name]().to_frame()
+    exprs = (
+        ps.Normal(0.0, 1.0).pdf(pl.col("x")),
+        ps.Normal(mu=pl.col("x"), sigma=1.0).mean(),
+        ps.Normal(mu=pl.col("x"), sigma=1.0).sample(seed=0),
+    )
+    for shape, expr in zip(_SHAPES, exprs, strict=True):
+        print(shape, _outcome(frame, expr))  # noqa: T201
+
+
+@pytest.mark.parametrize("dtype_name", [name for name in _SERIES if hasattr(pl, name)], ids=str)
+def test_plugin_boundary_does_not_abort(dtype_name: str) -> None:
+    """The child survives all three crossings, and at least one of them reaches Rust."""
+    proc = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", f"from {__name__} import probe; probe({dtype_name!r})"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    diagnosis = "aborted at the plugin boundary" if proc.returncode < 0 else "failed before the boundary"
+    assert proc.returncode == 0, f"{dtype_name} {diagnosis} (exit {proc.returncode})\n{proc.stdout}{proc.stderr[-400:]}"
+
+    outcomes = dict(line.split() for line in proc.stdout.splitlines())
+    assert tuple(outcomes) == _SHAPES, f"{dtype_name} reported {tuple(outcomes)}, expected {_SHAPES}"
+    assert _REACHED_RUST & set(outcomes.values()), f"{dtype_name} never reached Rust: {outcomes}"

--- a/tests/plugin_boundary_dtype_test.py
+++ b/tests/plugin_boundary_dtype_test.py
@@ -1,13 +1,13 @@
 """No dtype crossing the plugin boundary may kill the interpreter.
 
-`pyo3-polars` rebuilds the incoming `Series` inside this crate's polars build before any of our Rust
-runs; a dtype that build lacks panics there, and the panic crosses an `extern "C"` entry point and
-becomes a non-unwinding abort that nothing in Python can catch. The `dtype-full` feature on the
-`polars` dependency prevents it, and this module guards that feature.
+`pyo3-polars` rebuilds the incoming `Series` inside this crate's polars build before our Rust runs. A
+dtype that build lacks panics there, and the panic crosses the `extern "C"` entry point as an abort
+nothing in Python can catch. The `dtype-full` feature on the `polars` dependency prevents it; this
+module pins that feature.
 
-Each case runs in a subprocess, because an abort would take pytest with it. The parent asserts the
-child survived, reported all three shapes, and reached Rust in at least one of them: without the
-last check a Python-side dtype guard could short-circuit every shape and pass vacuously.
+Each case runs in a subprocess because an abort would take pytest down with it. The parent checks
+that the child survived, reported all three shapes, and reached Rust in at least one of them:
+without the last check a Python-side dtype guard could pass every shape vacuously.
 """
 
 from __future__ import annotations
@@ -15,7 +15,6 @@ from __future__ import annotations
 import subprocess
 import sys
 from decimal import Decimal
-from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
 import polars as pl
@@ -25,8 +24,6 @@ import polars_stats as ps
 
 if TYPE_CHECKING:
     from polars import Series
-
-_REPO_ROOT = Path(__file__).parent.parent
 
 _SERIES: dict[str, Callable[[], Series]] = {
     "Int128": lambda: pl.Series("x", [1, 2], dtype=pl.Int128),
@@ -42,17 +39,18 @@ _SERIES: dict[str, Callable[[], Series]] = {
     "Time": lambda: pl.Series("x", [1, 2], dtype=pl.Int64).cast(pl.Time),
     "Object": lambda: pl.Series("x", [object(), object()], dtype=pl.Object),
 }
-"""The first seven abort without `dtype-full`; the temporal dtypes and `Object` are live on every build.
+"""The first seven abort without `dtype-full`; the temporal dtypes and `Object` never did.
 
-Constructors are deferred so a dtype the installed polars predates costs a skip, not a collection error.
+Deferred so `pl.Int128` and friends are only touched on a polars that has them; the parametrize
+filter drops the rest.
 """
 
 _SHAPES = ("value", "parameter", "sampler")
 _REACHED_RUST = frozenset({"computed", "ComputeError"})
 
 
-def _outcome(frame: pl.DataFrame, expr: pl.Expr) -> str:
-    """`"computed"`, or the exception name: any catchable error is a pass, an abort is not catchable."""
+def _outcome(frame: pl.DataFrame, expr: pl.Expr) -> str:  # pragma: no cover
+    """`"computed"` or the exception name; any catchable error passes, an abort never returns."""
     try:
         frame.select(r=expr)
     except Exception as err:  # noqa: BLE001
@@ -60,8 +58,8 @@ def _outcome(frame: pl.DataFrame, expr: pl.Expr) -> str:
     return "computed"
 
 
-def probe(dtype_name: str) -> None:
-    """Cross the boundary in all three shapes for one dtype, printing each outcome. Runs in the child."""
+def probe(dtype_name: str) -> None:  # pragma: no cover
+    """Cross the boundary in all three shapes for one dtype, printing one `<shape> <outcome>` line each."""
     frame = _SERIES[dtype_name]().to_frame()
     exprs = (
         ps.Normal(0.0, 1.0).pdf(pl.col("x")),
@@ -74,10 +72,10 @@ def probe(dtype_name: str) -> None:
 
 @pytest.mark.parametrize("dtype_name", [name for name in _SERIES if hasattr(pl, name)], ids=str)
 def test_plugin_boundary_does_not_abort(dtype_name: str) -> None:
-    """The child survives all three crossings, and at least one of them reaches Rust."""
+    # Run this file as a script: `sys.path[0]` is then `tests/`, not the repo root, so `polars_stats`
+    # resolves to the installed build and not to the `.so`-less source tree CI checks out.
     proc = subprocess.run(  # noqa: S603
-        [sys.executable, "-c", f"from {__name__} import probe; probe({dtype_name!r})"],
-        cwd=_REPO_ROOT,
+        [sys.executable, __file__, dtype_name],
         capture_output=True,
         text=True,
         timeout=60,
@@ -86,6 +84,10 @@ def test_plugin_boundary_does_not_abort(dtype_name: str) -> None:
     diagnosis = "aborted at the plugin boundary" if proc.returncode < 0 else "failed before the boundary"
     assert proc.returncode == 0, f"{dtype_name} {diagnosis} (exit {proc.returncode})\n{proc.stdout}{proc.stderr[-400:]}"
 
-    outcomes = dict(line.split() for line in proc.stdout.splitlines())
+    outcomes = dict(line.split() for line in proc.stdout.splitlines() if line.startswith(_SHAPES))
     assert tuple(outcomes) == _SHAPES, f"{dtype_name} reported {tuple(outcomes)}, expected {_SHAPES}"
     assert _REACHED_RUST & set(outcomes.values()), f"{dtype_name} never reached Rust: {outcomes}"
+
+
+if __name__ == "__main__":
+    probe(sys.argv[1])

--- a/tests/property/value_dtype_test.py
+++ b/tests/property/value_dtype_test.py
@@ -1,4 +1,4 @@
-"""Value-keyed methods accept integer-typed evaluation points; non-numeric dtypes fail fast.
+"""Value-keyed methods accept narrow numeric evaluation points; non-numeric dtypes fail fast.
 
 `propagate_null_and_nan` in `_base.py` applies `is_nan` to the coerced value expression as-is,
 with no `Float64` cast. That relies on two polars behaviours, both verified on every supported
@@ -8,17 +8,20 @@ version (1.15.0 through current) and pinned here so a regression in either direc
   integer-typed value column, or the integer literal a scalar like `cdf(0)` coerces to,
   flows through the guard and must evaluate exactly as its `Float64`-cast equivalent. The Rust
   plugins cast the evaluation point to `Float64` internally; the closed-form hooks combine it
-  under polars supertype rules; both are exact for the integer grids used here.
+  under polars supertype rules; both are exact for the grids used here.
 * `is_nan` raises `InvalidOperationError` for non-numeric dtypes (`Boolean`, `String`, temporal),
   so an invalid value column is rejected up front, before any hook or plugin sees it. This is the
   strict half of the contract: a numeric `String` column must not silently parse through the
   statrs-backed paths (both a Python-side `cast` and the plugin's internal Rust cast would
   otherwise accept it).
+
+Whether a dtype reaches either half at all is `tests/plugin_boundary_dtype_test.py`'s question.
 """
 
 from __future__ import annotations
 
 import math
+from decimal import Decimal
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -28,15 +31,15 @@ from hypothesis import strategies as st
 
 from polars_stats import Normal, Uniform
 from polars_stats.distributions._base import ContinuousDistribution, DiscreteDistribution
-from tests._polars_compat import assert_series_equal
+from tests._polars_compat import assert_series_equal, available_dtypes
 from tests.property._specs import ALL_SPECS
 
 if TYPE_CHECKING:
     from polars_stats.distributions._base import _UnivariateDistribution
     from tests.property._specs import DistSpec
 
-_INT_DTYPES = (pl.Int64(), pl.UInt32())
-"""One signed and one unsigned integer dtype; the guard and the hooks are dtype-generic past that."""
+_VALUE_DTYPES = (pl.Int64(), pl.UInt32(), pl.Float32(), *available_dtypes("Int128", "UInt128", "Float16"))
+"""`Int64` and `UInt32` cover the contract; `Int128`, `UInt128` and `Float16` each need a polars build feature."""
 
 _MAX_GRID = 16
 
@@ -48,7 +51,7 @@ def _int_grid(lo: float, hi: float, dtype: pl.DataType) -> list[int | None]:
     negative part of a signed evaluation range.
     """
     lo_i, hi_i = math.floor(lo), math.ceil(hi)
-    if dtype in (pl.UInt8(), pl.UInt16(), pl.UInt32(), pl.UInt64()):
+    if dtype.is_unsigned_integer():
         lo_i = max(lo_i, 0)
         hi_i = max(hi_i, lo_i)
     step = max(1, (hi_i - lo_i) // _MAX_GRID)
@@ -65,20 +68,21 @@ def _log_density(dist: _UnivariateDistribution, value: pl.Expr) -> pl.Expr:
     raise TypeError(msg)  # pragma: no cover
 
 
-@pytest.mark.parametrize("dtype", _INT_DTYPES, ids=str)
+@pytest.mark.parametrize("dtype", _VALUE_DTYPES, ids=str)
 @pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
 @given(data=st.data())
-def test_integer_value_column_matches_float64(spec: DistSpec, dtype: pl.DataType, data: st.DataObject) -> None:
-    """Every value-keyed method evaluates an integer value column exactly as its `Float64` cast.
+def test_narrow_value_column_matches_float64(spec: DistSpec, dtype: pl.DataType, data: st.DataObject) -> None:
+    """Every value-keyed method evaluates a narrow value column exactly as its `Float64` cast, nulls included.
 
-    A null in the integer column must also propagate identically (the guard's null branch is
-    dtype-agnostic, but this pins it on the integer path specifically).
+    Every grid value is exactly representable in every dtype here, so a mismatch means a misread
+    buffer, not a hook doing its arithmetic at the column's width.
     """
     params = data.draw(spec.params)
     dist = spec.make(params)
     lo, hi = spec.eval_range(params)
-    values = pl.DataFrame({"x": _int_grid(lo, hi, dtype)}, schema={"x": dtype})
-    quantiles = pl.DataFrame({"q": [0, 1, None]}, schema={"q": dtype})
+    values = pl.Series("x", _int_grid(lo, hi, dtype)).cast(dtype).to_frame()
+    q_grid = [0, 1, None] if dtype.is_integer() else [0.0, 0.25, 0.5, 0.75, 1.0, None]
+    quantiles = pl.Series("q", q_grid).cast(dtype).to_frame()
 
     x, q = pl.col("x"), pl.col("q")
     cases = [
@@ -91,10 +95,8 @@ def test_integer_value_column_matches_float64(spec: DistSpec, dtype: pl.DataType
         (quantiles, dist.ppf(q), dist.ppf(q.cast(pl.Float64()))),
         (quantiles, dist.isf(q), dist.isf(q.cast(pl.Float64()))),
     ]
-    for frame, int_expr, float_expr in cases:
-        as_int = frame.select(r=int_expr)["r"]
-        as_float = frame.select(r=float_expr)["r"]
-        assert_series_equal(as_int, as_float, check_exact=True)
+    for frame, narrow_expr, wide_expr in cases:
+        assert_series_equal(frame.select(r=narrow_expr)["r"], frame.select(r=wide_expr)["r"], check_exact=True)
 
 
 @pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
@@ -111,18 +113,29 @@ def test_integer_scalar_value_matches_float_scalar(spec: DistSpec, data: st.Data
     assert_series_equal(frame.select(r=dist.cdf(1))["r"], frame.select(r=dist.cdf(1.0))["r"], check_exact=True)
 
 
+_REFUSED_VALUES = (
+    pl.Series("x", [True, False]),
+    pl.Series("x", ["0.5", "1.0"]),
+    pl.Series("x", [Decimal("0.50"), Decimal("1.00")], dtype=pl.Decimal(10, 2)),
+    pl.Series("x", ["a", "b"], dtype=pl.Categorical),
+    pl.Series("x", ["a", "b"], dtype=pl.Enum(["a", "b"])),
+    pl.Series("x", [{"a": 1}, {"a": 2}], dtype=pl.Struct({"a": pl.Int64})),
+    pl.Series("x", [1, 2], dtype=pl.Int32).cast(pl.Date),
+    pl.Series("x", [1, 2], dtype=pl.Int64).cast(pl.Datetime("us")),
+    pl.Series("x", [1, 2], dtype=pl.Int64).cast(pl.Duration("us")),
+    pl.Series("x", [1, 2], dtype=pl.Int64).cast(pl.Time),
+)
+"""Every dtype an evaluation point may not be. `Decimal` is numeric but `is_nan` has no `NaN` to test on it."""
+
+
 @pytest.mark.parametrize(
     "dist",
     [Normal(mu=0.0, sigma=1.0), Uniform(min=0.0, max=1.0)],
     ids=["normal", "uniform"],
 )
-@pytest.mark.parametrize(
-    "series",
-    [pl.Series("x", [True, False]), pl.Series("x", ["0.5", "1.0"])],
-    ids=["boolean", "string"],
-)
+@pytest.mark.parametrize("series", _REFUSED_VALUES, ids=lambda s: str(s.dtype))
 def test_non_numeric_value_column_raises(dist: _UnivariateDistribution, series: pl.Series) -> None:
-    """A `Boolean` or `String` value column is rejected up front, plugin-backed or closed-form alike.
+    """A non-numeric value column is rejected up front, plugin-backed or closed-form alike.
 
     Only the exception type is pinned, not the message: whether the guard's `is_nan` or a hook
     operation (e.g. `Uniform`'s division on a `String`) resolves first is a polars
@@ -131,3 +144,33 @@ def test_non_numeric_value_column_raises(dist: _UnivariateDistribution, series: 
     """
     with pytest.raises(pl.exceptions.InvalidOperationError):
         series.to_frame().select(dist.cdf(pl.col("x")))
+
+
+_REFUSED_PARAMETERS = (
+    pl.Series("mu", ["a", "b"], dtype=pl.Categorical),
+    pl.Series("mu", ["a", "b"], dtype=pl.Enum(["a", "b"])),
+    pl.Series("mu", [{"a": 1}, {"a": 2}], dtype=pl.Struct({"a": pl.Int64})),
+)
+"""Parameter dtypes the Rust cast refuses; `Boolean`, `String` and the temporal dtypes survive it and compute."""
+
+
+@pytest.mark.parametrize("series", _REFUSED_PARAMETERS, ids=lambda s: str(s.dtype))
+@pytest.mark.parametrize("method", ["mean", "sample"], ids=str)
+def test_refused_parameter_column_raises_from_the_plugin(series: pl.Series, method: str) -> None:
+    """A refused *parameter* raises `ComputeError` from Rust: no Python-side guard sees a parameter column."""
+    dist = Normal(mu="mu", sigma=1.0)
+    expr = dist.mean() if method == "mean" else dist.sample(seed=0)
+    with pytest.raises(pl.exceptions.ComputeError):
+        series.to_frame().select(r=expr)
+
+
+@pytest.mark.parametrize("dtype", [*available_dtypes("Int128", "UInt128", "Float16"), pl.Decimal(10, 2)], ids=str)
+def test_feature_gated_parameter_column_computes(dtype: pl.DataType) -> None:
+    """A parameter column in a build-feature-gated dtype reaches Rust with its value intact.
+
+    `cdf`, not a moment: a moment returns the parameter column itself and never reads its value.
+    """
+    frame = pl.Series("mu", [1, 2], dtype=pl.Int64()).cast(dtype).to_frame()
+    narrow = frame.select(r=Normal(mu="mu", sigma=1.0).cdf(0.0))["r"]
+    wide = frame.select(r=Normal(mu=pl.col("mu").cast(pl.Float64()), sigma=1.0).cdf(0.0))["r"]
+    assert_series_equal(narrow, wide, check_exact=True)

--- a/tests/property/value_dtype_test.py
+++ b/tests/property/value_dtype_test.py
@@ -74,8 +74,8 @@ def _log_density(dist: _UnivariateDistribution, value: pl.Expr) -> pl.Expr:
 def test_narrow_value_column_matches_float64(spec: DistSpec, dtype: pl.DataType, data: st.DataObject) -> None:
     """Every value-keyed method evaluates a narrow value column exactly as its `Float64` cast, nulls included.
 
-    Every grid value is exactly representable in every dtype here, so a mismatch means a misread
-    buffer, not a hook doing its arithmetic at the column's width.
+    Every grid value is exactly representable in every dtype here, so a mismatch is a misread buffer,
+    not a hook computing at the column's width.
     """
     params = data.draw(spec.params)
     dist = spec.make(params)


### PR DESCRIPTION
An Int128, UInt128, Float16, Decimal, Categorical, Enum or Struct column reaching any plugin killed the whole Python process with SIGABRT: pyo3-polars rebuilds the Series inside our polars build, and a dtype that build lacks panics before our code runs. Replacing the four narrow-int features with dtype-full turns every case into a computed value or a catchable error (+3.4 MiB on the installed .so). A subprocess-based test guards the build flag, the in-process dtype matrix now covers the 128-bit and Float16 widths and parameter position, and the docs state what each position actually accepts.

