### PR TITLE
fix(validation): validate every present parameter over the whole column, finiteness included

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -137,7 +137,7 @@ code rather than halfway through, write the scipy-parity test first, and keep a 
       invalid-parameter error contract in one place. The per-row `<name>_sample` / `<name>_samples` (multi-draw,
       backing `samples`) take the parameter columns plus a row index as the last input: `<name>_sample` calls
       `sample_per_row_binary` (one parameter column) or `sample_per_row_ternary` (two), passing a `build` that
-      validates and constructs the row's draw state; `<name>_samples` feeds `binary_param_rows` /
+      constructs the row's draw state; `<name>_samples` feeds `binary_param_rows` /
       `ternary_param_rows` into `samples_per_row`. The constant-parameter fast paths `<name>_sample_scalar` /
       `<name>_samples_scalar` are shells over `sample_by_index` / `samples_by_index`, taking
       `SampleScalarKwargs<<Name>ParamsKwargs>` / `SamplesScalarKwargs<<Name>ParamsKwargs>` so the parameters are
@@ -190,8 +190,13 @@ code rather than halfway through, write the scipy-parity test first, and keep a 
           null input: a null parameter has to reach `derive` as `None` so the branches whose answer carries no
           parameter still
           answer (`Bernoulli.pmf(2) = 0`, `Exponential.cdf(-1) = 0`, `Uniform.pdf` above a known `max`).
-    * Factor the validating constructor into a `build_dist(...) -> PolarsResult<Dist>` helper so an invalid parameter
-      maps through a `ComputeError` consistently.
+    * State each parameter's domain once as a `ParamDomain` constant (`ParamDomain::finite("mu")`,
+      `ParamDomain::positive("sigma")`, `ParamDomain::probability("p")`, or a literal for any other rule) and a joint
+      constraint as a `PairDomain`. Every column-parameter plugin runs `check_column` / `check_columns` over its
+      parameter columns before its row loop, and every `<Name>ParamsKwargs::build` runs `check` once, so an invalid
+      parameter raises the same `ComputeError` in both regimes whatever else its row holds. Keep a
+      `build_dist(...) -> PolarsResult<Dist>` around the `statrs` constructor for the row loops; behind the pass it
+      cannot fail.
 2. **Python.** Add `polars_stats/distributions/_<name>.py`, subclassing `ContinuousDistribution` or
    `DiscreteDistribution`. In `__init__`, coerce each parameter with `coerce_param` / `coerce_n` (types only, **never
    validate values** at construction, let invalid values raise in Rust) and store the fast-path bundle
@@ -206,11 +211,9 @@ code rather than halfway through, write the scipy-parity test first, and keep a 
       statrs-backed method, return `self._value_plugin("<name>_<method>", value)`: the base routes constant parameters
       to the `_scalar` fast path and column parameters to the per-row plugin.
     * A validating plugin returning a reused quantity that raises on invalid parameters and nulls on a null one (e.g.
-      `uniform_range` returns `max - min`). Write it as a `#[polars_expr]` shell over the generic
-      `validate_params_binary` / `validate_params_unary` drivers in `src/distributions/mod.rs`: cast each input,
-      take its accessor (`.f64()` / `.u64()`, so the two parameter dtypes may differ as Binomial's `(n, p)` does),
-      and pass a closure that calls `build_dist` and returns the quantity to emit. Keep that closure a generic
-      `F: Fn` so it monomorphises into the row loop. These drivers take no output name: polars resolves an
+      `uniform_range` returns `max - min`). Cast each input, run the domain pass, then return the quantity: the
+      checked column itself for one parameter (`bernoulli_proba`), or a `binary_elementwise` over both columns that
+      nulls where either is null (`normal_sigma`, `uniform_range`). It takes no output name: polars resolves an
       expression's output name from its first input, so the column follows `inputs[0]` whatever the plugin calls
       its `Series`. For a statrs-backed
       distribution whose moment formulas may omit a parameter, expose the validator as `_checked_params` and gate

--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -86,8 +86,8 @@ serves distributions needing a single uniform per draw, so it is deliberately no
 
 `sample` ships a second plugin, `<name>_sample_scalar`, used when every parameter is a Python scalar. The general
 sampler is built for the differentiator (column-valued parameters), but it makes the common constant-parameter case pay
-for machinery it does not use: each scalar is broadcast to a full-length column, marshalled across FFI, and
-re-validated on every row, and the distribution is rebuilt per row. For a cheap draw (uniform is one multiply-add) that
+for machinery it does not use: each scalar is broadcast to a full-length column, marshalled across FFI, checked
+over the whole column, and the distribution is rebuilt per row. For a cheap draw (uniform is one multiply-add) that
 fixed overhead dominates the draw itself.
 
 The fast path passes the constant parameters in `kwargs`, validates and builds the distribution once, and sends only the
@@ -105,8 +105,8 @@ The moments (`mean`, `variance`, `std`, `entropy`) do not build a distribution; 
 they still route their *validation* through a small Rust plugin (`normal_sigma`, `uniform_range`, `bernoulli_proba`,
 `binomial_params`, `lognormal_sigma`, `exponential_rate`, `geometric_p`, `beta_params`) so an invalid parameterisation
 raises the same `ComputeError` as the sampler and value-keyed methods rather than silently producing a nonsense moment
-(see "Invalid parameters raise"). With column parameters that plugin runs over the parameter columns, validating each
-row.
+(see "Invalid parameters raise"). With column parameters that plugin checks each parameter column once, over the
+whole column, before any row is built.
 
 For all-scalar parameters the same plugin is called on length-1 `pl.lit` inputs, so its elementwise closure runs once.
 The validated quantity (or, for `Beta.entropy` and `Binomial.entropy`, the entropy itself) is returned behind a
@@ -143,13 +143,15 @@ does not go through `statrs`; every value-keyed method (`pmf`, `cdf`, `ppf`, ...
 
 ### Invalid parameters raise, they never silently null
 
-An invalid parameter value, scalar or one bad column row (`sigma <= 0`, `max <= min`, `p` outside `[0, 1]`, a
-non-finite bound), maps the `statrs` constructor error through a `ComputeError` and fails the whole evaluation.
+An invalid parameter value, scalar or one bad column row (`sigma <= 0`, `max <= min`, `p` outside `[0, 1]`, any
+non-finite parameter), raises `ComputeError` from the library's own domain check and fails the whole evaluation. The
+check runs over each parameter column before any row is built, so a null sibling parameter on the same row does not
+hide it.
 
 This reverses an earlier "produce null, keep the pipeline running" decision. Silently nulling hides a modelling error: a
 user who does not check for nulls gets wrong answers downstream, and an invalid-parameter null is indistinguishable from
 a legitimately-null input. Raising is loud, uniform across distributions, and uniform across scalar vs column inputs,
-because scalars are coerced to columns and validated per row exactly like columns. Construction rejects only wrong
+because a scalar and a column pass through the same domain check. Construction rejects only wrong
 *types*. A closed-form distribution cannot raise from a bare `pl.Expr`, so it routes parameters through one small
 validating plugin (see [Architecture / Plugin granularity](architecture.md#plugin-granularity)).
 

--- a/docs/how-to/nulls-and-errors.md
+++ b/docs/how-to/nulls-and-errors.md
@@ -83,8 +83,8 @@ except pl.exceptions.ComputeError as exc:
     print(str(exc).splitlines()[0])
 ```
 
-Scalar parameters are validated once and column parameters per row, but a bad scalar and a bad column row surface the
-same way:
+A scalar parameter is checked once and a column parameter over the whole column before any row computes, and a bad
+scalar and a bad column row surface the same way:
 
 ```python exec="yes" source="above" session="nulls-and-errors" result="python"
 try:

--- a/docs/reference/parameters-and-contracts.md
+++ b/docs/reference/parameters-and-contracts.md
@@ -104,7 +104,8 @@ may hold any count its dtype can, up to `UInt64`.
 | `DiscreteUniform(min, max)` | `min <= max`, both inclusive | `max - min + 1` fits `Int64` |
 | `Geometric(p)` | `0 < p <= 1` | `p = 0` rejected, unlike `Bernoulli` |
 
-A violation raises `ComputeError` and fails the whole evaluation. See
+A violation raises `ComputeError` and fails the whole evaluation. The check runs over each parameter column before
+any row computes, so an invalid value raises even on a row whose other parameter is null. See
 [nulls, NaNs and errors](#nulls-nans-and-errors) below.
 
 ## Sampling

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -5,6 +5,7 @@ use statrs::distribution::Bernoulli;
 
 use crate::distributions::{
     align_inputs, validate_params_unary, value_keyed_derived_per_row, value_keyed_derived_scalar,
+    ParamDomain,
 };
 use crate::rng::{
     binary_param_rows, sample_by_index, sample_per_row_binary, samples_bool_output,
@@ -12,6 +13,14 @@ use crate::rng::{
     SamplesScalarKwargs,
 };
 
+/// `p` alone: finite, in `[0, 1]`.
+const P: ParamDomain = ParamDomain {
+    name: "p",
+    domain: "in [0, 1]",
+    accepts: |p| p.is_finite() && (0.0..=1.0).contains(&p),
+};
+
+/// Construct a `statrs::Bernoulli` behind [`P`], as the row loops' backstop.
 fn build_dist(proba: f64) -> PolarsResult<Bernoulli> {
     Bernoulli::new(proba).map_err(|e| {
         PolarsError::InvalidOperation(format!("p must be in [0, 1], got {proba}: {e}").into())
@@ -26,10 +35,11 @@ struct BernoulliParamsKwargs {
 
 impl BernoulliParamsKwargs {
     fn build(&self) -> PolarsResult<Bernoulli> {
+        P.check(self.p)?;
         build_dist(self.p)
     }
 
-    /// Binds the constant parameter and `build_dist` into [`value_keyed_derived_scalar`], which
+    /// Binds the constant parameter and its domain into [`value_keyed_derived_scalar`], which
     /// validates and derives once per call rather than per row.
     fn value_keyed<Branches>(
         &self,
@@ -37,12 +47,12 @@ impl BernoulliParamsKwargs {
         derive: impl Fn(Option<f64>) -> Branches,
         select: impl Fn(&Branches, f64) -> Option<f64>,
     ) -> PolarsResult<Series> {
-        value_keyed_derived_scalar(value, self.p, build_dist, derive, select)
+        value_keyed_derived_scalar(value, self.p, &P, derive, select)
     }
 }
 
 /// Element-wise validation of the success probability: returns `p` unchanged, raising
-/// `InvalidOperation` if `p` is outside `[0, 1]`. `null` propagates.
+/// `ComputeError` if `p` is outside `[0, 1]`. `null` propagates.
 ///
 /// The moments derive from this so they report an invalid `p` consistently with `bernoulli_sample`,
 /// instead of silently computing a negative variance. The value-keyed methods validate inside their
@@ -50,6 +60,7 @@ impl BernoulliParamsKwargs {
 #[polars_expr(output_type=Float64)]
 fn bernoulli_proba(inputs: &[Series]) -> PolarsResult<Series> {
     let proba = inputs[0].cast(&DataType::Float64)?;
+    P.check_column(proba.f64()?)?;
 
     validate_params_unary(proba.f64()?, |proba| {
         build_dist(proba)?;
@@ -228,49 +239,49 @@ fn isf_at(p: &Option<f64>, quantile: f64) -> Option<f64> {
 /// See [`value_keyed_derived_per_row`] for the null/error contract.
 #[polars_expr(output_type=Float64)]
 fn bernoulli_pmf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, Mass::pmf, Mass::at)
+    value_keyed_derived_per_row(inputs, &P, Mass::pmf, Mass::at)
 }
 
 /// Element-wise log-pmf; see [`Mass::ln_pmf`] for the `ln_1p` reason.
 #[polars_expr(output_type=Float64)]
 fn bernoulli_ln_pmf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, Mass::ln_pmf, Mass::at)
+    value_keyed_derived_per_row(inputs, &P, Mass::ln_pmf, Mass::at)
 }
 
 /// Element-wise cdf `P(X <= value)`; see [`Steps::cdf`].
 #[polars_expr(output_type=Float64)]
 fn bernoulli_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, Steps::cdf, Steps::at)
+    value_keyed_derived_per_row(inputs, &P, Steps::cdf, Steps::at)
 }
 
 /// Element-wise log-cdf; see [`Steps::ln_cdf`].
 #[polars_expr(output_type=Float64)]
 fn bernoulli_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, Steps::ln_cdf, Steps::at)
+    value_keyed_derived_per_row(inputs, &P, Steps::ln_cdf, Steps::at)
 }
 
 /// Element-wise survival function `P(X > value)`; see [`Steps::sf`] for why it is not `1 - cdf`.
 #[polars_expr(output_type=Float64)]
 fn bernoulli_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, Steps::sf, Steps::at)
+    value_keyed_derived_per_row(inputs, &P, Steps::sf, Steps::at)
 }
 
 /// Element-wise log-sf; see [`Steps::ln_sf`].
 #[polars_expr(output_type=Float64)]
 fn bernoulli_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, Steps::ln_sf, Steps::at)
+    value_keyed_derived_per_row(inputs, &P, Steps::ln_sf, Steps::at)
 }
 
 /// Element-wise ppf (inverse cdf), returning the support point as `f64`; see [`PpfCutoffs::at`].
 #[polars_expr(output_type=Float64)]
 fn bernoulli_ppf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, PpfCutoffs::derive, PpfCutoffs::at)
+    value_keyed_derived_per_row(inputs, &P, PpfCutoffs::derive, PpfCutoffs::at)
 }
 
 /// Element-wise inverse survival function; see [`isf_at`] for why it never forms a complement.
 #[polars_expr(output_type=Float64)]
 fn bernoulli_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, isf_proba, isf_at)
+    value_keyed_derived_per_row(inputs, &P, isf_proba, isf_at)
 }
 
 /// Constant-parameter fast path for [`bernoulli_pmf`].
@@ -349,6 +360,7 @@ fn bernoulli_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Ser
     let proba = inputs[0].cast(&DataType::Float64)?;
     let index = inputs[1].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
+    P.check_column(proba.f64()?)?;
 
     sample_per_row_binary(
         name,
@@ -399,6 +411,7 @@ fn bernoulli_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<S
     let proba = inputs[0].cast(&DataType::Float64)?;
     let index = inputs[1].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
+    P.check_column(proba.f64()?)?;
 
     let rows = binary_param_rows(proba.f64()?, index.u64()?, build_dist);
 

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -4,8 +4,7 @@ use rand::distr::Distribution;
 use statrs::distribution::Bernoulli;
 
 use crate::distributions::{
-    align_inputs, validate_params_unary, value_keyed_derived_per_row, value_keyed_derived_scalar,
-    ParamDomain,
+    align_inputs, value_keyed_derived_per_row, value_keyed_derived_scalar, ParamDomain,
 };
 use crate::rng::{
     binary_param_rows, sample_by_index, sample_per_row_binary, samples_bool_output,
@@ -13,18 +12,11 @@ use crate::rng::{
     SamplesScalarKwargs,
 };
 
-/// `p` alone: finite, in `[0, 1]`.
-const P: ParamDomain = ParamDomain {
-    name: "p",
-    domain: "in [0, 1]",
-    accepts: |p| p.is_finite() && (0.0..=1.0).contains(&p),
-};
+const P: ParamDomain = ParamDomain::probability("p");
 
-/// Construct a `statrs::Bernoulli` behind [`P`], as the row loops' backstop.
+/// Cannot fail behind [`P`]'s pass; the `statrs` error is kept as the backstop.
 fn build_dist(proba: f64) -> PolarsResult<Bernoulli> {
-    Bernoulli::new(proba).map_err(|e| {
-        PolarsError::InvalidOperation(format!("p must be in [0, 1], got {proba}: {e}").into())
-    })
+    Bernoulli::new(proba).map_err(|e| polars_err!(ComputeError: "{e}"))
 }
 
 /// Bernoulli's constant success probability, deserialised once per call.
@@ -51,21 +43,13 @@ impl BernoulliParamsKwargs {
     }
 }
 
-/// Element-wise validation of the success probability: returns `p` unchanged, raising
-/// `ComputeError` if `p` is outside `[0, 1]`. `null` propagates.
-///
-/// The moments derive from this so they report an invalid `p` consistently with `bernoulli_sample`,
-/// instead of silently computing a negative variance. The value-keyed methods validate inside their
-/// own plugin instead.
+/// `p` unchanged after [`P`]'s column pass, `null` included. The moments derive from this so an
+/// invalid `p` raises as it does from `bernoulli_sample`, instead of computing a negative variance.
 #[polars_expr(output_type=Float64)]
 fn bernoulli_proba(inputs: &[Series]) -> PolarsResult<Series> {
     let proba = inputs[0].cast(&DataType::Float64)?;
     P.check_column(proba.f64()?)?;
-
-    validate_params_unary(proba.f64()?, |proba| {
-        build_dist(proba)?;
-        Ok(proba)
-    })
+    Ok(proba)
 }
 
 // Per-method bodies, shared by the per-row plugins and their `*_scalar` twins. Each method pairs a
@@ -352,7 +336,7 @@ fn draw(dist: &Bernoulli, rng: &mut impl rand::Rng) -> bool {
 
 /// Element-wise Bernoulli sampler over `(p, row_index)`, returning `Boolean`.
 ///
-/// Per row, `null` propagates and an invalid `p` raises via [`build_dist`]. Seeding and
+/// Per row, `null` propagates; an invalid `p` raises from [`P`]'s column pass first. Seeding and
 /// chunk-invariance follow [`sample_per_row_binary`].
 #[polars_expr(output_type=Boolean)]
 fn bernoulli_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -1,45 +1,27 @@
+use polars::prelude::arity::{binary_elementwise, try_binary_elementwise};
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::{Beta, Continuous, ContinuousCDF};
 use statrs::statistics::Distribution as StatrsDistribution;
 
-use crate::distributions::{
-    align_inputs, validate_params_binary, value_keyed_per_row, value_keyed_scalar, ParamDomain,
-};
+use crate::distributions::{align_inputs, value_keyed_per_row, value_keyed_scalar, ParamDomain};
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
-/// Construct a `statrs::Beta` behind [`A`] and [`B`], as the row loops' backstop; `statrs` rejects
-/// the same set (a `NaN`, infinite or non-positive shape).
-fn build_dist(a: f64, b: f64) -> PolarsResult<Beta> {
-    Beta::new(a, b).map_err(|e| {
-        PolarsError::InvalidOperation(
-            format!("a and b must be finite and strictly positive, got a={a}, b={b}: {e}").into(),
-        )
-    })
-}
+const A: ParamDomain = ParamDomain::positive("a");
+const B: ParamDomain = ParamDomain::positive("b");
 
-/// `a` alone: finite, strictly positive.
-const A: ParamDomain = ParamDomain {
-    name: "a",
-    domain: "finite and strictly positive",
-    accepts: |a| a.is_finite() && a > 0.0,
-};
-
-/// `b` alone: finite, strictly positive.
-const B: ParamDomain = ParamDomain {
-    name: "b",
-    domain: "finite and strictly positive",
-    accepts: |b| b.is_finite() && b > 0.0,
-};
-
-/// The column pass every column-parameter funnel runs before its row loop.
-fn validate(a: &Float64Chunked, b: &Float64Chunked) -> PolarsResult<()> {
+fn check_params(a: &Float64Chunked, b: &Float64Chunked) -> PolarsResult<()> {
     A.check_column(a)?;
     B.check_column(b)
+}
+
+/// Cannot fail behind [`A`] and [`B`]'s pass; the `statrs` error is kept as the backstop.
+fn build_dist(a: f64, b: f64) -> PolarsResult<Beta> {
+    Beta::new(a, b).map_err(|e| polars_err!(ComputeError: "{e}"))
 }
 
 /// Beta's constant shapes, deserialised once per call.
@@ -75,18 +57,19 @@ impl BetaParamsKwargs {
 /// `inputs[0]` is `a`, `inputs[1]` is `b`. The Python closed-form moments (`mean = a / (a + b)`,
 /// `variance = a * b / ((a + b)^2 * (a + b + 1))`) are gated on this single FFI round-trip, so
 /// they raise on an invalid parameterisation exactly like the value-keyed methods. `null` in
-/// either input propagates; invalid raises via [`build_dist`].
+/// either input propagates.
 #[polars_expr(output_type=Float64)]
 fn beta_params(inputs: &[Series]) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
     let a = inputs[0].cast(&DataType::Float64)?;
     let b = inputs[1].cast(&DataType::Float64)?;
-    validate(a.f64()?, b.f64()?)?;
+    check_params(a.f64()?, b.f64()?)?;
 
-    validate_params_binary(a.f64()?, b.f64()?, |a, b| {
-        build_dist(a, b)?;
-        Ok(b)
-    })
+    let ca: Float64Chunked =
+        binary_elementwise(a.f64()?, b.f64()?, |a: Option<f64>, b: Option<f64>| {
+            a.and(b)
+        });
+    Ok(ca.into_series())
 }
 
 /// Apply a value-keyed `f(dist, value)` element-wise over `(value, a, b)`; shared by `pdf`,
@@ -99,7 +82,7 @@ where
     let value = inputs[0].cast(&DataType::Float64)?;
     let a = inputs[1].cast(&DataType::Float64)?;
     let b = inputs[2].cast(&DataType::Float64)?;
-    validate(a.f64()?, b.f64()?)?;
+    check_params(a.f64()?, b.f64()?)?;
 
     value_keyed_per_row(
         value.f64()?,
@@ -114,7 +97,7 @@ where
 /// Apply a parameter-keyed moment `f(dist)` element-wise over `(a, b)`.
 ///
 /// `inputs[0]` is `a`, `inputs[1]` is `b`. `null` in either propagates; an invalid shape raises
-/// via [`build_dist`]. Only `entropy` routes through here (the one moment without an elementary
+/// from [`check_params`]. Only `entropy` routes through here (the one moment without an elementary
 /// closed form); `mean` and `variance` are closed forms computed in Polars and gated on
 /// [`beta_params`].
 fn params_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
@@ -124,9 +107,16 @@ where
     let inputs = align_inputs(inputs)?;
     let a = inputs[0].cast(&DataType::Float64)?;
     let b = inputs[1].cast(&DataType::Float64)?;
-    validate(a.f64()?, b.f64()?)?;
+    check_params(a.f64()?, b.f64()?)?;
 
-    validate_params_binary(a.f64()?, b.f64()?, |a, b| Ok(f(&build_dist(a, b)?)))
+    let ca: Float64Chunked =
+        try_binary_elementwise(a.f64()?, b.f64()?, |a, b| -> PolarsResult<Option<f64>> {
+            match (a, b) {
+                (Some(a), Some(b)) => Ok(Some(f(&build_dist(a, b)?))),
+                _ => Ok(None),
+            }
+        })?;
+    Ok(ca.into_series())
 }
 
 /// One Beta draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
@@ -140,7 +130,7 @@ fn draw(dist: &Beta, rng: &mut impl rand::Rng) -> f64 {
 
 /// Element-wise Beta sampler over `(a, b, row_index)`, returning `Float64`.
 ///
-/// Per row, `null` propagates and an invalid shape raises via [`build_dist`]. Seeding and
+/// Per row, `null` propagates; an invalid shape raises from [`check_params`] first. Seeding and
 /// chunk-invariance follow [`sample_per_row_ternary`].
 ///
 /// The draw keeps `statrs` (two `O(1)`-amortised Gamma draws, normalised); routing it through
@@ -153,7 +143,7 @@ fn beta_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> 
     let b = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    validate(a.f64()?, b.f64()?)?;
+    check_params(a.f64()?, b.f64()?)?;
 
     sample_per_row_ternary(
         name,
@@ -206,7 +196,7 @@ fn beta_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series
     let b = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    validate(a.f64()?, b.f64()?)?;
+    check_params(a.f64()?, b.f64()?)?;
 
     let rows = ternary_param_rows(a.f64()?, b.f64()?, index.u64()?, build_dist);
 

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -5,23 +5,41 @@ use statrs::distribution::{Beta, Continuous, ContinuousCDF};
 use statrs::statistics::Distribution as StatrsDistribution;
 
 use crate::distributions::{
-    align_inputs, validate_params_binary, value_keyed_per_row, value_keyed_scalar,
+    align_inputs, validate_params_binary, value_keyed_per_row, value_keyed_scalar, ParamDomain,
 };
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
-/// Construct a `statrs::Beta`, mapping the invalid-parameter case to a `ComputeError`.
-///
-/// `statrs::Beta::new(shape_a, shape_b)` rejects a `NaN`, infinite, or non-positive shape. That surfaces as
-/// `InvalidOperation`, so an invalid shape fails the whole evaluation rather than silently nulling the row.
+/// Construct a `statrs::Beta` behind [`A`] and [`B`], as the row loops' backstop; `statrs` rejects
+/// the same set (a `NaN`, infinite or non-positive shape).
 fn build_dist(a: f64, b: f64) -> PolarsResult<Beta> {
     Beta::new(a, b).map_err(|e| {
         PolarsError::InvalidOperation(
             format!("a and b must be finite and strictly positive, got a={a}, b={b}: {e}").into(),
         )
     })
+}
+
+/// `a` alone: finite, strictly positive.
+const A: ParamDomain = ParamDomain {
+    name: "a",
+    domain: "finite and strictly positive",
+    accepts: |a| a.is_finite() && a > 0.0,
+};
+
+/// `b` alone: finite, strictly positive.
+const B: ParamDomain = ParamDomain {
+    name: "b",
+    domain: "finite and strictly positive",
+    accepts: |b| b.is_finite() && b > 0.0,
+};
+
+/// The column pass every column-parameter funnel runs before its row loop.
+fn validate(a: &Float64Chunked, b: &Float64Chunked) -> PolarsResult<()> {
+    A.check_column(a)?;
+    B.check_column(b)
 }
 
 /// Beta's constant shapes, deserialised once per call.
@@ -36,6 +54,8 @@ struct BetaParamsKwargs {
 
 impl BetaParamsKwargs {
     fn build(&self) -> PolarsResult<Beta> {
+        A.check(self.a)?;
+        B.check(self.b)?;
         build_dist(self.a, self.b)
     }
 
@@ -61,6 +81,7 @@ fn beta_params(inputs: &[Series]) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
     let a = inputs[0].cast(&DataType::Float64)?;
     let b = inputs[1].cast(&DataType::Float64)?;
+    validate(a.f64()?, b.f64()?)?;
 
     validate_params_binary(a.f64()?, b.f64()?, |a, b| {
         build_dist(a, b)?;
@@ -78,6 +99,7 @@ where
     let value = inputs[0].cast(&DataType::Float64)?;
     let a = inputs[1].cast(&DataType::Float64)?;
     let b = inputs[2].cast(&DataType::Float64)?;
+    validate(a.f64()?, b.f64()?)?;
 
     value_keyed_per_row(
         value.f64()?,
@@ -102,6 +124,7 @@ where
     let inputs = align_inputs(inputs)?;
     let a = inputs[0].cast(&DataType::Float64)?;
     let b = inputs[1].cast(&DataType::Float64)?;
+    validate(a.f64()?, b.f64()?)?;
 
     validate_params_binary(a.f64()?, b.f64()?, |a, b| Ok(f(&build_dist(a, b)?)))
 }
@@ -130,6 +153,7 @@ fn beta_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> 
     let b = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
+    validate(a.f64()?, b.f64()?)?;
 
     sample_per_row_ternary(
         name,
@@ -182,6 +206,7 @@ fn beta_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series
     let b = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
+    validate(a.f64()?, b.f64()?)?;
 
     let rows = ternary_param_rows(a.f64()?, b.f64()?, index.u64()?, build_dist);
 

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -1,3 +1,4 @@
+use polars::prelude::arity::{binary_elementwise, try_binary_elementwise};
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution as RandDistribution;
@@ -5,31 +6,20 @@ use rand_distr::Binomial as BinomialSampler;
 use statrs::distribution::{Binomial, Discrete, DiscreteCDF};
 use statrs::statistics::Distribution as StatrsDistribution;
 
-use crate::distributions::{
-    align_inputs, validate_params_binary, value_keyed_per_row, value_keyed_scalar, ParamDomain,
-};
+use crate::distributions::{align_inputs, value_keyed_per_row, value_keyed_scalar, ParamDomain};
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_per_row, samples_u64_output,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
-/// `p` alone: finite, in `[0, 1]`. `n` has no domain of its own beyond the `u64` [`coerce_n`] makes
-/// it.
-const P: ParamDomain = ParamDomain {
-    name: "p",
-    domain: "in [0, 1]",
-    accepts: |p| p.is_finite() && (0.0..=1.0).contains(&p),
-};
+/// `n` has no rule of its own beyond the `u64` [`coerce_n`] makes it.
+const P: ParamDomain = ParamDomain::probability("p");
 
-/// Construct a `statrs::Binomial` behind [`P`], as the row loops' backstop.
-///
-/// `statrs::Binomial::new(p, n)` takes the arguments in the opposite order to this crate's `(n, p)`
-/// and only rejects a `NaN` `p` or `p` outside `[0, 1]`. Its `n` is a `u64` and so is this one, so no
-/// row converts a trial count and a negative cannot arrive here at all.
+/// `statrs::Binomial::new(p, n)` takes the arguments in the opposite order to this crate's `(n, p)`.
+/// Its `n` is a `u64` and so is this one, so no row converts a trial count and a negative cannot
+/// arrive here at all; behind [`P`]'s pass this cannot fail.
 fn build_dist(n: u64, p: f64) -> PolarsResult<Binomial> {
-    Binomial::new(p, n).map_err(|e| {
-        PolarsError::InvalidOperation(format!("p must be in [0, 1], got {p}: {e}").into())
-    })
+    Binomial::new(p, n).map_err(|e| polars_err!(ComputeError: "{e}"))
 }
 
 /// Construct a `rand_distr::Binomial` for sampling, mirroring [`build_dist`]'s validation contract.
@@ -163,8 +153,8 @@ where
 
 /// Apply a parameter-keyed moment `f(dist)` element-wise over `(n, p)`.
 ///
-/// `inputs[0]` is `n`, `inputs[1]` is `p`. `null` in either propagates; an invalid parameterisation
-/// raises via [`build_dist`]. Only `entropy` routes through here (the one moment without an
+/// `inputs[0]` is `n`, `inputs[1]` is `p`. `null` in either propagates; an invalid `p` raises from
+/// [`P`]'s column pass. Only `entropy` routes through here (the one moment without an
 /// elementary closed form); `mean` and `variance` are closed forms computed in Polars and gated on
 /// [`binomial_params`].
 ///
@@ -180,15 +170,22 @@ where
     let p = inputs[1].cast(&DataType::Float64)?;
     P.check_column(p.f64()?)?;
 
-    validate_params_binary(&n, p.f64()?, |n, p| {
-        // TODO(FBruzzesi): Remove `n == u64::MAX` guard once fixed upstream in statrs
-        if n == u64::MAX {
-            return Err(PolarsError::InvalidOperation(
-                format!("n = {n} overflows the entropy support sum: statrs iterates 0..=n via n + 1, which wraps at u64::MAX").into(),
-            ));
-        }
-        Ok(f(&build_dist(n, p)?))
-    })
+    let ca: Float64Chunked = try_binary_elementwise(
+        &n,
+        p.f64()?,
+        |n, p| -> PolarsResult<Option<f64>> {
+            let (Some(n), Some(p)) = (n, p) else {
+                return Ok(None);
+            };
+            // TODO(FBruzzesi): Remove `n == u64::MAX` guard once fixed upstream in statrs
+            polars_ensure!(
+                n != u64::MAX,
+                ComputeError: "n = {} overflows the entropy support sum: statrs iterates 0..=n via n + 1, which wraps at u64::MAX", n
+            );
+            Ok(Some(f(&build_dist(n, p)?)))
+        },
+    )?;
+    Ok(ca.into_series())
 }
 
 /// One Binomial draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
@@ -203,7 +200,7 @@ fn draw(dist: &BinomialSampler, rng: &mut impl rand::Rng) -> u64 {
 
 /// Element-wise Binomial sampler over `(n, p, row_index)`, returning `UInt64`.
 ///
-/// Per row, `null` propagates and an invalid parameterisation raises via [`build_sampler`].
+/// Per row, `null` propagates; an invalid `p` raises from [`P`]'s column pass first.
 /// Seeding and chunk-invariance follow [`sample_per_row_ternary`].
 #[polars_expr(output_type=UInt64)]
 fn binomial_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
@@ -426,7 +423,7 @@ fn binomial_ppf_scalar(inputs: &[Series], kwargs: BinomialParamsKwargs) -> Polar
 /// `inputs[0]` is `n`, `inputs[1]` is `p`. The Python closed-form moments (`mean = n * p`,
 /// `variance = n * p * (1 - p)`) are gated on this single FFI round-trip, so they raise on an
 /// invalid parameterisation exactly like the value-keyed methods. `null` in either input
-/// propagates; invalid raises via [`build_dist`].
+/// propagates.
 #[polars_expr(output_type=Float64)]
 fn binomial_params(inputs: &[Series]) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
@@ -434,10 +431,9 @@ fn binomial_params(inputs: &[Series]) -> PolarsResult<Series> {
     let p = inputs[1].cast(&DataType::Float64)?;
     P.check_column(p.f64()?)?;
 
-    validate_params_binary(&n, p.f64()?, |n, p| {
-        build_dist(n, p)?;
-        Ok(p)
-    })
+    let ca: Float64Chunked =
+        binary_elementwise(&n, p.f64()?, |n: Option<u64>, p: Option<f64>| n.and(p));
+    Ok(ca.into_series())
 }
 
 /// Element-wise Shannon entropy (in nats) via `statrs` `Distribution::entropy`, the exact support

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -6,20 +6,26 @@ use statrs::distribution::{Binomial, Discrete, DiscreteCDF};
 use statrs::statistics::Distribution as StatrsDistribution;
 
 use crate::distributions::{
-    align_inputs, validate_params_binary, value_keyed_per_row, value_keyed_scalar,
+    align_inputs, validate_params_binary, value_keyed_per_row, value_keyed_scalar, ParamDomain,
 };
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_per_row, samples_u64_output,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
-/// Construct a `statrs::Binomial`, mapping an invalid `p` to a `ComputeError`.
+/// `p` alone: finite, in `[0, 1]`. `n` has no domain of its own beyond the `u64` [`coerce_n`] makes
+/// it.
+const P: ParamDomain = ParamDomain {
+    name: "p",
+    domain: "in [0, 1]",
+    accepts: |p| p.is_finite() && (0.0..=1.0).contains(&p),
+};
+
+/// Construct a `statrs::Binomial` behind [`P`], as the row loops' backstop.
 ///
 /// `statrs::Binomial::new(p, n)` takes the arguments in the opposite order to this crate's `(n, p)`
 /// and only rejects a `NaN` `p` or `p` outside `[0, 1]`. Its `n` is a `u64` and so is this one, so no
-/// row converts a trial count and a negative cannot arrive here at all. The failure
-/// surfaces as `InvalidOperation`, so an invalid parameterisation fails the whole evaluation rather
-/// than silently nulling the row.
+/// row converts a trial count and a negative cannot arrive here at all.
 fn build_dist(n: u64, p: f64) -> PolarsResult<Binomial> {
     Binomial::new(p, n).map_err(|e| {
         PolarsError::InvalidOperation(format!("p must be in [0, 1], got {p}: {e}").into())
@@ -97,12 +103,14 @@ struct BinomialParamsKwargs {
 impl BinomialParamsKwargs {
     /// The `statrs` distribution, for the value-keyed methods.
     fn build(&self) -> PolarsResult<Binomial> {
+        P.check(self.p)?;
         build_dist(self.n, self.p)
     }
 
     /// The `rand_distr` sampler, for the samplers. The free [`build_sampler`] carries the note on
     /// why the two families use different distribution types.
     fn build_sampler(&self) -> PolarsResult<BinomialSampler> {
+        P.check(self.p)?;
         build_sampler(self.n, self.p)
     }
 
@@ -141,6 +149,7 @@ where
     let value = inputs[0].cast(&DataType::Float64)?;
     let n = coerce_n(&inputs[1])?;
     let p = inputs[2].cast(&DataType::Float64)?;
+    P.check_column(p.f64()?)?;
 
     value_keyed_per_row(
         value.f64()?,
@@ -169,6 +178,7 @@ where
     let inputs = align_inputs(inputs)?;
     let n = coerce_n(&inputs[0])?;
     let p = inputs[1].cast(&DataType::Float64)?;
+    P.check_column(p.f64()?)?;
 
     validate_params_binary(&n, p.f64()?, |n, p| {
         // TODO(FBruzzesi): Remove `n == u64::MAX` guard once fixed upstream in statrs
@@ -202,6 +212,7 @@ fn binomial_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Seri
     let p = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
+    P.check_column(p.f64()?)?;
 
     sample_per_row_ternary(
         name,
@@ -256,6 +267,7 @@ fn binomial_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Se
     let p = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
+    P.check_column(p.f64()?)?;
 
     let rows = ternary_param_rows(&n, p.f64()?, index.u64()?, build_sampler);
 
@@ -420,6 +432,7 @@ fn binomial_params(inputs: &[Series]) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
     let n = coerce_n(&inputs[0])?;
     let p = inputs[1].cast(&DataType::Float64)?;
+    P.check_column(p.f64()?)?;
 
     validate_params_binary(&n, p.f64()?, |n, p| {
         build_dist(n, p)?;

--- a/src/distributions/discrete_uniform.rs
+++ b/src/distributions/discrete_uniform.rs
@@ -5,26 +5,27 @@ use rand::distr::Distribution;
 use statrs::distribution::DiscreteUniform;
 
 use crate::distributions::{
-    align_inputs, validate_params_binary, value_keyed_per_row, value_keyed_scalar,
+    align_inputs, validate_params_binary, value_keyed_per_row, value_keyed_scalar, PairDomain,
 };
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_i64_output, samples_per_row,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
-/// Construct a `statrs::DiscreteUniform`, mapping an invalid parameterisation to `InvalidOperation`.
-///
-/// `statrs` only rejects `max < min` (`min == max` is the legitimate one-point mass), so the one
-/// extra guard here is the support count: `max - min + 1` overflows `i64` for a span wider than
-/// `i64::MAX - 1`, and every closed form divides by that count. The width is computed in `i128`
-/// so the check itself cannot wrap.
+/// The pair: `min <= max` (`min == max` is the legitimate one-point mass), and a support count
+/// `max - min + 1` that fits in `i64`, since every closed form divides by that count. The width is
+/// computed in `i128` so the check itself cannot wrap. The bounds have no domain of their own: an
+/// integer column is one by dtype, through [`coerce_bound`].
+const BOUNDS: PairDomain<i64> = PairDomain {
+    names: ("min", "max"),
+    domain: "greater than or equal to min, with a support width max - min + 1 that fits in i64",
+    accepts: |min, max| min <= max && i64::try_from(i128::from(max) - i128::from(min) + 1).is_ok(),
+};
+
+/// Construct a `statrs::DiscreteUniform` behind [`BOUNDS`]: the constant regime's once-per-call
+/// check, and the row loops' backstop. `statrs` itself only rejects `max < min`.
 fn build_dist(min: i64, max: i64) -> PolarsResult<DiscreteUniform> {
-    let n = max as i128 - min as i128 + 1;
-    if n > i64::MAX as i128 {
-        return Err(PolarsError::InvalidOperation(
-            format!("support width max - min + 1 must fit in i64, got min={min}, max={max}").into(),
-        ));
-    }
+    BOUNDS.check(min, max)?;
     DiscreteUniform::new(min, max).map_err(|e| {
         PolarsError::InvalidOperation(
             format!("max must be greater than or equal to min, got min={min}, max={max}: {e}")
@@ -344,6 +345,7 @@ where
     let name = inputs[0].name().clone();
     let min = coerce_bound(&inputs[1])?;
     let max = coerce_bound(&inputs[2])?;
+    BOUNDS.check_columns(&min, &max)?;
 
     let ca: Float64Chunked = match coerce_points(&inputs[0])? {
         Points::Float(v) => try_ternary_elementwise(&v, &min, &max, |v, lo, hi| {
@@ -429,6 +431,7 @@ fn discreteuniform_ppf(inputs: &[Series]) -> PolarsResult<Series> {
     let value = inputs[0].cast(&DataType::Float64)?;
     let min = coerce_bound(&inputs[1])?;
     let max = coerce_bound(&inputs[2])?;
+    BOUNDS.check_columns(&min, &max)?;
     value_keyed_per_row(
         value.f64()?,
         &min,
@@ -446,6 +449,7 @@ fn discreteuniform_isf(inputs: &[Series]) -> PolarsResult<Series> {
     let value = inputs[0].cast(&DataType::Float64)?;
     let min = coerce_bound(&inputs[1])?;
     let max = coerce_bound(&inputs[2])?;
+    BOUNDS.check_columns(&min, &max)?;
     value_keyed_per_row(
         value.f64()?,
         &min,
@@ -549,6 +553,7 @@ fn discreteuniform_range(inputs: &[Series]) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
     let min = coerce_bound(&inputs[0])?;
     let max = coerce_bound(&inputs[1])?;
+    BOUNDS.check_columns(&min, &max)?;
 
     validate_params_binary(&min, &max, |lo, hi| {
         build_dist(lo, hi)?;
@@ -576,6 +581,7 @@ fn discreteuniform_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResu
     let max = coerce_bound(&inputs[1])?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
+    BOUNDS.check_columns(&min, &max)?;
 
     sample_per_row_ternary(
         name,
@@ -629,6 +635,7 @@ fn discreteuniform_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsRe
     let max = coerce_bound(&inputs[1])?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
+    BOUNDS.check_columns(&min, &max)?;
 
     let rows = ternary_param_rows(&min, &max, index.u64()?, build_dist);
 

--- a/src/distributions/discrete_uniform.rs
+++ b/src/distributions/discrete_uniform.rs
@@ -1,37 +1,30 @@
-use polars::prelude::arity::{try_ternary_elementwise, unary_elementwise};
+use polars::prelude::arity::{binary_elementwise, try_ternary_elementwise, unary_elementwise};
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution;
 use statrs::distribution::DiscreteUniform;
 
-use crate::distributions::{
-    align_inputs, validate_params_binary, value_keyed_per_row, value_keyed_scalar, PairDomain,
-};
+use crate::distributions::{align_inputs, value_keyed_per_row, value_keyed_scalar, PairDomain};
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_i64_output, samples_per_row,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
-/// The pair: `min <= max` (`min == max` is the legitimate one-point mass), and a support count
-/// `max - min + 1` that fits in `i64`, since every closed form divides by that count. The width is
-/// computed in `i128` so the check itself cannot wrap. The bounds have no domain of their own: an
-/// integer column is one by dtype, through [`coerce_bound`].
+/// `min == max` is the legitimate one-point mass. Every closed form divides by the count
+/// `max - min + 1`, so it must fit `i64`; the width is computed in `i128` so the check itself
+/// cannot wrap. The bounds have no rule of their own: an integer column is one by dtype, through
+/// [`coerce_bound`].
 const BOUNDS: PairDomain<i64> = PairDomain {
     names: ("min", "max"),
-    domain: "greater than or equal to min, with a support width max - min + 1 that fits in i64",
+    rule: "greater than or equal to min, with a support width max - min + 1 that fits in i64",
     accepts: |min, max| min <= max && i64::try_from(i128::from(max) - i128::from(min) + 1).is_ok(),
 };
 
-/// Construct a `statrs::DiscreteUniform` behind [`BOUNDS`]: the constant regime's once-per-call
-/// check, and the row loops' backstop. `statrs` itself only rejects `max < min`.
+/// The constant regime's once-per-call check, and the row loops' backstop. `statrs` itself only
+/// rejects `max < min`, so behind [`BOUNDS`] its error is unreachable and kept as is.
 fn build_dist(min: i64, max: i64) -> PolarsResult<DiscreteUniform> {
     BOUNDS.check(min, max)?;
-    DiscreteUniform::new(min, max).map_err(|e| {
-        PolarsError::InvalidOperation(
-            format!("max must be greater than or equal to min, got min={min}, max={max}: {e}")
-                .into(),
-        )
-    })
+    DiscreteUniform::new(min, max).map_err(|e| polars_err!(ComputeError: "{e}"))
 }
 
 /// Widen a bound column to the `Int64` both distribution types take.
@@ -114,7 +107,7 @@ struct Support {
     n: f64,
 }
 
-/// Validate `(min, max)` via [`build_dist`] and size the support once.
+/// Size the support once, behind [`build_dist`].
 fn build_support(min: i64, max: i64) -> PolarsResult<Support> {
     build_dist(min, max)?;
     let n = (max as i128 - min as i128 + 1) as f64;
@@ -336,7 +329,7 @@ fn coerce_points(value: &Series) -> PolarsResult<Points> {
 /// Apply a closed-form `f(support, point)` element-wise over `(value, min, max)`; shared by the
 /// six value-keyed plugins with an integer-exact path. Null and `NaN` contracts follow
 /// [`value_keyed_per_row`]: a null bound nulls the row without building, and an invalid
-/// parameterisation raises via [`build_support`] whatever the row's point is.
+/// parameterisation raises from [`BOUNDS`]'s column pass whatever the row's point is.
 fn du_value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
 where
     F: Fn(&Support, Point) -> Option<f64>,
@@ -555,10 +548,10 @@ fn discreteuniform_range(inputs: &[Series]) -> PolarsResult<Series> {
     let max = coerce_bound(&inputs[1])?;
     BOUNDS.check_columns(&min, &max)?;
 
-    validate_params_binary(&min, &max, |lo, hi| {
-        build_dist(lo, hi)?;
-        Ok((hi as i128 - lo as i128 + 1) as f64)
-    })
+    let ca: Float64Chunked = binary_elementwise(&min, &max, |lo: Option<i64>, hi: Option<i64>| {
+        Some((i128::from(hi?) - i128::from(lo?) + 1) as f64)
+    });
+    Ok(ca.into_series())
 }
 
 /// One DiscreteUniform draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
@@ -572,8 +565,8 @@ fn draw(dist: &DiscreteUniform, rng: &mut impl rand::Rng) -> i64 {
 
 /// Element-wise DiscreteUniform sampler over `(min, max, row_index)`, returning `Int64`.
 ///
-/// Per row, `null` propagates and an invalid parameterisation raises via [`build_dist`]. Seeding
-/// and chunk-invariance follow [`sample_per_row_ternary`].
+/// Per row, `null` propagates; an invalid parameterisation raises from [`BOUNDS`]'s column pass.
+/// Seeding and chunk-invariance follow [`sample_per_row_ternary`].
 #[polars_expr(output_type=Int64)]
 fn discreteuniform_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -4,8 +4,8 @@ use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::Exp;
 
 use crate::distributions::{
-    align_inputs, expm1, validate_params_unary, value_keyed_derived_per_row,
-    value_keyed_derived_scalar, Domain, ParamDomain, Sides,
+    align_inputs, expm1, value_keyed_derived_per_row, value_keyed_derived_scalar, Domain,
+    ParamDomain, Sides,
 };
 use crate::rng::{
     binary_param_rows, sample_by_index, sample_per_row_binary, samples_by_index,
@@ -13,23 +13,12 @@ use crate::rng::{
     SamplesScalarKwargs,
 };
 
-/// `rate` alone: strictly positive and finite.
-const RATE: ParamDomain = ParamDomain {
-    name: "rate",
-    domain: "strictly positive and finite",
-    accepts: |rate| rate.is_finite() && rate > 0.0,
-};
+const RATE: ParamDomain = ParamDomain::positive("rate");
 
-/// Construct a `statrs::Exp` behind [`RATE`], as the row loops' backstop.
-///
-/// `statrs::Exp::new` rejects a `NaN` rate or `rate <= 0` and accepts a positive-infinite one (a
-/// degenerate point mass at 0), so [`RATE`] is what refuses `inf`, not the constructor.
+/// `statrs::Exp::new` accepts a positive-infinite rate (a degenerate point mass at 0), so [`RATE`]
+/// is what refuses it; behind its pass this cannot fail.
 fn build_dist(rate: f64) -> PolarsResult<Exp> {
-    Exp::new(rate).map_err(|e| {
-        PolarsError::InvalidOperation(
-            format!("rate must be strictly positive, got rate={rate}: {e}").into(),
-        )
-    })
+    Exp::new(rate).map_err(|e| polars_err!(ComputeError: "{e}"))
 }
 
 /// Exponential's constant rate, deserialised once per call.
@@ -56,21 +45,13 @@ impl ExponentialParamsKwargs {
     }
 }
 
-/// Element-wise validation of the rate (λ): returns `rate` unchanged, raising `ComputeError` if
-/// `rate` is not finite or `rate <= 0`. `null` propagates.
-///
-/// The moments derive from this so they report an invalid rate consistently with
-/// `exponential_sample`, instead of silently computing with a non-positive rate. The value-keyed
-/// methods validate inside their own plugin instead.
+/// `rate` unchanged after [`RATE`]'s column pass, `null` included. The moments derive from this so
+/// an invalid rate raises as it does from `exponential_sample`.
 #[polars_expr(output_type=Float64)]
 fn exponential_rate(inputs: &[Series]) -> PolarsResult<Series> {
     let rate = inputs[0].cast(&DataType::Float64)?;
     RATE.check_column(rate.f64()?)?;
-
-    validate_params_unary(rate.f64()?, |rate| {
-        build_dist(rate)?;
-        Ok(rate)
-    })
+    Ok(rate)
 }
 
 /// Crossover of [`derive_cdf`], in units of `t = rate * x`.
@@ -331,8 +312,8 @@ fn draw(dist: &Exp, rng: &mut impl rand::Rng) -> f64 {
 
 /// Element-wise Exponential sampler over `(rate, row_index)`, returning `Float64`.
 ///
-/// Per row, `null` propagates and an invalid rate raises via [`build_dist`]. Seeding and
-/// chunk-invariance follow [`sample_per_row_binary`].
+/// Per row, `null` propagates; an invalid rate raises from [`RATE`]'s column pass first. Seeding
+/// and chunk-invariance follow [`sample_per_row_binary`].
 ///
 /// The draw keeps `statrs` (`O(1)` ziggurat: `sample_exp_1(rng) / rate`); routing it through
 /// `rand_distr` would buy nothing, since that is already the algorithm class `statrs` uses (unlike

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -5,7 +5,7 @@ use statrs::distribution::Exp;
 
 use crate::distributions::{
     align_inputs, expm1, validate_params_unary, value_keyed_derived_per_row,
-    value_keyed_derived_scalar, Domain, Sides,
+    value_keyed_derived_scalar, Domain, ParamDomain, Sides,
 };
 use crate::rng::{
     binary_param_rows, sample_by_index, sample_per_row_binary, samples_by_index,
@@ -13,11 +13,17 @@ use crate::rng::{
     SamplesScalarKwargs,
 };
 
-/// Construct a `statrs::Exp`, mapping the invalid-parameter case to a `ComputeError`.
+/// `rate` alone: strictly positive and finite.
+const RATE: ParamDomain = ParamDomain {
+    name: "rate",
+    domain: "strictly positive and finite",
+    accepts: |rate| rate.is_finite() && rate > 0.0,
+};
+
+/// Construct a `statrs::Exp` behind [`RATE`], as the row loops' backstop.
 ///
-/// `statrs::Exp::new` rejects a `NaN` rate or `rate <= 0` (a positive-infinite rate is accepted, as a
-/// degenerate point mass at 0). That surfaces as `InvalidOperation`, so an invalid rate fails the whole
-/// evaluation rather than silently nulling the row.
+/// `statrs::Exp::new` rejects a `NaN` rate or `rate <= 0` and accepts a positive-infinite one (a
+/// degenerate point mass at 0), so [`RATE`] is what refuses `inf`, not the constructor.
 fn build_dist(rate: f64) -> PolarsResult<Exp> {
     Exp::new(rate).map_err(|e| {
         PolarsError::InvalidOperation(
@@ -34,10 +40,11 @@ struct ExponentialParamsKwargs {
 
 impl ExponentialParamsKwargs {
     fn build(&self) -> PolarsResult<Exp> {
+        RATE.check(self.rate)?;
         build_dist(self.rate)
     }
 
-    /// Binds the constant rate and `build_dist` into [`value_keyed_derived_scalar`], which
+    /// Binds the constant rate and its domain into [`value_keyed_derived_scalar`], which
     /// validates and derives once per call rather than per row.
     fn value_keyed<Branches>(
         &self,
@@ -45,12 +52,12 @@ impl ExponentialParamsKwargs {
         derive: impl Fn(Option<f64>) -> Branches,
         select: impl Fn(&Branches, f64) -> Option<f64>,
     ) -> PolarsResult<Series> {
-        value_keyed_derived_scalar(value, self.rate, build_dist, derive, select)
+        value_keyed_derived_scalar(value, self.rate, &RATE, derive, select)
     }
 }
 
-/// Element-wise validation of the rate (λ): returns `rate` unchanged, raising `InvalidOperation`
-/// if `rate` is `NaN` or `rate <= 0`. `null` propagates.
+/// Element-wise validation of the rate (λ): returns `rate` unchanged, raising `ComputeError` if
+/// `rate` is not finite or `rate <= 0`. `null` propagates.
 ///
 /// The moments derive from this so they report an invalid rate consistently with
 /// `exponential_sample`, instead of silently computing with a non-positive rate. The value-keyed
@@ -58,6 +65,7 @@ impl ExponentialParamsKwargs {
 #[polars_expr(output_type=Float64)]
 fn exponential_rate(inputs: &[Series]) -> PolarsResult<Series> {
     let rate = inputs[0].cast(&DataType::Float64)?;
+    RATE.check_column(rate.f64()?)?;
 
     validate_params_unary(rate.f64()?, |rate| {
         build_dist(rate)?;
@@ -195,49 +203,49 @@ fn derive_isf(rate: Option<f64>) -> Domain<impl Fn(f64) -> f64> {
 /// See [`value_keyed_derived_per_row`] for the null/error contract.
 #[polars_expr(output_type=Float64)]
 fn exponential_pdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, derive_pdf, Sides::at)
+    value_keyed_derived_per_row(inputs, &RATE, derive_pdf, Sides::at)
 }
 
 /// Element-wise log-pdf; see [`derive_ln_pdf`].
 #[polars_expr(output_type=Float64)]
 fn exponential_ln_pdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, derive_ln_pdf, Sides::at)
+    value_keyed_derived_per_row(inputs, &RATE, derive_ln_pdf, Sides::at)
 }
 
 /// Element-wise cdf `P(X <= value)`; see [`derive_cdf`] and [`CDF_SINH_MAX`].
 #[polars_expr(output_type=Float64)]
 fn exponential_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, derive_cdf, Sides::at)
+    value_keyed_derived_per_row(inputs, &RATE, derive_cdf, Sides::at)
 }
 
 /// Element-wise log-cdf; see [`derive_ln_cdf`].
 #[polars_expr(output_type=Float64)]
 fn exponential_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, derive_ln_cdf, Sides::at)
+    value_keyed_derived_per_row(inputs, &RATE, derive_ln_cdf, Sides::at)
 }
 
 /// Element-wise survival function `P(X > value)`; see [`derive_sf`] for why it is not `1 - cdf`.
 #[polars_expr(output_type=Float64)]
 fn exponential_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, derive_sf, Sides::at)
+    value_keyed_derived_per_row(inputs, &RATE, derive_sf, Sides::at)
 }
 
 /// Element-wise log-sf; see [`derive_ln_sf`].
 #[polars_expr(output_type=Float64)]
 fn exponential_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, derive_ln_sf, Sides::at)
+    value_keyed_derived_per_row(inputs, &RATE, derive_ln_sf, Sides::at)
 }
 
 /// Element-wise ppf (inverse cdf); see [`derive_ppf`].
 #[polars_expr(output_type=Float64)]
 fn exponential_ppf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, derive_ppf, Domain::at)
+    value_keyed_derived_per_row(inputs, &RATE, derive_ppf, Domain::at)
 }
 
 /// Element-wise inverse survival function; see [`derive_isf`] for why it never forms a complement.
 #[polars_expr(output_type=Float64)]
 fn exponential_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, derive_isf, Domain::at)
+    value_keyed_derived_per_row(inputs, &RATE, derive_isf, Domain::at)
 }
 
 /// Constant-rate fast path for [`exponential_pdf`].
@@ -335,6 +343,7 @@ fn exponential_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<S
     let rate = inputs[0].cast(&DataType::Float64)?;
     let index = inputs[1].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
+    RATE.check_column(rate.f64()?)?;
 
     sample_per_row_binary(
         name,
@@ -385,6 +394,7 @@ fn exponential_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult
     let rate = inputs[0].cast(&DataType::Float64)?;
     let index = inputs[1].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
+    RATE.check_column(rate.f64()?)?;
 
     let rows = binary_param_rows(rate.f64()?, index.u64()?, build_dist);
 

--- a/src/distributions/geometric.rs
+++ b/src/distributions/geometric.rs
@@ -4,28 +4,24 @@ use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::Geometric;
 
 use crate::distributions::{
-    align_inputs, expm1, ln_abs_expm1, validate_params_unary, value_keyed_derived_per_row,
-    value_keyed_derived_scalar, Domain, ParamDomain, Sides,
+    align_inputs, expm1, ln_abs_expm1, value_keyed_derived_per_row, value_keyed_derived_scalar,
+    Domain, ParamDomain, Sides,
 };
 use crate::rng::{
     binary_param_rows, sample_by_index, sample_per_row_binary, samples_by_index, samples_per_row,
     samples_u64_output, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
-/// `p` alone: finite, in `(0, 1]`. Unlike `Bernoulli` the degenerate `p = 0` point mass is not
-/// representable.
+/// Unlike `Bernoulli`, the degenerate `p = 0` point mass is not representable.
 const P: ParamDomain = ParamDomain {
     name: "p",
-    domain: "in (0, 1]",
+    rule: "in (0, 1]",
     accepts: |p| p.is_finite() && p > 0.0 && p <= 1.0,
 };
 
-/// Construct a `statrs::Geometric` behind [`P`], as the row loops' backstop; `statrs` rejects the
-/// same set.
+/// Cannot fail behind [`P`]'s pass; the `statrs` error is kept as the backstop.
 fn build_dist(proba: f64) -> PolarsResult<Geometric> {
-    Geometric::new(proba).map_err(|e| {
-        PolarsError::InvalidOperation(format!("p must be in (0, 1], got {proba}: {e}").into())
-    })
+    Geometric::new(proba).map_err(|e| polars_err!(ComputeError: "{e}"))
 }
 
 /// `ln(1 - p)` as `ln_1p(-p)`: the literal `ln(1.0 - p)` inherits the rounding of `1 - p` (a few
@@ -35,9 +31,8 @@ fn ln_failure(proba: f64) -> f64 {
     (-proba).ln_1p()
 }
 
-/// The samplers' per-row state: [`ln_failure`], validated through [`build_dist`] so an invalid `p`
-/// raises identically either way. Built once per row, not once per draw: the multi-draw and
-/// constant-parameter paths take many draws per state.
+/// The samplers' per-row state: [`ln_failure`], behind [`build_dist`]'s backstop. Built once per
+/// row, not once per draw: the multi-draw and constant-parameter paths take many draws per state.
 fn build_sampler(proba: f64) -> PolarsResult<f64> {
     build_dist(proba)?;
     Ok(ln_failure(proba))
@@ -67,21 +62,13 @@ impl GeometricParamsKwargs {
     }
 }
 
-/// Element-wise validation of the success probability: returns `p` unchanged, raising
-/// `ComputeError` if `p` is outside `(0, 1]`. `null` propagates.
-///
-/// The moments derive from this so they report an invalid `p` consistently with `geometric_sample`,
-/// instead of silently computing with a non-positive probability. The value-keyed methods validate
-/// inside their own plugin instead.
+/// `p` unchanged after [`P`]'s column pass, `null` included. The moments derive from this so an
+/// invalid `p` raises as it does from `geometric_sample`.
 #[polars_expr(output_type=Float64)]
 fn geometric_p(inputs: &[Series]) -> PolarsResult<Series> {
     let proba = inputs[0].cast(&DataType::Float64)?;
     P.check_column(proba.f64()?)?;
-
-    validate_params_unary(proba.f64()?, |proba| {
-        build_dist(proba)?;
-        Ok(proba)
-    })
+    Ok(proba)
 }
 
 /// Crossover of [`derive_cdf`], in units of `ln(sf)`.
@@ -419,7 +406,7 @@ fn draw(ln_failure: &f64, rng: &mut impl rand::Rng) -> u64 {
 
 /// Element-wise Geometric sampler over `(p, row_index)`, returning `UInt64`.
 ///
-/// Per row, `null` propagates and an invalid `p` raises via [`build_sampler`]. Seeding and
+/// Per row, `null` propagates; an invalid `p` raises from [`P`]'s column pass first. Seeding and
 /// chunk-invariance follow [`sample_per_row_binary`].
 #[polars_expr(output_type=UInt64)]
 fn geometric_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {

--- a/src/distributions/geometric.rs
+++ b/src/distributions/geometric.rs
@@ -5,15 +5,23 @@ use statrs::distribution::Geometric;
 
 use crate::distributions::{
     align_inputs, expm1, ln_abs_expm1, validate_params_unary, value_keyed_derived_per_row,
-    value_keyed_derived_scalar, Domain, Sides,
+    value_keyed_derived_scalar, Domain, ParamDomain, Sides,
 };
 use crate::rng::{
     binary_param_rows, sample_by_index, sample_per_row_binary, samples_by_index, samples_per_row,
     samples_u64_output, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
-/// `statrs::Geometric::new` rejects `NaN` and any `p` outside `(0, 1]`, so unlike `Bernoulli` the
-/// degenerate `p = 0` point mass is not representable.
+/// `p` alone: finite, in `(0, 1]`. Unlike `Bernoulli` the degenerate `p = 0` point mass is not
+/// representable.
+const P: ParamDomain = ParamDomain {
+    name: "p",
+    domain: "in (0, 1]",
+    accepts: |p| p.is_finite() && p > 0.0 && p <= 1.0,
+};
+
+/// Construct a `statrs::Geometric` behind [`P`], as the row loops' backstop; `statrs` rejects the
+/// same set.
 fn build_dist(proba: f64) -> PolarsResult<Geometric> {
     Geometric::new(proba).map_err(|e| {
         PolarsError::InvalidOperation(format!("p must be in (0, 1], got {proba}: {e}").into())
@@ -43,10 +51,11 @@ struct GeometricParamsKwargs {
 
 impl GeometricParamsKwargs {
     fn build_sampler(&self) -> PolarsResult<f64> {
+        P.check(self.p)?;
         build_sampler(self.p)
     }
 
-    /// Binds the constant `p` and `build_dist` into [`value_keyed_derived_scalar`], which validates
+    /// Binds the constant `p` and its domain into [`value_keyed_derived_scalar`], which validates
     /// and derives once per call rather than per row.
     fn value_keyed<Branches>(
         &self,
@@ -54,12 +63,12 @@ impl GeometricParamsKwargs {
         derive: impl Fn(Option<f64>) -> Branches,
         select: impl Fn(&Branches, f64) -> Option<f64>,
     ) -> PolarsResult<Series> {
-        value_keyed_derived_scalar(value, self.p, build_dist, derive, select)
+        value_keyed_derived_scalar(value, self.p, &P, derive, select)
     }
 }
 
 /// Element-wise validation of the success probability: returns `p` unchanged, raising
-/// `InvalidOperation` if `p` is outside `(0, 1]`. `null` propagates.
+/// `ComputeError` if `p` is outside `(0, 1]`. `null` propagates.
 ///
 /// The moments derive from this so they report an invalid `p` consistently with `geometric_sample`,
 /// instead of silently computing with a non-positive probability. The value-keyed methods validate
@@ -67,6 +76,7 @@ impl GeometricParamsKwargs {
 #[polars_expr(output_type=Float64)]
 fn geometric_p(inputs: &[Series]) -> PolarsResult<Series> {
     let proba = inputs[0].cast(&DataType::Float64)?;
+    P.check_column(proba.f64()?)?;
 
     validate_params_unary(proba.f64()?, |proba| {
         build_dist(proba)?;
@@ -286,49 +296,49 @@ fn derive_isf(p: Option<f64>) -> Domain<impl Fn(f64) -> f64> {
 /// See [`value_keyed_derived_per_row`] for the null/error contract.
 #[polars_expr(output_type=Float64)]
 fn geometric_pmf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, derive_pmf, Mass::at)
+    value_keyed_derived_per_row(inputs, &P, derive_pmf, Mass::at)
 }
 
 /// Element-wise log-pmf; see [`derive_ln_pmf`].
 #[polars_expr(output_type=Float64)]
 fn geometric_ln_pmf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, derive_ln_pmf, Mass::at)
+    value_keyed_derived_per_row(inputs, &P, derive_ln_pmf, Mass::at)
 }
 
 /// Element-wise cdf `P(X <= value)`; see [`derive_cdf`] and [`CDF_DIRECT_COMPLEMENT_MAX`].
 #[polars_expr(output_type=Float64)]
 fn geometric_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, derive_cdf, Tail::at)
+    value_keyed_derived_per_row(inputs, &P, derive_cdf, Tail::at)
 }
 
 /// Element-wise log-cdf; see [`derive_ln_cdf`] and [`LN_CDF_LN_1P_MAX`].
 #[polars_expr(output_type=Float64)]
 fn geometric_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, derive_ln_cdf, Tail::at)
+    value_keyed_derived_per_row(inputs, &P, derive_ln_cdf, Tail::at)
 }
 
 /// Element-wise survival function `P(X > value)`; see [`derive_sf`] for why it is not `1 - cdf`.
 #[polars_expr(output_type=Float64)]
 fn geometric_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, derive_sf, Tail::at)
+    value_keyed_derived_per_row(inputs, &P, derive_sf, Tail::at)
 }
 
 /// Element-wise log-sf; see [`derive_ln_sf`].
 #[polars_expr(output_type=Float64)]
 fn geometric_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, derive_ln_sf, Tail::at)
+    value_keyed_derived_per_row(inputs, &P, derive_ln_sf, Tail::at)
 }
 
 /// Element-wise ppf (inverse cdf); see [`derive_ppf`] and [`smallest_support_point`].
 #[polars_expr(output_type=Float64)]
 fn geometric_ppf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, derive_ppf, Domain::at)
+    value_keyed_derived_per_row(inputs, &P, derive_ppf, Domain::at)
 }
 
 /// Element-wise inverse survival function; see [`derive_isf`] for why it never forms a complement.
 #[polars_expr(output_type=Float64)]
 fn geometric_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, build_dist, derive_isf, Domain::at)
+    value_keyed_derived_per_row(inputs, &P, derive_isf, Domain::at)
 }
 
 /// Constant-`p` fast path for [`geometric_pmf`].
@@ -417,6 +427,7 @@ fn geometric_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Ser
     let proba = inputs[0].cast(&DataType::Float64)?;
     let index = inputs[1].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
+    P.check_column(proba.f64()?)?;
 
     sample_per_row_binary(
         name,
@@ -467,6 +478,7 @@ fn geometric_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<S
     let proba = inputs[0].cast(&DataType::Float64)?;
     let index = inputs[1].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
+    P.check_column(proba.f64()?)?;
 
     let rows = binary_param_rows(proba.f64()?, index.u64()?, build_sampler);
 

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -1,50 +1,29 @@
+use polars::prelude::arity::binary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::{Continuous, ContinuousCDF, LogNormal, Normal};
 
 use crate::distributions::{
-    align_inputs, normal, validate_params_binary, value_keyed_per_row, value_keyed_scalar,
-    ParamDomain,
+    align_inputs, normal, value_keyed_per_row, value_keyed_scalar, ParamDomain,
 };
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
-/// Construct a `statrs::LogNormal` behind [`MU`] and [`SIGMA`], as the row loops' backstop.
-///
-/// `statrs::LogNormal::new` rejects a `NaN` `mu`, a `NaN` `sigma` or `sigma <= 0`, and accepts an
-/// infinite `mu` or `sigma`, so the two domains are what refuse the infinities, not the constructor.
-fn build_dist(mu: f64, sigma: f64) -> PolarsResult<LogNormal> {
-    LogNormal::new(mu, sigma).map_err(|e| {
-        PolarsError::InvalidOperation(
-            format!(
-                "sigma must be finite and strictly positive (mu must be finite), got mu={mu}, sigma={sigma}: {e}"
-            )
-            .into(),
-        )
-    })
-}
+const MU: ParamDomain = ParamDomain::finite("mu");
+const SIGMA: ParamDomain = ParamDomain::positive("sigma");
 
-/// `mu` alone: finite.
-const MU: ParamDomain = ParamDomain {
-    name: "mu",
-    domain: "finite",
-    accepts: f64::is_finite,
-};
-
-/// `sigma` alone: finite, strictly positive.
-const SIGMA: ParamDomain = ParamDomain {
-    name: "sigma",
-    domain: "finite and strictly positive",
-    accepts: |sigma| sigma.is_finite() && sigma > 0.0,
-};
-
-/// The column pass every column-parameter funnel runs before its row loop.
-fn validate(mu: &Float64Chunked, sigma: &Float64Chunked) -> PolarsResult<()> {
+fn check_params(mu: &Float64Chunked, sigma: &Float64Chunked) -> PolarsResult<()> {
     MU.check_column(mu)?;
     SIGMA.check_column(sigma)
+}
+
+/// `statrs::LogNormal::new` accepts an infinite `mu` or `sigma`, so [`MU`] and [`SIGMA`] are what
+/// refuse them; behind their pass this cannot fail.
+fn build_dist(mu: f64, sigma: f64) -> PolarsResult<LogNormal> {
+    LogNormal::new(mu, sigma).map_err(|e| polars_err!(ComputeError: "{e}"))
 }
 
 /// LogNormal's constant parameters, deserialised once per call.
@@ -80,7 +59,7 @@ impl LogNormalParamsKwargs {
 /// / `isf`, which reuse the normal's `ln_erfc` forms on `ln(x)`.
 ///
 /// Infallible: any `(location, scale)` a built `LogNormal` carries is a valid `Normal`
-/// parameterisation, so validation stays with [`build_dist`] alone.
+/// parameterisation, so this carries no check of its own.
 fn underlying_normal(dist: &LogNormal) -> Normal {
     Normal::new(dist.location(), dist.scale())
         .expect("Normal::new accepts every (location, scale) a built LogNormal carries")
@@ -96,7 +75,7 @@ where
     let value = inputs[0].cast(&DataType::Float64)?;
     let mu = inputs[1].cast(&DataType::Float64)?;
     let sigma = inputs[2].cast(&DataType::Float64)?;
-    validate(mu.f64()?, sigma.f64()?)?;
+    check_params(mu.f64()?, sigma.f64()?)?;
 
     value_keyed_per_row(
         value.f64()?,
@@ -108,22 +87,24 @@ where
     )
 }
 
-/// Validate the `(mu, sigma)` parameterisation and return the validated `sigma`.
+/// `sigma` where both of `(mu, sigma)` are present, null elsewhere, after [`check_params`].
 ///
 /// `inputs[0]` is `mu`, `inputs[1]` is `sigma`. The Python closed-form moments all derive from
 /// this single FFI round-trip, so they raise on an invalid parameterisation exactly like the
-/// value-keyed methods. `null` in either input propagates; invalid raises via [`build_dist`].
+/// value-keyed methods.
 #[polars_expr(output_type=Float64)]
 fn lognormal_sigma(inputs: &[Series]) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
     let mu = inputs[0].cast(&DataType::Float64)?;
     let sigma = inputs[1].cast(&DataType::Float64)?;
-    validate(mu.f64()?, sigma.f64()?)?;
+    check_params(mu.f64()?, sigma.f64()?)?;
 
-    validate_params_binary(mu.f64()?, sigma.f64()?, |mu, sigma| {
-        build_dist(mu, sigma)?;
-        Ok(sigma)
-    })
+    let ca: Float64Chunked = binary_elementwise(
+        mu.f64()?,
+        sigma.f64()?,
+        |mu: Option<f64>, sigma: Option<f64>| mu.and(sigma),
+    );
+    Ok(ca.into_series())
 }
 
 /// One LogNormal draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
@@ -137,8 +118,8 @@ fn draw(dist: &LogNormal, rng: &mut impl rand::Rng) -> f64 {
 
 /// Element-wise LogNormal sampler over `(mu, sigma, row_index)`, returning `Float64`.
 ///
-/// Per row, `null` propagates and an invalid parameterisation raises via [`build_dist`]. Seeding
-/// and chunk-invariance follow [`sample_per_row_ternary`].
+/// Per row, `null` propagates; an invalid parameterisation raises from [`check_params`] first.
+/// Seeding and chunk-invariance follow [`sample_per_row_ternary`].
 #[polars_expr(output_type=Float64)]
 fn lognormal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
@@ -146,7 +127,7 @@ fn lognormal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Ser
     let sigma = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    validate(mu.f64()?, sigma.f64()?)?;
+    check_params(mu.f64()?, sigma.f64()?)?;
 
     sample_per_row_ternary(
         name,
@@ -199,7 +180,7 @@ fn lognormal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<S
     let sigma = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    validate(mu.f64()?, sigma.f64()?)?;
+    check_params(mu.f64()?, sigma.f64()?)?;
 
     let rows = ternary_param_rows(mu.f64()?, sigma.f64()?, index.u64()?, build_dist);
 

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -5,17 +5,17 @@ use statrs::distribution::{Continuous, ContinuousCDF, LogNormal, Normal};
 
 use crate::distributions::{
     align_inputs, normal, validate_params_binary, value_keyed_per_row, value_keyed_scalar,
+    ParamDomain,
 };
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
-/// Construct a `statrs::LogNormal`, mapping the invalid-parameter case to a `ComputeError`.
+/// Construct a `statrs::LogNormal` behind [`MU`] and [`SIGMA`], as the row loops' backstop.
 ///
-/// `statrs::LogNormal::new` rejects a `NaN` `mu`, a `NaN` `sigma`, or `sigma <= 0`. That surfaces as
-/// `InvalidOperation`, so an invalid parameterisation fails the whole evaluation rather than silently
-/// nulling the row.
+/// `statrs::LogNormal::new` rejects a `NaN` `mu`, a `NaN` `sigma` or `sigma <= 0`, and accepts an
+/// infinite `mu` or `sigma`, so the two domains are what refuse the infinities, not the constructor.
 fn build_dist(mu: f64, sigma: f64) -> PolarsResult<LogNormal> {
     LogNormal::new(mu, sigma).map_err(|e| {
         PolarsError::InvalidOperation(
@@ -25,6 +25,26 @@ fn build_dist(mu: f64, sigma: f64) -> PolarsResult<LogNormal> {
             .into(),
         )
     })
+}
+
+/// `mu` alone: finite.
+const MU: ParamDomain = ParamDomain {
+    name: "mu",
+    domain: "finite",
+    accepts: f64::is_finite,
+};
+
+/// `sigma` alone: finite, strictly positive.
+const SIGMA: ParamDomain = ParamDomain {
+    name: "sigma",
+    domain: "finite and strictly positive",
+    accepts: |sigma| sigma.is_finite() && sigma > 0.0,
+};
+
+/// The column pass every column-parameter funnel runs before its row loop.
+fn validate(mu: &Float64Chunked, sigma: &Float64Chunked) -> PolarsResult<()> {
+    MU.check_column(mu)?;
+    SIGMA.check_column(sigma)
 }
 
 /// LogNormal's constant parameters, deserialised once per call.
@@ -39,6 +59,8 @@ struct LogNormalParamsKwargs {
 
 impl LogNormalParamsKwargs {
     fn build(&self) -> PolarsResult<LogNormal> {
+        MU.check(self.mu)?;
+        SIGMA.check(self.sigma)?;
         build_dist(self.mu, self.sigma)
     }
 
@@ -74,6 +96,7 @@ where
     let value = inputs[0].cast(&DataType::Float64)?;
     let mu = inputs[1].cast(&DataType::Float64)?;
     let sigma = inputs[2].cast(&DataType::Float64)?;
+    validate(mu.f64()?, sigma.f64()?)?;
 
     value_keyed_per_row(
         value.f64()?,
@@ -95,6 +118,7 @@ fn lognormal_sigma(inputs: &[Series]) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
     let mu = inputs[0].cast(&DataType::Float64)?;
     let sigma = inputs[1].cast(&DataType::Float64)?;
+    validate(mu.f64()?, sigma.f64()?)?;
 
     validate_params_binary(mu.f64()?, sigma.f64()?, |mu, sigma| {
         build_dist(mu, sigma)?;
@@ -122,6 +146,7 @@ fn lognormal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Ser
     let sigma = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
+    validate(mu.f64()?, sigma.f64()?)?;
 
     sample_per_row_ternary(
         name,
@@ -174,6 +199,7 @@ fn lognormal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<S
     let sigma = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
+    validate(mu.f64()?, sigma.f64()?)?;
 
     let rows = ternary_param_rows(mu.f64()?, sigma.f64()?, index.u64()?, build_dist);
 

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -11,8 +11,7 @@ pub mod uniform;
 use std::borrow::Cow;
 
 use polars::prelude::arity::{
-    binary_elementwise, ternary_elementwise, try_binary_elementwise, try_ternary_elementwise,
-    try_unary_elementwise, unary_elementwise,
+    binary_elementwise, ternary_elementwise, try_ternary_elementwise, unary_elementwise,
 };
 use polars::prelude::*;
 
@@ -61,73 +60,76 @@ pub(crate) fn align_inputs(inputs: &[Series]) -> PolarsResult<Cow<'_, [Series]>>
     ))
 }
 
-/// What one float parameter must satisfy on its own, stated once per distribution file and checked
-/// the same way in both regimes: [`Self::check`] once per call on a constant, [`Self::check_column`]
-/// over the whole column before any row is built.
+/// What one float parameter must satisfy on its own, checked once per call: [`Self::check`] on a
+/// constant, [`Self::check_column`] over the whole column before any row is built.
 ///
-/// Every domain spells finiteness explicitly. The `statrs` constructors do not check it
-/// (`Normal::new(0.0, f64::INFINITY)` is `Ok`), so the constructor error inside a row loop is a
-/// backstop, not what the contract rests on.
+/// Every rule spells finiteness because the `statrs` constructors do not (`Normal::new(0.0,
+/// f64::INFINITY)` is `Ok`); behind the pass, the constructor inside a row loop cannot fail.
 pub(crate) struct ParamDomain {
     pub(crate) name: &'static str,
-    /// Read as "`name` must be {domain}".
-    pub(crate) domain: &'static str,
+    /// Read as "`name` must be {rule}".
+    pub(crate) rule: &'static str,
     pub(crate) accepts: fn(f64) -> bool,
 }
 
 impl ParamDomain {
-    fn violation(&self, value: f64) -> String {
-        format!("{} must be {}, got {}", self.name, self.domain, value)
+    pub(crate) const fn finite(name: &'static str) -> Self {
+        Self {
+            name,
+            rule: "finite",
+            accepts: f64::is_finite,
+        }
+    }
+
+    pub(crate) const fn positive(name: &'static str) -> Self {
+        Self {
+            name,
+            rule: "finite and strictly positive",
+            accepts: |x| x.is_finite() && x > 0.0,
+        }
+    }
+
+    pub(crate) const fn probability(name: &'static str) -> Self {
+        Self {
+            name,
+            rule: "in [0, 1]",
+            accepts: |p| p.is_finite() && (0.0..=1.0).contains(&p),
+        }
     }
 
     pub(crate) fn check(&self, value: f64) -> PolarsResult<()> {
-        polars_ensure!((self.accepts)(value), ComputeError: "{}", self.violation(value));
+        polars_ensure!(
+            (self.accepts)(value),
+            ComputeError: "{} must be {}, got {}", self.name, self.rule, value
+        );
         Ok(())
     }
 
-    /// Raise on the first present value outside the domain, naming its row.
-    ///
-    /// A plain iterator with an early exit, not the vectorised primitives: those would build one
-    /// boolean column per predicate and still need a scan to name the offender.
+    /// Nulls are skipped: a missing parameter is a missing answer, not an invalid one.
     pub(crate) fn check_column(&self, ca: &Float64Chunked) -> PolarsResult<()> {
-        for (row, value) in ca.iter().enumerate() {
-            if let Some(value) = value {
-                polars_ensure!(
-                    (self.accepts)(value),
-                    ComputeError: "{} at row {}", self.violation(value), row
-                );
-            }
-        }
-        Ok(())
+        ca.iter().flatten().try_for_each(|value| self.check(value))
     }
 }
 
 /// What two parameters must satisfy together (`Uniform`'s `max > min`, `DiscreteUniform`'s
-/// `min <= max`), checked only where both are present: a row with one null bound is `null` under
-/// the null contract, and the present bound still passes its own [`ParamDomain`].
+/// `min <= max`), checked only where both are present.
 pub(crate) struct PairDomain<N> {
     pub(crate) names: (&'static str, &'static str),
-    /// Read as "`names.1` must be {domain}".
-    pub(crate) domain: &'static str,
+    /// Read as "`names.1` must be {rule}".
+    pub(crate) rule: &'static str,
     pub(crate) accepts: fn(N, N) -> bool,
 }
 
 impl<N: Copy + std::fmt::Display> PairDomain<N> {
-    fn violation(&self, a: N, b: N) -> String {
-        let (a_name, b_name) = self.names;
-        format!(
-            "{b_name} must be {}, got {a_name}={a}, {b_name}={b}",
-            self.domain
-        )
-    }
-
     pub(crate) fn check(&self, a: N, b: N) -> PolarsResult<()> {
-        polars_ensure!((self.accepts)(a, b), ComputeError: "{}", self.violation(a, b));
+        let (a_name, b_name) = self.names;
+        polars_ensure!(
+            (self.accepts)(a, b),
+            ComputeError: "{} must be {}, got {}={}, {}={}", b_name, self.rule, a_name, a, b_name, b
+        );
         Ok(())
     }
 
-    /// The column twin of [`Self::check`]: raise on the first row where both are present and the
-    /// pair is outside the domain, naming the row.
     pub(crate) fn check_columns<T>(
         &self,
         a: &ChunkedArray<T>,
@@ -136,15 +138,10 @@ impl<N: Copy + std::fmt::Display> PairDomain<N> {
     where
         T: PolarsNumericType<Native = N>,
     {
-        for (row, pair) in a.iter().zip(b.iter()).enumerate() {
-            if let (Some(a), Some(b)) = pair {
-                polars_ensure!(
-                    (self.accepts)(a, b),
-                    ComputeError: "{} at row {}", self.violation(a, b), row
-                );
-            }
-        }
-        Ok(())
+        a.iter().zip(b.iter()).try_for_each(|pair| match pair {
+            (Some(a), Some(b)) => self.check(a, b),
+            _ => Ok(()),
+        })
     }
 }
 
@@ -153,25 +150,18 @@ impl<N: Copy + std::fmt::Display> PairDomain<N> {
 /// The constant-parameter counterpart of each distribution's `value_keyed` helper: when every
 /// distribution parameter is a Python scalar, the caller validates them and builds the
 /// distribution **once**, and only the evaluation-point column crosses FFI. This maps `f` over
-/// that single column, where `f` is the same per-method body the per-row path uses (a named
-/// function in each distribution file), so the two paths cannot drift and output is bit-identical.
+/// that single column, where `f` is the same per-method body the per-row path uses, so the two
+/// paths cannot drift and output is bit-identical.
 ///
-/// Null contract: `value` is the only nullable input this driver sees. The distribution
-/// parameters are not passed here at all; the caller validates them once (via `build_dist`,
-/// which raises on an invalid or non-finite parameterisation before this runs) and bakes them
-/// into `f` through a pre-built `dist`. So a null `value` propagates to null, and `f` returning
-/// `None` nulls the row on the method's own terms (e.g. `ppf` outside `[0, 1]`), matching the
-/// per-row path element for element.
+/// Null contract: `value` is the only nullable input this driver sees; a null `value` propagates,
+/// and `f` returning `None` nulls the row on the method's own terms (`ppf` outside `[0, 1]`).
 ///
 /// `NaN` contract: a `NaN` evaluation point short-circuits to `NaN` (scipy semantics) before `f`
 /// runs, for every method including `ppf`. The short-circuit is central (here and in
-/// [`value_keyed_per_row`]) rather than per body, because two bodies genuinely need it and none
-/// may be forgotten: the regularized incomplete beta behind `Beta` `cdf`/`sf` panics on `NaN`
-/// (aborting the whole query), and binomial's support mapping saturates (`NaN.floor() as u64` is
-/// `0`), returning a confident `P(X <= 0)`. The Python-side `propagate_null_and_nan` guard cannot
-/// substitute: polars evaluates every `when`/`then`/`otherwise` branch over the full column, so a
-/// plugin runs on the `NaN` rows even though the guard discards their output. Pinned by
-/// `tests/distributions/plugin_nan_test.py`.
+/// [`value_keyed_per_row`]) rather than per body, because two bodies need it and none may be
+/// forgotten: the regularized incomplete beta behind `Beta` `cdf`/`sf` panics on `NaN`, aborting
+/// the whole query, and binomial's support mapping saturates (`NaN.floor() as u64` is `0`),
+/// returning a confident `P(X <= 0)`. Pinned by `tests/distributions/plugin_nan_test.py`.
 pub(crate) fn value_keyed_scalar<F>(value: &Series, f: F) -> PolarsResult<Series>
 where
     F: Fn(f64) -> Option<f64>,
@@ -211,20 +201,20 @@ where
 /// Shared driver for the column-parameter value-keyed per-row paths.
 ///
 /// The column-parameter counterpart of [`value_keyed_scalar`]: at least one distribution parameter
-/// is a column, so `build` validates and constructs once per row instead of once per call. `f` is
-/// the same named per-method body the fast path applies (`cdf_value`, `ppf_value`, ...), so the two
-/// paths cannot drift and agree bit for bit.
+/// is a column, so `build` constructs once per row instead of once per call. `f` is the same named
+/// per-method body the fast path applies (`cdf_value`, `ppf_value`, ...), so the two paths cannot
+/// drift and agree bit for bit.
 ///
 /// The caller does the cast and the accessor (`.f64()` / `.u64()`), which fixes `A` and `B`, so a
 /// mixed `(u64, f64)` parameterisation (Binomial's `UInt64` `n` beside its `Float64` `p`) fits, as in
 /// [`ternary_param_rows`](crate::rng::ternary_param_rows). `S` needs no trait bound: it is whatever
 /// `build` returns.
 ///
-/// Null contract: any null among `(value, p1, p2)` nulls the row without calling `build`, matching
-/// the samplers.
+/// The caller has run the parameter columns through their [`ParamDomain`]s, so `build` cannot fail
+/// here; it stays `PolarsResult` because the `statrs` constructors are.
 ///
-/// `NaN` contract: as in [`value_keyed_scalar`], except that the short-circuit runs after `build`,
-/// so an invalid parameterisation still raises on a `NaN` row.
+/// Null contract: any null among `(value, p1, p2)` nulls the row without calling `build`, matching
+/// the samplers. `NaN` contract: as in [`value_keyed_scalar`].
 ///
 /// Keep `build` and `f` generic `Fn`s: they monomorphise into the row loop, where a `&dyn Fn` or a
 /// `fn` pointer would cost an indirect call per row.
@@ -247,21 +237,13 @@ where
         p1,
         p2,
         |value_opt, p1_opt, p2_opt| -> PolarsResult<Option<f64>> {
-            let (Some(p1), Some(p2)) = (p1_opt, p2_opt) else {
+            let (Some(value), Some(p1), Some(p2)) = (value_opt, p1_opt, p2_opt) else {
                 return Ok(None);
             };
-            // Build before the value is read at all, so an invalid parameterisation raises whatever
-            // the row's value is. Only a null or `NaN` *value* propagates. Pinned by
-            // `tests/distributions/plugin_nan_test.py` and `invalid_param_null_value_test.py`.
-            let dist = build(p1, p2)?;
-            let Some(value) = value_opt else {
-                return Ok(None);
-            };
-            Ok(if value.is_nan() {
-                Some(f64::NAN)
-            } else {
-                f(&dist, value)
-            })
+            if value.is_nan() {
+                return Ok(Some(f64::NAN));
+            }
+            Ok(f(&build(p1, p2)?, value))
         },
     )?;
 
@@ -276,16 +258,14 @@ where
 /// with another's `select` does not compile. Both run per row here; [`value_keyed_derived_scalar`]
 /// is the twin that runs `derive` once per call.
 ///
-/// Validation is `domain`'s column pass, run once over the parameter column before any row is
-/// built: an invalid present parameter raises whatever else its row holds, a null or `NaN` value
-/// included. Nothing inside the row loop validates.
+/// `domain`'s column pass runs once before any row is built, so nothing inside the row loop
+/// validates.
 ///
 /// Null contract, and the reason this is not [`value_keyed_per_row`]: that driver nulls the row on
-/// **any** null input without calling `build`, which is right for a `statrs`-backed distribution and
-/// wrong here. A null parameter reaches `derive` as `None`, so the branches whose answer is a
-/// parameter-free constant still answer: `Bernoulli`'s `pmf(2) = 0` and `Exponential`'s
-/// `cdf(-1) = 0` survive a null parameter, and each distribution's `null_param(s)_test.py` pins it.
-/// A null **value** nulls the row, matching the samplers.
+/// **any** null input, which is right for a `statrs`-backed distribution and wrong here. A null
+/// parameter reaches `derive` as `None`, so the branches whose answer is a parameter-free constant
+/// still answer: `Bernoulli`'s `pmf(2) = 0` and `Exponential`'s `cdf(-1) = 0` survive a null
+/// parameter, pinned by each distribution's `null_param(s)_test.py`. A null **value** nulls the row.
 ///
 /// `NaN` contract: a `NaN` value short-circuits to `NaN`, as in [`value_keyed_scalar`].
 ///
@@ -402,22 +382,18 @@ impl<Arm: Fn(f64) -> f64> Domain<Arm> {
 /// three `Series`. Kept beside the one-parameter version rather than generified over arity, because
 /// `derive` needs both `Option`s in scope to answer from one bound while the other is null.
 ///
-/// `validate` is the caller's column pass over the two parameter columns, each bound alone and the
-/// pair together, run once before any row is built. Nothing inside the row loop validates.
-///
-/// Null contract: as in [`value_keyed_derived_per_row`], with the parameter half now two-sided. A
-/// null **value** nulls the row. A null parameter reaches `derive` as `None`, so the branches a
-/// single known parameter already settles still answer.
-///
-/// `NaN` contract: a `NaN` value short-circuits to `NaN`.
-pub(crate) fn value_keyed_derived_pair_per_row<Branches, Validate, Derive, Select>(
+/// `check_params` is the caller's column pass over the two parameter columns, each bound alone and
+/// the pair together, run once before any row is built. Null and `NaN` contracts as in
+/// [`value_keyed_derived_per_row`], with the parameter half two-sided: the branches a single known
+/// bound already settles still answer.
+pub(crate) fn value_keyed_derived_pair_per_row<Branches, CheckParams, Derive, Select>(
     inputs: &[Series],
-    validate: Validate,
+    check_params: CheckParams,
     derive: Derive,
     select: Select,
 ) -> PolarsResult<Series>
 where
-    Validate: Fn(&Float64Chunked, &Float64Chunked) -> PolarsResult<()>,
+    CheckParams: Fn(&Float64Chunked, &Float64Chunked) -> PolarsResult<()>,
     Derive: Fn(Option<f64>, Option<f64>) -> Branches,
     Select: Fn(&Branches, f64) -> Option<f64>,
 {
@@ -427,7 +403,7 @@ where
     let param_b = inputs[2].cast(&DataType::Float64)?;
     let (a, b) = (param_a.f64()?, param_b.f64()?);
     let name = inputs[0].name().clone();
-    validate(a, b)?;
+    check_params(a, b)?;
 
     let ca: Float64Chunked = ternary_elementwise(value.f64()?, a, b, |value_opt, a_opt, b_opt| {
         let value = value_opt?;
@@ -439,61 +415,4 @@ where
     });
 
     Ok(ca.with_name(name).into_series())
-}
-
-/// Shared driver for the two-parameter validation plugins: `validate` builds the distribution per
-/// row and returns the `Float64` to emit, either a parameter itself (`sigma`) or a quantity derived
-/// from both (Uniform's `max - min`), `?`-propagating the `InvalidOperation` out of `build_dist`.
-/// Any null input nulls the row without calling `validate`, matching the samplers.
-///
-/// These plugins are what let the closed-form moments report an invalid parameterisation through
-/// the same Rust `build_dist` as the value-keyed methods and the samplers. The constant-parameter
-/// fast path calls the same plugin on length-1 `pl.lit` inputs, so it is built once instead of per
-/// row.
-///
-/// The two parameter dtypes are independent, so a mixed `(u64, f64)` parameterisation (Binomial)
-/// fits, as in [`ternary_param_rows`](crate::rng::ternary_param_rows): the caller does the cast and
-/// the accessor (`.f64()` / `.u64()`), which fixes `A` and `B`.
-///
-/// Takes no output name: polars resolves a plugin expression's output name from its first input, so
-/// the frame column follows `inputs[0]` (pinned by `tests/distributions/output_name_test.py`).
-///
-/// Keep `validate` a generic `F: Fn`: it monomorphises into the row loop, where a `&dyn Fn` or a
-/// `fn` pointer would cost an indirect call per row.
-pub(crate) fn validate_params_binary<A, B, F>(
-    a: &ChunkedArray<A>,
-    b: &ChunkedArray<B>,
-    validate: F,
-) -> PolarsResult<Series>
-where
-    A: PolarsNumericType,
-    B: PolarsNumericType,
-    F: Fn(A::Native, B::Native) -> PolarsResult<f64>,
-{
-    let ca: Float64Chunked =
-        try_binary_elementwise(a, b, |a_opt, b_opt| -> PolarsResult<Option<f64>> {
-            match (a_opt, b_opt) {
-                (Some(a), Some(b)) => Ok(Some(validate(a, b)?)),
-                _ => Ok(None),
-            }
-        })?;
-
-    Ok(ca.into_series())
-}
-
-/// Single-parameter counterpart of [`validate_params_binary`], same contracts
-/// (`bernoulli_proba`, `exponential_rate`).
-pub(crate) fn validate_params_unary<A, F>(a: &ChunkedArray<A>, validate: F) -> PolarsResult<Series>
-where
-    A: PolarsNumericType,
-    F: Fn(A::Native) -> PolarsResult<f64>,
-{
-    let ca: Float64Chunked = try_unary_elementwise(a, |a_opt| -> PolarsResult<Option<f64>> {
-        match a_opt {
-            Some(a) => Ok(Some(validate(a)?)),
-            None => Ok(None),
-        }
-    })?;
-
-    Ok(ca.into_series())
 }

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -11,7 +11,8 @@ pub mod uniform;
 use std::borrow::Cow;
 
 use polars::prelude::arity::{
-    try_binary_elementwise, try_ternary_elementwise, try_unary_elementwise, unary_elementwise,
+    binary_elementwise, ternary_elementwise, try_binary_elementwise, try_ternary_elementwise,
+    try_unary_elementwise, unary_elementwise,
 };
 use polars::prelude::*;
 
@@ -60,6 +61,93 @@ pub(crate) fn align_inputs(inputs: &[Series]) -> PolarsResult<Cow<'_, [Series]>>
     ))
 }
 
+/// What one float parameter must satisfy on its own, stated once per distribution file and checked
+/// the same way in both regimes: [`Self::check`] once per call on a constant, [`Self::check_column`]
+/// over the whole column before any row is built.
+///
+/// Every domain spells finiteness explicitly. The `statrs` constructors do not check it
+/// (`Normal::new(0.0, f64::INFINITY)` is `Ok`), so the constructor error inside a row loop is a
+/// backstop, not what the contract rests on.
+pub(crate) struct ParamDomain {
+    pub(crate) name: &'static str,
+    /// Read as "`name` must be {domain}".
+    pub(crate) domain: &'static str,
+    pub(crate) accepts: fn(f64) -> bool,
+}
+
+impl ParamDomain {
+    fn violation(&self, value: f64) -> String {
+        format!("{} must be {}, got {}", self.name, self.domain, value)
+    }
+
+    pub(crate) fn check(&self, value: f64) -> PolarsResult<()> {
+        polars_ensure!((self.accepts)(value), ComputeError: "{}", self.violation(value));
+        Ok(())
+    }
+
+    /// Raise on the first present value outside the domain, naming its row.
+    ///
+    /// A plain iterator with an early exit, not the vectorised primitives: those would build one
+    /// boolean column per predicate and still need a scan to name the offender.
+    pub(crate) fn check_column(&self, ca: &Float64Chunked) -> PolarsResult<()> {
+        for (row, value) in ca.iter().enumerate() {
+            if let Some(value) = value {
+                polars_ensure!(
+                    (self.accepts)(value),
+                    ComputeError: "{} at row {}", self.violation(value), row
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+/// What two parameters must satisfy together (`Uniform`'s `max > min`, `DiscreteUniform`'s
+/// `min <= max`), checked only where both are present: a row with one null bound is `null` under
+/// the null contract, and the present bound still passes its own [`ParamDomain`].
+pub(crate) struct PairDomain<N> {
+    pub(crate) names: (&'static str, &'static str),
+    /// Read as "`names.1` must be {domain}".
+    pub(crate) domain: &'static str,
+    pub(crate) accepts: fn(N, N) -> bool,
+}
+
+impl<N: Copy + std::fmt::Display> PairDomain<N> {
+    fn violation(&self, a: N, b: N) -> String {
+        let (a_name, b_name) = self.names;
+        format!(
+            "{b_name} must be {}, got {a_name}={a}, {b_name}={b}",
+            self.domain
+        )
+    }
+
+    pub(crate) fn check(&self, a: N, b: N) -> PolarsResult<()> {
+        polars_ensure!((self.accepts)(a, b), ComputeError: "{}", self.violation(a, b));
+        Ok(())
+    }
+
+    /// The column twin of [`Self::check`]: raise on the first row where both are present and the
+    /// pair is outside the domain, naming the row.
+    pub(crate) fn check_columns<T>(
+        &self,
+        a: &ChunkedArray<T>,
+        b: &ChunkedArray<T>,
+    ) -> PolarsResult<()>
+    where
+        T: PolarsNumericType<Native = N>,
+    {
+        for (row, pair) in a.iter().zip(b.iter()).enumerate() {
+            if let (Some(a), Some(b)) = pair {
+                polars_ensure!(
+                    (self.accepts)(a, b),
+                    ComputeError: "{} at row {}", self.violation(a, b), row
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
 /// Shared driver for the constant-parameter value-keyed fast paths.
 ///
 /// The constant-parameter counterpart of each distribution's `value_keyed` helper: when every
@@ -100,23 +188,22 @@ where
 
 /// Constant-parameter twin of [`value_keyed_derived_per_row`], over [`value_keyed_scalar`].
 ///
-/// Validates and derives once per call, then maps `select` over the evaluation-point column. The
-/// Python side routes here only once the parameter is a Python scalar, so `derive` always sees
-/// `Some`, and the parameter-only terms it hoists (`Bernoulli`'s `1 - p`, `Exponential`'s
-/// `ln(rate)`) are computed once instead of per row.
-pub(crate) fn value_keyed_derived_scalar<Dist, Branches, Validate, Derive, Select>(
+/// Checks the parameter against `domain` and derives once per call, then maps `select` over the
+/// evaluation-point column. The Python side routes here only once the parameter is a Python scalar,
+/// so `derive` always sees `Some`, and the parameter-only terms it hoists (`Bernoulli`'s `1 - p`,
+/// `Exponential`'s `ln(rate)`) are computed once instead of per row.
+pub(crate) fn value_keyed_derived_scalar<Branches, Derive, Select>(
     value: &Series,
     param: f64,
-    validate: Validate,
+    domain: &ParamDomain,
     derive: Derive,
     select: Select,
 ) -> PolarsResult<Series>
 where
-    Validate: Fn(f64) -> PolarsResult<Dist>,
     Derive: Fn(Option<f64>) -> Branches,
     Select: Fn(&Branches, f64) -> Option<f64>,
 {
-    validate(param)?;
+    domain.check(param)?;
     let branches = derive(Some(param));
     value_keyed_scalar(value, |v| select(&branches, v))
 }
@@ -189,59 +276,46 @@ where
 /// with another's `select` does not compile. Both run per row here; [`value_keyed_derived_scalar`]
 /// is the twin that runs `derive` once per call.
 ///
+/// Validation is `domain`'s column pass, run once over the parameter column before any row is
+/// built: an invalid present parameter raises whatever else its row holds, a null or `NaN` value
+/// included. Nothing inside the row loop validates.
+///
 /// Null contract, and the reason this is not [`value_keyed_per_row`]: that driver nulls the row on
 /// **any** null input without calling `build`, which is right for a `statrs`-backed distribution and
 /// wrong here. A null parameter reaches `derive` as `None`, so the branches whose answer is a
 /// parameter-free constant still answer: `Bernoulli`'s `pmf(2) = 0` and `Exponential`'s
 /// `cdf(-1) = 0` survive a null parameter, and each distribution's `null_param(s)_test.py` pins it.
-/// A null **value** still nulls the row without validating, matching the samplers. Nothing is
-/// validated on a null-parameter row, since there is no parameterisation to reject.
+/// A null **value** nulls the row, matching the samplers.
 ///
-/// `NaN` contract: a `NaN` value short-circuits to `NaN`, but only after `validate` has run, so an
-/// invalid parameterisation still raises on a `NaN` row, exactly as [`value_keyed_per_row`] orders
-/// it.
+/// `NaN` contract: a `NaN` value short-circuits to `NaN`, as in [`value_keyed_scalar`].
 ///
-/// `validate` is each distribution's `build_dist`; its return value is discarded, since these
-/// methods compute from the parameter rather than from the built distribution.
-///
-/// Keep `validate`, `derive` and `select` generic `Fn`s: they monomorphise into the row loop, where
-/// a `&dyn Fn` or a `fn` pointer would cost an indirect call per row.
-pub(crate) fn value_keyed_derived_per_row<Dist, Branches, Validate, Derive, Select>(
+/// Keep `derive` and `select` generic `Fn`s: they monomorphise into the row loop, where a `&dyn Fn`
+/// or a `fn` pointer would cost an indirect call per row.
+pub(crate) fn value_keyed_derived_per_row<Branches, Derive, Select>(
     inputs: &[Series],
-    validate: Validate,
+    domain: &ParamDomain,
     derive: Derive,
     select: Select,
 ) -> PolarsResult<Series>
 where
-    Validate: Fn(f64) -> PolarsResult<Dist>,
     Derive: Fn(Option<f64>) -> Branches,
     Select: Fn(&Branches, f64) -> Option<f64>,
 {
     let inputs = align_inputs(inputs)?;
     let value = inputs[0].cast(&DataType::Float64)?;
     let param = inputs[1].cast(&DataType::Float64)?;
+    let param_ca = param.f64()?;
     let name = inputs[0].name().clone();
+    domain.check_column(param_ca)?;
 
-    let ca: Float64Chunked = try_binary_elementwise(
-        value.f64()?,
-        param.f64()?,
-        |value_opt, param_opt| -> PolarsResult<Option<f64>> {
-            // Validate before the value is read at all, so an invalid parameter raises whatever the
-            // row's value is. Only a null or `NaN` *value* propagates. Pinned by
-            // `tests/distributions/plugin_nan_test.py` and `invalid_param_null_value_test.py`.
-            if let Some(param) = param_opt {
-                validate(param)?;
-            }
-            let Some(value) = value_opt else {
-                return Ok(None);
-            };
-            Ok(if value.is_nan() {
-                Some(f64::NAN)
-            } else {
-                select(&derive(param_opt), value)
-            })
-        },
-    )?;
+    let ca: Float64Chunked = binary_elementwise(value.f64()?, param_ca, |value_opt, param_opt| {
+        let value = value_opt?;
+        if value.is_nan() {
+            Some(f64::NAN)
+        } else {
+            select(&derive(param_opt), value)
+        }
+    });
 
     Ok(ca.with_name(name).into_series())
 }
@@ -322,27 +396,28 @@ impl<Arm: Fn(f64) -> f64> Domain<Arm> {
     }
 }
 
-/// Two-parameter sibling of [`value_keyed_derived_per_row`], over `try_ternary_elementwise`.
+/// Two-parameter sibling of [`value_keyed_derived_per_row`], over `ternary_elementwise`.
 ///
 /// "Pair" counts the *distribution parameters* (`Uniform`'s two bounds); the driver itself takes
 /// three `Series`. Kept beside the one-parameter version rather than generified over arity, because
 /// `derive` needs both `Option`s in scope to answer from one bound while the other is null.
 ///
-/// Null contract: as in [`value_keyed_derived_per_row`], with the parameter half now two-sided. A
-/// null **value** nulls the row without validating. A null parameter reaches `derive` as `None`, so
-/// the branches a single known parameter already settles still answer. Nothing is validated there,
-/// since a half-specified parameterisation is not one to reject.
+/// `validate` is the caller's column pass over the two parameter columns, each bound alone and the
+/// pair together, run once before any row is built. Nothing inside the row loop validates.
 ///
-/// `NaN` contract: a `NaN` value short-circuits to `NaN`, but only after `validate` has run, so an
-/// invalid parameterisation still raises on a `NaN` row.
-pub(crate) fn value_keyed_derived_pair_per_row<Dist, Branches, Validate, Derive, Select>(
+/// Null contract: as in [`value_keyed_derived_per_row`], with the parameter half now two-sided. A
+/// null **value** nulls the row. A null parameter reaches `derive` as `None`, so the branches a
+/// single known parameter already settles still answer.
+///
+/// `NaN` contract: a `NaN` value short-circuits to `NaN`.
+pub(crate) fn value_keyed_derived_pair_per_row<Branches, Validate, Derive, Select>(
     inputs: &[Series],
     validate: Validate,
     derive: Derive,
     select: Select,
 ) -> PolarsResult<Series>
 where
-    Validate: Fn(f64, f64) -> PolarsResult<Dist>,
+    Validate: Fn(&Float64Chunked, &Float64Chunked) -> PolarsResult<()>,
     Derive: Fn(Option<f64>, Option<f64>) -> Branches,
     Select: Fn(&Branches, f64) -> Option<f64>,
 {
@@ -350,29 +425,18 @@ where
     let value = inputs[0].cast(&DataType::Float64)?;
     let param_a = inputs[1].cast(&DataType::Float64)?;
     let param_b = inputs[2].cast(&DataType::Float64)?;
+    let (a, b) = (param_a.f64()?, param_b.f64()?);
     let name = inputs[0].name().clone();
+    validate(a, b)?;
 
-    let ca: Float64Chunked = try_ternary_elementwise(
-        value.f64()?,
-        param_a.f64()?,
-        param_b.f64()?,
-        |value_opt, a_opt, b_opt| -> PolarsResult<Option<f64>> {
-            // Validate before the value is read at all, so an invalid parameterisation raises
-            // whatever the row's value is. Only a null or `NaN` *value* propagates. Pinned by
-            // `tests/distributions/plugin_nan_test.py` and `invalid_param_null_value_test.py`.
-            if let (Some(a), Some(b)) = (a_opt, b_opt) {
-                validate(a, b)?;
-            }
-            let Some(value) = value_opt else {
-                return Ok(None);
-            };
-            Ok(if value.is_nan() {
-                Some(f64::NAN)
-            } else {
-                select(&derive(a_opt, b_opt), value)
-            })
-        },
-    )?;
+    let ca: Float64Chunked = ternary_elementwise(value.f64()?, a, b, |value_opt, a_opt, b_opt| {
+        let value = value_opt?;
+        if value.is_nan() {
+            Some(f64::NAN)
+        } else {
+            select(&derive(a_opt, b_opt), value)
+        }
+    });
 
     Ok(ca.with_name(name).into_series())
 }

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -8,17 +8,17 @@ use statrs::function::erf;
 use statrs::statistics::Distribution as StatrsDistribution;
 
 use crate::distributions::{
-    align_inputs, validate_params_binary, value_keyed_per_row, value_keyed_scalar,
+    align_inputs, validate_params_binary, value_keyed_per_row, value_keyed_scalar, ParamDomain,
 };
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
-/// Construct a `statrs::Normal`, mapping the invalid-parameter case to a `ComputeError`.
+/// Construct a `statrs::Normal` behind [`MU`] and [`SIGMA`], as the row loops' backstop.
 ///
-/// `statrs::Normal::new` rejects a non-finite `mu`, a `NaN` `sigma`, or `sigma <= 0`. That surfaces as
-/// `InvalidOperation`, so an invalid scale fails the whole evaluation rather than silently nulling the row.
+/// `statrs::Normal::new` rejects a `NaN` `mu`, a `NaN` `sigma` or `sigma <= 0`, and accepts an
+/// infinite `mu` or `sigma`, so the two domains are what refuse the infinities, not the constructor.
 fn build_dist(mu: f64, sigma: f64) -> PolarsResult<Normal> {
     Normal::new(mu, sigma).map_err(|e| {
         PolarsError::InvalidOperation(
@@ -26,6 +26,26 @@ fn build_dist(mu: f64, sigma: f64) -> PolarsResult<Normal> {
                 .into(),
         )
     })
+}
+
+/// `mu` alone: finite.
+const MU: ParamDomain = ParamDomain {
+    name: "mu",
+    domain: "finite",
+    accepts: f64::is_finite,
+};
+
+/// `sigma` alone: finite, strictly positive.
+const SIGMA: ParamDomain = ParamDomain {
+    name: "sigma",
+    domain: "finite and strictly positive",
+    accepts: |sigma| sigma.is_finite() && sigma > 0.0,
+};
+
+/// The column pass every column-parameter funnel runs before its row loop.
+fn validate(mu: &Float64Chunked, sigma: &Float64Chunked) -> PolarsResult<()> {
+    MU.check_column(mu)?;
+    SIGMA.check_column(sigma)
 }
 
 /// Normal's constant parameters, deserialised once per call.
@@ -40,6 +60,8 @@ struct NormalParamsKwargs {
 
 impl NormalParamsKwargs {
     fn build(&self) -> PolarsResult<Normal> {
+        MU.check(self.mu)?;
+        SIGMA.check(self.sigma)?;
         build_dist(self.mu, self.sigma)
     }
 
@@ -64,6 +86,7 @@ fn normal_sigma(inputs: &[Series]) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
     let mu = inputs[0].cast(&DataType::Float64)?;
     let sigma = inputs[1].cast(&DataType::Float64)?;
+    validate(mu.f64()?, sigma.f64()?)?;
 
     validate_params_binary(mu.f64()?, sigma.f64()?, |mu, sigma| {
         build_dist(mu, sigma)?;
@@ -81,6 +104,7 @@ where
     let value = inputs[0].cast(&DataType::Float64)?;
     let mu = inputs[1].cast(&DataType::Float64)?;
     let sigma = inputs[2].cast(&DataType::Float64)?;
+    validate(mu.f64()?, sigma.f64()?)?;
 
     value_keyed_per_row(
         value.f64()?,
@@ -112,6 +136,7 @@ fn normal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series
     let sigma = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
+    validate(mu.f64()?, sigma.f64()?)?;
 
     sample_per_row_ternary(
         name,
@@ -164,6 +189,7 @@ fn normal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Seri
     let sigma = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
+    validate(mu.f64()?, sigma.f64()?)?;
 
     let rows = ternary_param_rows(mu.f64()?, sigma.f64()?, index.u64()?, build_dist);
 

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -1,5 +1,6 @@
 use std::f64::consts::{LN_2, SQRT_2};
 
+use polars::prelude::arity::binary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution as RandDistribution;
@@ -7,45 +8,24 @@ use statrs::distribution::{Continuous, ContinuousCDF, Normal};
 use statrs::function::erf;
 use statrs::statistics::Distribution as StatrsDistribution;
 
-use crate::distributions::{
-    align_inputs, validate_params_binary, value_keyed_per_row, value_keyed_scalar, ParamDomain,
-};
+use crate::distributions::{align_inputs, value_keyed_per_row, value_keyed_scalar, ParamDomain};
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
-/// Construct a `statrs::Normal` behind [`MU`] and [`SIGMA`], as the row loops' backstop.
-///
-/// `statrs::Normal::new` rejects a `NaN` `mu`, a `NaN` `sigma` or `sigma <= 0`, and accepts an
-/// infinite `mu` or `sigma`, so the two domains are what refuse the infinities, not the constructor.
-fn build_dist(mu: f64, sigma: f64) -> PolarsResult<Normal> {
-    Normal::new(mu, sigma).map_err(|e| {
-        PolarsError::InvalidOperation(
-            format!("sigma must be finite and strictly positive, got mu={mu}, sigma={sigma}: {e}")
-                .into(),
-        )
-    })
-}
+const MU: ParamDomain = ParamDomain::finite("mu");
+const SIGMA: ParamDomain = ParamDomain::positive("sigma");
 
-/// `mu` alone: finite.
-const MU: ParamDomain = ParamDomain {
-    name: "mu",
-    domain: "finite",
-    accepts: f64::is_finite,
-};
-
-/// `sigma` alone: finite, strictly positive.
-const SIGMA: ParamDomain = ParamDomain {
-    name: "sigma",
-    domain: "finite and strictly positive",
-    accepts: |sigma| sigma.is_finite() && sigma > 0.0,
-};
-
-/// The column pass every column-parameter funnel runs before its row loop.
-fn validate(mu: &Float64Chunked, sigma: &Float64Chunked) -> PolarsResult<()> {
+fn check_params(mu: &Float64Chunked, sigma: &Float64Chunked) -> PolarsResult<()> {
     MU.check_column(mu)?;
     SIGMA.check_column(sigma)
+}
+
+/// `statrs::Normal::new` accepts an infinite `mu` or `sigma`, so [`MU`] and [`SIGMA`] are what
+/// refuse them; behind their pass this cannot fail.
+fn build_dist(mu: f64, sigma: f64) -> PolarsResult<Normal> {
+    Normal::new(mu, sigma).map_err(|e| polars_err!(ComputeError: "{e}"))
 }
 
 /// Normal's constant parameters, deserialised once per call.
@@ -76,22 +56,24 @@ impl NormalParamsKwargs {
     }
 }
 
-/// Validate the `(mu, sigma)` parameterisation and return the validated `sigma`.
+/// `sigma` where both of `(mu, sigma)` are present, null elsewhere, after [`check_params`].
 ///
 /// `inputs[0]` is `mu`, `inputs[1]` is `sigma`. The Python closed-form moments all derive from
 /// this single FFI round-trip, so they raise on an invalid parameterisation exactly like the
-/// value-keyed methods. `null` in either input propagates; invalid raises via [`build_dist`].
+/// value-keyed methods.
 #[polars_expr(output_type=Float64)]
 fn normal_sigma(inputs: &[Series]) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
     let mu = inputs[0].cast(&DataType::Float64)?;
     let sigma = inputs[1].cast(&DataType::Float64)?;
-    validate(mu.f64()?, sigma.f64()?)?;
+    check_params(mu.f64()?, sigma.f64()?)?;
 
-    validate_params_binary(mu.f64()?, sigma.f64()?, |mu, sigma| {
-        build_dist(mu, sigma)?;
-        Ok(sigma)
-    })
+    let ca: Float64Chunked = binary_elementwise(
+        mu.f64()?,
+        sigma.f64()?,
+        |mu: Option<f64>, sigma: Option<f64>| mu.and(sigma),
+    );
+    Ok(ca.into_series())
 }
 
 /// Apply a value-keyed `f(dist, value)` element-wise over `(value, mu, sigma)`; shared by `pdf`,
@@ -104,7 +86,7 @@ where
     let value = inputs[0].cast(&DataType::Float64)?;
     let mu = inputs[1].cast(&DataType::Float64)?;
     let sigma = inputs[2].cast(&DataType::Float64)?;
-    validate(mu.f64()?, sigma.f64()?)?;
+    check_params(mu.f64()?, sigma.f64()?)?;
 
     value_keyed_per_row(
         value.f64()?,
@@ -127,8 +109,8 @@ fn draw(dist: &Normal, rng: &mut impl rand::Rng) -> f64 {
 
 /// Element-wise Normal sampler over `(mu, sigma, row_index)`, returning `Float64`.
 ///
-/// Per row, `null` propagates and an invalid parameterisation raises via [`build_dist`]. Seeding
-/// and chunk-invariance follow [`sample_per_row_ternary`].
+/// Per row, `null` propagates; an invalid parameterisation raises from [`check_params`] first.
+/// Seeding and chunk-invariance follow [`sample_per_row_ternary`].
 #[polars_expr(output_type=Float64)]
 fn normal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
@@ -136,7 +118,7 @@ fn normal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series
     let sigma = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    validate(mu.f64()?, sigma.f64()?)?;
+    check_params(mu.f64()?, sigma.f64()?)?;
 
     sample_per_row_ternary(
         name,
@@ -189,7 +171,7 @@ fn normal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Seri
     let sigma = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    validate(mu.f64()?, sigma.f64()?)?;
+    check_params(mu.f64()?, sigma.f64()?)?;
 
     let rows = ternary_param_rows(mu.f64()?, sigma.f64()?, index.u64()?, build_dist);
 

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -1,50 +1,37 @@
+use polars::prelude::arity::binary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distr::{Distribution, StandardUniform};
 
 use crate::distributions::{
-    align_inputs, validate_params_binary, value_keyed_derived_pair_per_row, value_keyed_scalar,
-    Domain, PairDomain, ParamDomain,
+    align_inputs, value_keyed_derived_pair_per_row, value_keyed_scalar, Domain, PairDomain,
+    ParamDomain,
 };
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
-/// `min` alone: finite.
-const MIN: ParamDomain = ParamDomain {
-    name: "min",
-    domain: "finite",
-    accepts: f64::is_finite,
-};
+const MIN: ParamDomain = ParamDomain::finite("min");
+const MAX: ParamDomain = ParamDomain::finite("max");
 
-/// `max` alone: finite.
-const MAX: ParamDomain = ParamDomain {
-    name: "max",
-    domain: "finite",
-    accepts: f64::is_finite,
-};
-
-/// The pair: `max > min`, and a width `max - min` that does not overflow to `inf`. It does for
-/// `min=-1e308, max=1e308`, and with it every derived quantity (`range`, the moments, the draw)
-/// would silently emit `inf` instead of erroring.
+/// `max - min` overflows to `inf` for `min=-1e308, max=1e308`, and with it every derived quantity
+/// (`range`, the moments, the draw) would silently be `inf`.
 const BOUNDS: PairDomain<f64> = PairDomain {
     names: ("min", "max"),
-    domain: "strictly greater than min, and max - min must be finite",
+    rule: "strictly greater than min, and max - min must be finite",
     accepts: |min, max| max > min && (max - min).is_finite(),
 };
 
-/// Both bounds alone and the pair together: the constant regime's once-per-call check, and the row
-/// loops' backstop.
-fn build_dist(min: f64, max: f64) -> PolarsResult<(f64, f64)> {
+/// The constant regime's once-per-call check, and the row loops' backstop.
+fn checked_bounds(min: f64, max: f64) -> PolarsResult<(f64, f64)> {
     MIN.check(min)?;
     MAX.check(max)?;
     BOUNDS.check(min, max)?;
     Ok((min, max))
 }
 
-/// [`build_dist`] over columns: the pass every column-bounds funnel runs before its row loop.
-fn validate_bounds(min: &Float64Chunked, max: &Float64Chunked) -> PolarsResult<()> {
+fn check_params(min: &Float64Chunked, max: &Float64Chunked) -> PolarsResult<()> {
     MIN.check_column(min)?;
     MAX.check_column(max)?;
     BOUNDS.check_columns(min, max)
@@ -70,7 +57,7 @@ impl UniformParamsKwargs {
         derive: impl Fn(Option<f64>, Option<f64>) -> Branches,
         select: impl Fn(&Branches, f64) -> Option<f64>,
     ) -> PolarsResult<Series> {
-        build_dist(self.min, self.max)?;
+        checked_bounds(self.min, self.max)?;
         let branches = derive(Some(self.min), Some(self.max));
         value_keyed_scalar(value, |v| select(&branches, v))
     }
@@ -298,50 +285,50 @@ fn derive_isf(min: Option<f64>, max: Option<f64>) -> Domain<impl Fn(f64) -> f64>
 /// See [`value_keyed_derived_pair_per_row`] for the null/error contract.
 #[polars_expr(output_type=Float64)]
 fn uniform_pdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, validate_bounds, Density::pdf, Density::at)
+    value_keyed_derived_pair_per_row(inputs, check_params, Density::pdf, Density::at)
 }
 
 /// Element-wise log-pdf; see [`Density::ln_pdf`].
 #[polars_expr(output_type=Float64)]
 fn uniform_ln_pdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, validate_bounds, Density::ln_pdf, Density::at)
+    value_keyed_derived_pair_per_row(inputs, check_params, Density::ln_pdf, Density::at)
 }
 
 /// Element-wise cdf `P(X <= value)`; see [`derive_cdf`].
 #[polars_expr(output_type=Float64)]
 fn uniform_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, validate_bounds, derive_cdf, Regions::at)
+    value_keyed_derived_pair_per_row(inputs, check_params, derive_cdf, Regions::at)
 }
 
 /// Element-wise log-cdf; see [`derive_ln_cdf`].
 #[polars_expr(output_type=Float64)]
 fn uniform_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, validate_bounds, derive_ln_cdf, Regions::at)
+    value_keyed_derived_pair_per_row(inputs, check_params, derive_ln_cdf, Regions::at)
 }
 
 /// Element-wise survival function `P(X > value)`; see [`derive_sf`] for why it is not `1 - cdf`.
 #[polars_expr(output_type=Float64)]
 fn uniform_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, validate_bounds, derive_sf, Regions::at)
+    value_keyed_derived_pair_per_row(inputs, check_params, derive_sf, Regions::at)
 }
 
 /// Element-wise log-sf; see [`derive_ln_sf`].
 #[polars_expr(output_type=Float64)]
 fn uniform_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, validate_bounds, derive_ln_sf, Regions::at)
+    value_keyed_derived_pair_per_row(inputs, check_params, derive_ln_sf, Regions::at)
 }
 
 /// Element-wise ppf (inverse cdf); see [`derive_inverse`].
 #[polars_expr(output_type=Float64)]
 fn uniform_ppf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, validate_bounds, derive_ppf, Domain::at)
+    value_keyed_derived_pair_per_row(inputs, check_params, derive_ppf, Domain::at)
 }
 
 /// Element-wise inverse survival function; see [`derive_inverse`] for why it never forms a
 /// complement.
 #[polars_expr(output_type=Float64)]
 fn uniform_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, validate_bounds, derive_isf, Domain::at)
+    value_keyed_derived_pair_per_row(inputs, check_params, derive_isf, Domain::at)
 }
 
 /// Constant-bounds fast path for [`uniform_pdf`].
@@ -422,9 +409,9 @@ fn draw_half_open(lo: f64, hi: f64, rng: &mut impl rand::Rng) -> f64 {
 /// Element-wise continuous Uniform sampler over `[min, max)`, taking `(min, max, row_index)` and
 /// returning `Float64`.
 ///
-/// Per row, `null` propagates and an invalid parameterisation (`max <= min`, non-finite bounds, or
-/// a width overflowing `f64`) raises via [`build_dist`]. Seeding and chunk-invariance follow
-/// [`sample_per_row_ternary`].
+/// Per row, `null` propagates; an invalid parameterisation (`max <= min`, non-finite bounds, or a
+/// width overflowing `f64`) raises from [`check_params`] before any row is drawn. Seeding and
+/// chunk-invariance follow [`sample_per_row_ternary`].
 #[polars_expr(output_type=Float64)]
 fn uniform_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
@@ -432,7 +419,7 @@ fn uniform_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Serie
     let max = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    validate_bounds(min.f64()?, max.f64()?)?;
+    check_params(min.f64()?, max.f64()?)?;
 
     sample_per_row_ternary(
         name,
@@ -440,7 +427,7 @@ fn uniform_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Serie
         max.f64()?,
         index.u64()?,
         kwargs.seed,
-        build_dist,
+        checked_bounds,
         |&(lo, hi), rng| draw_half_open(lo, hi, rng),
     )
 }
@@ -451,7 +438,7 @@ fn uniform_sample_scalar(
     inputs: &[Series],
     kwargs: SampleScalarKwargs<UniformParamsKwargs>,
 ) -> PolarsResult<Series> {
-    let (lo, hi) = build_dist(kwargs.params.min, kwargs.params.max)?;
+    let (lo, hi) = checked_bounds(kwargs.params.min, kwargs.params.max)?;
     let name = inputs[0].name().clone();
 
     sample_by_index(name, &inputs[0], kwargs.seed, |rng| {
@@ -468,7 +455,7 @@ fn uniform_samples_scalar(
     inputs: &[Series],
     kwargs: SamplesScalarKwargs<UniformParamsKwargs>,
 ) -> PolarsResult<Series> {
-    let (lo, hi) = build_dist(kwargs.params.min, kwargs.params.max)?;
+    let (lo, hi) = checked_bounds(kwargs.params.min, kwargs.params.max)?;
     let name = inputs[0].name().clone();
 
     samples_by_index(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
@@ -476,8 +463,8 @@ fn uniform_samples_scalar(
     })
 }
 
-/// Element-wise multi-draw Uniform sampler over `[min, max)`: `size` draws per row in one call,
-/// the bounds validated once per row. Returns `Array(Float64, size)`.
+/// Element-wise multi-draw Uniform sampler over `[min, max)`: `size` draws per row in one call.
+/// Returns `Array(Float64, size)`.
 ///
 /// Seeding and the null/error contract follow [`samples_per_row`] and [`uniform_sample`]; the
 /// draw is the shared [`draw_half_open`].
@@ -488,16 +475,16 @@ fn uniform_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Ser
     let max = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    validate_bounds(min.f64()?, max.f64()?)?;
+    check_params(min.f64()?, max.f64()?)?;
 
-    let rows = ternary_param_rows(min.f64()?, max.f64()?, index.u64()?, build_dist);
+    let rows = ternary_param_rows(min.f64()?, max.f64()?, index.u64()?, checked_bounds);
 
     samples_per_row(name, rows, kwargs.seed, kwargs.size, |&(lo, hi), rng| {
         draw_half_open(lo, hi, rng)
     })
 }
 
-/// Element-wise support width `max - min`, validating the parameterisation.
+/// Element-wise support width `max - min`, behind [`check_params`].
 ///
 /// `inputs[0]` is the lower bound, `inputs[1]` the upper bound. `null` in either propagates;
 /// `max <= min`, non-finite bounds, or a width overflowing `f64` raise `ComputeError`.
@@ -510,9 +497,12 @@ fn uniform_range(inputs: &[Series]) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
     let min = inputs[0].cast(&DataType::Float64)?;
     let max = inputs[1].cast(&DataType::Float64)?;
-    validate_bounds(min.f64()?, max.f64()?)?;
+    check_params(min.f64()?, max.f64()?)?;
 
-    validate_params_binary(min.f64()?, max.f64()?, |lo, hi| {
-        build_dist(lo, hi).map(|(lo, hi)| hi - lo)
-    })
+    let ca: Float64Chunked = binary_elementwise(
+        min.f64()?,
+        max.f64()?,
+        |lo: Option<f64>, hi: Option<f64>| Some(hi? - lo?),
+    );
+    Ok(ca.into_series())
 }

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -1,34 +1,53 @@
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distr::{Distribution, StandardUniform};
-use statrs::distribution::Uniform;
 
 use crate::distributions::{
     align_inputs, validate_params_binary, value_keyed_derived_pair_per_row, value_keyed_scalar,
-    Domain,
+    Domain, PairDomain, ParamDomain,
 };
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
+/// `min` alone: finite.
+const MIN: ParamDomain = ParamDomain {
+    name: "min",
+    domain: "finite",
+    accepts: f64::is_finite,
+};
+
+/// `max` alone: finite.
+const MAX: ParamDomain = ParamDomain {
+    name: "max",
+    domain: "finite",
+    accepts: f64::is_finite,
+};
+
+/// The pair: `max > min`, and a width `max - min` that does not overflow to `inf`. It does for
+/// `min=-1e308, max=1e308`, and with it every derived quantity (`range`, the moments, the draw)
+/// would silently emit `inf` instead of erroring.
+const BOUNDS: PairDomain<f64> = PairDomain {
+    names: ("min", "max"),
+    domain: "strictly greater than min, and max - min must be finite",
+    accepts: |min, max| max > min && (max - min).is_finite(),
+};
+
+/// Both bounds alone and the pair together: the constant regime's once-per-call check, and the row
+/// loops' backstop.
 fn build_dist(min: f64, max: f64) -> PolarsResult<(f64, f64)> {
-    // `statrs` accepts any finite `min < max`, but a support wider than `f64::MAX` (e.g.
-    // `min=-1e308, max=1e308`) makes `max - min` overflow to `inf`, and with it every derived
-    // quantity: `range`, the moments, and the draw itself would all silently emit `inf` instead
-    // of erroring. Reject it here so all uniform plugins report it as an invalid
-    // parameterisation.
-    if !(max - min).is_finite() {
-        return Err(PolarsError::InvalidOperation(
-            format!("max - min must be finite, got min={min:e}, max={max:e}").into(),
-        ));
-    }
-    Uniform::new(min, max).map_err(|e| {
-        PolarsError::InvalidOperation(
-            format!("max must be strictly greater than min, got min={min}, max={max}: {e}").into(),
-        )
-    })?;
+    MIN.check(min)?;
+    MAX.check(max)?;
+    BOUNDS.check(min, max)?;
     Ok((min, max))
+}
+
+/// [`build_dist`] over columns: the pass every column-bounds funnel runs before its row loop.
+fn validate_bounds(min: &Float64Chunked, max: &Float64Chunked) -> PolarsResult<()> {
+    MIN.check_column(min)?;
+    MAX.check_column(max)?;
+    BOUNDS.check_columns(min, max)
 }
 
 /// Uniform's constant bounds, deserialised once per call.
@@ -279,50 +298,50 @@ fn derive_isf(min: Option<f64>, max: Option<f64>) -> Domain<impl Fn(f64) -> f64>
 /// See [`value_keyed_derived_pair_per_row`] for the null/error contract.
 #[polars_expr(output_type=Float64)]
 fn uniform_pdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, build_dist, Density::pdf, Density::at)
+    value_keyed_derived_pair_per_row(inputs, validate_bounds, Density::pdf, Density::at)
 }
 
 /// Element-wise log-pdf; see [`Density::ln_pdf`].
 #[polars_expr(output_type=Float64)]
 fn uniform_ln_pdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, build_dist, Density::ln_pdf, Density::at)
+    value_keyed_derived_pair_per_row(inputs, validate_bounds, Density::ln_pdf, Density::at)
 }
 
 /// Element-wise cdf `P(X <= value)`; see [`derive_cdf`].
 #[polars_expr(output_type=Float64)]
 fn uniform_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, build_dist, derive_cdf, Regions::at)
+    value_keyed_derived_pair_per_row(inputs, validate_bounds, derive_cdf, Regions::at)
 }
 
 /// Element-wise log-cdf; see [`derive_ln_cdf`].
 #[polars_expr(output_type=Float64)]
 fn uniform_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, build_dist, derive_ln_cdf, Regions::at)
+    value_keyed_derived_pair_per_row(inputs, validate_bounds, derive_ln_cdf, Regions::at)
 }
 
 /// Element-wise survival function `P(X > value)`; see [`derive_sf`] for why it is not `1 - cdf`.
 #[polars_expr(output_type=Float64)]
 fn uniform_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, build_dist, derive_sf, Regions::at)
+    value_keyed_derived_pair_per_row(inputs, validate_bounds, derive_sf, Regions::at)
 }
 
 /// Element-wise log-sf; see [`derive_ln_sf`].
 #[polars_expr(output_type=Float64)]
 fn uniform_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, build_dist, derive_ln_sf, Regions::at)
+    value_keyed_derived_pair_per_row(inputs, validate_bounds, derive_ln_sf, Regions::at)
 }
 
 /// Element-wise ppf (inverse cdf); see [`derive_inverse`].
 #[polars_expr(output_type=Float64)]
 fn uniform_ppf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, build_dist, derive_ppf, Domain::at)
+    value_keyed_derived_pair_per_row(inputs, validate_bounds, derive_ppf, Domain::at)
 }
 
 /// Element-wise inverse survival function; see [`derive_inverse`] for why it never forms a
 /// complement.
 #[polars_expr(output_type=Float64)]
 fn uniform_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, build_dist, derive_isf, Domain::at)
+    value_keyed_derived_pair_per_row(inputs, validate_bounds, derive_isf, Domain::at)
 }
 
 /// Constant-bounds fast path for [`uniform_pdf`].
@@ -413,6 +432,7 @@ fn uniform_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Serie
     let max = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
+    validate_bounds(min.f64()?, max.f64()?)?;
 
     sample_per_row_ternary(
         name,
@@ -468,6 +488,7 @@ fn uniform_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Ser
     let max = inputs[1].cast(&DataType::Float64)?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
+    validate_bounds(min.f64()?, max.f64()?)?;
 
     let rows = ternary_param_rows(min.f64()?, max.f64()?, index.u64()?, build_dist);
 
@@ -479,8 +500,7 @@ fn uniform_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Ser
 /// Element-wise support width `max - min`, validating the parameterisation.
 ///
 /// `inputs[0]` is the lower bound, `inputs[1]` the upper bound. `null` in either propagates;
-/// `max <= min`, non-finite bounds, or a width overflowing `f64` raise `InvalidOperation`
-/// (surfaces as a `ComputeError`).
+/// `max <= min`, non-finite bounds, or a width overflowing `f64` raise `ComputeError`.
 ///
 /// Every closed-form Python method derives from this width, so routing it through Rust is what
 /// lets them report an invalid parameterisation consistently with `uniform_sample`, instead of
@@ -490,6 +510,7 @@ fn uniform_range(inputs: &[Series]) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
     let min = inputs[0].cast(&DataType::Float64)?;
     let max = inputs[1].cast(&DataType::Float64)?;
+    validate_bounds(min.f64()?, max.f64()?)?;
 
     validate_params_binary(min.f64()?, max.f64()?, |lo, hi| {
         build_dist(lo, hi).map(|(lo, hi)| hi - lo)

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -163,8 +163,8 @@ impl DrawValue for bool {
 ///
 /// The column-parameter counterpart of [`sample_by_index`], and the single-draw counterpart of
 /// [`samples_per_row`]. `build` constructs the row's draw state once per row; `draw` takes one
-/// value from that row's stream. Any null input nulls the row without calling `build`; an invalid
-/// parameterisation `?`-raises out of the row closure.
+/// value from that row's stream. Any null input nulls the row without calling `build`; the caller
+/// has run the parameter columns through their domain pass, so `build` cannot fail here.
 ///
 /// Seeding follows [`sample_by_index`]: row `i` draws from a stream keyed `(root_seed, i)`, a
 /// function of position only, never of the parameters, so the scalar and column paths stay

--- a/tests/distributions/beta/construct_test.py
+++ b/tests/distributions/beta/construct_test.py
@@ -25,7 +25,7 @@ def test_construct_scalar_invalid_shape_defers_to_eval(a: float, b: float) -> No
     # No early Python validation (matching Normal / Uniform): construction succeeds; the invalid
     # shape surfaces as a ComputeError when a method is evaluated, not a ValueError here.
     Beta(a=a, b=b)
-    with pytest.raises(pl.exceptions.ComputeError, match="a and b must be finite and strictly positive"):
+    with pytest.raises(pl.exceptions.ComputeError, match="must be finite and strictly positive"):
         pl.DataFrame({"x": [0.5]}).select(r=Beta(a=a, b=b).pdf(pl.col("x")))
 
 

--- a/tests/distributions/beta/sample_test.py
+++ b/tests/distributions/beta/sample_test.py
@@ -86,7 +86,7 @@ def test_sample_non_positive_shape_row_raises(seed: int) -> None:
     # An invalid shape on a row raises (no early Python validation), the same way Normal reports a
     # non-positive scale. Plugin errors surface as `ComputeError`.
     dframe = pl.DataFrame({"a": [2.0, 1.0, 3.0], "b": [3.0, -2.0, 1.0]})  # row 1: b = -2.0
-    with pytest.raises(pl.exceptions.ComputeError, match="a and b must be finite and strictly positive"):
+    with pytest.raises(pl.exceptions.ComputeError, match="must be finite and strictly positive"):
         dframe.with_columns(z=Beta(a=pl.col("a"), b=pl.col("b")).sample(seed=seed))
 
 

--- a/tests/distributions/beta/samples_test.py
+++ b/tests/distributions/beta/samples_test.py
@@ -73,5 +73,5 @@ def test_samples_null_param_row_is_null_array(seed: int) -> None:
 
 def test_samples_non_positive_shape_raises(seed: int) -> None:
     dframe = pl.DataFrame({"a": [2.0, 1.0], "b": [3.0, -2.0]})  # row 1: b = -2.0
-    with pytest.raises(pl.exceptions.ComputeError, match="a and b must be finite and strictly positive"):
+    with pytest.raises(pl.exceptions.ComputeError, match="must be finite and strictly positive"):
         dframe.select(s=Beta(a=pl.col("a"), b=pl.col("b")).samples(size=4, seed=seed))

--- a/tests/distributions/beta/validation_test.py
+++ b/tests/distributions/beta/validation_test.py
@@ -37,7 +37,7 @@ _METHODS: dict[str, Callable[[Beta], pl.Expr]] = {
 def test_method_raises_on_non_positive_shape_column(expr_fn: Callable[[Beta], pl.Expr]) -> None:
     df = pl.DataFrame({"a": [2.0, -1.0], "b": [3.0, 2.0], "x": [0.5, 0.5], "q": [0.5, 0.5]})
     dist = Beta(a=pl.col("a"), b=pl.col("b"))  # row 1: a = -1.0
-    with pytest.raises(pl.exceptions.ComputeError, match="a and b must be finite and strictly positive"):
+    with pytest.raises(pl.exceptions.ComputeError, match="must be finite and strictly positive"):
         df.select(r=expr_fn(dist))
 
 
@@ -45,7 +45,7 @@ def test_method_raises_on_non_positive_shape_column(expr_fn: Callable[[Beta], pl
 def test_method_raises_on_non_positive_shape_scalar(expr_fn: Callable[[Beta], pl.Expr]) -> None:
     df = pl.DataFrame({"x": [0.5], "q": [0.5]})
     dist = Beta(a=2.0, b=-1.0)
-    with pytest.raises(pl.exceptions.ComputeError, match="a and b must be finite and strictly positive"):
+    with pytest.raises(pl.exceptions.ComputeError, match="must be finite and strictly positive"):
         df.select(r=expr_fn(dist))
 
 
@@ -59,5 +59,5 @@ def test_method_raises_on_non_positive_shape_scalar(expr_fn: Callable[[Beta], pl
 )
 def test_infinite_shape_raises(dist: Beta) -> None:
     # Unlike the Normal / LogNormal scale, statrs rejects an infinite Beta shape.
-    with pytest.raises(pl.exceptions.ComputeError, match="a and b must be finite and strictly positive"):
+    with pytest.raises(pl.exceptions.ComputeError, match="must be finite and strictly positive"):
         pl.DataFrame({"x": [0.5]}).select(r=dist.pdf(pl.col("x")))

--- a/tests/distributions/exponential/construct_test.py
+++ b/tests/distributions/exponential/construct_test.py
@@ -19,7 +19,7 @@ def test_construct_scalar_invalid_rate_defers_to_eval(bad_rate: float) -> None:
     # No early Python validation: construction succeeds (matching Uniform / Bernoulli's deferral);
     # the invalid rate surfaces as a ComputeError when a method is evaluated, not a ValueError here.
     Exponential(rate=bad_rate)
-    with pytest.raises(pl.exceptions.ComputeError, match="rate must be strictly positive"):
+    with pytest.raises(pl.exceptions.ComputeError, match="rate must be finite and strictly positive"):
         pl.DataFrame({"x": [0.5]}).select(r=Exponential(rate=bad_rate).pdf(pl.col("x")))
 
 

--- a/tests/distributions/exponential/sample_test.py
+++ b/tests/distributions/exponential/sample_test.py
@@ -74,7 +74,7 @@ def test_sample_null_rate_row_is_null(seed: int) -> None:
 def test_sample_non_positive_rate_row_raises(seed: int) -> None:
     # An invalid rate on a row raises (no early Python validation), like Uniform / Bernoulli.
     dframe = pl.DataFrame({"rate": [1.0, -0.5, 2.0]})  # row 1: rate <= 0
-    with pytest.raises(pl.exceptions.ComputeError, match="rate must be strictly positive"):
+    with pytest.raises(pl.exceptions.ComputeError, match="rate must be finite and strictly positive"):
         dframe.with_columns(e=Exponential(rate=pl.col("rate")).sample(seed=seed))
 
 

--- a/tests/distributions/exponential/samples_test.py
+++ b/tests/distributions/exponential/samples_test.py
@@ -65,5 +65,5 @@ def test_samples_null_rate_row_is_null_array(seed: int) -> None:
 
 def test_samples_non_positive_rate_raises(seed: int) -> None:
     dframe = pl.DataFrame({"rate": [1.0, -0.5]})  # row 1: rate <= 0
-    with pytest.raises(pl.exceptions.ComputeError, match="rate must be strictly positive"):
+    with pytest.raises(pl.exceptions.ComputeError, match="rate must be finite and strictly positive"):
         dframe.select(s=Exponential(rate=pl.col("rate")).samples(size=4, seed=seed))

--- a/tests/distributions/exponential/validation_test.py
+++ b/tests/distributions/exponential/validation_test.py
@@ -36,7 +36,7 @@ _METHODS: dict[str, Callable[[Exponential], pl.Expr]] = {
 def test_method_raises_on_non_positive_rate_column(expr_fn: Callable[[Exponential], pl.Expr]) -> None:
     df = pl.DataFrame({"rate": [1.0, -0.5], "x": [0.5, 0.5], "q": [0.5, 0.5]})  # row 1: rate <= 0
     e = Exponential(rate=pl.col("rate"))
-    with pytest.raises(pl.exceptions.ComputeError, match="rate must be strictly positive"):
+    with pytest.raises(pl.exceptions.ComputeError, match="rate must be finite and strictly positive"):
         df.select(r=expr_fn(e))
 
 
@@ -44,7 +44,7 @@ def test_method_raises_on_non_positive_rate_column(expr_fn: Callable[[Exponentia
 def test_method_raises_on_non_positive_rate_scalar(expr_fn: Callable[[Exponential], pl.Expr]) -> None:
     df = pl.DataFrame({"x": [0.5], "q": [0.5]})
     e = Exponential(rate=-1.0)
-    with pytest.raises(pl.exceptions.ComputeError, match="rate must be strictly positive"):
+    with pytest.raises(pl.exceptions.ComputeError, match="rate must be finite and strictly positive"):
         df.select(r=expr_fn(e))
 
 
@@ -52,5 +52,5 @@ def test_method_raises_on_non_positive_rate_scalar(expr_fn: Callable[[Exponentia
 def test_method_raises_on_nan_rate_scalar(expr_fn: Callable[[Exponential], pl.Expr]) -> None:
     df = pl.DataFrame({"x": [0.5], "q": [0.5]})
     e = Exponential(rate=float("nan"))
-    with pytest.raises(pl.exceptions.ComputeError, match="rate must be strictly positive"):
+    with pytest.raises(pl.exceptions.ComputeError, match="rate must be finite and strictly positive"):
         df.select(r=expr_fn(e))

--- a/tests/distributions/moment_fast_path_test.py
+++ b/tests/distributions/moment_fast_path_test.py
@@ -9,11 +9,11 @@ all-scalar parameters that plugin is called once on length-1 `pl.lit` inputs ins
 this module pins the parts that test does not reach:
 
 * **Both paths agree on validation.** An invalid scalar parameterisation must raise the same
-  `ComputeError` as the equivalent per-row columns; an accepted non-finite one (a positive-infinite
-  scale, which `statrs` allows) must produce identical output on both. The fast path cannot quietly
-  accept or reject something the per-row path does not. Unlike the value-keyed fast-path test, this
-  covers `Uniform` and `Bernoulli` too: their moments *do* route through a validator, so the scalar
-  path can drift there.
+  `ComputeError` as the equivalent per-row columns, a non-finite parameter included: finiteness is
+  the library's own check, applied whether or not `statrs` would accept the value. The fast path
+  cannot quietly accept or reject something the per-row path does not. Unlike the value-keyed
+  fast-path test, this covers `Uniform` and `Bernoulli` too: their moments *do* route through a
+  validator, so the scalar path can drift there.
 * **The validator runs once, whatever the frame height.** A length-1 plugin input exists independently
   of the frame, so an empty frame still validates and an invalid scalar parameterisation still raises,
   matching the value-keyed kwargs fast path (`value_keyed_fast_path_test.py`). The scalar moment is then
@@ -58,17 +58,17 @@ def _col(value: float, dtype: pl.DataType | None = None) -> pl.Expr:
 
 # id -> (scalar instance, equivalent per-row instance, should_raise). `variance` is the representative
 # moment: it routes through the parameter validator for every distribution (Normal/LogNormal/Binomial
-# via `_moment`, Uniform via `range`, Bernoulli via `_checked_p`). The accepted-`inf` cases guard that
-# the fast path does not reject a parameterisation the per-row path accepts.
+# via `_moment`, Uniform via `range`, Bernoulli via `_checked_p`). The `inf` cases guard that the fast
+# path applies the library's own finiteness check where `statrs` alone would accept the value.
 _CASES: dict[str, tuple[_UnivariateDistribution, _UnivariateDistribution, bool]] = {
     "normal mu=nan": (Normal(_NAN, 1.0), Normal(_col(_NAN), _col(1.0)), True),
     "normal std=0": (Normal(0.0, 0.0), Normal(_col(0.0), _col(0.0)), True),
     "normal std=-1": (Normal(0.0, -1.0), Normal(_col(0.0), _col(-1.0)), True),
     "normal std=nan": (Normal(0.0, _NAN), Normal(_col(0.0), _col(_NAN)), True),
-    "normal std=inf (accepted)": (Normal(0.0, _INF), Normal(_col(0.0), _col(_INF)), False),
+    "normal std=inf": (Normal(0.0, _INF), Normal(_col(0.0), _col(_INF)), True),
     "lognormal sigma=-1": (LogNormal(0.0, -1.0), LogNormal(_col(0.0), _col(-1.0)), True),
     "lognormal sigma=nan": (LogNormal(0.0, _NAN), LogNormal(_col(0.0), _col(_NAN)), True),
-    "lognormal sigma=inf (accepted)": (LogNormal(0.0, _INF), LogNormal(_col(0.0), _col(_INF)), False),
+    "lognormal sigma=inf": (LogNormal(0.0, _INF), LogNormal(_col(0.0), _col(_INF)), True),
     "uniform max<min": (Uniform(2.0, 1.0), Uniform(_col(2.0), _col(1.0)), True),
     "uniform max=min": (Uniform(1.0, 1.0), Uniform(_col(1.0), _col(1.0)), True),
     "uniform min=nan": (Uniform(_NAN, 1.0), Uniform(_col(_NAN), _col(1.0)), True),
@@ -87,8 +87,7 @@ _CASES: dict[str, tuple[_UnivariateDistribution, _UnivariateDistribution, bool]]
     "beta a=0": (Beta(0.0, 1.0), Beta(_col(0.0), _col(1.0)), True),
     "beta b=-1": (Beta(2.0, -1.0), Beta(_col(2.0), _col(-1.0)), True),
     "beta a=nan": (Beta(_NAN, 1.0), Beta(_col(_NAN), _col(1.0)), True),
-    # An infinite shape is *rejected* by statrs, unlike the Normal / LogNormal scale.
-    "beta a=inf (rejected)": (Beta(_INF, 1.0), Beta(_col(_INF), _col(1.0)), True),
+    "beta a=inf": (Beta(_INF, 1.0), Beta(_col(_INF), _col(1.0)), True),
 }
 
 

--- a/tests/distributions/moment_fast_path_test.py
+++ b/tests/distributions/moment_fast_path_test.py
@@ -62,6 +62,7 @@ def _col(value: float, dtype: pl.DataType | None = None) -> pl.Expr:
 # path applies the library's own finiteness check where `statrs` alone would accept the value.
 _CASES: dict[str, tuple[_UnivariateDistribution, _UnivariateDistribution, bool]] = {
     "normal mu=nan": (Normal(_NAN, 1.0), Normal(_col(_NAN), _col(1.0)), True),
+    "normal mu=inf": (Normal(_INF, 1.0), Normal(_col(_INF), _col(1.0)), True),
     "normal std=0": (Normal(0.0, 0.0), Normal(_col(0.0), _col(0.0)), True),
     "normal std=-1": (Normal(0.0, -1.0), Normal(_col(0.0), _col(-1.0)), True),
     "normal std=nan": (Normal(0.0, _NAN), Normal(_col(0.0), _col(_NAN)), True),
@@ -69,6 +70,7 @@ _CASES: dict[str, tuple[_UnivariateDistribution, _UnivariateDistribution, bool]]
     "lognormal sigma=-1": (LogNormal(0.0, -1.0), LogNormal(_col(0.0), _col(-1.0)), True),
     "lognormal sigma=nan": (LogNormal(0.0, _NAN), LogNormal(_col(0.0), _col(_NAN)), True),
     "lognormal sigma=inf": (LogNormal(0.0, _INF), LogNormal(_col(0.0), _col(_INF)), True),
+    "lognormal mu=inf": (LogNormal(_INF, 1.0), LogNormal(_col(_INF), _col(1.0)), True),
     "uniform max<min": (Uniform(2.0, 1.0), Uniform(_col(2.0), _col(1.0)), True),
     "uniform max=min": (Uniform(1.0, 1.0), Uniform(_col(1.0), _col(1.0)), True),
     "uniform min=nan": (Uniform(_NAN, 1.0), Uniform(_col(_NAN), _col(1.0)), True),
@@ -133,8 +135,8 @@ def test_moment_fast_path_on_empty_frame_is_a_scalar() -> None:
     """On a zero-row frame the scalar moment is still one row, and still validates.
 
     Both follow from the scalar path being built from length-1 literals, exactly as
-    `df.head(0).select(pl.lit(1.0))` is one row. The per-row path validates inside its row closure,
-    which never runs on an empty frame, so it returns empty without raising.
+    `df.head(0).select(pl.lit(1.0))` is one row. The per-row path's column pass sees no value on an
+    empty frame, so it returns empty without raising.
     """
     empty = pl.DataFrame({"_": []}, schema={"_": pl.Int64})
 

--- a/tests/distributions/null_nan_contract_test.py
+++ b/tests/distributions/null_nan_contract_test.py
@@ -1,0 +1,142 @@
+"""The parameter-validity half of the null / `NaN` contract: an invalid present parameter raises.
+
+`NaN`, `+inf` and `-inf` in any float parameter slot raise `ComputeError` on every method, whatever
+else the row holds: a `NaN` or null evaluation point, or a null sibling parameter. So does a finite
+value outside the slot's own domain beside a null sibling. Validation is a property of the parameter
+column, run in Rust once per call before any row is built, so it cannot depend on which *other*
+columns happen to be null on the same row.
+
+Value-keyed methods are probed through the private `_x` hooks: the public wrappers overlay
+`propagate_null_and_nan` (`_base.py`), which from polars 1.44 masks the plugin out of the null and
+`NaN` rows before it validates. Moments and samplers have no wrapper and go through the public API.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import polars as pl
+import pytest
+
+from polars_stats import Bernoulli, Beta, Binomial, DiscreteUniform, Exponential, Geometric, LogNormal, Normal, Uniform
+from polars_stats.distributions._base import DiscreteDistribution, _UnivariateDistribution
+
+
+@dataclass(frozen=True)
+class _Dist:
+    """One distribution with every parameter a column, a valid row for it, and which slots are integers."""
+
+    name: str
+    dist: _UnivariateDistribution
+    valid: dict[str, float]
+    integer: frozenset[str] = frozenset()
+
+    @property
+    def float_slots(self) -> tuple[str, ...]:
+        return tuple(name for name in self.valid if name not in self.integer)
+
+    def frame(self, overrides: dict[str, float | None], x: float | None) -> pl.DataFrame:
+        """One row: the valid parameters with `overrides` applied, and the evaluation point `x`."""
+        schema = {name: (pl.Int64 if name in self.integer else pl.Float64) for name in self.valid}
+        data = {name: [overrides.get(name, value)] for name, value in self.valid.items()}
+        return pl.DataFrame({**data, "x": [x]}, schema={**schema, "x": pl.Float64})
+
+
+_DISTS: tuple[_Dist, ...] = (
+    _Dist("Bernoulli", Bernoulli(p=pl.col("p")), {"p": 0.5}),
+    _Dist("Binomial", Binomial(n=pl.col("n"), p=pl.col("p")), {"n": 10, "p": 0.5}, integer=frozenset({"n"})),
+    _Dist("Beta", Beta(a=pl.col("a"), b=pl.col("b")), {"a": 2.0, "b": 3.0}),
+    _Dist("Exponential", Exponential(rate=pl.col("rate")), {"rate": 1.0}),
+    _Dist("Geometric", Geometric(p=pl.col("p")), {"p": 0.5}),
+    _Dist("Normal", Normal(mu=pl.col("mu"), sigma=pl.col("sigma")), {"mu": 0.0, "sigma": 1.0}),
+    _Dist("LogNormal", LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")), {"mu": 0.0, "sigma": 1.0}),
+    _Dist("Uniform", Uniform(min=pl.col("min"), max=pl.col("max")), {"min": 0.0, "max": 1.0}),
+    _Dist(
+        "DiscreteUniform",
+        DiscreteUniform(min=pl.col("min"), max=pl.col("max")),
+        {"min": 0, "max": 5},
+        integer=frozenset({"min", "max"}),
+    ),
+)
+_BY_NAME = {dist.name: dist for dist in _DISTS}
+
+_MOMENTS = ("mean", "variance", "std", "median", "entropy")
+
+_NON_FINITE = {"nan": math.nan, "inf": math.inf, "-inf": -math.inf}
+
+_OUT_OF_DOMAIN: tuple[tuple[str, str, float], ...] = (
+    ("Normal", "sigma", -1.0),
+    ("LogNormal", "sigma", -1.0),
+    ("Beta", "a", -1.0),
+    ("Beta", "b", -1.0),
+    ("Binomial", "p", -1.0),
+)
+"""A finite value outside a slot's own domain, for every two-parameter distribution that has one.
+
+`Uniform` and `DiscreteUniform` have none: a bound alone is any finite value (any integer), and the
+pair constraint runs only where both bounds are present.
+"""
+
+
+def _value_hooks(dist: _UnivariateDistribution) -> tuple[str, ...]:
+    """Every value-keyed `_x` hook of `dist`, density methods named by family."""
+    density = ("_pmf", "_log_pmf") if isinstance(dist, DiscreteDistribution) else ("_pdf", "_log_pdf")
+    return (*density, "_cdf", "_log_cdf", "_sf", "_log_sf", "_ppf", "_isf")
+
+
+def _report(frame: pl.DataFrame, expr: pl.Expr) -> str | None:
+    """The `ComputeError` message, or `None` when the query computed."""
+    try:
+        frame.select(r=expr)
+    except pl.exceptions.ComputeError as err:
+        return str(err)
+    return None
+
+
+def _unreported(dist: _Dist, overrides: dict[str, float | None], slot: str) -> list[str]:
+    """Every method that computes, or raises without naming `slot`, on the row `overrides` describes.
+
+    The value-keyed hooks run at a finite, a `NaN` and a null evaluation point; the moments and the
+    samplers read no point, so they run once.
+    """
+    probes = [
+        (f"{hook}(x={x})", dist.frame(overrides, x), getattr(dist.dist, hook)(pl.col("x")))
+        for x in (0.5, math.nan, None)
+        for hook in _value_hooks(dist.dist)
+    ]
+    row = dist.frame(overrides, 0.5)
+    probes += [(method, row, getattr(dist.dist, method)()) for method in _MOMENTS]
+    probes += [("sample", row, dist.dist.sample(seed=0)), ("samples", row, dist.dist.samples(3, seed=0))]
+    fragment = f"{slot} must be"
+    return [
+        label for label, frame, expr in probes if (report := _report(frame, expr)) is None or fragment not in report
+    ]
+
+
+_NON_FINITE_CASES = [
+    pytest.param(dist, slot, bad, id=f"{dist.name}.{slot}={label}")
+    for dist in _DISTS
+    for slot in dist.float_slots
+    for label, bad in _NON_FINITE.items()
+]
+
+
+@pytest.mark.parametrize(("dist", "slot", "bad"), _NON_FINITE_CASES)
+def test_non_finite_parameter_raises_on_every_method(dist: _Dist, slot: str, bad: float) -> None:
+    """With the sibling parameters present, and again with each sibling null."""
+    rows: list[dict[str, float | None]] = [
+        {slot: bad},
+        *({slot: bad, other: None} for other in dist.valid if other != slot),
+    ]
+    unreported = [(label, row) for row in rows for label in _unreported(dist, row, slot)]
+    assert not unreported, f"{dist.name} did not report `{slot} must be` in {unreported}"
+
+
+@pytest.mark.parametrize(("name", "slot", "bad"), _OUT_OF_DOMAIN, ids=[f"{n}.{s}={b}" for n, s, b in _OUT_OF_DOMAIN])
+def test_invalid_parameter_beside_a_null_sibling_raises(name: str, slot: str, bad: float) -> None:
+    """A null sibling is a missing answer on its row, not a reason to skip validating the present parameter."""
+    dist = _BY_NAME[name]
+    (sibling,) = (other for other in dist.valid if other != slot)
+    unreported = _unreported(dist, {slot: bad, sibling: None}, slot)
+    assert not unreported, f"{name} did not report `{slot} must be` beside a null `{sibling}` in {unreported}"

--- a/tests/distributions/null_nan_contract_test.py
+++ b/tests/distributions/null_nan_contract_test.py
@@ -1,14 +1,13 @@
-"""The parameter-validity half of the null / `NaN` contract: an invalid present parameter raises.
+"""An invalid present parameter raises, whatever else its row holds.
 
-`NaN`, `+inf` and `-inf` in any float parameter slot raise `ComputeError` on every method, whatever
-else the row holds: a `NaN` or null evaluation point, or a null sibling parameter. So does a finite
-value outside the slot's own domain beside a null sibling. Validation is a property of the parameter
-column, run in Rust once per call before any row is built, so it cannot depend on which *other*
-columns happen to be null on the same row.
+`NaN`, `+inf` and `-inf` in any float parameter slot raise `ComputeError` on every method, beside a
+`NaN` or null evaluation point and beside a null sibling parameter alike; so does a finite value
+outside the slot's domain beside a null sibling. Validation runs over the parameter column before any
+row is built, so it cannot depend on what else is null on the row.
 
-Value-keyed methods are probed through the private `_x` hooks: the public wrappers overlay
-`propagate_null_and_nan` (`_base.py`), which from polars 1.44 masks the plugin out of the null and
-`NaN` rows before it validates. Moments and samplers have no wrapper and go through the public API.
+Value-keyed methods go through the private `_x` hooks: on polars >= 1.44 the public wrapper
+`propagate_null_and_nan` masks the plugin out of the null and `NaN` rows before it can validate.
+Moments and samplers have no wrapper and go through the public API.
 """
 
 from __future__ import annotations
@@ -19,14 +18,12 @@ from dataclasses import dataclass
 import polars as pl
 import pytest
 
-from polars_stats import Bernoulli, Beta, Binomial, DiscreteUniform, Exponential, Geometric, LogNormal, Normal, Uniform
+from polars_stats import Bernoulli, Beta, Binomial, Exponential, Geometric, LogNormal, Normal, Uniform
 from polars_stats.distributions._base import DiscreteDistribution, _UnivariateDistribution
 
 
 @dataclass(frozen=True)
 class _Dist:
-    """One distribution with every parameter a column, a valid row for it, and which slots are integers."""
-
     name: str
     dist: _UnivariateDistribution
     valid: dict[str, float]
@@ -52,19 +49,13 @@ _DISTS: tuple[_Dist, ...] = (
     _Dist("Normal", Normal(mu=pl.col("mu"), sigma=pl.col("sigma")), {"mu": 0.0, "sigma": 1.0}),
     _Dist("LogNormal", LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")), {"mu": 0.0, "sigma": 1.0}),
     _Dist("Uniform", Uniform(min=pl.col("min"), max=pl.col("max")), {"min": 0.0, "max": 1.0}),
-    _Dist(
-        "DiscreteUniform",
-        DiscreteUniform(min=pl.col("min"), max=pl.col("max")),
-        {"min": 0, "max": 5},
-        integer=frozenset({"min", "max"}),
-    ),
 )
 _BY_NAME = {dist.name: dist for dist in _DISTS}
 
 _MOMENTS = ("mean", "variance", "std", "median", "entropy")
-
 _NON_FINITE = {"nan": math.nan, "inf": math.inf, "-inf": -math.inf}
 
+# `Uniform` is absent: a bound alone is any finite value, and the pair rule needs both bounds present.
 _OUT_OF_DOMAIN: tuple[tuple[str, str, float], ...] = (
     ("Normal", "sigma", -1.0),
     ("LogNormal", "sigma", -1.0),
@@ -72,15 +63,9 @@ _OUT_OF_DOMAIN: tuple[tuple[str, str, float], ...] = (
     ("Beta", "b", -1.0),
     ("Binomial", "p", -1.0),
 )
-"""A finite value outside a slot's own domain, for every two-parameter distribution that has one.
-
-`Uniform` and `DiscreteUniform` have none: a bound alone is any finite value (any integer), and the
-pair constraint runs only where both bounds are present.
-"""
 
 
 def _value_hooks(dist: _UnivariateDistribution) -> tuple[str, ...]:
-    """Every value-keyed `_x` hook of `dist`, density methods named by family."""
     density = ("_pmf", "_log_pmf") if isinstance(dist, DiscreteDistribution) else ("_pdf", "_log_pdf")
     return (*density, "_cdf", "_log_cdf", "_sf", "_log_sf", "_ppf", "_isf")
 
@@ -94,12 +79,8 @@ def _report(frame: pl.DataFrame, expr: pl.Expr) -> str | None:
     return None
 
 
-def _unreported(dist: _Dist, overrides: dict[str, float | None], slot: str) -> list[str]:
-    """Every method that computes, or raises without naming `slot`, on the row `overrides` describes.
-
-    The value-keyed hooks run at a finite, a `NaN` and a null evaluation point; the moments and the
-    samplers read no point, so they run once.
-    """
+def _unreported(dist: _Dist, overrides: dict[str, float | None], slot: str) -> list[tuple[str, str | None]]:
+    """Every method that computes, or raises without naming `slot`, with what it reported."""
     probes = [
         (f"{hook}(x={x})", dist.frame(overrides, x), getattr(dist.dist, hook)(pl.col("x")))
         for x in (0.5, math.nan, None)
@@ -109,34 +90,32 @@ def _unreported(dist: _Dist, overrides: dict[str, float | None], slot: str) -> l
     probes += [(method, row, getattr(dist.dist, method)()) for method in _MOMENTS]
     probes += [("sample", row, dist.dist.sample(seed=0)), ("samples", row, dist.dist.samples(3, seed=0))]
     fragment = f"{slot} must be"
-    return [
-        label for label, frame, expr in probes if (report := _report(frame, expr)) is None or fragment not in report
-    ]
+    reports = [(label, _report(frame, expr)) for label, frame, expr in probes]
+    return [(label, report) for label, report in reports if report is None or fragment not in report]
 
 
-_NON_FINITE_CASES = [
-    pytest.param(dist, slot, bad, id=f"{dist.name}.{slot}={label}")
-    for dist in _DISTS
-    for slot in dist.float_slots
-    for label, bad in _NON_FINITE.items()
-]
-
-
-@pytest.mark.parametrize(("dist", "slot", "bad"), _NON_FINITE_CASES)
+@pytest.mark.parametrize(
+    ("dist", "slot", "bad"),
+    [
+        pytest.param(dist, slot, bad, id=f"{dist.name}.{slot}={label}")
+        for dist in _DISTS
+        for slot in dist.float_slots
+        for label, bad in _NON_FINITE.items()
+    ],
+)
 def test_non_finite_parameter_raises_on_every_method(dist: _Dist, slot: str, bad: float) -> None:
     """With the sibling parameters present, and again with each sibling null."""
     rows: list[dict[str, float | None]] = [
         {slot: bad},
         *({slot: bad, other: None} for other in dist.valid if other != slot),
     ]
-    unreported = [(label, row) for row in rows for label in _unreported(dist, row, slot)]
-    assert not unreported, f"{dist.name} did not report `{slot} must be` in {unreported}"
+    unreported = [(label, row, report) for row in rows for label, report in _unreported(dist, row, slot)]
+    assert not unreported, f"{dist.name} did not report `{slot} must be`: {unreported}"
 
 
 @pytest.mark.parametrize(("name", "slot", "bad"), _OUT_OF_DOMAIN, ids=[f"{n}.{s}={b}" for n, s, b in _OUT_OF_DOMAIN])
 def test_invalid_parameter_beside_a_null_sibling_raises(name: str, slot: str, bad: float) -> None:
-    """A null sibling is a missing answer on its row, not a reason to skip validating the present parameter."""
     dist = _BY_NAME[name]
     (sibling,) = (other for other in dist.valid if other != slot)
     unreported = _unreported(dist, {slot: bad, sibling: None}, slot)
-    assert not unreported, f"{name} did not report `{slot} must be` beside a null `{sibling}` in {unreported}"
+    assert not unreported, f"{name} did not report `{slot} must be` beside a null `{sibling}`: {unreported}"

--- a/tests/distributions/validation_contract_test.py
+++ b/tests/distributions/validation_contract_test.py
@@ -52,7 +52,7 @@ class _Case:
 
 _CASES: tuple[_Case, ...] = (
     _Case("Bernoulli", Bernoulli(p=pl.col("p")), {"p": [0.3, 1.5]}, "p must be in"),
-    _Case("Beta", Beta(a=pl.col("a"), b=pl.col("b")), {"a": [2.0, -1.0], "b": [3.0, 3.0]}, "a and b must be"),
+    _Case("Beta", Beta(a=pl.col("a"), b=pl.col("b")), {"a": [2.0, -1.0], "b": [3.0, 3.0]}, "a must be"),
     _Case("Binomial", Binomial(n=pl.col("n"), p=pl.col("p")), {"n": [10, 10], "p": [0.3, 1.5]}, "p must be in"),
     _Case(
         "DiscreteUniform",

--- a/tests/distributions/value_keyed_fast_path_test.py
+++ b/tests/distributions/value_keyed_fast_path_test.py
@@ -3,8 +3,8 @@
 Covers every distribution: each has per-method Rust plugins.
 
 `pdf` / `pmf` / `cdf` / `sf` / `ppf` with all-scalar parameters route through a dedicated ``<name>_<method>_scalar``
-plugin that validates and builds the `statrs` distribution once (via the shared `build_dist`), instead of rebuilding it
-per row. Two properties of that routing are pinned here, both of which the bit-equality property test
+plugin that validates the parameters and builds the distribution once, instead of per row. Two properties of that
+routing are pinned here, both of which the bit-equality property test
 (`tests/property/value_keyed_test.py`, valid params only) does not exercise:
 
 * **Both paths agree on validation.** For an invalid parameterisation both the fast path and the
@@ -13,11 +13,10 @@ per row. Two properties of that routing are pinned here, both of which the bit-e
   must produce identical output. A non-finite parameter is invalid by the library's own check,
   whether or not `statrs` would accept it. The fast path cannot quietly accept or reject something
   the per-row path does not.
-* **The fast path validates up front.** `build_dist` runs once before any value is touched, so
-  invalid scalar parameters raise even on a zero-row frame; the per-row path validates inside its
-  per-element closure, which never runs on an empty frame, so it returns empty. This divergence is
-  intentional (validate-once, mirroring the sampler fast path) and pinned so it cannot regress
-  silently.
+* **The fast path validates up front.** The scalar check runs once before any value is touched, so
+  invalid scalar parameters raise even on a zero-row frame; the per-row path's column pass sees no
+  value on an empty frame, so it returns empty. This divergence is intentional (validate-once,
+  mirroring the sampler fast path) and pinned so it cannot regress silently.
 
 A Python `None` parameter cannot reach either path: `coerce_param` rejects it as a `TypeError` at construction, covered
 by each distribution's `construct_test.py`. So there is no "null scalar parameter" case to test here, and none for
@@ -66,6 +65,7 @@ _CASES: dict[str, tuple[Callable[[], _UnivariateDistribution], Callable[[], _Uni
     "bernoulli p=0 (accepted)": (lambda: Bernoulli(0.0), lambda: Bernoulli(_col(0.0)), False),
     "bernoulli p=1 (accepted)": (lambda: Bernoulli(1.0), lambda: Bernoulli(_col(1.0)), False),
     "normal mu=nan": (lambda: Normal(_NAN, 1.0), lambda: Normal(_col(_NAN), _col(1.0)), True),
+    "normal mu=inf": (lambda: Normal(_INF, 1.0), lambda: Normal(_col(_INF), _col(1.0)), True),
     "normal std=0": (lambda: Normal(0.0, 0.0), lambda: Normal(_col(0.0), _col(0.0)), True),
     "normal std=-1": (lambda: Normal(0.0, -1.0), lambda: Normal(_col(0.0), _col(-1.0)), True),
     "normal std=nan": (lambda: Normal(0.0, _NAN), lambda: Normal(_col(0.0), _col(_NAN)), True),
@@ -75,6 +75,7 @@ _CASES: dict[str, tuple[Callable[[], _UnivariateDistribution], Callable[[], _Uni
     "lognormal sigma=nan": (lambda: LogNormal(0.0, _NAN), lambda: LogNormal(_col(0.0), _col(_NAN)), True),
     "lognormal sigma=-1": (lambda: LogNormal(0.0, -1.0), lambda: LogNormal(_col(0.0), _col(-1.0)), True),
     "lognormal sigma=inf": (lambda: LogNormal(0.0, _INF), lambda: LogNormal(_col(0.0), _col(_INF)), True),
+    "lognormal mu=inf": (lambda: LogNormal(_INF, 1.0), lambda: LogNormal(_col(_INF), _col(1.0)), True),
     "binomial p=nan": (lambda: Binomial(5, _NAN), lambda: Binomial(_col(5, pl.Int64()), _col(_NAN)), True),
     "binomial p=1.5": (lambda: Binomial(5, 1.5), lambda: Binomial(_col(5, pl.Int64()), _col(1.5)), True),
     "beta a=nan": (lambda: Beta(_NAN, 1.0), lambda: Beta(_col(_NAN), _col(1.0)), True),
@@ -140,10 +141,10 @@ def test_scalar_and_column_paths_agree_on_validation(
 def test_scalar_fast_path_validates_on_empty_input() -> None:
     """The fast path raises on invalid scalar params even with no rows; the per-row path returns empty.
 
-    `build_dist` runs once up front on the fast path, so an invalid scale is caught regardless of
-    input length. The per-row path validates inside the per-element closure, which is never entered
-    on a zero-row frame, so it produces an empty result instead. Pinned because it is the one
-    intended observable difference between the two paths.
+    The scalar check runs once up front on the fast path, so an invalid scale is caught regardless
+    of input length. The per-row path's column pass sees no value on a zero-row frame, so it
+    produces an empty result instead. Pinned because it is the one intended observable difference
+    between the two paths.
     """
     empty = pl.DataFrame({"x": []}, schema={"x": pl.Float64})
 

--- a/tests/distributions/value_keyed_fast_path_test.py
+++ b/tests/distributions/value_keyed_fast_path_test.py
@@ -8,10 +8,11 @@ per row. Two properties of that routing are pinned here, both of which the bit-e
 (`tests/property/value_keyed_test.py`, valid params only) does not exercise:
 
 * **Both paths agree on validation.** For an invalid parameterisation both the fast path and the
-  general per-row path must raise the same `ComputeError`; for a non-finite-but-accepted one (a
-  positive-infinite scale, which `statrs` allows: only `NaN` or a non-positive scale is rejected)
-  both must produce identical output. The fast path cannot quietly accept or reject something the
-  per-row path does not.
+  general per-row path must raise the same `ComputeError`; for an accepted degenerate one
+  (`Bernoulli`'s point masses, `Geometric`'s `p = 1`, `DiscreteUniform`'s one-point support) both
+  must produce identical output. A non-finite parameter is invalid by the library's own check,
+  whether or not `statrs` would accept it. The fast path cannot quietly accept or reject something
+  the per-row path does not.
 * **The fast path validates up front.** `build_dist` runs once before any value is touched, so
   invalid scalar parameters raise even on a zero-row frame; the per-row path validates inside its
   per-element closure, which never runs on an empty frame, so it returns empty. This divergence is
@@ -68,26 +69,24 @@ _CASES: dict[str, tuple[Callable[[], _UnivariateDistribution], Callable[[], _Uni
     "normal std=0": (lambda: Normal(0.0, 0.0), lambda: Normal(_col(0.0), _col(0.0)), True),
     "normal std=-1": (lambda: Normal(0.0, -1.0), lambda: Normal(_col(0.0), _col(-1.0)), True),
     "normal std=nan": (lambda: Normal(0.0, _NAN), lambda: Normal(_col(0.0), _col(_NAN)), True),
-    # A positive-infinite scale is accepted by statrs (only NaN / non-positive is rejected); both
-    # paths must accept it identically, not merely both reject the bad cases.
-    "normal std=inf (accepted)": (lambda: Normal(0.0, _INF), lambda: Normal(_col(0.0), _col(_INF)), False),
+    # `statrs` accepts a positive-infinite scale; the library's own finiteness check refuses it, and
+    # both paths must apply that check.
+    "normal std=inf": (lambda: Normal(0.0, _INF), lambda: Normal(_col(0.0), _col(_INF)), True),
     "lognormal sigma=nan": (lambda: LogNormal(0.0, _NAN), lambda: LogNormal(_col(0.0), _col(_NAN)), True),
     "lognormal sigma=-1": (lambda: LogNormal(0.0, -1.0), lambda: LogNormal(_col(0.0), _col(-1.0)), True),
-    "lognormal sigma=inf (accepted)": (lambda: LogNormal(0.0, _INF), lambda: LogNormal(_col(0.0), _col(_INF)), False),
+    "lognormal sigma=inf": (lambda: LogNormal(0.0, _INF), lambda: LogNormal(_col(0.0), _col(_INF)), True),
     "binomial p=nan": (lambda: Binomial(5, _NAN), lambda: Binomial(_col(5, pl.Int64()), _col(_NAN)), True),
     "binomial p=1.5": (lambda: Binomial(5, 1.5), lambda: Binomial(_col(5, pl.Int64()), _col(1.5)), True),
     "beta a=nan": (lambda: Beta(_NAN, 1.0), lambda: Beta(_col(_NAN), _col(1.0)), True),
     "beta a=0": (lambda: Beta(0.0, 1.0), lambda: Beta(_col(0.0), _col(1.0)), True),
     "beta b=-1": (lambda: Beta(2.0, -1.0), lambda: Beta(_col(2.0), _col(-1.0)), True),
-    # An infinite shape is *rejected* by statrs, unlike the Normal / LogNormal scale; both paths must
-    # agree on that too.
-    "beta a=inf (rejected)": (lambda: Beta(_INF, 1.0), lambda: Beta(_col(_INF), _col(1.0)), True),
+    "beta a=inf": (lambda: Beta(_INF, 1.0), lambda: Beta(_col(_INF), _col(1.0)), True),
     "exponential rate=nan": (lambda: Exponential(_NAN), lambda: Exponential(_col(_NAN)), True),
     "exponential rate=0": (lambda: Exponential(0.0), lambda: Exponential(_col(0.0)), True),
     "exponential rate=-1": (lambda: Exponential(-1.0), lambda: Exponential(_col(-1.0)), True),
-    # An infinite rate is accepted by statrs as the degenerate point mass at 0, like the Normal
-    # scale and unlike the Beta shape; both paths must accept it identically.
-    "exponential rate=inf (accepted)": (lambda: Exponential(_INF), lambda: Exponential(_col(_INF)), False),
+    # `statrs` accepts an infinite rate as the degenerate point mass at 0; the library's finiteness
+    # check refuses it, as for the Normal scale.
+    "exponential rate=inf": (lambda: Exponential(_INF), lambda: Exponential(_col(_INF)), True),
     "geometric p=nan": (lambda: Geometric(_NAN), lambda: Geometric(_col(_NAN)), True),
     "geometric p=1.5": (lambda: Geometric(1.5), lambda: Geometric(_col(1.5)), True),
     # `p = 0` is the one endpoint Geometric rejects where Bernoulli accepts it: the trial count of a


### PR DESCRIPTION
Every parameter column now goes through its domain check before any row computes, in every regime and at every entry point (value-keyed methods, moments, samplers, scalar kwargs), so an infinite Normal/LogNormal/Exponential parameter and an invalid parameter beside a null sibling both raise `ComputeError` instead of computing. Nothing that returned a correct answer before changes. The check runs once per column rather than per row, which halves Bernoulli's moment timings and leaves everything else within noise.
