### PR TITLE
fix(distributions): a null parameter is a null answer, at every evaluation point

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -178,7 +178,7 @@ code rather than halfway through, write the scipy-parity test first, and keep a 
           `uniform.rs`'s `Density::pdf`); where a branch still depends on the evaluation point, the table carries an
           `Arm` type parameter and `derive` is a free function (`exponential.rs`'s and `geometric.rs`'s `derive_cdf`
           over the shared `Sides<Arm, FLOOR>` in `mod.rs`, `uniform.rs`'s `derive_cdf` / `Regions::at`). An inverse
-          needs no table at all: `derive` returns the arm and `select` is the shared `in_unit_domain`. The Polars
+          needs no table at all: `derive` returns the arm and `select` is the shared `on_unit_interval`. The Polars
           expression it replaces computed `1 - p` once on a
           length-1 literal and broadcast it; a body that recomputes per row regressed the constant-parameter path by
           up to 195% at 10M rows. `derive` runs once per call on the constant path and once per row when a parameter

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -177,7 +177,8 @@ code rather than halfway through, write the scipy-parity test first, and keep a 
           non-generic and `derive` is an associated constructor (`bernoulli.rs`'s `Mass::pmf` / `Mass::at`,
           `uniform.rs`'s `Density::pdf`); where a branch still depends on the evaluation point, the table carries an
           `Arm` type parameter and `derive` is a free function (`exponential.rs`'s and `geometric.rs`'s `derive_cdf`
-          over the shared `Sides<Arm, FLOOR>` in `mod.rs`, `uniform.rs`'s `derive_cdf` / `Regions::at`). The Polars
+          over the shared `Sides<Arm, FLOOR>` in `mod.rs`, `uniform.rs`'s `derive_cdf` / `Regions::at`). An inverse
+          needs no table at all: `derive` returns the arm and `select` is the shared `in_unit_domain`. The Polars
           expression it replaces computed `1 - p` once on a
           length-1 literal and broadcast it; a body that recomputes per row regressed the constant-parameter path by
           up to 195% at 10M rows. `derive` runs once per call on the constant path and once per row when a parameter
@@ -186,10 +187,9 @@ code rather than halfway through, write the scipy-parity test first, and keep a 
           `value_keyed_derived_scalar` in `src/distributions/mod.rs`. A two-parameter one takes
           `value_keyed_derived_pair_per_row` beside them, and keeps its constant-parameter twin local
           (`UniformParamsKwargs::value_keyed`) until a second distribution needs it; both plugin shells are still one
-          line and neither names a driver internal. They are not `value_keyed_per_row`, which nulls a row on **any**
-          null input: a null parameter has to reach `derive` as `None` so the branches whose answer carries no
-          parameter still
-          answer (`Bernoulli.pmf(2) = 0`, `Exponential.cdf(-1) = 0`, `Uniform.pdf` above a known `max`).
+          line and neither names a driver internal. They are not `value_keyed_per_row`, which builds a `statrs`
+          distribution per row: `derive` takes plain `f64`s and hoists the parameter-only terms out of the loop.
+          Every driver nulls a row on any null parameter, before it reads the evaluation point.
     * State each parameter's domain once as a `ParamDomain` constant (`ParamDomain::finite("mu")`,
       `ParamDomain::positive("sigma")`, `ParamDomain::probability("p")`, or a literal for any other rule) and a joint
       constraint as a `PairDomain`. Every column-parameter plugin runs `check_column` / `check_columns` over its

--- a/docs/how-to/nulls-and-errors.md
+++ b/docs/how-to/nulls-and-errors.md
@@ -23,9 +23,8 @@ print(df.with_columns(density=ps.Normal().pdf("x")))
 ```
 
 A null *parameter* behaves the same way: that row's result is null, and no error is raised. This matters when
-parameters are estimated, because an under-sized group yields a null `sigma`. The one refinement is that a null
-parameter nulls the answer only where the answer depends on it, so an off-support constant survives: on a row
-whose `lo` is null, `Uniform(min="lo", max="hi").pdf(5.0)` is still `0.0` wherever `hi` is below `5.0`; see
+parameters are estimated, because an under-sized group yields a null `sigma`. The rule has no exceptions, so a
+null parameter nulls the row even where the evaluation point alone would have settled the answer; see
 [Reference / Parameters and contracts](../reference/parameters-and-contracts.md#nulls-nans-and-errors).
 
 ## Find the rows that would raise

--- a/docs/reference/parameters-and-contracts.md
+++ b/docs/reference/parameters-and-contracts.md
@@ -147,7 +147,7 @@ indistinguishable from a legitimately missing input, and would propagate wrong a
 | Wrong parameter *type* (a `list`, an `int` for a float parameter, a `bool`) | Python `__init__` | `TypeError`, no query runs |
 | Invalid parameter *value*, scalar or one column row | Rust evaluation | `ComputeError`, fails the whole evaluation, never silently nulls (one exception on polars >= 1.44, see [Known limitation](index.md#compatibility)) |
 | `null` value or quantile argument on a row | per row | `null` on that row |
-| `null` parameter on a row | per row | `null` on that row, no error, except where a branch that carries no parameter already settles the answer (see below) |
+| `null` parameter on a row | per row | `null` on that row, on every method and off the support too, no error (see below) |
 | `NaN` value or quantile argument on a row | per row | `NaN` on that row (matches scipy) |
 | Non-numeric column as an *argument* | evaluation | Polars raises `InvalidOperationError` |
 | Non-numeric column as a *parameter* | Rust evaluation, if at all | `ComputeError` for `Categorical` / `Enum` / `Struct` / `Object`; `Boolean`, `String` and the temporal dtypes are **not** rejected and compute, an unparsable `String` nulling its row (see [Accepted inputs](#accepted-inputs)) |
@@ -156,13 +156,14 @@ indistinguishable from a legitimately missing input, and would propagate wrong a
 | `pmf(3.5)` for a discrete distribution | per row | `0.0` (matches scipy) |
 | Deep-tail underflow (`sf` of a 60-sigma event) | per row | `0.0`; `log_sf` keeps resolution where it has a stable form, see [Numerical accuracy](../explanation/accuracy.md) |
 
-**A `null` parameter nulls the answer only where the answer depends on it.** Off the support the answer is often a
-constant that no parameter enters, and that constant survives: on a row whose `p` is null, `Bernoulli(p="p").pmf(2)`
-is `0.0`, not `null`, and so is `Exponential(rate="rate").cdf(-1)`. `Uniform` has two bounds, so the rule is per
-bound: an answer survives a null bound exactly when the *other*, known bound places the evaluation point outside the
-support. On a row whose `min` is null and whose `max` is `1.0`, `pdf(5.0)` is `0.0` and `cdf(5.0)` is `1.0`, while
-every method nulls at `0.5`. Both of `Uniform`'s
+**A `null` parameter nulls the answer, on the support and off it.** A missing parameter is a missing answer, as
+`null * 0` is `null` in polars, so no off-support constant outranks it: on a row whose `p` is null,
+`Bernoulli(p="p").pmf(2)` is `null` rather than `0.0`, and so is `Exponential(rate="rate").cdf(-1)`. The same holds
+per bound for `Uniform`, whose two bounds might otherwise have settled the answer between them: on a row whose `min`
+is null and whose `max` is `1.0`, `pdf(5.0)` and `cdf(5.0)` are both `null`, as is every method at `0.5`. Both
 inverses null at every quantile under either null bound, in range and out.
+
+`fill_null` on the parameter column restores the older, narrower answer for anyone who wants it.
 
 Every distribution shipped today has finite moments on its valid parameter range, so this contract is exhaustive for
 them. The policy for distributions whose moments can be undefined is in

--- a/docs/reference/parameters-and-contracts.md
+++ b/docs/reference/parameters-and-contracts.md
@@ -163,8 +163,6 @@ per bound for `Uniform`, whose two bounds might otherwise have settled the answe
 is null and whose `max` is `1.0`, `pdf(5.0)` and `cdf(5.0)` are both `null`, as is every method at `0.5`. Both
 inverses null at every quantile under either null bound, in range and out.
 
-`fill_null` on the parameter column restores the older, narrower answer for anyone who wants it.
-
 Every distribution shipped today has finite moments on its valid parameter range, so this contract is exhaustive for
 them. The policy for distributions whose moments can be undefined is in
 [Design notes](../explanation/design.md#moments-that-are-undefined-return-null-divergent-ones-return-inf).

--- a/polars_stats/distributions/_bernoulli.py
+++ b/polars_stats/distributions/_bernoulli.py
@@ -27,8 +27,7 @@ class Bernoulli(DiscreteDistribution):
     An invalid ``p`` (``p < 0``, ``p > 1`` or ``NaN``) is not checked at construction; matching every other
     distribution, it raises ``InvalidOperation`` (a ``ComputeError``) when any method is evaluated.
 
-    A null ``p`` propagates to null wherever the result depends on ``p``; the off-support constants
-    (``pmf(2) = 0``, ``cdf(-1) = 0``, ``sf(1) = 0``) do not.
+    A null ``p`` nulls every method, on the support and off it.
 
     The value-keyed methods compute in Rust, so an invalid ``p`` is reported whichever branch the
     value selects. The moments stay in Polars, reading ``p`` through the same Rust validator.

--- a/polars_stats/distributions/_bernoulli.py
+++ b/polars_stats/distributions/_bernoulli.py
@@ -54,7 +54,7 @@ class Bernoulli(DiscreteDistribution):
         return self._checked("bernoulli_proba", self._p)
 
     def _pmf(self, value: pl.Expr) -> pl.Expr:
-        """``1 - p`` at 0, ``p`` at 1, ``0`` elsewhere; the off-support ``0`` carries no ``p``."""
+        """``1 - p`` at 0, ``p`` at 1, ``0`` elsewhere."""
         return self._value_plugin("bernoulli_pmf", value)
 
     def _log_pmf(self, value: pl.Expr) -> pl.Expr:

--- a/polars_stats/distributions/_exponential.py
+++ b/polars_stats/distributions/_exponential.py
@@ -32,8 +32,7 @@ class Exponential(ContinuousDistribution):
     evaluated. The support is ``x >= 0``: ``pdf`` and ``cdf`` are ``0`` for ``x < 0``, and ``sf`` is
     ``1`` there.
 
-    A null ``rate`` nulls every method, on the support and below it. Both inverses null at every
-    quantile, in range and out.
+    A null ``rate`` nulls every method, on the support and below it.
 
     The value-keyed methods compute in Rust, so an invalid ``rate`` is reported whichever branch the
     value selects. The moments stay in Polars, reading ``rate`` through the same Rust validator.

--- a/polars_stats/distributions/_exponential.py
+++ b/polars_stats/distributions/_exponential.py
@@ -32,9 +32,8 @@ class Exponential(ContinuousDistribution):
     evaluated. The support is ``x >= 0``: ``pdf`` and ``cdf`` are ``0`` for ``x < 0``, and ``sf`` is
     ``1`` there.
 
-    A null ``rate`` propagates to null wherever the result depends on it; the below-support constants
-    (``pdf`` and ``cdf`` ``0``, ``sf`` ``1``, ``log_pdf`` and ``log_cdf`` ``-inf``, ``log_sf`` ``0``)
-    do not. Both inverses null at every quantile, in range and out.
+    A null ``rate`` nulls every method, on the support and below it. Both inverses null at every
+    quantile, in range and out.
 
     The value-keyed methods compute in Rust, so an invalid ``rate`` is reported whichever branch the
     value selects. The moments stay in Polars, reading ``rate`` through the same Rust validator.

--- a/polars_stats/distributions/_geometric.py
+++ b/polars_stats/distributions/_geometric.py
@@ -30,10 +30,9 @@ class Geometric(DiscreteDistribution):
 
     An invalid ``p`` (``p <= 0``, ``p > 1`` or ``NaN``) is not checked at construction; matching every
     other distribution, it raises ``InvalidOperation`` (a ``ComputeError``) when any method is
-    evaluated. A null ``p`` propagates to null wherever the result depends on ``p``; the off-support
-    constants (``pmf(0) = 0``, ``cdf(0) = 0``, ``sf(0) = 1``, and ``pmf`` at any non-integral point)
-    do not, as in ``Bernoulli``. Samples are ``UInt64`` trial counts, so unlike ``Bernoulli`` the
-    degenerate ``p = 0`` point mass is not representable.
+    evaluated. A null ``p`` nulls every method, on the support and off it.
+    Samples are ``UInt64`` trial counts, so unlike ``Bernoulli`` the degenerate ``p = 0`` point mass
+    is not representable.
 
     The value-keyed methods compute in Rust, so an invalid ``p`` is reported whichever branch the
     value selects. The moments stay in Polars, reading ``p`` through the same Rust validator.

--- a/polars_stats/distributions/_uniform.py
+++ b/polars_stats/distributions/_uniform.py
@@ -33,10 +33,9 @@ class Uniform(ContinuousDistribution):
     overflowing ``float64``) is not checked at construction; matching every other distribution, it
     raises ``InvalidOperation`` (a ``ComputeError``) when any method is evaluated.
 
-    A null bound propagates to null wherever the result depends on it. Where the *other*, known
-    bound already places the evaluation point outside the support, the bound-free constant survives
-    instead (``pdf`` ``0``, ``log_pdf`` ``-inf``, and the saturated end of ``cdf`` / ``log_cdf`` /
-    ``sf`` / ``log_sf``). Both inverses null at every quantile under either null bound.
+    A null bound nulls every method, on the support and off it, including where the other bound
+    alone would have placed the point outside. Both inverses null at every quantile under either
+    null bound.
     """
 
     _min: pl.Expr

--- a/polars_stats/distributions/_uniform.py
+++ b/polars_stats/distributions/_uniform.py
@@ -33,9 +33,7 @@ class Uniform(ContinuousDistribution):
     overflowing ``float64``) is not checked at construction; matching every other distribution, it
     raises ``InvalidOperation`` (a ``ComputeError``) when any method is evaluated.
 
-    A null bound nulls every method, on the support and off it, including where the other bound
-    alone would have placed the point outside. Both inverses null at every quantile under either
-    null bound.
+    A null bound nulls every method, on the support and off it.
     """
 
     _min: pl.Expr

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -4,7 +4,7 @@ use rand::distr::Distribution;
 use statrs::distribution::Bernoulli;
 
 use crate::distributions::{
-    align_inputs, in_unit_domain, value_keyed_derived_per_row, value_keyed_derived_scalar,
+    align_inputs, on_unit_interval, value_keyed_derived_per_row, value_keyed_derived_scalar,
     ParamDomain,
 };
 use crate::rng::{
@@ -178,21 +178,19 @@ impl PpfCutoffs {
     }
 
     /// Smallest `x` with `cdf(x) >= q`: `0.0` if `q <= 1 - p` else `1.0`; `None` (null) outside
-    /// `[0, 1]`. The support point comes back as `Float64` rather than a `Boolean` so the wrapper's
-    /// `NaN -> NaN` contract stays representable.
+    /// `[0, 1]`. The support point is a `Float64`, not a `Boolean`, so `NaN` stays representable.
     ///
     /// `q == 1` is a separate branch because `1 - p` rounds to exactly `1.0` below `p ~ 1.1e-16`,
     /// which made `q > 1 - p` false and answered `0.0` where `1.0` is the only correct answer. Every
     /// representable `q < 1` is safely below the true `1 - p` for such a `p`, so the branch is
     /// needed only at the endpoint; `p == 0` keeps `0.0`.
     fn at(&self, quantile: f64) -> Option<f64> {
-        if !(0.0..=1.0).contains(&quantile) {
-            return None;
-        }
-        Some(if quantile == 1.0 {
-            self.at_quantile_one
-        } else {
-            f64::from(quantile > self.step)
+        (0.0..=1.0).contains(&quantile).then(|| {
+            if quantile == 1.0 {
+                self.at_quantile_one
+            } else {
+                f64::from(quantile > self.step)
+            }
         })
     }
 }
@@ -253,7 +251,7 @@ fn bernoulli_ppf(inputs: &[Series]) -> PolarsResult<Series> {
 /// Element-wise inverse survival function; see [`derive_isf`] for why it never forms a complement.
 #[polars_expr(output_type=Float64)]
 fn bernoulli_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, derive_isf, in_unit_domain)
+    value_keyed_derived_per_row(inputs, &P, derive_isf, on_unit_interval)
 }
 
 /// Constant-parameter fast path for [`bernoulli_pmf`].
@@ -310,7 +308,7 @@ fn bernoulli_ppf_scalar(inputs: &[Series], kwargs: BernoulliParamsKwargs) -> Pol
 /// Constant-parameter fast path for [`bernoulli_isf`].
 #[polars_expr(output_type=Float64)]
 fn bernoulli_isf_scalar(inputs: &[Series], kwargs: BernoulliParamsKwargs) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], derive_isf, in_unit_domain)
+    kwargs.value_keyed(&inputs[0], derive_isf, on_unit_interval)
 }
 
 /// One Bernoulli draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -4,7 +4,8 @@ use rand::distr::Distribution;
 use statrs::distribution::Bernoulli;
 
 use crate::distributions::{
-    align_inputs, value_keyed_derived_per_row, value_keyed_derived_scalar, ParamDomain,
+    align_inputs, in_unit_domain, value_keyed_derived_per_row, value_keyed_derived_scalar,
+    ParamDomain,
 };
 use crate::rng::{
     binary_param_rows, sample_by_index, sample_per_row_binary, samples_bool_output,
@@ -36,7 +37,7 @@ impl BernoulliParamsKwargs {
     fn value_keyed<Branches>(
         &self,
         value: &Series,
-        derive: impl Fn(Option<f64>) -> Branches,
+        derive: impl Fn(f64) -> Branches,
         select: impl Fn(&Branches, f64) -> Option<f64>,
     ) -> PolarsResult<Series> {
         value_keyed_derived_scalar(value, self.p, &P, derive, select)
@@ -56,27 +57,21 @@ fn bernoulli_proba(inputs: &[Series]) -> PolarsResult<Series> {
 // `derive` that turns `p` into its branch answers with an `at` that picks one by where the value
 // sits. `derive` runs once per call on the constant path and once per row only when `p` is a column,
 // which is what keeps the constant path from recomputing a logarithm 10M times.
-//
-// Every slot is an `Option<f64>`, so a null `p` nulls exactly the answers that read it. The slots
-// holding a plain `Some(constant)` are the off-support answers (`pmf(2) = 0`, `cdf(-1) = 0`,
-// `sf(1) = 0`), which are documented to survive a null `p`: writing them as constants leaves no `p`
-// in scope to thread through them by accident. Pinned by
-// `tests/distributions/bernoulli/null_param_test.py`.
 
 /// `pmf` / `log_pmf`: the answer at each of the two support points, and off the support.
 struct Mass {
-    at_zero: Option<f64>,
-    at_one: Option<f64>,
-    off_support: Option<f64>,
+    at_zero: f64,
+    at_one: f64,
+    off_support: f64,
 }
 
 impl Mass {
     /// `1 - p` at 0, `p` at 1, `0` off the support.
-    fn pmf(p: Option<f64>) -> Self {
+    fn pmf(p: f64) -> Self {
         Mass {
-            at_zero: p.map(|p| 1.0 - p),
+            at_zero: 1.0 - p,
             at_one: p,
-            off_support: Some(0.0),
+            off_support: 0.0,
         }
     }
 
@@ -85,51 +80,51 @@ impl Mass {
     /// `ln_1p`, not `ln(1 - p)`: the latter collapses to `0.0` below `p ~ 1.1e-16`. Both logarithms
     /// are derived where a row reads one, which costs the column path a spare `ln` and saves the
     /// constant path a per-row one.
-    fn ln_pmf(p: Option<f64>) -> Self {
+    fn ln_pmf(p: f64) -> Self {
         Mass {
-            at_zero: p.map(|p| (-p).ln_1p()),
-            at_one: p.map(f64::ln),
-            off_support: Some(f64::NEG_INFINITY),
+            at_zero: (-p).ln_1p(),
+            at_one: p.ln(),
+            off_support: f64::NEG_INFINITY,
         }
     }
 
     /// Exact `f64` equality, never a cast to an integer type, so a non-integral value is off the
     /// support rather than an error: `pmf(0.5)` is `0.0`.
     fn at(&self, value: f64) -> Option<f64> {
-        if value == 0.0 {
+        Some(if value == 0.0 {
             self.at_zero
         } else if value == 1.0 {
             self.at_one
         } else {
             self.off_support
-        }
+        })
     }
 }
 
 /// `cdf` / `log_cdf` / `sf` / `log_sf`: the answer on each side of the two steps, at 0 and at 1.
 struct Steps {
-    below_zero: Option<f64>,
-    below_one: Option<f64>,
-    at_least_one: Option<f64>,
+    below_zero: f64,
+    below_one: f64,
+    at_least_one: f64,
 }
 
 impl Steps {
     /// `0` below 0, `1 - p` on `[0, 1)`, `1` at or above 1.
-    fn cdf(p: Option<f64>) -> Self {
+    fn cdf(p: f64) -> Self {
         Steps {
-            below_zero: Some(0.0),
-            below_one: p.map(|p| 1.0 - p),
-            at_least_one: Some(1.0),
+            below_zero: 0.0,
+            below_one: 1.0 - p,
+            at_least_one: 1.0,
         }
     }
 
     /// `-inf` below 0, `ln_1p(-p)` on `[0, 1)`, `0` at or above 1; same `ln_1p` reason as
     /// [`Mass::ln_pmf`].
-    fn ln_cdf(p: Option<f64>) -> Self {
+    fn ln_cdf(p: f64) -> Self {
         Steps {
-            below_zero: Some(f64::NEG_INFINITY),
-            below_one: p.map(|p| (-p).ln_1p()),
-            at_least_one: Some(0.0),
+            below_zero: f64::NEG_INFINITY,
+            below_one: (-p).ln_1p(),
+            at_least_one: 0.0,
         }
     }
 
@@ -137,48 +132,48 @@ impl Steps {
     ///
     /// Read straight off `p`, never as `1 - cdf`: that recomputes `p` as `1 - (1 - p)` and so
     /// quantises it to the `1.1e-16` spacing of `1.0`, reaching `0.0` below that.
-    fn sf(p: Option<f64>) -> Self {
+    fn sf(p: f64) -> Self {
         Steps {
-            below_zero: Some(1.0),
+            below_zero: 1.0,
             below_one: p,
-            at_least_one: Some(0.0),
+            at_least_one: 0.0,
         }
     }
 
     /// The plain log of [`Steps::sf`], slot for slot: `ln(1) = 0` and `ln(0) = -inf` are exact, and
     /// the middle slot is `p` itself, so there is no complement for an `ln_1p` to rescue.
-    fn ln_sf(p: Option<f64>) -> Self {
+    fn ln_sf(p: f64) -> Self {
         Steps {
-            below_zero: Some(0.0),
-            below_one: p.map(f64::ln),
-            at_least_one: Some(f64::NEG_INFINITY),
+            below_zero: 0.0,
+            below_one: p.ln(),
+            at_least_one: f64::NEG_INFINITY,
         }
     }
 
     fn at(&self, value: f64) -> Option<f64> {
-        if value < 0.0 {
+        Some(if value < 0.0 {
             self.below_zero
         } else if value < 1.0 {
             self.below_one
         } else {
             self.at_least_one
-        }
+        })
     }
 }
 
 /// `ppf`: the cdf step the quantile is compared against, and the answer at `q == 1`.
 struct PpfCutoffs {
     /// `1 - p`, the only step in the cdf.
-    step: Option<f64>,
+    step: f64,
     /// `1.0` unless the mass at 1 is zero, in which case `0.0`.
-    at_quantile_one: Option<f64>,
+    at_quantile_one: f64,
 }
 
 impl PpfCutoffs {
-    fn derive(p: Option<f64>) -> Self {
+    fn derive(p: f64) -> Self {
         PpfCutoffs {
-            step: p.map(|p| 1.0 - p),
-            at_quantile_one: p.map(|p| f64::from(p > 0.0)),
+            step: 1.0 - p,
+            at_quantile_one: f64::from(p > 0.0),
         }
     }
 
@@ -194,29 +189,22 @@ impl PpfCutoffs {
         if !(0.0..=1.0).contains(&quantile) {
             return None;
         }
-        if quantile == 1.0 {
+        Some(if quantile == 1.0 {
             self.at_quantile_one
         } else {
-            self.step.map(|step| f64::from(quantile > step))
-        }
+            f64::from(quantile > self.step)
+        })
     }
 }
 
-/// `isf` compares against `p` itself, so there is nothing to derive.
-fn isf_proba(p: Option<f64>) -> Option<f64> {
-    p
-}
-
-/// Smallest `x` with `sf(x) <= q`: `1.0` if `p > q` else `0.0`; `None` (null) outside `[0, 1]`.
+/// Smallest `x` with `sf(x) <= q`: `1.0` if `p > q` else `0.0`; null outside `[0, 1]`.
 ///
-/// Tested against `q` itself, never as `ppf(1 - q)`: `sf(0)` *is* `p`, so this comparison forms no
+/// Compared against `q` itself, never as `ppf(1 - q)`: `sf(0)` *is* `p`, so this comparison forms no
 /// complement, while `ppf(1 - q)` forms two and loses the answer whenever either saturates
-/// (`Bernoulli(1e-17).isf(1e-20)` gave `0.0` against a true `1.0`).
-fn isf_at(p: &Option<f64>, quantile: f64) -> Option<f64> {
-    if !(0.0..=1.0).contains(&quantile) {
-        return None;
-    }
-    p.map(|p| f64::from(p > quantile))
+/// (`Bernoulli(1e-17).isf(1e-20)` gave `0.0` against a true `1.0`). So `isf` reads `p` directly and
+/// hoists nothing.
+fn derive_isf(p: f64) -> impl Fn(f64) -> f64 {
+    move |quantile: f64| f64::from(p > quantile)
 }
 
 /// Element-wise pmf: `1 - p` at 0, `p` at 1, `0` off the support.
@@ -262,10 +250,10 @@ fn bernoulli_ppf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed_derived_per_row(inputs, &P, PpfCutoffs::derive, PpfCutoffs::at)
 }
 
-/// Element-wise inverse survival function; see [`isf_at`] for why it never forms a complement.
+/// Element-wise inverse survival function; see [`derive_isf`] for why it never forms a complement.
 #[polars_expr(output_type=Float64)]
 fn bernoulli_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, isf_proba, isf_at)
+    value_keyed_derived_per_row(inputs, &P, derive_isf, in_unit_domain)
 }
 
 /// Constant-parameter fast path for [`bernoulli_pmf`].
@@ -322,7 +310,7 @@ fn bernoulli_ppf_scalar(inputs: &[Series], kwargs: BernoulliParamsKwargs) -> Pol
 /// Constant-parameter fast path for [`bernoulli_isf`].
 #[polars_expr(output_type=Float64)]
 fn bernoulli_isf_scalar(inputs: &[Series], kwargs: BernoulliParamsKwargs) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], isf_proba, isf_at)
+    kwargs.value_keyed(&inputs[0], derive_isf, in_unit_domain)
 }
 
 /// One Bernoulli draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -4,7 +4,7 @@ use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::Exp;
 
 use crate::distributions::{
-    align_inputs, expm1, value_keyed_derived_per_row, value_keyed_derived_scalar, Domain,
+    align_inputs, expm1, in_unit_domain, value_keyed_derived_per_row, value_keyed_derived_scalar,
     ParamDomain, Sides,
 };
 use crate::rng::{
@@ -38,7 +38,7 @@ impl ExponentialParamsKwargs {
     fn value_keyed<Branches>(
         &self,
         value: &Series,
-        derive: impl Fn(Option<f64>) -> Branches,
+        derive: impl Fn(f64) -> Branches,
         select: impl Fn(&Branches, f64) -> Option<f64>,
     ) -> PolarsResult<Series> {
         value_keyed_derived_scalar(value, self.rate, &RATE, derive, select)
@@ -67,27 +67,25 @@ const CDF_SINH_MAX: f64 = 1.0;
 /// range while the scale is still to be applied, and the final multiply then magnifies what the
 /// subnormal threw away. Halving the exponent keeps the intermediate normal, at the cost of one
 /// multiply and no branch.
-fn derive_pdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64, 0> {
+fn derive_pdf(rate: f64) -> Sides<impl Fn(f64) -> f64, 0> {
     Sides {
         below_support: 0.0,
-        on_support: rate.map(|rate| {
-            move |x: f64| {
-                let half_exp = (-rate * x / 2.0).exp();
-                (rate * half_exp) * half_exp
-            }
-        }),
+        on_support: move |x: f64| {
+            let half_exp = (-rate * x / 2.0).exp();
+            (rate * half_exp) * half_exp
+        },
     }
 }
 
 /// `ln(rate) - rate * x` on `x >= 0`, `-inf` below. `ln(rate)` is the only term the rate alone fixes,
 /// so it is the only one [`value_keyed_derived_scalar`] can lift out of the loop.
-fn derive_ln_pdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64, 0> {
+fn derive_ln_pdf(rate: f64) -> Sides<impl Fn(f64) -> f64, 0> {
     Sides {
         below_support: f64::NEG_INFINITY,
-        on_support: rate.map(|rate| {
+        on_support: {
             let ln_rate = rate.ln();
             move |x: f64| ln_rate - rate * x
-        }),
+        },
     }
 }
 
@@ -95,19 +93,17 @@ fn derive_ln_pdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64, 0> {
 ///
 /// `1 - exp(-t)` cancels to `0` below `t ~ 1.1e-16`, so the small branch reads it as `-expm1(-t)`;
 /// see [`CDF_SINH_MAX`] for why the crossover is where it is.
-fn derive_cdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64, 0> {
+fn derive_cdf(rate: f64) -> Sides<impl Fn(f64) -> f64, 0> {
     Sides {
         below_support: 0.0,
-        on_support: rate.map(|rate| {
-            move |x: f64| {
-                let t = rate * x;
-                if t < CDF_SINH_MAX {
-                    -expm1(-t)
-                } else {
-                    1.0 - (-t).exp()
-                }
+        on_support: move |x: f64| {
+            let t = rate * x;
+            if t < CDF_SINH_MAX {
+                -expm1(-t)
+            } else {
+                1.0 - (-t).exp()
             }
-        }),
+        },
     }
 }
 
@@ -121,19 +117,17 @@ fn derive_cdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64, 0> {
 /// against the computed cdf. It coincides with [`CDF_SINH_MAX`] rather than deriving from it, which
 /// is what lets the left arm inline [`derive_cdf`]'s `expm1` branch: on the support and below
 /// `t = 1` that is the only branch it would take.
-fn derive_ln_cdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64, 0> {
+fn derive_ln_cdf(rate: f64) -> Sides<impl Fn(f64) -> f64, 0> {
     Sides {
         below_support: f64::NEG_INFINITY,
-        on_support: rate.map(|rate| {
-            move |x: f64| {
-                let t = rate * x;
-                if t < 1.0 {
-                    (-expm1(-t)).ln()
-                } else {
-                    (-(-t).exp()).ln_1p()
-                }
+        on_support: move |x: f64| {
+            let t = rate * x;
+            if t < 1.0 {
+                (-expm1(-t)).ln()
+            } else {
+                (-(-t).exp()).ln_1p()
             }
-        }),
+        },
     }
 }
 
@@ -141,18 +135,18 @@ fn derive_ln_cdf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64, 0> {
 ///
 /// The closed form, never `1 - cdf`: the complement quantises the upper tail to the `1.1e-16`
 /// spacing of `1.0` and reaches `0.0` below that.
-fn derive_sf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64, 0> {
+fn derive_sf(rate: f64) -> Sides<impl Fn(f64) -> f64, 0> {
     Sides {
         below_support: 1.0,
-        on_support: rate.map(|rate| move |x: f64| (-rate * x).exp()),
+        on_support: move |x: f64| (-rate * x).exp(),
     }
 }
 
 /// `-rate * x` on `x >= 0`, `0` below: the plain log of [`derive_sf`].
-fn derive_ln_sf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64, 0> {
+fn derive_ln_sf(rate: f64) -> Sides<impl Fn(f64) -> f64, 0> {
     Sides {
         below_support: 0.0,
-        on_support: rate.map(|rate| move |x: f64| -rate * x),
+        on_support: move |x: f64| -rate * x,
     }
 }
 
@@ -164,20 +158,16 @@ fn derive_ln_sf(rate: Option<f64>) -> Sides<impl Fn(f64) -> f64, 0> {
 /// The rate is divided by, never reciprocated: `x * (1 / rate)` rounds twice where `x / rate` rounds
 /// once, and at a subnormal rate the reciprocal reaches `inf` and `NaN` where the division stays
 /// finite. So neither inverse hoists anything into its `derive`.
-fn derive_ppf(rate: Option<f64>) -> Domain<impl Fn(f64) -> f64> {
-    Domain {
-        inside: rate.map(|rate| move |quantile: f64| (-((-quantile).ln_1p())) / rate),
-    }
+fn derive_ppf(rate: f64) -> impl Fn(f64) -> f64 {
+    move |quantile: f64| (-((-quantile).ln_1p())) / rate
 }
 
 /// `-ln(q) / rate`, the exact inverse survival function; null outside `[0, 1]`.
 ///
 /// Never `ppf(1 - q)`: that forms the complement and then undoes it, losing the answer whenever
 /// either step saturates.
-fn derive_isf(rate: Option<f64>) -> Domain<impl Fn(f64) -> f64> {
-    Domain {
-        inside: rate.map(|rate| move |quantile: f64| (-quantile.ln()) / rate),
-    }
+fn derive_isf(rate: f64) -> impl Fn(f64) -> f64 {
+    move |quantile: f64| (-quantile.ln()) / rate
 }
 
 /// Element-wise pdf; see [`derive_pdf`] for the subnormal reassociation.
@@ -220,13 +210,13 @@ fn exponential_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
 /// Element-wise ppf (inverse cdf); see [`derive_ppf`].
 #[polars_expr(output_type=Float64)]
 fn exponential_ppf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &RATE, derive_ppf, Domain::at)
+    value_keyed_derived_per_row(inputs, &RATE, derive_ppf, in_unit_domain)
 }
 
 /// Element-wise inverse survival function; see [`derive_isf`] for why it never forms a complement.
 #[polars_expr(output_type=Float64)]
 fn exponential_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &RATE, derive_isf, Domain::at)
+    value_keyed_derived_per_row(inputs, &RATE, derive_isf, in_unit_domain)
 }
 
 /// Constant-rate fast path for [`exponential_pdf`].
@@ -289,7 +279,7 @@ fn exponential_ppf_scalar(
     inputs: &[Series],
     kwargs: ExponentialParamsKwargs,
 ) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], derive_ppf, Domain::at)
+    kwargs.value_keyed(&inputs[0], derive_ppf, in_unit_domain)
 }
 
 /// Constant-rate fast path for [`exponential_isf`].
@@ -298,7 +288,7 @@ fn exponential_isf_scalar(
     inputs: &[Series],
     kwargs: ExponentialParamsKwargs,
 ) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], derive_isf, Domain::at)
+    kwargs.value_keyed(&inputs[0], derive_isf, in_unit_domain)
 }
 
 /// One Exponential draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -4,7 +4,7 @@ use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::Exp;
 
 use crate::distributions::{
-    align_inputs, expm1, in_unit_domain, value_keyed_derived_per_row, value_keyed_derived_scalar,
+    align_inputs, expm1, on_unit_interval, value_keyed_derived_per_row, value_keyed_derived_scalar,
     ParamDomain, Sides,
 };
 use crate::rng::{
@@ -210,13 +210,13 @@ fn exponential_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
 /// Element-wise ppf (inverse cdf); see [`derive_ppf`].
 #[polars_expr(output_type=Float64)]
 fn exponential_ppf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &RATE, derive_ppf, in_unit_domain)
+    value_keyed_derived_per_row(inputs, &RATE, derive_ppf, on_unit_interval)
 }
 
 /// Element-wise inverse survival function; see [`derive_isf`] for why it never forms a complement.
 #[polars_expr(output_type=Float64)]
 fn exponential_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &RATE, derive_isf, in_unit_domain)
+    value_keyed_derived_per_row(inputs, &RATE, derive_isf, on_unit_interval)
 }
 
 /// Constant-rate fast path for [`exponential_pdf`].
@@ -279,7 +279,7 @@ fn exponential_ppf_scalar(
     inputs: &[Series],
     kwargs: ExponentialParamsKwargs,
 ) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], derive_ppf, in_unit_domain)
+    kwargs.value_keyed(&inputs[0], derive_ppf, on_unit_interval)
 }
 
 /// Constant-rate fast path for [`exponential_isf`].
@@ -288,7 +288,7 @@ fn exponential_isf_scalar(
     inputs: &[Series],
     kwargs: ExponentialParamsKwargs,
 ) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], derive_isf, in_unit_domain)
+    kwargs.value_keyed(&inputs[0], derive_isf, on_unit_interval)
 }
 
 /// One Exponential draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.

--- a/src/distributions/geometric.rs
+++ b/src/distributions/geometric.rs
@@ -4,7 +4,7 @@ use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::Geometric;
 
 use crate::distributions::{
-    align_inputs, expm1, in_unit_domain, ln_abs_expm1, value_keyed_derived_per_row,
+    align_inputs, expm1, ln_abs_expm1, on_unit_interval, value_keyed_derived_per_row,
     value_keyed_derived_scalar, ParamDomain, Sides,
 };
 use crate::rng::{
@@ -310,13 +310,13 @@ fn geometric_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
 /// Element-wise ppf (inverse cdf); see [`derive_ppf`] and [`smallest_support_point`].
 #[polars_expr(output_type=Float64)]
 fn geometric_ppf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, derive_ppf, in_unit_domain)
+    value_keyed_derived_per_row(inputs, &P, derive_ppf, on_unit_interval)
 }
 
 /// Element-wise inverse survival function; see [`derive_isf`] for why it never forms a complement.
 #[polars_expr(output_type=Float64)]
 fn geometric_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, derive_isf, in_unit_domain)
+    value_keyed_derived_per_row(inputs, &P, derive_isf, on_unit_interval)
 }
 
 /// Constant-`p` fast path for [`geometric_pmf`].
@@ -367,13 +367,13 @@ fn geometric_ln_sf_scalar(
 /// Constant-`p` fast path for [`geometric_ppf`].
 #[polars_expr(output_type=Float64)]
 fn geometric_ppf_scalar(inputs: &[Series], kwargs: GeometricParamsKwargs) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], derive_ppf, in_unit_domain)
+    kwargs.value_keyed(&inputs[0], derive_ppf, on_unit_interval)
 }
 
 /// Constant-`p` fast path for [`geometric_isf`].
 #[polars_expr(output_type=Float64)]
 fn geometric_isf_scalar(inputs: &[Series], kwargs: GeometricParamsKwargs) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], derive_isf, in_unit_domain)
+    kwargs.value_keyed(&inputs[0], derive_isf, on_unit_interval)
 }
 
 /// One Geometric draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.

--- a/src/distributions/geometric.rs
+++ b/src/distributions/geometric.rs
@@ -4,8 +4,8 @@ use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::Geometric;
 
 use crate::distributions::{
-    align_inputs, expm1, ln_abs_expm1, value_keyed_derived_per_row, value_keyed_derived_scalar,
-    Domain, ParamDomain, Sides,
+    align_inputs, expm1, in_unit_domain, ln_abs_expm1, value_keyed_derived_per_row,
+    value_keyed_derived_scalar, ParamDomain, Sides,
 };
 use crate::rng::{
     binary_param_rows, sample_by_index, sample_per_row_binary, samples_by_index, samples_per_row,
@@ -55,7 +55,7 @@ impl GeometricParamsKwargs {
     fn value_keyed<Branches>(
         &self,
         value: &Series,
-        derive: impl Fn(Option<f64>) -> Branches,
+        derive: impl Fn(f64) -> Branches,
         select: impl Fn(&Branches, f64) -> Option<f64>,
     ) -> PolarsResult<Series> {
         value_keyed_derived_scalar(value, self.p, &P, derive, select)
@@ -84,12 +84,11 @@ const CDF_DIRECT_COMPLEMENT_MAX: f64 = -20.0;
 /// exactly, down through the `cdf ~ 1 - 1e-16` zone where `cdf.ln()` reads the tail mass as `0`.
 const LN_CDF_LN_1P_MAX: f64 = -1.0;
 
-/// `pmf` / `log_pmf`: `off_support` is a plain `f64` because a point below `1` or a non-integral one
-/// carries no mass whatever `p` is, so a null `p` must not null it; `on_support` is `None` exactly
-/// when `p` is null. Pinned by `tests/distributions/geometric/null_param_test.py`.
+/// `pmf` / `log_pmf`: the constant off the support (below `1`, or a non-integral point), and the arm
+/// `p` derives on it.
 struct Mass<Arm> {
     off_support: f64,
-    on_support: Option<Arm>,
+    on_support: Arm,
 }
 
 impl<Arm: Fn(f64) -> f64> Mass<Arm> {
@@ -98,11 +97,11 @@ impl<Arm: Fn(f64) -> f64> Mass<Arm> {
     /// `0` through the arm instead of saturating. A `NaN` point never reaches here: both drivers
     /// short-circuit it.
     fn at(&self, value: f64) -> Option<f64> {
-        if value >= 1.0 && value.floor() == value {
-            self.on_support.as_ref().map(|arm| arm(value))
+        Some(if value >= 1.0 && value.floor() == value {
+            (self.on_support)(value)
         } else {
-            Some(self.off_support)
-        }
+            self.off_support
+        })
     }
 }
 
@@ -115,10 +114,10 @@ type Tail<Arm> = Sides<Arm, 1>;
 ///
 /// `k = 1` short-circuits the power: its exponent `(k - 1) * ln(1 - p)` is `0 * -inf = NaN` at
 /// `p = 1`, where the whole mass sits on `k = 1`.
-fn derive_pmf(p: Option<f64>) -> Mass<impl Fn(f64) -> f64> {
+fn derive_pmf(p: f64) -> Mass<impl Fn(f64) -> f64> {
     Mass {
         off_support: 0.0,
-        on_support: p.map(|p| {
+        on_support: {
             let ln_failure = ln_failure(p);
             move |k: f64| {
                 if k == 1.0 {
@@ -127,7 +126,7 @@ fn derive_pmf(p: Option<f64>) -> Mass<impl Fn(f64) -> f64> {
                     p * ((k - 1.0) * ln_failure).exp()
                 }
             }
-        }),
+        },
     }
 }
 
@@ -135,10 +134,10 @@ fn derive_pmf(p: Option<f64>) -> Mass<impl Fn(f64) -> f64> {
 ///
 /// Not `ln(pmf)`, whose `ln(1 - p)` collapses to `0.0` below `p ~ 1.1e-16`. `k = 1` reads `ln(p)`
 /// alone, for the same `0 * -inf` reason as [`derive_pmf`].
-fn derive_ln_pmf(p: Option<f64>) -> Mass<impl Fn(f64) -> f64> {
+fn derive_ln_pmf(p: f64) -> Mass<impl Fn(f64) -> f64> {
     Mass {
         off_support: f64::NEG_INFINITY,
-        on_support: p.map(|p| {
+        on_support: {
             let (ln_failure, ln_p) = (ln_failure(p), p.ln());
             move |k: f64| {
                 if k == 1.0 {
@@ -147,7 +146,7 @@ fn derive_ln_pmf(p: Option<f64>) -> Mass<impl Fn(f64) -> f64> {
                     (k - 1.0) * ln_failure + ln_p
                 }
             }
-        }),
+        },
     }
 }
 
@@ -155,10 +154,10 @@ fn derive_ln_pmf(p: Option<f64>) -> Mass<impl Fn(f64) -> f64> {
 ///
 /// Below [`CDF_DIRECT_COMPLEMENT_MAX`] it is the direct `1 - exp(ln_sf)` instead. The literal
 /// `1 - (1 - p)^k` would inherit the rounding of both `1 - p` and the subtraction against `1`.
-fn derive_cdf(p: Option<f64>) -> Tail<impl Fn(f64) -> f64> {
+fn derive_cdf(p: f64) -> Tail<impl Fn(f64) -> f64> {
     Tail {
         below_support: 0.0,
-        on_support: p.map(|p| {
+        on_support: {
             let ln_failure = ln_failure(p);
             move |k: f64| {
                 let ln_sf = k.floor() * ln_failure;
@@ -168,7 +167,7 @@ fn derive_cdf(p: Option<f64>) -> Tail<impl Fn(f64) -> f64> {
                     -expm1(ln_sf)
                 }
             }
-        }),
+        },
     }
 }
 
@@ -177,10 +176,10 @@ fn derive_cdf(p: Option<f64>) -> Tail<impl Fn(f64) -> f64> {
 /// Split at [`LN_CDF_LN_1P_MAX`], where the answer's own magnitude stops dwarfing the absolute
 /// granularity of the pieces: below it `ln_1p` carries the difference from `1` exactly, above it
 /// [`ln_abs_expm1`] assembles the answer on the log scale so the rounding stays relative.
-fn derive_ln_cdf(p: Option<f64>) -> Tail<impl Fn(f64) -> f64> {
+fn derive_ln_cdf(p: f64) -> Tail<impl Fn(f64) -> f64> {
     Tail {
         below_support: f64::NEG_INFINITY,
-        on_support: p.map(|p| {
+        on_support: {
             let ln_failure = ln_failure(p);
             move |k: f64| {
                 let ln_sf = k.floor() * ln_failure;
@@ -190,7 +189,7 @@ fn derive_ln_cdf(p: Option<f64>) -> Tail<impl Fn(f64) -> f64> {
                     ln_abs_expm1(ln_sf)
                 }
             }
-        }),
+        },
     }
 }
 
@@ -198,24 +197,24 @@ fn derive_ln_cdf(p: Option<f64>) -> Tail<impl Fn(f64) -> f64> {
 ///
 /// Never `1 - cdf`, which recomputes `p` as `1 - (1 - p)` and so quantises it to the `1.1e-16`
 /// spacing of `1.0`, reaching `0.0` below that.
-fn derive_sf(p: Option<f64>) -> Tail<impl Fn(f64) -> f64> {
+fn derive_sf(p: f64) -> Tail<impl Fn(f64) -> f64> {
     Tail {
         below_support: 1.0,
-        on_support: p.map(|p| {
+        on_support: {
             let ln_failure = ln_failure(p);
             move |k: f64| (k.floor() * ln_failure).exp()
-        }),
+        },
     }
 }
 
 /// `ln(sf) = floor(k) * ln(1 - p)` from `1` up, `0` below.
-fn derive_ln_sf(p: Option<f64>) -> Tail<impl Fn(f64) -> f64> {
+fn derive_ln_sf(p: f64) -> Tail<impl Fn(f64) -> f64> {
     Tail {
         below_support: 0.0,
-        on_support: p.map(|p| {
+        on_support: {
             let ln_failure = ln_failure(p);
             move |k: f64| k.floor() * ln_failure
-        }),
+        },
     }
 }
 
@@ -243,18 +242,14 @@ fn smallest_support_point(log_target: f64, ln_failure: f64) -> f64 {
 /// `1` is the only correct answer. `q = 1` runs the ratio off to `+inf`, right for an unbounded
 /// support. `p = 1` short-circuits before [`smallest_support_point`], where the ratio would be
 /// `-inf / -inf = NaN`.
-fn derive_ppf(p: Option<f64>) -> Domain<impl Fn(f64) -> f64> {
-    Domain {
-        inside: p.map(|p| {
-            let ln_failure = ln_failure(p);
-            move |quantile: f64| {
-                if p == 1.0 {
-                    1.0
-                } else {
-                    smallest_support_point((-quantile).ln_1p(), ln_failure)
-                }
-            }
-        }),
+fn derive_ppf(p: f64) -> impl Fn(f64) -> f64 {
+    let ln_failure = ln_failure(p);
+    move |quantile: f64| {
+        if p == 1.0 {
+            1.0
+        } else {
+            smallest_support_point((-quantile).ln_1p(), ln_failure)
+        }
     }
 }
 
@@ -264,18 +259,14 @@ fn derive_ppf(p: Option<f64>) -> Domain<impl Fn(f64) -> f64> {
 /// before the inverse runs. `q = 1` degenerates to `-0.0` and `q = 0` flows through as `+inf`. At
 /// `p = 1` every survival quantile inverts to `k = 1`, `q = 0` included, since `sf(1) = 0` already
 /// satisfies the inequality.
-fn derive_isf(p: Option<f64>) -> Domain<impl Fn(f64) -> f64> {
-    Domain {
-        inside: p.map(|p| {
-            let ln_failure = ln_failure(p);
-            move |quantile: f64| {
-                if p == 1.0 {
-                    1.0
-                } else {
-                    smallest_support_point(quantile.ln(), ln_failure)
-                }
-            }
-        }),
+fn derive_isf(p: f64) -> impl Fn(f64) -> f64 {
+    let ln_failure = ln_failure(p);
+    move |quantile: f64| {
+        if p == 1.0 {
+            1.0
+        } else {
+            smallest_support_point(quantile.ln(), ln_failure)
+        }
     }
 }
 
@@ -319,13 +310,13 @@ fn geometric_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
 /// Element-wise ppf (inverse cdf); see [`derive_ppf`] and [`smallest_support_point`].
 #[polars_expr(output_type=Float64)]
 fn geometric_ppf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, derive_ppf, Domain::at)
+    value_keyed_derived_per_row(inputs, &P, derive_ppf, in_unit_domain)
 }
 
 /// Element-wise inverse survival function; see [`derive_isf`] for why it never forms a complement.
 #[polars_expr(output_type=Float64)]
 fn geometric_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, derive_isf, Domain::at)
+    value_keyed_derived_per_row(inputs, &P, derive_isf, in_unit_domain)
 }
 
 /// Constant-`p` fast path for [`geometric_pmf`].
@@ -376,13 +367,13 @@ fn geometric_ln_sf_scalar(
 /// Constant-`p` fast path for [`geometric_ppf`].
 #[polars_expr(output_type=Float64)]
 fn geometric_ppf_scalar(inputs: &[Series], kwargs: GeometricParamsKwargs) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], derive_ppf, Domain::at)
+    kwargs.value_keyed(&inputs[0], derive_ppf, in_unit_domain)
 }
 
 /// Constant-`p` fast path for [`geometric_isf`].
 #[polars_expr(output_type=Float64)]
 fn geometric_isf_scalar(inputs: &[Series], kwargs: GeometricParamsKwargs) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], derive_isf, Domain::at)
+    kwargs.value_keyed(&inputs[0], derive_isf, in_unit_domain)
 }
 
 /// One Geometric draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -179,8 +179,7 @@ where
 /// Constant-parameter twin of [`value_keyed_derived_per_row`], over [`value_keyed_scalar`].
 ///
 /// Checks the parameter against `domain` and derives once per call, then maps `select` over the
-/// evaluation-point column. The Python side routes here only once the parameter is a Python scalar,
-/// so `derive` always sees `Some`, and the parameter-only terms it hoists (`Bernoulli`'s `1 - p`,
+/// evaluation-point column, so the parameter-only terms `derive` hoists (`Bernoulli`'s `1 - p`,
 /// `Exponential`'s `ln(rate)`) are computed once instead of per row.
 pub(crate) fn value_keyed_derived_scalar<Branches, Derive, Select>(
     value: &Series,
@@ -190,11 +189,11 @@ pub(crate) fn value_keyed_derived_scalar<Branches, Derive, Select>(
     select: Select,
 ) -> PolarsResult<Series>
 where
-    Derive: Fn(Option<f64>) -> Branches,
+    Derive: Fn(f64) -> Branches,
     Select: Fn(&Branches, f64) -> Option<f64>,
 {
     domain.check(param)?;
-    let branches = derive(Some(param));
+    let branches = derive(param);
     value_keyed_scalar(value, |v| select(&branches, v))
 }
 
@@ -261,11 +260,9 @@ where
 /// `domain`'s column pass runs once before any row is built, so nothing inside the row loop
 /// validates.
 ///
-/// Null contract, and the reason this is not [`value_keyed_per_row`]: that driver nulls the row on
-/// **any** null input, which is right for a `statrs`-backed distribution and wrong here. A null
-/// parameter reaches `derive` as `None`, so the branches whose answer is a parameter-free constant
-/// still answer: `Bernoulli`'s `pmf(2) = 0` and `Exponential`'s `cdf(-1) = 0` survive a null
-/// parameter, pinned by each distribution's `null_param(s)_test.py`. A null **value** nulls the row.
+/// Null contract: a null parameter nulls the row before the evaluation point is read; then a null
+/// value nulls it. `select` returning `None` nulls it on the method's own terms (`ppf` outside
+/// `[0, 1]`).
 ///
 /// `NaN` contract: a `NaN` value short-circuits to `NaN`, as in [`value_keyed_scalar`].
 ///
@@ -278,7 +275,7 @@ pub(crate) fn value_keyed_derived_per_row<Branches, Derive, Select>(
     select: Select,
 ) -> PolarsResult<Series>
 where
-    Derive: Fn(Option<f64>) -> Branches,
+    Derive: Fn(f64) -> Branches,
     Select: Fn(&Branches, f64) -> Option<f64>,
 {
     let inputs = align_inputs(inputs)?;
@@ -289,11 +286,12 @@ where
     domain.check_column(param_ca)?;
 
     let ca: Float64Chunked = binary_elementwise(value.f64()?, param_ca, |value_opt, param_opt| {
+        let param = param_opt?;
         let value = value_opt?;
         if value.is_nan() {
             Some(f64::NAN)
         } else {
-            select(&derive(param_opt), value)
+            select(&derive(param), value)
         }
     });
 
@@ -328,15 +326,11 @@ pub(crate) fn ln_abs_expm1(t: f64) -> f64 {
 }
 
 /// The two sides of a support whose floor is the integer `FLOOR`, for the value-keyed methods of a
-/// distribution that computes its own closed form.
-///
-/// Below the floor every answer is a parameter-free constant, so a null parameter must not null it:
-/// `below_support` is a plain `f64`, leaving nothing to thread the parameter through by accident.
-/// `on_support` is `None` exactly when the parameter is null. Each distribution's
-/// `null_param(s)_test.py` pins its constants.
+/// distribution that computes its own closed form: a constant below the floor, the parameter's arm
+/// on it.
 pub(crate) struct Sides<Arm, const FLOOR: i8> {
     pub(crate) below_support: f64,
-    pub(crate) on_support: Option<Arm>,
+    pub(crate) on_support: Arm,
 }
 
 impl<Arm: Fn(f64) -> f64, const FLOOR: i8> Sides<Arm, FLOOR> {
@@ -345,47 +339,39 @@ impl<Arm: Fn(f64) -> f64, const FLOOR: i8> Sides<Arm, FLOOR> {
     /// A `NaN` value never reaches here: every driver short-circuits it. That is what lets this be a
     /// bare `<`; the `!(value >= FLOOR)` a negated predicate would spell puts `NaN` below the support.
     pub(crate) fn at(&self, value: f64) -> Option<f64> {
-        if value < f64::from(FLOOR) {
-            Some(self.below_support)
+        Some(if value < f64::from(FLOOR) {
+            self.below_support
         } else {
-            self.on_support.as_ref().map(|arm| arm(value))
-        }
+            (self.on_support)(value)
+        })
     }
 }
 
-/// The closed quantile domain `[0, 1]`, for the inverses of a distribution that computes its own
-/// closed form rather than building a `statrs` one.
+/// The `select` every inverse shares: the arm inside the closed quantile domain `[0, 1]`, `None`
+/// (null) outside it. `-0.0` is inside, since `-0.0 == 0.0`.
 ///
-/// One slot rather than the two a support needs, because no part of either inverse survives a
-/// null parameter, at any quantile in range or out; each distribution's `null_param(s)_test.py` pins
-/// it.
-pub(crate) struct Domain<Arm> {
-    pub(crate) inside: Option<Arm>,
-}
-
-impl<Arm: Fn(f64) -> f64> Domain<Arm> {
-    /// `None` (null) outside `[0, 1]`; `-0.0` is inside, since `-0.0 == 0.0`.
-    ///
-    /// A `NaN` quantile never reaches here: every driver short-circuits it, which is what lets this
-    /// be a plain range check.
-    pub(crate) fn at(&self, quantile: f64) -> Option<f64> {
-        if !(0.0..=1.0).contains(&quantile) {
-            return None;
-        }
-        self.inside.as_ref().map(|arm| arm(quantile))
+/// An inverse needs no branch table, unlike a support: outside `[0, 1]` the answer is null rather
+/// than a constant, so `derive` returns the arm itself and this is the whole selector.
+///
+/// A `NaN` quantile never reaches here: every driver short-circuits it, which is what lets this be a
+/// plain range check.
+#[inline]
+pub(crate) fn in_unit_domain<Arm: Fn(f64) -> f64>(arm: &Arm, quantile: f64) -> Option<f64> {
+    if !(0.0..=1.0).contains(&quantile) {
+        return None;
     }
+    Some(arm(quantile))
 }
 
 /// Two-parameter sibling of [`value_keyed_derived_per_row`], over `ternary_elementwise`.
 ///
 /// "Pair" counts the *distribution parameters* (`Uniform`'s two bounds); the driver itself takes
-/// three `Series`. Kept beside the one-parameter version rather than generified over arity, because
-/// `derive` needs both `Option`s in scope to answer from one bound while the other is null.
+/// three `Series`. Not generified over arity: `binary_elementwise` and `ternary_elementwise` are
+/// separate polars combinators, so a trait over arity would cost more than the two bodies share.
 ///
 /// `check_params` is the caller's column pass over the two parameter columns, each bound alone and
 /// the pair together, run once before any row is built. Null and `NaN` contracts as in
-/// [`value_keyed_derived_per_row`], with the parameter half two-sided: the branches a single known
-/// bound already settles still answer.
+/// [`value_keyed_derived_per_row`]: a null in either bound nulls the row.
 pub(crate) fn value_keyed_derived_pair_per_row<Branches, CheckParams, Derive, Select>(
     inputs: &[Series],
     check_params: CheckParams,
@@ -394,25 +380,27 @@ pub(crate) fn value_keyed_derived_pair_per_row<Branches, CheckParams, Derive, Se
 ) -> PolarsResult<Series>
 where
     CheckParams: Fn(&Float64Chunked, &Float64Chunked) -> PolarsResult<()>,
-    Derive: Fn(Option<f64>, Option<f64>) -> Branches,
+    Derive: Fn(f64, f64) -> Branches,
     Select: Fn(&Branches, f64) -> Option<f64>,
 {
     let inputs = align_inputs(inputs)?;
     let value = inputs[0].cast(&DataType::Float64)?;
     let param_a = inputs[1].cast(&DataType::Float64)?;
     let param_b = inputs[2].cast(&DataType::Float64)?;
-    let (a, b) = (param_a.f64()?, param_b.f64()?);
+    let (a_ca, b_ca) = (param_a.f64()?, param_b.f64()?);
     let name = inputs[0].name().clone();
-    check_params(a, b)?;
+    check_params(a_ca, b_ca)?;
 
-    let ca: Float64Chunked = ternary_elementwise(value.f64()?, a, b, |value_opt, a_opt, b_opt| {
-        let value = value_opt?;
-        if value.is_nan() {
-            Some(f64::NAN)
-        } else {
-            select(&derive(a_opt, b_opt), value)
-        }
-    });
+    let ca: Float64Chunked =
+        ternary_elementwise(value.f64()?, a_ca, b_ca, |value_opt, a_opt, b_opt| {
+            let (a, b) = (a_opt?, b_opt?);
+            let value = value_opt?;
+            if value.is_nan() {
+                Some(f64::NAN)
+            } else {
+                select(&derive(a, b), value)
+            }
+        });
 
     Ok(ca.with_name(name).into_series())
 }

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -347,31 +347,24 @@ impl<Arm: Fn(f64) -> f64, const FLOOR: i8> Sides<Arm, FLOOR> {
     }
 }
 
-/// The `select` every inverse shares: the arm inside the closed quantile domain `[0, 1]`, `None`
+/// The `select` every inverse shares: the arm on the closed quantile interval `[0, 1]`, `None`
 /// (null) outside it. `-0.0` is inside, since `-0.0 == 0.0`.
-///
-/// An inverse needs no branch table, unlike a support: outside `[0, 1]` the answer is null rather
-/// than a constant, so `derive` returns the arm itself and this is the whole selector.
 ///
 /// A `NaN` quantile never reaches here: every driver short-circuits it, which is what lets this be a
 /// plain range check.
 #[inline]
-pub(crate) fn in_unit_domain<Arm: Fn(f64) -> f64>(arm: &Arm, quantile: f64) -> Option<f64> {
-    if !(0.0..=1.0).contains(&quantile) {
-        return None;
-    }
-    Some(arm(quantile))
+pub(crate) fn on_unit_interval<Arm: Fn(f64) -> f64>(arm: &Arm, quantile: f64) -> Option<f64> {
+    (0.0..=1.0).contains(&quantile).then(|| arm(quantile))
 }
 
 /// Two-parameter sibling of [`value_keyed_derived_per_row`], over `ternary_elementwise`.
 ///
 /// "Pair" counts the *distribution parameters* (`Uniform`'s two bounds); the driver itself takes
-/// three `Series`. Not generified over arity: `binary_elementwise` and `ternary_elementwise` are
-/// separate polars combinators, so a trait over arity would cost more than the two bodies share.
+/// three `Series`.
 ///
-/// `check_params` is the caller's column pass over the two parameter columns, each bound alone and
-/// the pair together, run once before any row is built. Null and `NaN` contracts as in
-/// [`value_keyed_derived_per_row`]: a null in either bound nulls the row.
+/// `check_params` is the caller's column pass over the two parameter columns, each alone and the
+/// pair together, run once before any row is built. Null and `NaN` contracts as in
+/// [`value_keyed_derived_per_row`]: a null in either parameter nulls the row.
 pub(crate) fn value_keyed_derived_pair_per_row<Branches, CheckParams, Derive, Select>(
     inputs: &[Series],
     check_params: CheckParams,

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -4,7 +4,7 @@ use pyo3_polars::derive::polars_expr;
 use rand::distr::{Distribution, StandardUniform};
 
 use crate::distributions::{
-    align_inputs, value_keyed_derived_pair_per_row, value_keyed_scalar, Domain, PairDomain,
+    align_inputs, in_unit_domain, value_keyed_derived_pair_per_row, value_keyed_scalar, PairDomain,
     ParamDomain,
 };
 use crate::rng::{
@@ -46,19 +46,16 @@ struct UniformParamsKwargs {
 
 impl UniformParamsKwargs {
     /// Constant-bounds twin of [`value_keyed_derived_pair_per_row`]: validates and derives once per
-    /// call, then maps `select` over the evaluation-point column.
-    ///
-    /// The Python side routes here only once both bounds are Python scalars, so `derive` always sees
-    /// `Some` and the bound-only terms it hoists (`1 / range`, `-ln(range)`) are computed once
-    /// instead of per row.
+    /// call, then maps `select` over the evaluation-point column, so the bound-only terms `derive`
+    /// hoists (`1 / range`, `-ln(range)`) are computed once instead of per row.
     fn value_keyed<Branches>(
         &self,
         value: &Series,
-        derive: impl Fn(Option<f64>, Option<f64>) -> Branches,
+        derive: impl Fn(f64, f64) -> Branches,
         select: impl Fn(&Branches, f64) -> Option<f64>,
     ) -> PolarsResult<Series> {
         checked_bounds(self.min, self.max)?;
-        let branches = derive(Some(self.min), Some(self.max));
+        let branches = derive(self.min, self.max);
         value_keyed_scalar(value, |v| select(&branches, v))
     }
 }
@@ -74,18 +71,15 @@ struct Span {
     range: f64,
 }
 
-/// `None` when either bound is null, leaving the `interior` / `on_support` slots below `None` on
-/// exactly the rows whose answer needs both bounds.
-fn span(min: Option<f64>, max: Option<f64>) -> Option<Span> {
-    let (min, max) = (min?, max?);
-    Some(Span {
-        min,
-        max,
-        range: max - min,
-    })
-}
-
 impl Span {
+    fn new(min: f64, max: f64) -> Self {
+        Span {
+            min,
+            max,
+            range: max - min,
+        }
+    }
+
     /// Where the two log methods swap conditioning, as `min + range / 2` rather than
     /// `(min + max) / 2`.
     ///
@@ -97,35 +91,32 @@ impl Span {
 }
 
 /// `pdf` / `log_pdf`: the answer on the closed support `[min, max]`, and off it.
-///
-/// The bounds are `Option`s and the off-support answer a plain `f64`, so a slot answers whenever the
-/// bound that places the point is known, whatever the other one is.
 struct Density {
-    min: Option<f64>,
-    max: Option<f64>,
+    min: f64,
+    max: f64,
     off_support: f64,
-    on_support: Option<f64>,
+    on_support: f64,
 }
 
 impl Density {
     /// `1 / range` on the support, `0` off it.
-    fn pdf(min: Option<f64>, max: Option<f64>) -> Self {
+    fn pdf(min: f64, max: f64) -> Self {
         Density {
             min,
             max,
             off_support: 0.0,
-            on_support: span(min, max).map(|s| 1.0 / s.range),
+            on_support: 1.0 / (max - min),
         }
     }
 
     /// `-ln(range)` on the support, `-inf` off it. From the width rather than as `ln(pdf)`, so it
     /// stays exact where the density itself has underflowed or overflowed.
-    fn ln_pdf(min: Option<f64>, max: Option<f64>) -> Self {
+    fn ln_pdf(min: f64, max: f64) -> Self {
         Density {
             min,
             max,
             off_support: f64::NEG_INFINITY,
-            on_support: span(min, max).map(|s| -s.range.ln()),
+            on_support: -(max - min).ln(),
         }
     }
 
@@ -135,10 +126,11 @@ impl Density {
     ///
     /// A `NaN` point never reaches here: both drivers short-circuit it.
     fn at(&self, value: f64) -> Option<f64> {
-        if self.min.is_some_and(|min| value < min) || self.max.is_some_and(|max| value > max) {
-            return Some(self.off_support);
-        }
-        self.on_support
+        Some(if value < self.min || value > self.max {
+            self.off_support
+        } else {
+            self.on_support
+        })
     }
 }
 
@@ -147,33 +139,36 @@ impl Density {
 ///
 /// These saturate from `max` up, so `max` takes `at_or_above_max` rather than the interior.
 struct Regions<Arm> {
-    min: Option<f64>,
-    max: Option<f64>,
+    min: f64,
+    max: f64,
     below_min: f64,
     at_or_above_max: f64,
-    interior: Option<Arm>,
+    interior: Arm,
 }
 
 impl<Arm: Fn(f64) -> f64> Regions<Arm> {
     fn at(&self, value: f64) -> Option<f64> {
-        if self.min.is_some_and(|min| value < min) {
-            return Some(self.below_min);
-        }
-        if self.max.is_some_and(|max| value >= max) {
-            return Some(self.at_or_above_max);
-        }
-        self.interior.as_ref().map(|arm| arm(value))
+        Some(if value < self.min {
+            self.below_min
+        } else if value >= self.max {
+            self.at_or_above_max
+        } else {
+            (self.interior)(value)
+        })
     }
 }
 
 /// `(value - min) / range` on the support, clamped to `0` below and `1` from `max` up.
-fn derive_cdf(min: Option<f64>, max: Option<f64>) -> Regions<impl Fn(f64) -> f64> {
+fn derive_cdf(min: f64, max: f64) -> Regions<impl Fn(f64) -> f64> {
     Regions {
         min,
         max,
         below_min: 0.0,
         at_or_above_max: 1.0,
-        interior: span(min, max).map(|s| move |value: f64| (value - s.min) / s.range),
+        interior: {
+            let span = Span::new(min, max);
+            move |value: f64| (value - span.min) / span.range
+        },
     }
 }
 
@@ -183,22 +178,23 @@ fn derive_cdf(min: Option<f64>, max: Option<f64>) -> Regions<impl Fn(f64) -> f64
 /// small negative, so the near-certain half reads the *survival* fraction through `ln_1p` instead.
 /// The other half is well conditioned and takes the plain log, the same branch `normal.rs`'s
 /// `ln_half_erfc` takes.
-fn derive_ln_cdf(min: Option<f64>, max: Option<f64>) -> Regions<impl Fn(f64) -> f64> {
+fn derive_ln_cdf(min: f64, max: f64) -> Regions<impl Fn(f64) -> f64> {
     Regions {
         min,
         max,
         below_min: f64::NEG_INFINITY,
         at_or_above_max: 0.0,
-        interior: span(min, max).map(|s| {
-            let midpoint = s.midpoint();
+        interior: {
+            let span = Span::new(min, max);
+            let midpoint = span.midpoint();
             move |value: f64| {
                 if value > midpoint {
-                    (-((s.max - value) / s.range)).ln_1p()
+                    (-((span.max - value) / span.range)).ln_1p()
                 } else {
-                    ((value - s.min) / s.range).ln()
+                    ((value - span.min) / span.range).ln()
                 }
             }
-        }),
+        },
     }
 }
 
@@ -206,34 +202,38 @@ fn derive_ln_cdf(min: Option<f64>, max: Option<f64>) -> Regions<impl Fn(f64) -> 
 ///
 /// The closed form, never `1 - cdf`: the complement quantises the upper tail to the `1.1e-16`
 /// spacing of `1.0` and reaches `0.0` below that.
-fn derive_sf(min: Option<f64>, max: Option<f64>) -> Regions<impl Fn(f64) -> f64> {
+fn derive_sf(min: f64, max: f64) -> Regions<impl Fn(f64) -> f64> {
     Regions {
         min,
         max,
         below_min: 1.0,
         at_or_above_max: 0.0,
-        interior: span(min, max).map(|s| move |value: f64| (s.max - value) / s.range),
+        interior: {
+            let span = Span::new(min, max);
+            move |value: f64| (span.max - value) / span.range
+        },
     }
 }
 
 /// The mirror of [`derive_ln_cdf`]: `0` below `min`, `-inf` from `max` up, and the `ln_1p` branch on
 /// the **lower** half, which is where the survival function is the near-certain one.
-fn derive_ln_sf(min: Option<f64>, max: Option<f64>) -> Regions<impl Fn(f64) -> f64> {
+fn derive_ln_sf(min: f64, max: f64) -> Regions<impl Fn(f64) -> f64> {
     Regions {
         min,
         max,
         below_min: 0.0,
         at_or_above_max: f64::NEG_INFINITY,
-        interior: span(min, max).map(|s| {
-            let midpoint = s.midpoint();
+        interior: {
+            let span = Span::new(min, max);
+            let midpoint = span.midpoint();
             move |value: f64| {
                 if value > midpoint {
-                    ((s.max - value) / s.range).ln()
+                    ((span.max - value) / span.range).ln()
                 } else {
-                    (-((value - s.min) / s.range)).ln_1p()
+                    (-((value - span.min) / span.range)).ln_1p()
                 }
             }
-        }),
+        },
     }
 }
 
@@ -248,36 +248,29 @@ fn derive_ln_sf(min: Option<f64>, max: Option<f64>) -> Regions<impl Fn(f64) -> f
 /// `ascending` is `true` for `ppf`, whose quantile `0` sits at `min`, and `false` for `isf`, whose
 /// sits at `max`. Mirroring rather than `ppf(1 - q)`: below `q ~ 1.1e-16` that complement rounds to
 /// `1.0` and the whole tail collapses onto one bound.
-fn derive_inverse(
-    min: Option<f64>,
-    max: Option<f64>,
-    ascending: bool,
-) -> Domain<impl Fn(f64) -> f64> {
-    Domain {
-        inside: span(min, max).map(move |s| {
-            let (at_zero, at_one, step) = if ascending {
-                (s.min, s.max, s.range)
-            } else {
-                (s.max, s.min, -s.range)
-            };
-            move |quantile: f64| {
-                if quantile <= MEDIAN_QUANTILE {
-                    at_zero + quantile * step
-                } else {
-                    at_one - (1.0 - quantile) * step
-                }
-            }
-        }),
+fn derive_inverse(min: f64, max: f64, ascending: bool) -> impl Fn(f64) -> f64 {
+    let span = Span::new(min, max);
+    let (at_zero, at_one, step) = if ascending {
+        (span.min, span.max, span.range)
+    } else {
+        (span.max, span.min, -span.range)
+    };
+    move |quantile: f64| {
+        if quantile <= MEDIAN_QUANTILE {
+            at_zero + quantile * step
+        } else {
+            at_one - (1.0 - quantile) * step
+        }
     }
 }
 
 /// `min + quantile * range`, from `max` down above the median; null outside `[0, 1]`.
-fn derive_ppf(min: Option<f64>, max: Option<f64>) -> Domain<impl Fn(f64) -> f64> {
+fn derive_ppf(min: f64, max: f64) -> impl Fn(f64) -> f64 {
     derive_inverse(min, max, true)
 }
 
 /// `max - quantile * range`, from `min` up above the median; null outside `[0, 1]`.
-fn derive_isf(min: Option<f64>, max: Option<f64>) -> Domain<impl Fn(f64) -> f64> {
+fn derive_isf(min: f64, max: f64) -> impl Fn(f64) -> f64 {
     derive_inverse(min, max, false)
 }
 
@@ -321,14 +314,14 @@ fn uniform_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
 /// Element-wise ppf (inverse cdf); see [`derive_inverse`].
 #[polars_expr(output_type=Float64)]
 fn uniform_ppf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, check_params, derive_ppf, Domain::at)
+    value_keyed_derived_pair_per_row(inputs, check_params, derive_ppf, in_unit_domain)
 }
 
 /// Element-wise inverse survival function; see [`derive_inverse`] for why it never forms a
 /// complement.
 #[polars_expr(output_type=Float64)]
 fn uniform_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, check_params, derive_isf, Domain::at)
+    value_keyed_derived_pair_per_row(inputs, check_params, derive_isf, in_unit_domain)
 }
 
 /// Constant-bounds fast path for [`uniform_pdf`].
@@ -370,13 +363,13 @@ fn uniform_ln_sf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> Polar
 /// Constant-bounds fast path for [`uniform_ppf`].
 #[polars_expr(output_type=Float64)]
 fn uniform_ppf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], derive_ppf, Domain::at)
+    kwargs.value_keyed(&inputs[0], derive_ppf, in_unit_domain)
 }
 
 /// Constant-bounds fast path for [`uniform_isf`].
 #[polars_expr(output_type=Float64)]
 fn uniform_isf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], derive_isf, Domain::at)
+    kwargs.value_keyed(&inputs[0], derive_isf, in_unit_domain)
 }
 
 /// One half-open `[lo, hi)` draw: `lo + (hi - lo) * U[0, 1)`, matching scipy's

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -4,8 +4,8 @@ use pyo3_polars::derive::polars_expr;
 use rand::distr::{Distribution, StandardUniform};
 
 use crate::distributions::{
-    align_inputs, in_unit_domain, value_keyed_derived_pair_per_row, value_keyed_scalar, PairDomain,
-    ParamDomain,
+    align_inputs, on_unit_interval, value_keyed_derived_pair_per_row, value_keyed_scalar,
+    PairDomain, ParamDomain,
 };
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
@@ -63,31 +63,12 @@ impl UniformParamsKwargs {
 /// Where both inverses switch which bound they interpolate from; see [`derive_inverse`].
 const MEDIAN_QUANTILE: f64 = 0.5;
 
-/// A validated `(min, max)` pair and its width, which every branch table below reads.
-#[derive(Clone, Copy)]
-struct Span {
-    min: f64,
-    max: f64,
-    range: f64,
-}
-
-impl Span {
-    fn new(min: f64, max: f64) -> Self {
-        Span {
-            min,
-            max,
-            range: max - min,
-        }
-    }
-
-    /// Where the two log methods swap conditioning, as `min + range / 2` rather than
-    /// `(min + max) / 2`.
-    ///
-    /// The two round differently on a span that straddles zero, and `min + max` can overflow where
-    /// `range / 2` cannot: `range` is already known finite.
-    fn midpoint(self) -> f64 {
-        self.min + self.range / 2.0
-    }
+/// Where the two log methods swap conditioning, as `min + range / 2` rather than `(min + max) / 2`.
+///
+/// The two round differently on a span that straddles zero, and `min + max` can overflow where
+/// `range / 2` cannot: `range` is already known finite.
+fn midpoint(min: f64, range: f64) -> f64 {
+    min + range / 2.0
 }
 
 /// `pdf` / `log_pdf`: the answer on the closed support `[min, max]`, and off it.
@@ -166,8 +147,8 @@ fn derive_cdf(min: f64, max: f64) -> Regions<impl Fn(f64) -> f64> {
         below_min: 0.0,
         at_or_above_max: 1.0,
         interior: {
-            let span = Span::new(min, max);
-            move |value: f64| (value - span.min) / span.range
+            let range = max - min;
+            move |value: f64| (value - min) / range
         },
     }
 }
@@ -185,13 +166,13 @@ fn derive_ln_cdf(min: f64, max: f64) -> Regions<impl Fn(f64) -> f64> {
         below_min: f64::NEG_INFINITY,
         at_or_above_max: 0.0,
         interior: {
-            let span = Span::new(min, max);
-            let midpoint = span.midpoint();
+            let range = max - min;
+            let midpoint = midpoint(min, range);
             move |value: f64| {
                 if value > midpoint {
-                    (-((span.max - value) / span.range)).ln_1p()
+                    (-((max - value) / range)).ln_1p()
                 } else {
-                    ((value - span.min) / span.range).ln()
+                    ((value - min) / range).ln()
                 }
             }
         },
@@ -209,8 +190,8 @@ fn derive_sf(min: f64, max: f64) -> Regions<impl Fn(f64) -> f64> {
         below_min: 1.0,
         at_or_above_max: 0.0,
         interior: {
-            let span = Span::new(min, max);
-            move |value: f64| (span.max - value) / span.range
+            let range = max - min;
+            move |value: f64| (max - value) / range
         },
     }
 }
@@ -224,13 +205,13 @@ fn derive_ln_sf(min: f64, max: f64) -> Regions<impl Fn(f64) -> f64> {
         below_min: 0.0,
         at_or_above_max: f64::NEG_INFINITY,
         interior: {
-            let span = Span::new(min, max);
-            let midpoint = span.midpoint();
+            let range = max - min;
+            let midpoint = midpoint(min, range);
             move |value: f64| {
                 if value > midpoint {
-                    ((span.max - value) / span.range).ln()
+                    ((max - value) / range).ln()
                 } else {
-                    (-((value - span.min) / span.range)).ln_1p()
+                    (-((value - min) / range)).ln_1p()
                 }
             }
         },
@@ -249,11 +230,11 @@ fn derive_ln_sf(min: f64, max: f64) -> Regions<impl Fn(f64) -> f64> {
 /// sits at `max`. Mirroring rather than `ppf(1 - q)`: below `q ~ 1.1e-16` that complement rounds to
 /// `1.0` and the whole tail collapses onto one bound.
 fn derive_inverse(min: f64, max: f64, ascending: bool) -> impl Fn(f64) -> f64 {
-    let span = Span::new(min, max);
+    let range = max - min;
     let (at_zero, at_one, step) = if ascending {
-        (span.min, span.max, span.range)
+        (min, max, range)
     } else {
-        (span.max, span.min, -span.range)
+        (max, min, -range)
     };
     move |quantile: f64| {
         if quantile <= MEDIAN_QUANTILE {
@@ -314,14 +295,14 @@ fn uniform_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
 /// Element-wise ppf (inverse cdf); see [`derive_inverse`].
 #[polars_expr(output_type=Float64)]
 fn uniform_ppf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, check_params, derive_ppf, in_unit_domain)
+    value_keyed_derived_pair_per_row(inputs, check_params, derive_ppf, on_unit_interval)
 }
 
 /// Element-wise inverse survival function; see [`derive_inverse`] for why it never forms a
 /// complement.
 #[polars_expr(output_type=Float64)]
 fn uniform_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, check_params, derive_isf, in_unit_domain)
+    value_keyed_derived_pair_per_row(inputs, check_params, derive_isf, on_unit_interval)
 }
 
 /// Constant-bounds fast path for [`uniform_pdf`].
@@ -363,13 +344,13 @@ fn uniform_ln_sf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> Polar
 /// Constant-bounds fast path for [`uniform_ppf`].
 #[polars_expr(output_type=Float64)]
 fn uniform_ppf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], derive_ppf, in_unit_domain)
+    kwargs.value_keyed(&inputs[0], derive_ppf, on_unit_interval)
 }
 
 /// Constant-bounds fast path for [`uniform_isf`].
 #[polars_expr(output_type=Float64)]
 fn uniform_isf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], derive_isf, in_unit_domain)
+    kwargs.value_keyed(&inputs[0], derive_isf, on_unit_interval)
 }
 
 /// One half-open `[lo, hi)` draw: `lo + (hi - lo) * U[0, 1)`, matching scipy's

--- a/tests/distributions/bernoulli/null_param_test.py
+++ b/tests/distributions/bernoulli/null_param_test.py
@@ -1,44 +1,16 @@
-"""A null `p` nulls every answer that depends on it, and only those.
+"""A null `p` nulls every answer on the support, where the answer reads `p` directly.
 
-`pmf(2) = 0`, `cdf(-1) = 0` and `sf(1) = 0` carry no `p`, so they survive a null one; the class
-docstring promises it and `Geometric` behaves the same way.
-
-The contract lives in how the Rust bodies derive their branches: `p` arrives as an `Option<f64>` and
-only the slots whose answer reads it are `p.map(...)`. Threading `p` through one `Option` chain
-around a whole body would null the constants out and leave the rest of the suite green, since the
-per-method null tests all evaluate on the support.
+Off-support, `NaN` and null evaluation points live in `null_nan_contract_test.py`.
 """
 
 from __future__ import annotations
-
-import math
 
 import polars as pl
 import pytest
 
 from polars_stats import Bernoulli
 
-_NEG_INF = float("-inf")
-
-# (method, value, expected) for the answers that hold with no `p` at all.
-_OFF_SUPPORT: list[tuple[str, float, float]] = [
-    ("pmf", -1.0, 0.0),
-    ("pmf", 0.5, 0.0),
-    ("pmf", 2.0, 0.0),
-    ("log_pmf", -1.0, _NEG_INF),
-    ("log_pmf", 0.5, _NEG_INF),
-    ("log_pmf", 2.0, _NEG_INF),
-    ("cdf", -1.0, 0.0),
-    ("cdf", 1.0, 1.0),
-    ("log_cdf", -1.0, _NEG_INF),
-    ("log_cdf", 1.0, 0.0),
-    ("sf", -1.0, 1.0),
-    ("sf", 1.0, 0.0),
-    ("log_sf", -1.0, 0.0),
-    ("log_sf", 1.0, _NEG_INF),
-]
-
-# (method, value) pairs whose answer reads `p`, so a null one must reach the result.
+# (method, value) pairs whose answer reads `p`.
 _ON_SUPPORT: list[tuple[str, float]] = [
     ("pmf", 0.0),
     ("pmf", 1.0),
@@ -55,16 +27,6 @@ _MOMENTS = ["mean", "variance", "std", "median", "entropy"]
 
 def _null_p() -> pl.DataFrame:
     return pl.DataFrame({"p": [None]}, schema={"p": pl.Float64})
-
-
-@pytest.mark.parametrize(
-    ("method", "value", "expected"),
-    _OFF_SUPPORT,
-    ids=[f"{method}({value})" for method, value, _ in _OFF_SUPPORT],
-)
-def test_off_support_constant_survives_a_null_p(method: str, value: float, expected: float) -> None:
-    result = _null_p().select(r=getattr(Bernoulli(p=pl.col("p")), method)(value))["r"].item()
-    assert result == expected
 
 
 @pytest.mark.parametrize(("method", "value"), _ON_SUPPORT, ids=[f"{method}({value})" for method, value in _ON_SUPPORT])
@@ -85,14 +47,3 @@ def test_inverse_nulls_under_a_null_p(method: str, quantile: float) -> None:
     The endpoints are probed because `ppf(1.0)` reads its own derived slot rather than the cdf step.
     """
     assert _null_p().select(r=getattr(Bernoulli(p=pl.col("p")), method)(quantile))["r"].item() is None
-
-
-def test_nan_value_stays_nan_under_a_null_p() -> None:
-    """A `NaN` evaluation point short-circuits before the branches, so a null `p` does not null it.
-
-    The one row where the local driver diverges from the shared `value_keyed_per_row`, which nulls a
-    row on any null parameter. Reached through the private hook, since the public wrapper answers
-    `NaN` on its own.
-    """
-    result = _null_p().select(r=Bernoulli(p=pl.col("p"))._pmf(pl.lit(math.nan)))["r"].item()
-    assert math.isnan(result)

--- a/tests/distributions/bernoulli/null_param_test.py
+++ b/tests/distributions/bernoulli/null_param_test.py
@@ -42,8 +42,4 @@ def test_moment_nulls_under_a_null_p(method: str) -> None:
 @pytest.mark.parametrize("method", ["ppf", "isf"])
 @pytest.mark.parametrize("quantile", [0.0, 0.5, 1.0, 2.0])
 def test_inverse_nulls_under_a_null_p(method: str, quantile: float) -> None:
-    """Null inside `[0, 1]` because the answer needs `p`, and null outside it by the domain contract.
-
-    The endpoints are probed because `ppf(1.0)` reads its own derived slot rather than the cdf step.
-    """
     assert _null_p().select(r=getattr(Bernoulli(p=pl.col("p")), method)(quantile))["r"].item() is None

--- a/tests/distributions/exponential/null_params_test.py
+++ b/tests/distributions/exponential/null_params_test.py
@@ -15,8 +15,7 @@ from polars_stats import Exponential
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-# Every closed-form method must propagate a null rate to a null result. The value-keyed methods are
-# evaluated at an on-support point (`x >= 0`, `q in [0, 1]`), where the rate enters the formula.
+# The value-keyed methods are evaluated at an on-support point (`x >= 0`, `q in [0, 1]`).
 _METHODS: dict[str, Callable[[Exponential], pl.Expr]] = {
     "pdf": lambda e: e.pdf(pl.lit(0.5)),
     "log_pdf": lambda e: e.log_pdf(pl.lit(0.5)),
@@ -44,6 +43,5 @@ def test_method_propagates_null_in_rate(expr_fn: Callable[[Exponential], pl.Expr
 @pytest.mark.parametrize("method", ["ppf", "isf"])
 @pytest.mark.parametrize("quantile", [0.0, 0.5, 1.0, 2.0])
 def test_inverse_nulls_under_a_null_rate(method: str, quantile: float) -> None:
-    """Endpoints as well as interior ones."""
     df = pl.DataFrame({"rate": [None]}, schema={"rate": pl.Float64})
     assert df.select(r=getattr(Exponential(rate=pl.col("rate")), method)(quantile))["r"].item() is None

--- a/tests/distributions/exponential/null_params_test.py
+++ b/tests/distributions/exponential/null_params_test.py
@@ -1,6 +1,10 @@
+"""A null `rate` nulls every answer on the support, where the answer reads the rate directly.
+
+Off-support, `NaN` and null evaluation points live in `null_nan_contract_test.py`.
+"""
+
 from __future__ import annotations
 
-import math
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -12,9 +16,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 # Every closed-form method must propagate a null rate to a null result. The value-keyed methods are
-# evaluated at an on-support point (`x >= 0`, `q in [0, 1]`) where the rate enters the formula, so the
-# null flows through; below the support they return the rate-independent support constant instead (see
-# `test_value_keyed_below_support_ignores_null_rate`).
+# evaluated at an on-support point (`x >= 0`, `q in [0, 1]`), where the rate enters the formula.
 _METHODS: dict[str, Callable[[Exponential], pl.Expr]] = {
     "pdf": lambda e: e.pdf(pl.lit(0.5)),
     "log_pdf": lambda e: e.log_pdf(pl.lit(0.5)),
@@ -39,35 +41,9 @@ def test_method_propagates_null_in_rate(expr_fn: Callable[[Exponential], pl.Expr
     assert result.is_null().to_list() == [False, True, False]
 
 
-def test_value_keyed_below_support_ignores_null_rate() -> None:
-    # Closed-form trait shared with Uniform: below the support all six value-keyed methods return the
-    # rate-independent support constant, so a null rate does NOT null the row there. statrs-backed
-    # distributions (Binomial) null it instead. Bernoulli keeps the same contract in Rust
-    # (tests/distributions/bernoulli/null_param_test.py).
-    df = pl.DataFrame({"rate": [1.0, None, 2.0]}, schema={"rate": pl.Float64})
-    e = Exponential(rate=pl.col("rate"))
-    assert df.select(r=e.pdf(pl.lit(-1.0)))["r"].to_list() == [0.0, 0.0, 0.0]
-    assert df.select(r=e.cdf(pl.lit(-1.0)))["r"].to_list() == [0.0, 0.0, 0.0]
-    assert df.select(r=e.sf(pl.lit(-1.0)))["r"].to_list() == [1.0, 1.0, 1.0]
-    assert df.select(r=e.log_pdf(pl.lit(-1.0)))["r"].to_list() == [-math.inf] * 3
-    assert df.select(r=e.log_cdf(pl.lit(-1.0)))["r"].to_list() == [-math.inf] * 3
-    assert df.select(r=e.log_sf(pl.lit(-1.0)))["r"].to_list() == [0.0, 0.0, 0.0]
-
-
 @pytest.mark.parametrize("method", ["ppf", "isf"])
 @pytest.mark.parametrize("quantile", [0.0, 0.5, 1.0, 2.0])
 def test_inverse_nulls_under_a_null_rate(method: str, quantile: float) -> None:
-    """Endpoints as well as interior: neither inverse has a rate-free branch anywhere in its domain."""
+    """Endpoints as well as interior ones."""
     df = pl.DataFrame({"rate": [None]}, schema={"rate": pl.Float64})
     assert df.select(r=getattr(Exponential(rate=pl.col("rate")), method)(quantile))["r"].item() is None
-
-
-def test_nan_value_stays_nan_under_a_null_rate() -> None:
-    """A `NaN` evaluation point short-circuits before the branches, so a null rate does not null it.
-
-    Reached through the private hook, since the public wrapper answers `NaN` on its own. Without the
-    short-circuit `NaN` would land on the support (it is not `< 0`) and the null rate would null it.
-    """
-    df = pl.DataFrame({"rate": [None]}, schema={"rate": pl.Float64})
-    result = df.select(r=Exponential(rate=pl.col("rate"))._pdf(pl.lit(math.nan)))["r"].item()
-    assert math.isnan(result)

--- a/tests/distributions/geometric/null_param_test.py
+++ b/tests/distributions/geometric/null_param_test.py
@@ -47,5 +47,4 @@ def test_moment_nulls_under_a_null_p(method: str) -> None:
 @pytest.mark.parametrize("method", ["ppf", "isf"])
 @pytest.mark.parametrize("quantile", [0.0, 0.5, 1.0, 2.0])
 def test_inverse_nulls_under_a_null_p(method: str, quantile: float) -> None:
-    """Null inside `[0, 1]` because the answer needs `p`, and null outside it by the domain contract."""
     assert _null_p().select(r=getattr(Geometric(p=pl.col("p")), method)(quantile))["r"].item() is None

--- a/tests/distributions/geometric/null_param_test.py
+++ b/tests/distributions/geometric/null_param_test.py
@@ -1,50 +1,17 @@
-"""A null `p` nulls every answer that depends on it, and only those.
+"""A null `p` nulls every answer on the support, where the answer reads `p` directly.
 
-`pmf(0) = 0`, `cdf(0) = 0` and `sf(0) = 1` are off-support constants with no `p` in them, so they
-survive a null one; the class docstring promises it and `Bernoulli` behaves the same way. The split is
-per method: a non-integral point in range carries no mass, so `pmf(2.5) = 0` survives, but `cdf(2.5)`
-is `cdf(2)`, needs `p`, and nulls.
-
-Nothing else pins the constants: the per-method null tests all evaluate on the support.
+Off-support, `NaN` and null evaluation points live in `null_nan_contract_test.py`.
 """
 
 from __future__ import annotations
-
-import math
 
 import polars as pl
 import pytest
 
 from polars_stats import Geometric
 
-_NEG_INF = float("-inf")
-
-# (method, value, expected) for the answers that hold with no `p` at all: below the support for every
-# method, and at a non-integral point in range for the two mass methods.
-_OFF_SUPPORT: list[tuple[str, float, float]] = [
-    ("pmf", -1.0, 0.0),
-    ("pmf", 0.0, 0.0),
-    ("pmf", 0.5, 0.0),
-    ("pmf", 2.5, 0.0),
-    ("log_pmf", -1.0, _NEG_INF),
-    ("log_pmf", 0.0, _NEG_INF),
-    ("log_pmf", 0.5, _NEG_INF),
-    ("log_pmf", 2.5, _NEG_INF),
-    ("cdf", -1.0, 0.0),
-    ("cdf", 0.0, 0.0),
-    ("cdf", 0.5, 0.0),
-    ("log_cdf", -1.0, _NEG_INF),
-    ("log_cdf", 0.0, _NEG_INF),
-    ("log_cdf", 0.5, _NEG_INF),
-    ("sf", -1.0, 1.0),
-    ("sf", 0.0, 1.0),
-    ("sf", 0.5, 1.0),
-    ("log_sf", -1.0, 0.0),
-    ("log_sf", 0.0, 0.0),
-    ("log_sf", 0.5, 0.0),
-]
-
-# (method, value) pairs whose answer reads `p`, so a null one must reach the result.
+# (method, value) pairs whose answer reads `p`; `cdf(2.5)` is `cdf(2)`, so a non-integral point in
+# range is on the support for the tail methods.
 _ON_SUPPORT: list[tuple[str, float]] = [
     ("pmf", 1.0),
     ("pmf", 3.0),
@@ -67,16 +34,6 @@ def _null_p() -> pl.DataFrame:
     return pl.DataFrame({"p": [None]}, schema={"p": pl.Float64})
 
 
-@pytest.mark.parametrize(
-    ("method", "value", "expected"),
-    _OFF_SUPPORT,
-    ids=[f"{method}({value})" for method, value, _ in _OFF_SUPPORT],
-)
-def test_off_support_constant_survives_a_null_p(method: str, value: float, expected: float) -> None:
-    result = _null_p().select(r=getattr(Geometric(p=pl.col("p")), method)(value))["r"].item()
-    assert result == expected
-
-
 @pytest.mark.parametrize(("method", "value"), _ON_SUPPORT, ids=[f"{method}({value})" for method, value in _ON_SUPPORT])
 def test_on_support_value_nulls_under_a_null_p(method: str, value: float) -> None:
     assert _null_p().select(r=getattr(Geometric(p=pl.col("p")), method)(value))["r"].item() is None
@@ -92,12 +49,3 @@ def test_moment_nulls_under_a_null_p(method: str) -> None:
 def test_inverse_nulls_under_a_null_p(method: str, quantile: float) -> None:
     """Null inside `[0, 1]` because the answer needs `p`, and null outside it by the domain contract."""
     assert _null_p().select(r=getattr(Geometric(p=pl.col("p")), method)(quantile))["r"].item() is None
-
-
-def test_nan_value_stays_nan_under_a_null_p() -> None:
-    """A `NaN` point short-circuits before the branches, so a null `p` does not null it.
-
-    Probed through the private hook, since the public wrapper answers `NaN` on its own.
-    """
-    result = _null_p().select(r=Geometric(p=pl.col("p"))._pmf(pl.lit(math.nan)))["r"].item()
-    assert math.isnan(result)

--- a/tests/distributions/null_nan_contract_test.py
+++ b/tests/distributions/null_nan_contract_test.py
@@ -1,9 +1,13 @@
-"""An invalid present parameter raises, whatever else its row holds.
+"""An invalid present parameter raises, whatever else its row holds; a null one nulls every answer.
 
 `NaN`, `+inf` and `-inf` in any float parameter slot raise `ComputeError` on every method, beside a
 `NaN` or null evaluation point and beside a null sibling parameter alike; so does a finite value
 outside the slot's domain beside a null sibling. Validation runs over the parameter column before any
 row is built, so it cannot depend on what else is null on the row.
+
+A null parameter is answered before the evaluation point is read, so every method nulls at a finite,
+`NaN`, null and off-support point alike. Neither an off-support constant nor the `NaN` short-circuit
+outranks a missing parameter.
 
 Value-keyed methods go through the private `_x` hooks: on polars >= 1.44 the public wrapper
 `propagate_null_and_nan` masks the plugin out of the null and `NaN` rows before it can validate.
@@ -18,7 +22,17 @@ from dataclasses import dataclass
 import polars as pl
 import pytest
 
-from polars_stats import Bernoulli, Beta, Binomial, Exponential, Geometric, LogNormal, Normal, Uniform
+from polars_stats import (
+    Bernoulli,
+    Beta,
+    Binomial,
+    DiscreteUniform,
+    Exponential,
+    Geometric,
+    LogNormal,
+    Normal,
+    Uniform,
+)
 from polars_stats.distributions._base import DiscreteDistribution, _UnivariateDistribution
 
 
@@ -28,6 +42,8 @@ class _Dist:
     dist: _UnivariateDistribution
     valid: dict[str, float]
     integer: frozenset[str] = frozenset()
+    off_support: float | None = None
+    """A point off the support, or `None` where the support is the whole line."""
 
     @property
     def float_slots(self) -> tuple[str, ...]:
@@ -41,14 +57,27 @@ class _Dist:
 
 
 _DISTS: tuple[_Dist, ...] = (
-    _Dist("Bernoulli", Bernoulli(p=pl.col("p")), {"p": 0.5}),
-    _Dist("Binomial", Binomial(n=pl.col("n"), p=pl.col("p")), {"n": 10, "p": 0.5}, integer=frozenset({"n"})),
-    _Dist("Beta", Beta(a=pl.col("a"), b=pl.col("b")), {"a": 2.0, "b": 3.0}),
-    _Dist("Exponential", Exponential(rate=pl.col("rate")), {"rate": 1.0}),
-    _Dist("Geometric", Geometric(p=pl.col("p")), {"p": 0.5}),
+    _Dist("Bernoulli", Bernoulli(p=pl.col("p")), {"p": 0.5}, off_support=2.0),
+    _Dist(
+        "Binomial",
+        Binomial(n=pl.col("n"), p=pl.col("p")),
+        {"n": 10, "p": 0.5},
+        integer=frozenset({"n"}),
+        off_support=-1.0,
+    ),
+    _Dist("Beta", Beta(a=pl.col("a"), b=pl.col("b")), {"a": 2.0, "b": 3.0}, off_support=2.0),
+    _Dist("Exponential", Exponential(rate=pl.col("rate")), {"rate": 1.0}, off_support=-1.0),
+    _Dist("Geometric", Geometric(p=pl.col("p")), {"p": 0.5}, off_support=0.0),
     _Dist("Normal", Normal(mu=pl.col("mu"), sigma=pl.col("sigma")), {"mu": 0.0, "sigma": 1.0}),
-    _Dist("LogNormal", LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")), {"mu": 0.0, "sigma": 1.0}),
-    _Dist("Uniform", Uniform(min=pl.col("min"), max=pl.col("max")), {"min": 0.0, "max": 1.0}),
+    _Dist("LogNormal", LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")), {"mu": 0.0, "sigma": 1.0}, off_support=-1.0),
+    _Dist("Uniform", Uniform(min=pl.col("min"), max=pl.col("max")), {"min": 0.0, "max": 1.0}, off_support=5.0),
+    _Dist(
+        "DiscreteUniform",
+        DiscreteUniform(min=pl.col("min"), max=pl.col("max")),
+        {"min": 0, "max": 5},
+        integer=frozenset({"min", "max"}),
+        off_support=10.0,
+    ),
 )
 _BY_NAME = {dist.name: dist for dist in _DISTS}
 
@@ -119,3 +148,28 @@ def test_invalid_parameter_beside_a_null_sibling_raises(name: str, slot: str, ba
     (sibling,) = (other for other in dist.valid if other != slot)
     unreported = _unreported(dist, {slot: bad, sibling: None}, slot)
     assert not unreported, f"{name} did not report `{slot} must be` beside a null `{sibling}`: {unreported}"
+
+
+def _answered(dist: _Dist, slot: str) -> list[str]:
+    """Every method that answers something other than null with `slot` null and the rest valid."""
+    overrides: dict[str, float | None] = {slot: None}
+    points = [0.5, math.nan, None] if dist.off_support is None else [0.5, math.nan, None, dist.off_support]
+    probes = [
+        (f"{hook}(x={x})", dist.frame(overrides, x), getattr(dist.dist, hook)(pl.col("x")))
+        for x in points
+        for hook in _value_hooks(dist.dist)
+    ]
+    row = dist.frame(overrides, 0.5)
+    probes += [(method, row, getattr(dist.dist, method)()) for method in _MOMENTS]
+    probes += [("sample", row, dist.dist.sample(seed=0)), ("samples", row, dist.dist.samples(3, seed=0))]
+    return [label for label, frame, expr in probes if frame.select(r=expr)["r"].item() is not None]
+
+
+@pytest.mark.parametrize(
+    ("dist", "slot"),
+    [pytest.param(dist, slot, id=f"{dist.name}.{slot}") for dist in _DISTS for slot in dist.valid],
+)
+def test_null_parameter_nulls_every_method(dist: _Dist, slot: str) -> None:
+    """Off-support constants and the `NaN` short-circuit included."""
+    answered = _answered(dist, slot)
+    assert not answered, f"{dist.name} answered with a null `{slot}`: {answered}"

--- a/tests/distributions/null_nan_contract_test.py
+++ b/tests/distributions/null_nan_contract_test.py
@@ -6,8 +6,7 @@ outside the slot's domain beside a null sibling. Validation runs over the parame
 row is built, so it cannot depend on what else is null on the row.
 
 A null parameter is answered before the evaluation point is read, so every method nulls at a finite,
-`NaN`, null and off-support point alike. Neither an off-support constant nor the `NaN` short-circuit
-outranks a missing parameter.
+`NaN`, null and off-support point alike.
 
 Value-keyed methods go through the private `_x` hooks: on polars >= 1.44 the public wrapper
 `propagate_null_and_nan` masks the plugin out of the null and `NaN` rows before it can validate.
@@ -42,8 +41,8 @@ class _Dist:
     dist: _UnivariateDistribution
     valid: dict[str, float]
     integer: frozenset[str] = frozenset()
-    off_support: float | None = None
-    """A point off the support, or `None` where the support is the whole line."""
+    off_support: tuple[float, ...] = ()
+    """Points off the support; empty where the support is the whole line."""
 
     @property
     def float_slots(self) -> tuple[str, ...]:
@@ -57,26 +56,28 @@ class _Dist:
 
 
 _DISTS: tuple[_Dist, ...] = (
-    _Dist("Bernoulli", Bernoulli(p=pl.col("p")), {"p": 0.5}, off_support=2.0),
+    _Dist("Bernoulli", Bernoulli(p=pl.col("p")), {"p": 0.5}, off_support=(2.0,)),
     _Dist(
         "Binomial",
         Binomial(n=pl.col("n"), p=pl.col("p")),
         {"n": 10, "p": 0.5},
         integer=frozenset({"n"}),
-        off_support=-1.0,
+        off_support=(-1.0,),
     ),
-    _Dist("Beta", Beta(a=pl.col("a"), b=pl.col("b")), {"a": 2.0, "b": 3.0}, off_support=2.0),
-    _Dist("Exponential", Exponential(rate=pl.col("rate")), {"rate": 1.0}, off_support=-1.0),
-    _Dist("Geometric", Geometric(p=pl.col("p")), {"p": 0.5}, off_support=0.0),
+    _Dist("Beta", Beta(a=pl.col("a"), b=pl.col("b")), {"a": 2.0, "b": 3.0}, off_support=(2.0,)),
+    _Dist("Exponential", Exponential(rate=pl.col("rate")), {"rate": 1.0}, off_support=(-1.0,)),
+    _Dist("Geometric", Geometric(p=pl.col("p")), {"p": 0.5}, off_support=(0.0, 2.5)),
     _Dist("Normal", Normal(mu=pl.col("mu"), sigma=pl.col("sigma")), {"mu": 0.0, "sigma": 1.0}),
-    _Dist("LogNormal", LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")), {"mu": 0.0, "sigma": 1.0}, off_support=-1.0),
-    _Dist("Uniform", Uniform(min=pl.col("min"), max=pl.col("max")), {"min": 0.0, "max": 1.0}, off_support=5.0),
+    _Dist(
+        "LogNormal", LogNormal(mu=pl.col("mu"), sigma=pl.col("sigma")), {"mu": 0.0, "sigma": 1.0}, off_support=(-1.0,)
+    ),
+    _Dist("Uniform", Uniform(min=pl.col("min"), max=pl.col("max")), {"min": 0.0, "max": 1.0}, off_support=(5.0,)),
     _Dist(
         "DiscreteUniform",
         DiscreteUniform(min=pl.col("min"), max=pl.col("max")),
         {"min": 0, "max": 5},
         integer=frozenset({"min", "max"}),
-        off_support=10.0,
+        off_support=(10.0,),
     ),
 )
 _BY_NAME = {dist.name: dist for dist in _DISTS}
@@ -108,18 +109,25 @@ def _report(frame: pl.DataFrame, expr: pl.Expr) -> str | None:
     return None
 
 
-def _unreported(dist: _Dist, overrides: dict[str, float | None], slot: str) -> list[tuple[str, str | None]]:
-    """Every method that computes, or raises without naming `slot`, with what it reported."""
+def _probes(
+    dist: _Dist, overrides: dict[str, float | None], points: tuple[float | None, ...]
+) -> list[tuple[str, pl.DataFrame, pl.Expr]]:
+    """Every value-keyed hook at every point, then the moments and both samplers, as `(label, frame, expr)`."""
     probes = [
         (f"{hook}(x={x})", dist.frame(overrides, x), getattr(dist.dist, hook)(pl.col("x")))
-        for x in (0.5, math.nan, None)
+        for x in points
         for hook in _value_hooks(dist.dist)
     ]
     row = dist.frame(overrides, 0.5)
     probes += [(method, row, getattr(dist.dist, method)()) for method in _MOMENTS]
     probes += [("sample", row, dist.dist.sample(seed=0)), ("samples", row, dist.dist.samples(3, seed=0))]
+    return probes
+
+
+def _unreported(dist: _Dist, overrides: dict[str, float | None], slot: str) -> list[tuple[str, str | None]]:
+    """Every method that computes, or raises without naming `slot`, with what it reported."""
     fragment = f"{slot} must be"
-    reports = [(label, _report(frame, expr)) for label, frame, expr in probes]
+    reports = [(label, _report(frame, expr)) for label, frame, expr in _probes(dist, overrides, (0.5, math.nan, None))]
     return [(label, report) for label, report in reports if report is None or fragment not in report]
 
 
@@ -150,18 +158,9 @@ def test_invalid_parameter_beside_a_null_sibling_raises(name: str, slot: str, ba
     assert not unreported, f"{name} did not report `{slot} must be` beside a null `{sibling}`: {unreported}"
 
 
-def _answered(dist: _Dist, slot: str) -> list[str]:
+def _non_null_answers(dist: _Dist, slot: str) -> list[str]:
     """Every method that answers something other than null with `slot` null and the rest valid."""
-    overrides: dict[str, float | None] = {slot: None}
-    points = [0.5, math.nan, None] if dist.off_support is None else [0.5, math.nan, None, dist.off_support]
-    probes = [
-        (f"{hook}(x={x})", dist.frame(overrides, x), getattr(dist.dist, hook)(pl.col("x")))
-        for x in points
-        for hook in _value_hooks(dist.dist)
-    ]
-    row = dist.frame(overrides, 0.5)
-    probes += [(method, row, getattr(dist.dist, method)()) for method in _MOMENTS]
-    probes += [("sample", row, dist.dist.sample(seed=0)), ("samples", row, dist.dist.samples(3, seed=0))]
+    probes = _probes(dist, {slot: None}, (0.5, math.nan, None, *dist.off_support))
     return [label for label, frame, expr in probes if frame.select(r=expr)["r"].item() is not None]
 
 
@@ -171,5 +170,5 @@ def _answered(dist: _Dist, slot: str) -> list[str]:
 )
 def test_null_parameter_nulls_every_method(dist: _Dist, slot: str) -> None:
     """Off-support constants and the `NaN` short-circuit included."""
-    answered = _answered(dist, slot)
+    answered = _non_null_answers(dist, slot)
     assert not answered, f"{dist.name} answered with a null `{slot}`: {answered}"

--- a/tests/distributions/plugin_nan_test.py
+++ b/tests/distributions/plugin_nan_test.py
@@ -15,9 +15,8 @@ in two places:
   would return a confident `P(X <= 0)` (and a `pmf` of `0.0`).
 
 `Bernoulli`, `Exponential` and `Geometric` take a third driver (`value_keyed_derived_per_row`) and
-`Uniform` its two-parameter sibling, both of which repeat the short-circuit: the shared per-row one
-nulls a row on any null parameter, and their off-support answers are contracted to survive one.
-Covered here so the drivers cannot drift.
+`Uniform` its two-parameter sibling; both repeat the short-circuit rather than share one, so every
+case here runs against all four and the drivers cannot drift apart.
 
 Both plugin shapes are covered: scalar-parameter instances route to the `<method>_scalar` twins,
 column-parameter instances to the per-row plugins.

--- a/tests/distributions/uniform/null_params_test.py
+++ b/tests/distributions/uniform/null_params_test.py
@@ -1,7 +1,7 @@
 """Null-bound contract: every method, both bounds, on and off the support.
 
-A null bound nulls the answer wherever the point sits, so the `(bounds, value)` table below is
-keyed to reach every region a known bound could have decided from, not to vary the expectation.
+The `(bounds, value)` table reaches every region the known bound alone could have placed the point
+in; the expectation is null throughout.
 """
 
 from __future__ import annotations
@@ -16,8 +16,7 @@ from polars_stats import Uniform
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-# Every method must propagate a null bound to a null result, evaluated here at an on-support point.
-# The points outside the support, which the known bound alone places, are covered below.
+# Evaluated at an on-support point; the points a known bound alone places are covered below.
 _METHODS: dict[str, Callable[[Uniform], pl.Expr]] = {
     "pdf": lambda u: u.pdf(pl.lit(0.5)),
     "log_pdf": lambda u: u.log_pdf(pl.lit(0.5)),
@@ -98,7 +97,6 @@ def test_value_keyed_answer_nulls_under_a_null_bound(bounds: tuple[float | None,
 def test_inverse_nulls_under_a_null_bound(
     method: str, quantile: float, bounds: tuple[float | None, float | None]
 ) -> None:
-    """Endpoints and out-of-range quantiles as well as interior ones, under either null bound."""
     lo, hi = bounds
     df = pl.DataFrame({"lo": [0.0, lo], "hi": [1.0, hi]}, schema=_SCHEMA)
     result = df.select(r=getattr(_column_bounds(), method)(quantile))["r"]

--- a/tests/distributions/uniform/null_params_test.py
+++ b/tests/distributions/uniform/null_params_test.py
@@ -1,12 +1,11 @@
 """Null-bound contract: every method, both bounds, on and off the support.
 
-An answer survives a null bound exactly when the other, known bound decides it. That is a rule about
-bounds rather than about methods, so the table below is keyed on `(bounds, value)`.
+A null bound nulls the answer wherever the point sits, so the `(bounds, value)` table below is
+keyed to reach every region a known bound could have decided from, not to vary the expectation.
 """
 
 from __future__ import annotations
 
-import math
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -17,9 +16,8 @@ from polars_stats import Uniform
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-# Every method must propagate a null bound to a null result. The value-keyed methods are evaluated at
-# an on-support point, where both bounds enter the formula, so the null flows through whichever one is
-# missing. The points where only one bound decides the answer are covered below.
+# Every method must propagate a null bound to a null result, evaluated here at an on-support point.
+# The points outside the support, which the known bound alone places, are covered below.
 _METHODS: dict[str, Callable[[Uniform], pl.Expr]] = {
     "pdf": lambda u: u.pdf(pl.lit(0.5)),
     "log_pdf": lambda u: u.log_pdf(pl.lit(0.5)),
@@ -63,64 +61,34 @@ def test_method_propagates_null_in_max(expr_fn: Callable[[Uniform], pl.Expr]) ->
 
 _VALUE_METHODS = ("pdf", "log_pdf", "cdf", "log_cdf", "sf", "log_sf")
 
-_BELOW_MIN: dict[str, float | None] = {
-    "pdf": 0.0,
-    "log_pdf": -math.inf,
-    "cdf": 0.0,
-    "log_cdf": -math.inf,
-    "sf": 1.0,
-    "log_sf": 0.0,
-}
-"""What the six value-keyed methods answer strictly below `min`, for every admissible `max`."""
-
-_ABOVE_MAX: dict[str, float | None] = {
-    "pdf": 0.0,
-    "log_pdf": -math.inf,
-    "cdf": 1.0,
-    "log_cdf": 0.0,
-    "sf": 0.0,
-    "log_sf": -math.inf,
-}
-"""What they answer strictly above `max`, for every admissible `min`."""
-
-_NULL: dict[str, float | None] = dict.fromkeys(_VALUE_METHODS)
-"""Nothing survives: the null bound is the one that would have placed the point."""
-
-# The `value == 1.0` row is where the two support conventions diverge: the densities treat the
-# support as the closed `[min, max]`, so a point at `max` is inside it and still needs `min`, while
-# `cdf` / `sf` and their logs are already saturated from `max` up. There is no lower-bound
-# counterpart: every method leaves `min` itself to the interior, so `value == min` under a null
-# `max` nulls throughout.
-_NULL_BOUND_CASES: tuple[tuple[tuple[float | None, float | None], float, dict[str, float | None]], ...] = (
-    ((None, 1.0), -5.0, _NULL),
-    ((None, 1.0), 0.5, _NULL),
-    ((None, 1.0), 1.0, {**_ABOVE_MAX, "pdf": None, "log_pdf": None}),
-    ((None, 1.0), 5.0, _ABOVE_MAX),
-    ((0.0, None), -5.0, _BELOW_MIN),
-    ((0.0, None), 0.0, _NULL),
-    ((0.0, None), 0.5, _NULL),
-    ((0.0, None), 5.0, _NULL),
-    ((None, None), -5.0, _NULL),
-    ((None, None), 0.5, _NULL),
-    ((None, None), 5.0, _NULL),
+_NULL_BOUND_CASES: tuple[tuple[tuple[float | None, float | None], float], ...] = (
+    ((None, 1.0), -5.0),
+    ((None, 1.0), 0.5),
+    ((None, 1.0), 1.0),
+    ((None, 1.0), 5.0),
+    ((0.0, None), -5.0),
+    ((0.0, None), 0.0),
+    ((0.0, None), 0.5),
+    ((0.0, None), 5.0),
+    ((None, None), -5.0),
+    ((None, None), 0.5),
+    ((None, None), 5.0),
 )
 
 
 @pytest.mark.parametrize(
-    ("bounds", "value", "expected"),
+    ("bounds", "value"),
     _NULL_BOUND_CASES,
-    ids=[f"min={lo},max={hi},v={v}" for (lo, hi), v, _ in _NULL_BOUND_CASES],
+    ids=[f"min={lo},max={hi},v={v}" for (lo, hi), v in _NULL_BOUND_CASES],
 )
-def test_value_keyed_answer_survives_only_when_the_known_bound_decides_it(
-    bounds: tuple[float | None, float | None], value: float, expected: dict[str, float | None]
-) -> None:
+def test_value_keyed_answer_nulls_under_a_null_bound(bounds: tuple[float | None, float | None], value: float) -> None:
     # Row 0 carries known bounds so the null bound shares a chunk with a fully specified one: a
     # driver that answered per chunk rather than per row would still pass a one-row frame.
     lo, hi = bounds
     df = pl.DataFrame({"lo": [0.0, lo], "hi": [1.0, hi]}, schema=_SCHEMA)
     dist = _column_bounds()
     got = df.select(**{name: getattr(dist, name)(pl.lit(value)) for name in _VALUE_METHODS})
-    assert {name: got[name][1] for name in _VALUE_METHODS} == expected
+    assert {name: got[name][1] for name in _VALUE_METHODS} == dict.fromkeys(_VALUE_METHODS)
     assert all(got[name][0] is not None for name in _VALUE_METHODS), "the known-bounds row nulled"
 
 
@@ -130,24 +98,9 @@ def test_value_keyed_answer_survives_only_when_the_known_bound_decides_it(
 def test_inverse_nulls_under_a_null_bound(
     method: str, quantile: float, bounds: tuple[float | None, float | None]
 ) -> None:
-    """Endpoints and out-of-range quantiles as well as interior ones: neither inverse has a
-    bound-free branch anywhere in its domain, under either null bound."""
+    """Endpoints and out-of-range quantiles as well as interior ones, under either null bound."""
     lo, hi = bounds
     df = pl.DataFrame({"lo": [0.0, lo], "hi": [1.0, hi]}, schema=_SCHEMA)
     result = df.select(r=getattr(_column_bounds(), method)(quantile))["r"]
     assert result[1] is None
     assert (result[0] is not None) == (0.0 <= quantile <= 1.0), "the known-bounds row disagreed"
-
-
-@pytest.mark.parametrize("hook", ["_pdf", "_log_pdf", "_cdf", "_log_cdf", "_sf", "_log_sf", "_ppf", "_isf"])
-@pytest.mark.parametrize("bounds", [(None, 1.0), (0.0, None), (None, None)], ids=str)
-def test_nan_value_stays_nan_under_a_null_bound(hook: str, bounds: tuple[float | None, float | None]) -> None:
-    """A `NaN` evaluation point short-circuits before the branches, so a null bound does not null it.
-
-    Reached through the private hook, since the public wrapper answers `NaN` on its own. Without the
-    short-circuit `NaN` would be placed by whichever bound is known and answer that bound's constant.
-    """
-    lo, hi = bounds
-    df = pl.DataFrame({"lo": [0.0, lo], "hi": [1.0, hi]}, schema=_SCHEMA)
-    result = df.select(r=getattr(_column_bounds(), hook)(pl.lit(math.nan)))["r"].to_list()
-    assert all(v is not None and math.isnan(v) for v in result), "a NaN evaluation point nulled"


### PR DESCRIPTION
A null parameter now nulls every method on its row, off-support constants and the NaN evaluation point included, so Bernoulli, Exponential, Geometric and Uniform stop answering `0` / `1` / `-inf` where the other five distributions already answered null. `Derive` narrows to plain `f64`, the `Domain` table becomes the shared `on_unit_interval` selector, and the contract test gains a null-parameter slice over all nine distributions.

Through the public API the null-parameter x NaN-point cell still reads NaN until we delete the wrapper; the docs describe the target contract.
