### PR TITLE
fix(distributions): refuse non-numeric columns in both positions, from one Rust dtype gate

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -250,11 +250,11 @@ code rather than halfway through, write the scipy-parity test first, and keep a 
 ## Numerical stability
 
 **Every method must be accurate in the regime it exists to serve.** `log_sf` exists for the deep tail, so a `log_sf`
-that returns `-inf` there does not work, even though every test passes. The base-class defaults `_cdf().log()`,
-`_sf().log()` and `_isf(q) = _ppf(1 - q)` are a convenience, not an implementation: inheriting one is a decision to
-justify. `_isf` is the sharpest case, because the loss happens *before* your code runs: `1 - q` resolves to `1.1e-16`
-absolute, so the tail mass is already quantised to `1.1e-16 / q` relative and no inverse can recover it. Solve against
-`q` itself, via a symmetry, a closed form, or entering a two-sided solve from the other end.
+that returns `-inf` there does not work, even though every test passes. The base-class defaults `_cdf().log()` and
+`_sf().log()` are a convenience, not an implementation: inheriting one is a decision to justify. `_isf` has no default
+at all, because the loss would happen *before* your code runs: `1 - q` resolves to `1.1e-16` absolute, so the tail
+mass is already quantised to `1.1e-16 / q` relative and no inverse can recover it. Solve against `q` itself, via a
+symmetry, a closed form, or entering a two-sided solve from the other end.
 
 **A composed method inherits the weakest part's range, and the composition is often wider than the part.** `std()`
 defaults to `variance().sqrt()`, and a variance that legitimately overflows can hide a standard deviation that does

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -32,12 +32,13 @@ returns the formula with no null or NaN handling; the base guarantees the input 
 Composing defaults live in the base and call the other hooks:
 
 * `_sf` defaults to `1 - _cdf(x)`
-* `_isf` defaults to `_ppf(1 - q)`
 * `_log_pdf` / `_log_pmf` / `_log_cdf` / `_log_sf` default to `.log()` of the underlying hook
 * `median` defaults to `ppf(0.5)`, `std` to `variance().sqrt()`
 
 A subclass overrides one of these only when `statrs` (or a closed form) is more numerically accurate, for instance
-binding a native `ln_pdf` instead of letting `log_pdf` underflow in the tails.
+binding a native `ln_pdf` instead of letting `log_pdf` underflow in the tails. `_isf` has no default: `_ppf(1 - q)`
+quantises a small quantile before the inverse runs, and polars would form `1 - q` ahead of the Rust dtype gate, so
+every distribution solves against `q` itself, in Rust.
 
 ## Column-valued parameters
 
@@ -54,8 +55,9 @@ An expression whose inputs are *all* constant is therefore a scalar column, so `
 is one row; any column-valued input sets the length instead. See
 [Reference / Parameters and contracts](../reference/parameters-and-contracts.md#accepted-inputs).
 
-On the Rust side, a plugin function receives `inputs: &[Series]` of `(value, param_1, ..., param_k)`, casts each to
-`Float64Chunked`, iterates per chunk, propagates nulls, and constructs the `statrs` distribution per row. `kwargs`
+On the Rust side, a plugin function receives `inputs: &[Series]` of `(value, param_1, ..., param_k)`, passes each
+through the numeric dtype gate (`coerce_f64`: a numeric or `Null`-typed column casts to `Float64Chunked`, anything
+else raises), iterates per chunk, propagates nulls, and constructs the `statrs` distribution per row. `kwargs`
 carries only static config that cannot be column-valued: the sampler `seed`, plus the constant parameters in the
 sampler fast path below (the one place a parameter rides in `kwargs`, valid precisely because there it is known to be a
 scalar).

--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -54,7 +54,7 @@ The table below is the rule, which every distribution follows. Method by method:
 | `mean`, `variance`, `entropy` | Polars if closed-form | `n * p`, `loc`, `1 / rate`, `log(4 * pi * scale)`. Rust only where there is no closed form: a support sum, or log-gamma plus digamma. |
 | `median` | override the default | The base default is `ppf(0.5)`. Bind native `Median::median` only where it agrees with scipy; Binomial's does not. |
 | `std` | Polars, and override | The base default `variance().sqrt()` saturates long before the answer does. |
-| `isf` | **always**, override the default | The base default `ppf(1 - q)` saturates long before the answer does, and it is value-keyed, so it carries the same arm-masking constraint as `ppf`. |
+| `isf` | **always**, in Rust | There is no base default: `ppf(1 - q)` saturates long before the answer does and, formed in polars, meets the quantile column ahead of the Rust dtype gate. It is value-keyed, so it carries the same arm-masking constraint as `ppf`. |
 
 ### Expose the conventional parameterisation, document the scipy mapping
 

--- a/docs/reference/parameters-and-contracts.md
+++ b/docs/reference/parameters-and-contracts.md
@@ -60,9 +60,12 @@ A length-1 *expression* is accepted wherever a column is and broadcasts rather t
     Computing a parameter with `.over("g")` and using it in a plain `select` is fine too; it is only putting the
     distribution expression itself inside `over()` or `agg()` that is affected.
 
-Numeric columns are cast to `Float64` at evaluation, so an integer column works wherever a float is expected. That
-covers every signed and unsigned integer width up to `Int128` / `UInt128`, and `Float16` / `Float32` / `Float64`.
-`Decimal` is the one numeric dtype the two positions treat differently: it works as a *parameter*, but as an
+A column in either position must be numeric: any `Int*` or `UInt*` width up to `Int128` / `UInt128`, `Float16` /
+`Float32` / `Float64`, or `Decimal`. A `Null`-typed column counts as numeric and propagates nulls. Numeric columns
+are cast to `Float64` at evaluation, so an integer column works wherever a float is expected.
+`Decimal` is the one numeric dtype the two positions treat differently. As a *parameter* it computes on every
+value-keyed method and sampler; the closed-form moments are polars arithmetic on the parameter itself and raise
+`InvalidOperationError` where polars has no `Decimal` kernel (`pow`, so `variance` on most distributions). As an
 evaluation point it raises `InvalidOperationError`, because the null/`NaN` guard applied to the value column has no
 `NaN` to test for on a decimal.
 
@@ -77,13 +80,11 @@ In **evaluation-point** position every non-numeric dtype is rejected: Polars fai
 dtypes, plus `Decimal`. Nothing silently parses and nothing silently nulls. (On polars older than 1.25, an `Object`
 column in either position raises `PanicException` from polars' own arrow export instead.)
 
-**Parameter** position is weaker: past the integer rule above there is no dtype check, and the Rust cast decides.
-`Categorical`, `Enum`, `Struct` and `Object` fail it and raise `ComputeError`. The rest are accepted: a `String`
-parameter is *parsed*, so `Normal(mu="mu", sigma=1.0).sample(seed=0)` on a `mu` column holding `"0.5"` draws from a
-normal centred at `0.5`, while a string that does not parse becomes a null parameter on its row and the row nulls
-with no error. A `Boolean`, `String` or temporal parameter carries its own dtype back out of a moment
-(`Normal(mu="mu", sigma=1.0).mean()` on a `Date` column returns `Date`). Cast a parameter to `Float64` when you mean
-a number.
+In **parameter** position the Rust plugin enforces the same rule on every method: a `Boolean`, `String`,
+`Categorical`, `Enum`, `Struct`, `Object` or temporal column raises `ComputeError` naming the column and its dtype,
+and no row computes. Nothing is parsed and nothing is read as `0` / `1`. The one variation is the exception type:
+where a closed-form moment's own polars arithmetic meets the column before the plugin does (`n * p` on a `String`
+`p`), polars raises `InvalidOperationError` instead. Cast a parameter to `Float64` when you mean a number.
 
 ## Parameter validity
 
@@ -150,7 +151,7 @@ indistinguishable from a legitimately missing input, and would propagate wrong a
 | `null` parameter on a row | per row | `null` on that row, on every method and off the support too, no error (see below) |
 | `NaN` value or quantile argument on a row | per row | `NaN` on that row (matches scipy) |
 | Non-numeric column as an *argument* | evaluation | Polars raises `InvalidOperationError` |
-| Non-numeric column as a *parameter* | Rust evaluation, if at all | `ComputeError` for `Categorical` / `Enum` / `Struct` / `Object`; `Boolean`, `String` and the temporal dtypes are **not** rejected and compute, an unparsable `String` nulling its row (see [Accepted inputs](#accepted-inputs)) |
+| Non-numeric column as a *parameter* | Rust evaluation | `ComputeError` naming the column and its dtype; polars' `InvalidOperationError` where a closed-form moment's arithmetic meets the column first. Nothing computes either way (see [Accepted inputs](#accepted-inputs)) |
 | `q` outside `[0, 1]` in `ppf` / `isf` | per row | `null`, guaranteed for every distribution and both parameter regimes (pinned by `tests/property/ppf_domain_test.py`). `q` exactly `0` or `1` is in range and maps to a support bound |
 | `x` outside the support (e.g. `pdf` below a `Uniform`'s `min`) | per row | `0.0` (matches scipy) |
 | `pmf(3.5)` for a discrete distribution | per row | `0.0` (matches scipy) |

--- a/docs/reference/parameters-and-contracts.md
+++ b/docs/reference/parameters-and-contracts.md
@@ -63,11 +63,13 @@ A length-1 *expression* is accepted wherever a column is and broadcasts rather t
 A column in either position must be numeric: any `Int*` or `UInt*` width up to `Int128` / `UInt128`, `Float16` /
 `Float32` / `Float64`, or `Decimal`. A `Null`-typed column counts as numeric and propagates nulls. Numeric columns
 are cast to `Float64` at evaluation, so an integer column works wherever a float is expected.
-`Decimal` is the one numeric dtype the two positions treat differently. As a *parameter* it computes on every
-value-keyed method and sampler; the closed-form moments are polars arithmetic on the parameter itself and raise
-`InvalidOperationError` where polars has no `Decimal` kernel (`pow`, so `variance` on most distributions). As an
-evaluation point it raises `InvalidOperationError`, because the null/`NaN` guard applied to the value column has no
-`NaN` to test for on a decimal.
+
+That cast is the plugin's. The closed-form moments are polars arithmetic on the parameter itself, so there polars
+decides: a moment that is the parameter (`Normal(mu="mu").mean()`) keeps the column's dtype, and a `Decimal` or
+`Null`-typed `sigma` raises `InvalidOperationError` where polars has no kernel for it on the bare column (`pow`,
+`log`, `exp`: `Normal`'s `variance` and `entropy`, `LogNormal`'s `mean`, `variance`, `std` and `entropy`). `Decimal`
+is also the one numeric dtype refused as an *evaluation point*: the null/`NaN` guard applied to the value column has
+no `NaN` to test for on a decimal and raises `InvalidOperationError`.
 
 The integer parameters are the exception to the cast: the count `n` and `DiscreteUniform`'s bounds must already hold
 integers, of any integer dtype, because casting a float one would silently truncate. `n` widens to `UInt64` and the
@@ -81,10 +83,11 @@ dtypes, plus `Decimal`. Nothing silently parses and nothing silently nulls. (On 
 column in either position raises `PanicException` from polars' own arrow export instead.)
 
 In **parameter** position the Rust plugin enforces the same rule on every method: a `Boolean`, `String`,
-`Categorical`, `Enum`, `Struct`, `Object` or temporal column raises `ComputeError` naming the column and its dtype,
-and no row computes. Nothing is parsed and nothing is read as `0` / `1`. The one variation is the exception type:
-where a closed-form moment's own polars arithmetic meets the column before the plugin does (`n * p` on a `String`
-`p`), polars raises `InvalidOperationError` instead. Cast a parameter to `Float64` when you mean a number.
+`Categorical`, `Enum`, `Struct`, `Object` or temporal column raises `ComputeError` naming the column and the dtype
+the plugin received (`Object` arrives as `binary`), and no row computes. Nothing is parsed and nothing is read as
+`0` / `1`. The one variation is the exception type: where a closed-form moment's own polars arithmetic meets the
+column before the plugin does (`n * p` on a `String` `p`), polars raises `InvalidOperationError` instead. Cast a
+parameter to `Float64` when you mean a number.
 
 ## Parameter validity
 

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -607,23 +607,13 @@ class _UnivariateDistribution(ABC):
         q = as_expr(quantile)
         return propagate_null_and_nan(q, self._isf(q))
 
+    @abstractmethod
     def _isf(self, quantile: pl.Expr) -> pl.Expr:
-        """Fallback `ppf(1 - quantile)`, correct only where `quantile` is not tiny.
+        """Core inverse-survival formula on a coerced expr; null handling is applied by `isf`.
 
-        `1 - quantile` resolves to `1.1e-16` absolute, so the tail mass a subclass is asked to invert
-        is quantised to `1.1e-16 / quantile` relative before the inverse ever runs. Like `_cdf().log()`
-        for `_log_cdf`, this is convenience rather than an implementation: inheriting it is a decision
-        to justify. The forms that worked here are a closed form (`Uniform`, `Bernoulli`, `Exponential`),
-        a symmetry (`Normal`, and `LogNormal` by composing it), and entering an existing two-sided
-        solve from the other tail.
-
-        Being integer-valued or piecewise-linear does *not* make a distribution safe here, which was
-        the tempting wrong conclusion: `Bernoulli(1e-17).isf(1e-20)` answered `0.0` where the answer
-        is `1.0`, and `Uniform(-1, 0).isf(1e-17)` answered `0.0` against a true `-1e-17`. Prove the
-        override unnecessary against `make audit`, with the parameter regime that would expose it,
-        before skipping it. See docs/contributing.md, "Numerical stability".
+        No `ppf(1 - quantile)` default: the complement quantises a small quantile before the inverse
+        runs, and polars would form it ahead of the Rust dtype gate. Solve against `quantile` itself.
         """
-        return self._ppf(1 - quantile)
 
     @property
     def _checked_params(self) -> pl.Expr:

--- a/polars_stats/distributions/_beta.py
+++ b/polars_stats/distributions/_beta.py
@@ -86,10 +86,7 @@ class Beta(ContinuousDistribution):
         return self._value_plugin("beta_ppf", quantile)
 
     def _isf(self, quantile: pl.Expr) -> pl.Expr:
-        """``ppf(1 - quantile)`` with the complement formed in Rust, so the quantile passes the plugin's dtype gate.
-
-        Keeps the composition's ``1.1e-16`` quantisation of a tiny quantile (see ``docs/explanation/accuracy.md``).
-        """
+        """``ppf(1 - quantile)``, the complement formed in Rust so the quantile passes the plugin's dtype gate."""
         return self._value_plugin("beta_isf", quantile)
 
     def mean(self) -> pl.Expr:

--- a/polars_stats/distributions/_beta.py
+++ b/polars_stats/distributions/_beta.py
@@ -70,10 +70,9 @@ class Beta(ContinuousDistribution):
     def _sf(self, value: pl.Expr) -> pl.Expr:
         """Survival function via native ``ContinuousCDF::sf`` (accurate in the upper tail).
 
-        ``isf`` inherits the base-class default ``ppf(1 - quantile)``. ``log_sf`` (and ``log_cdf``)
-        inherit the naive ``sf().log()`` / ``cdf().log()``, which underflow to ``-inf`` deep in the
-        tails: the regularized incomplete beta has no cheap stable log form (scipy's ``logsf`` /
-        ``logcdf`` are naive here too, so parity holds).
+        ``log_sf`` (and ``log_cdf``) inherit the naive ``sf().log()`` / ``cdf().log()``, which underflow to
+        ``-inf`` deep in the tails: the regularized incomplete beta has no cheap stable log form (scipy's
+        ``logsf`` / ``logcdf`` are naive here too, so parity holds).
         """
         return self._value_plugin("beta_sf", value)
 
@@ -85,6 +84,13 @@ class Beta(ContinuousDistribution):
         the beta median has no closed form.
         """
         return self._value_plugin("beta_ppf", quantile)
+
+    def _isf(self, quantile: pl.Expr) -> pl.Expr:
+        """``ppf(1 - quantile)`` with the complement formed in Rust, so the quantile passes the plugin's dtype gate.
+
+        Keeps the composition's ``1.1e-16`` quantisation of a tiny quantile (see ``docs/explanation/accuracy.md``).
+        """
+        return self._value_plugin("beta_isf", quantile)
 
     def mean(self) -> pl.Expr:
         """Expected value, ``a / (a + b)``."""

--- a/polars_stats/distributions/_binomial.py
+++ b/polars_stats/distributions/_binomial.py
@@ -92,10 +92,7 @@ class Binomial(DiscreteDistribution):
         return self._value_plugin("binomial_ppf", quantile)
 
     def _isf(self, quantile: pl.Expr) -> pl.Expr:
-        """``ppf(1 - quantile)`` with the complement formed in Rust, so the quantile passes the plugin's dtype gate.
-
-        Keeps the composition's ``1.1e-16`` quantisation of a tiny quantile (see ``docs/explanation/accuracy.md``).
-        """
+        """``ppf(1 - quantile)``, the complement formed in Rust so the quantile passes the plugin's dtype gate."""
         return self._value_plugin("binomial_isf", quantile)
 
     def mean(self) -> pl.Expr:

--- a/polars_stats/distributions/_binomial.py
+++ b/polars_stats/distributions/_binomial.py
@@ -75,10 +75,9 @@ class Binomial(DiscreteDistribution):
     def _sf(self, value: pl.Expr) -> pl.Expr:
         """Survival ``P(X > floor(value))`` via native ``DiscreteCDF::sf`` (accurate upper tail).
 
-        ``isf`` inherits the base-class default ``ppf(1 - quantile)``. ``log_sf`` (and ``log_cdf``)
-        inherit the naive ``sf().log()`` / ``cdf().log()``, which underflow to ``-inf`` deep in the
-        tails: the regularized incomplete beta has no cheap stable log form (scipy's ``logsf`` /
-        ``logcdf`` are naive here too, so parity holds).
+        ``log_sf`` (and ``log_cdf``) inherit the naive ``sf().log()`` / ``cdf().log()``, which underflow to
+        ``-inf`` deep in the tails: the regularized incomplete beta has no cheap stable log form (scipy's
+        ``logsf`` / ``logcdf`` are naive here too, so parity holds).
         """
         return self._value_plugin("binomial_sf", value)
 
@@ -91,6 +90,13 @@ class Binomial(DiscreteDistribution):
         statrs' native ``floor(n * p)`` median is a different convention and is deliberately not used.
         """
         return self._value_plugin("binomial_ppf", quantile)
+
+    def _isf(self, quantile: pl.Expr) -> pl.Expr:
+        """``ppf(1 - quantile)`` with the complement formed in Rust, so the quantile passes the plugin's dtype gate.
+
+        Keeps the composition's ``1.1e-16`` quantisation of a tiny quantile (see ``docs/explanation/accuracy.md``).
+        """
+        return self._value_plugin("binomial_isf", quantile)
 
     def mean(self) -> pl.Expr:
         """Expected value, ``n * p``."""

--- a/polars_stats/distributions/_discrete_uniform.py
+++ b/polars_stats/distributions/_discrete_uniform.py
@@ -141,9 +141,8 @@ class DiscreteUniform(DiscreteDistribution):
     def _isf(self, quantile: pl.Expr) -> pl.Expr:
         """The smallest support point whose survival mass is at most ``quantile``.
 
-        Entered against ``quantile`` itself rather than the base ``ppf(1 - quantile)``: the
-        complement rounds before the inverse runs, and the survival steps sit at multiples of
-        ``1 / N``, exactly where ``1 - q`` has spent its precision.
+        Entered against ``quantile`` itself: the survival steps sit at multiples of ``1 / N``, exactly
+        where ``1 - q`` has spent its precision.
         """
         return self._value_plugin("discreteuniform_isf", quantile)
 

--- a/polars_stats/distributions/_exponential.py
+++ b/polars_stats/distributions/_exponential.py
@@ -88,10 +88,7 @@ class Exponential(ContinuousDistribution):
         return self._value_plugin("exponential_ppf", quantile)
 
     def _isf(self, quantile: pl.Expr) -> pl.Expr:
-        """``-log(q) / rate``; null for ``q`` outside ``[0, 1]``.
-
-        Overrides the base ``ppf(1 - quantile)``, which forms the complement and then undoes it.
-        """
+        """``-log(q) / rate``; null for ``q`` outside ``[0, 1]``."""
         return self._value_plugin("exponential_isf", quantile)
 
     def mean(self) -> pl.Expr:

--- a/polars_stats/distributions/_lognormal.py
+++ b/polars_stats/distributions/_lognormal.py
@@ -104,11 +104,10 @@ class LogNormal(ContinuousDistribution):
         return self._value_plugin("lognormal_ppf", quantile)
 
     def _isf(self, quantile: pl.Expr) -> pl.Expr:
-        """Inverse survival function, the underlying normal's symmetry form exponentiated.
+        """Inverse survival function, ``Normal._isf``'s symmetry form exponentiated.
 
-        Overrides the base-class default ``ppf(1 - quantile)``. See ``Normal._isf``; composing
-        through ``exp`` turns the normal's absolute quantile error into a relative one here, so a
-        large ``sigma`` amplifies it.
+        ``exp`` turns the normal's absolute quantile error into a relative one here, so a large ``sigma``
+        amplifies it.
         """
         return self._value_plugin("lognormal_isf", quantile)
 

--- a/polars_stats/distributions/_normal.py
+++ b/polars_stats/distributions/_normal.py
@@ -100,9 +100,7 @@ class Normal(ContinuousDistribution):
     def _isf(self, quantile: pl.Expr) -> pl.Expr:
         """Inverse survival function via the symmetry form ``mu + sigma * sqrt(2) * erfc_inv(2q)``.
 
-        Overrides the base-class default ``ppf(1 - quantile)``, which quantises a small quantile to
-        the ``1.1e-16`` resolution of its complement before the inverse runs. Same domain contract
-        as ``ppf``, with the endpoints reversed (``isf(0) = +inf``, ``isf(1) = -inf``).
+        Same domain contract as ``ppf``, with the endpoints reversed (``isf(0) = +inf``, ``isf(1) = -inf``).
         """
         return self._value_plugin("normal_isf", quantile)
 

--- a/polars_stats/distributions/_uniform.py
+++ b/polars_stats/distributions/_uniform.py
@@ -99,13 +99,7 @@ class Uniform(ContinuousDistribution):
         return self._value_plugin("uniform_ppf", quantile)
 
     def _isf(self, quantile: pl.Expr) -> pl.Expr:
-        """``max - quantile * (max - min)``; null for ``quantile`` outside ``[0, 1]``.
-
-        The mirror of ``_ppf``, not the base-class ``ppf(1 - quantile)``: below
-        ``quantile ~ 1.1e-16`` that complement rounds to exactly ``1.0`` and the whole tail
-        collapses onto ``min + range``, which is total wherever ``max`` is near zero
-        (``Uniform(-1, 0).isf(1e-17)`` returned ``0.0`` against a true ``-1e-17``).
-        """
+        """``max - quantile * (max - min)``, the mirror of ``_ppf``; null for ``quantile`` outside ``[0, 1]``."""
         return self._value_plugin("uniform_isf", quantile)
 
     def mean(self) -> pl.Expr:

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -4,8 +4,8 @@ use rand::distr::Distribution;
 use statrs::distribution::Bernoulli;
 
 use crate::distributions::{
-    align_inputs, on_unit_interval, value_keyed_derived_per_row, value_keyed_derived_scalar,
-    ParamDomain,
+    align_inputs, coerce_f64, on_unit_interval, value_keyed_derived_per_row,
+    value_keyed_derived_scalar, ParamDomain,
 };
 use crate::rng::{
     binary_param_rows, sample_by_index, sample_per_row_binary, samples_bool_output,
@@ -48,9 +48,9 @@ impl BernoulliParamsKwargs {
 /// invalid `p` raises as it does from `bernoulli_sample`, instead of computing a negative variance.
 #[polars_expr(output_type=Float64)]
 fn bernoulli_proba(inputs: &[Series]) -> PolarsResult<Series> {
-    let proba = inputs[0].cast(&DataType::Float64)?;
-    P.check_column(proba.f64()?)?;
-    Ok(proba)
+    let proba = coerce_f64(&inputs[0])?;
+    P.check_column(&proba)?;
+    Ok(proba.into_series())
 }
 
 // Per-method bodies, shared by the per-row plugins and their `*_scalar` twins. Each method pairs a
@@ -327,19 +327,12 @@ fn draw(dist: &Bernoulli, rng: &mut impl rand::Rng) -> bool {
 #[polars_expr(output_type=Boolean)]
 fn bernoulli_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let proba = inputs[0].cast(&DataType::Float64)?;
+    let proba = coerce_f64(&inputs[0])?;
     let index = inputs[1].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    P.check_column(proba.f64()?)?;
+    P.check_column(&proba)?;
 
-    sample_per_row_binary(
-        name,
-        proba.f64()?,
-        index.u64()?,
-        kwargs.seed,
-        build_dist,
-        draw,
-    )
+    sample_per_row_binary(name, &proba, index.u64()?, kwargs.seed, build_dist, draw)
 }
 
 /// Constant-parameter fast path for [`bernoulli_sample`].
@@ -378,12 +371,12 @@ fn bernoulli_samples_scalar(
 #[polars_expr(output_type_func_with_kwargs=samples_bool_output)]
 fn bernoulli_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let proba = inputs[0].cast(&DataType::Float64)?;
+    let proba = coerce_f64(&inputs[0])?;
     let index = inputs[1].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    P.check_column(proba.f64()?)?;
+    P.check_column(&proba)?;
 
-    let rows = binary_param_rows(proba.f64()?, index.u64()?, build_dist);
+    let rows = binary_param_rows(&proba, index.u64()?, build_dist);
 
     samples_per_row(name, rows, kwargs.seed, kwargs.size, draw)
 }

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -5,7 +5,9 @@ use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::{Beta, Continuous, ContinuousCDF};
 use statrs::statistics::Distribution as StatrsDistribution;
 
-use crate::distributions::{align_inputs, value_keyed_per_row, value_keyed_scalar, ParamDomain};
+use crate::distributions::{
+    align_inputs, coerce_f64, value_keyed_per_row, value_keyed_scalar, ParamDomain,
+};
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
@@ -61,14 +63,11 @@ impl BetaParamsKwargs {
 #[polars_expr(output_type=Float64)]
 fn beta_params(inputs: &[Series]) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let a = inputs[0].cast(&DataType::Float64)?;
-    let b = inputs[1].cast(&DataType::Float64)?;
-    check_params(a.f64()?, b.f64()?)?;
+    let a = coerce_f64(&inputs[0])?;
+    let b = coerce_f64(&inputs[1])?;
+    check_params(&a, &b)?;
 
-    let ca: Float64Chunked =
-        binary_elementwise(a.f64()?, b.f64()?, |a: Option<f64>, b: Option<f64>| {
-            a.and(b)
-        });
+    let ca: Float64Chunked = binary_elementwise(&a, &b, |a: Option<f64>, b: Option<f64>| a.and(b));
     Ok(ca.into_series())
 }
 
@@ -79,19 +78,12 @@ where
     F: Fn(&Beta, f64) -> Option<f64>,
 {
     let inputs = align_inputs(inputs)?;
-    let value = inputs[0].cast(&DataType::Float64)?;
-    let a = inputs[1].cast(&DataType::Float64)?;
-    let b = inputs[2].cast(&DataType::Float64)?;
-    check_params(a.f64()?, b.f64()?)?;
+    let value = coerce_f64(&inputs[0])?;
+    let a = coerce_f64(&inputs[1])?;
+    let b = coerce_f64(&inputs[2])?;
+    check_params(&a, &b)?;
 
-    value_keyed_per_row(
-        value.f64()?,
-        a.f64()?,
-        b.f64()?,
-        inputs[0].name().clone(),
-        build_dist,
-        f,
-    )
+    value_keyed_per_row(&value, &a, &b, inputs[0].name().clone(), build_dist, f)
 }
 
 /// Apply a parameter-keyed moment `f(dist)` element-wise over `(a, b)`.
@@ -105,17 +97,16 @@ where
     F: Fn(&Beta) -> f64,
 {
     let inputs = align_inputs(inputs)?;
-    let a = inputs[0].cast(&DataType::Float64)?;
-    let b = inputs[1].cast(&DataType::Float64)?;
-    check_params(a.f64()?, b.f64()?)?;
+    let a = coerce_f64(&inputs[0])?;
+    let b = coerce_f64(&inputs[1])?;
+    check_params(&a, &b)?;
 
-    let ca: Float64Chunked =
-        try_binary_elementwise(a.f64()?, b.f64()?, |a, b| -> PolarsResult<Option<f64>> {
-            match (a, b) {
-                (Some(a), Some(b)) => Ok(Some(f(&build_dist(a, b)?))),
-                _ => Ok(None),
-            }
-        })?;
+    let ca: Float64Chunked = try_binary_elementwise(&a, &b, |a, b| -> PolarsResult<Option<f64>> {
+        match (a, b) {
+            (Some(a), Some(b)) => Ok(Some(f(&build_dist(a, b)?))),
+            _ => Ok(None),
+        }
+    })?;
     Ok(ca.into_series())
 }
 
@@ -139,21 +130,13 @@ fn draw(dist: &Beta, rng: &mut impl rand::Rng) -> f64 {
 #[polars_expr(output_type=Float64)]
 fn beta_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let a = inputs[0].cast(&DataType::Float64)?;
-    let b = inputs[1].cast(&DataType::Float64)?;
+    let a = coerce_f64(&inputs[0])?;
+    let b = coerce_f64(&inputs[1])?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    check_params(a.f64()?, b.f64()?)?;
+    check_params(&a, &b)?;
 
-    sample_per_row_ternary(
-        name,
-        a.f64()?,
-        b.f64()?,
-        index.u64()?,
-        kwargs.seed,
-        build_dist,
-        draw,
-    )
+    sample_per_row_ternary(name, &a, &b, index.u64()?, kwargs.seed, build_dist, draw)
 }
 
 /// Constant-parameter fast path for [`beta_sample`].
@@ -192,13 +175,13 @@ fn beta_samples_scalar(
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn beta_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let a = inputs[0].cast(&DataType::Float64)?;
-    let b = inputs[1].cast(&DataType::Float64)?;
+    let a = coerce_f64(&inputs[0])?;
+    let b = coerce_f64(&inputs[1])?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    check_params(a.f64()?, b.f64()?)?;
+    check_params(&a, &b)?;
 
-    let rows = ternary_param_rows(a.f64()?, b.f64()?, index.u64()?, build_dist);
+    let rows = ternary_param_rows(&a, &b, index.u64()?, build_dist);
 
     samples_per_row(name, rows, kwargs.seed, kwargs.size, draw)
 }
@@ -274,6 +257,18 @@ fn beta_ppf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, ppf_value)
 }
 
+/// `ppf(1 - q)`, so the endpoints reverse (`isf(0) = 1`, `isf(1) = 0`) and `q` outside `[0, 1]`
+/// yields `null` through [`ppf_value`].
+fn isf_value(dist: &Beta, q: f64) -> Option<f64> {
+    ppf_value(dist, 1.0 - q)
+}
+
+/// Element-wise inverse survival function; see [`isf_value`].
+#[polars_expr(output_type=Float64)]
+fn beta_isf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, isf_value)
+}
+
 /// Constant-parameter fast path for [`beta_pdf`].
 #[polars_expr(output_type=Float64)]
 fn beta_pdf_scalar(inputs: &[Series], kwargs: BetaParamsKwargs) -> PolarsResult<Series> {
@@ -302,6 +297,12 @@ fn beta_sf_scalar(inputs: &[Series], kwargs: BetaParamsKwargs) -> PolarsResult<S
 #[polars_expr(output_type=Float64)]
 fn beta_ppf_scalar(inputs: &[Series], kwargs: BetaParamsKwargs) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], ppf_value)
+}
+
+/// Constant-parameter fast path for [`beta_isf`].
+#[polars_expr(output_type=Float64)]
+fn beta_isf_scalar(inputs: &[Series], kwargs: BetaParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], isf_value)
 }
 
 /// Element-wise differential entropy (in nats) via `statrs` `Distribution::entropy`:

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -6,7 +6,9 @@ use rand_distr::Binomial as BinomialSampler;
 use statrs::distribution::{Binomial, Discrete, DiscreteCDF};
 use statrs::statistics::Distribution as StatrsDistribution;
 
-use crate::distributions::{align_inputs, value_keyed_per_row, value_keyed_scalar, ParamDomain};
+use crate::distributions::{
+    align_inputs, coerce_f64, value_keyed_per_row, value_keyed_scalar, ParamDomain,
+};
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_per_row, samples_u64_output,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
@@ -136,19 +138,12 @@ where
     F: Fn(&Binomial, f64) -> Option<f64>,
 {
     let inputs = align_inputs(inputs)?;
-    let value = inputs[0].cast(&DataType::Float64)?;
+    let value = coerce_f64(&inputs[0])?;
     let n = coerce_n(&inputs[1])?;
-    let p = inputs[2].cast(&DataType::Float64)?;
-    P.check_column(p.f64()?)?;
+    let p = coerce_f64(&inputs[2])?;
+    P.check_column(&p)?;
 
-    value_keyed_per_row(
-        value.f64()?,
-        &n,
-        p.f64()?,
-        inputs[0].name().clone(),
-        build_dist,
-        f,
-    )
+    value_keyed_per_row(&value, &n, &p, inputs[0].name().clone(), build_dist, f)
 }
 
 /// Apply a parameter-keyed moment `f(dist)` element-wise over `(n, p)`.
@@ -167,24 +162,20 @@ where
 {
     let inputs = align_inputs(inputs)?;
     let n = coerce_n(&inputs[0])?;
-    let p = inputs[1].cast(&DataType::Float64)?;
-    P.check_column(p.f64()?)?;
+    let p = coerce_f64(&inputs[1])?;
+    P.check_column(&p)?;
 
-    let ca: Float64Chunked = try_binary_elementwise(
-        &n,
-        p.f64()?,
-        |n, p| -> PolarsResult<Option<f64>> {
-            let (Some(n), Some(p)) = (n, p) else {
-                return Ok(None);
-            };
-            // TODO(FBruzzesi): Remove `n == u64::MAX` guard once fixed upstream in statrs
-            polars_ensure!(
-                n != u64::MAX,
-                ComputeError: "n = {} overflows the entropy support sum: statrs iterates 0..=n via n + 1, which wraps at u64::MAX", n
-            );
-            Ok(Some(f(&build_dist(n, p)?)))
-        },
-    )?;
+    let ca: Float64Chunked = try_binary_elementwise(&n, &p, |n, p| -> PolarsResult<Option<f64>> {
+        let (Some(n), Some(p)) = (n, p) else {
+            return Ok(None);
+        };
+        // TODO(FBruzzesi): Remove `n == u64::MAX` guard once fixed upstream in statrs
+        polars_ensure!(
+            n != u64::MAX,
+            ComputeError: "n = {} overflows the entropy support sum: statrs iterates 0..=n via n + 1, which wraps at u64::MAX", n
+        );
+        Ok(Some(f(&build_dist(n, p)?)))
+    })?;
     Ok(ca.into_series())
 }
 
@@ -206,20 +197,12 @@ fn draw(dist: &BinomialSampler, rng: &mut impl rand::Rng) -> u64 {
 fn binomial_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
     let n = coerce_n(&inputs[0])?;
-    let p = inputs[1].cast(&DataType::Float64)?;
+    let p = coerce_f64(&inputs[1])?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    P.check_column(p.f64()?)?;
+    P.check_column(&p)?;
 
-    sample_per_row_ternary(
-        name,
-        &n,
-        p.f64()?,
-        index.u64()?,
-        kwargs.seed,
-        build_sampler,
-        draw,
-    )
+    sample_per_row_ternary(name, &n, &p, index.u64()?, kwargs.seed, build_sampler, draw)
 }
 
 /// Constant-parameter fast path for [`binomial_sample`], on the same [`build_sampler`].
@@ -261,12 +244,12 @@ fn binomial_samples_scalar(
 fn binomial_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
     let n = coerce_n(&inputs[0])?;
-    let p = inputs[1].cast(&DataType::Float64)?;
+    let p = coerce_f64(&inputs[1])?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    P.check_column(p.f64()?)?;
+    P.check_column(&p)?;
 
-    let rows = ternary_param_rows(&n, p.f64()?, index.u64()?, build_sampler);
+    let rows = ternary_param_rows(&n, &p, index.u64()?, build_sampler);
 
     samples_per_row(name, rows, kwargs.seed, kwargs.size, draw)
 }
@@ -388,6 +371,18 @@ fn binomial_ppf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, ppf_value)
 }
 
+/// `ppf(1 - q)`, so the endpoints reverse (`isf(0) = n`, `isf(1) = 0`) and `q` outside `[0, 1]`
+/// yields `null` through [`ppf_value`].
+fn isf_value(dist: &Binomial, q: f64) -> Option<f64> {
+    ppf_value(dist, 1.0 - q)
+}
+
+/// Element-wise inverse survival function; see [`isf_value`].
+#[polars_expr(output_type=Float64)]
+fn binomial_isf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, isf_value)
+}
+
 /// Constant-parameter fast path for [`binomial_pmf`].
 #[polars_expr(output_type=Float64)]
 fn binomial_pmf_scalar(inputs: &[Series], kwargs: BinomialParamsKwargs) -> PolarsResult<Series> {
@@ -418,6 +413,12 @@ fn binomial_ppf_scalar(inputs: &[Series], kwargs: BinomialParamsKwargs) -> Polar
     kwargs.value_keyed(&inputs[0], ppf_value)
 }
 
+/// Constant-parameter fast path for [`binomial_isf`].
+#[polars_expr(output_type=Float64)]
+fn binomial_isf_scalar(inputs: &[Series], kwargs: BinomialParamsKwargs) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], isf_value)
+}
+
 /// Validate the `(n, p)` parameterisation and return the validated `p`.
 ///
 /// `inputs[0]` is `n`, `inputs[1]` is `p`. The Python closed-form moments (`mean = n * p`,
@@ -428,11 +429,10 @@ fn binomial_ppf_scalar(inputs: &[Series], kwargs: BinomialParamsKwargs) -> Polar
 fn binomial_params(inputs: &[Series]) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
     let n = coerce_n(&inputs[0])?;
-    let p = inputs[1].cast(&DataType::Float64)?;
-    P.check_column(p.f64()?)?;
+    let p = coerce_f64(&inputs[1])?;
+    P.check_column(&p)?;
 
-    let ca: Float64Chunked =
-        binary_elementwise(&n, p.f64()?, |n: Option<u64>, p: Option<f64>| n.and(p));
+    let ca: Float64Chunked = binary_elementwise(&n, &p, |n: Option<u64>, p: Option<f64>| n.and(p));
     Ok(ca.into_series())
 }
 

--- a/src/distributions/discrete_uniform.rs
+++ b/src/distributions/discrete_uniform.rs
@@ -4,7 +4,9 @@ use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution;
 use statrs::distribution::DiscreteUniform;
 
-use crate::distributions::{align_inputs, value_keyed_per_row, value_keyed_scalar, PairDomain};
+use crate::distributions::{
+    align_inputs, coerce_f64, value_keyed_per_row, value_keyed_scalar, PairDomain,
+};
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_i64_output, samples_per_row,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
@@ -297,11 +299,9 @@ fn isf_value(s: &Support, q: f64) -> Option<f64> {
     Some(chosen.clamp(lo, hi))
 }
 
-/// The evaluation-point column in the arithmetic its dtype earns: floats (and an all-null `Null`
-/// column) run the `Float64` path, integer dtypes stay exact. `UInt64` keeps its own accessor so a
-/// value above `i64::MAX` reaches [`Point::Int`] via `i128` instead of failing a cast; every other
-/// integer dtype fits `Int64`. A non-numeric column is refused, as polars itself refuses it in the
-/// expression forms.
+/// The evaluation-point column in the arithmetic its dtype earns: integer dtypes stay exact, with
+/// `UInt64` on its own accessor so a value above `i64::MAX` reaches [`Point::Int`] via `i128`;
+/// everything else goes through [`coerce_f64`].
 enum Points {
     Float(Float64Chunked),
     Int(Int64Chunked),
@@ -310,20 +310,13 @@ enum Points {
 
 fn coerce_points(value: &Series) -> PolarsResult<Points> {
     let dtype = value.dtype();
-    if dtype.is_float() || dtype == &DataType::Null {
-        return Ok(Points::Float(
-            value.cast(&DataType::Float64)?.f64()?.clone(),
-        ));
-    }
     if dtype == &DataType::UInt64 {
         return Ok(Points::Wide(value.u64()?.clone()));
     }
     if dtype.is_integer() {
         return Ok(Points::Int(value.cast(&DataType::Int64)?.i64()?.clone()));
     }
-    Err(PolarsError::InvalidOperation(
-        format!("value must be a numeric column, got {dtype}").into(),
-    ))
+    Ok(Points::Float(coerce_f64(value)?))
 }
 
 /// Apply a closed-form `f(support, point)` element-wise over `(value, min, max)`; shared by the
@@ -421,12 +414,12 @@ fn discreteuniform_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_ppf(inputs: &[Series]) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let value = inputs[0].cast(&DataType::Float64)?;
+    let value = coerce_f64(&inputs[0])?;
     let min = coerce_bound(&inputs[1])?;
     let max = coerce_bound(&inputs[2])?;
     BOUNDS.check_columns(&min, &max)?;
     value_keyed_per_row(
-        value.f64()?,
+        &value,
         &min,
         &max,
         inputs[0].name().clone(),
@@ -439,12 +432,12 @@ fn discreteuniform_ppf(inputs: &[Series]) -> PolarsResult<Series> {
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_isf(inputs: &[Series]) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let value = inputs[0].cast(&DataType::Float64)?;
+    let value = coerce_f64(&inputs[0])?;
     let min = coerce_bound(&inputs[1])?;
     let max = coerce_bound(&inputs[2])?;
     BOUNDS.check_columns(&min, &max)?;
     value_keyed_per_row(
-        value.f64()?,
+        &value,
         &min,
         &max,
         inputs[0].name().clone(),

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -4,8 +4,8 @@ use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::Exp;
 
 use crate::distributions::{
-    align_inputs, expm1, on_unit_interval, value_keyed_derived_per_row, value_keyed_derived_scalar,
-    ParamDomain, Sides,
+    align_inputs, coerce_f64, expm1, on_unit_interval, value_keyed_derived_per_row,
+    value_keyed_derived_scalar, ParamDomain, Sides,
 };
 use crate::rng::{
     binary_param_rows, sample_by_index, sample_per_row_binary, samples_by_index,
@@ -49,9 +49,9 @@ impl ExponentialParamsKwargs {
 /// an invalid rate raises as it does from `exponential_sample`.
 #[polars_expr(output_type=Float64)]
 fn exponential_rate(inputs: &[Series]) -> PolarsResult<Series> {
-    let rate = inputs[0].cast(&DataType::Float64)?;
-    RATE.check_column(rate.f64()?)?;
-    Ok(rate)
+    let rate = coerce_f64(&inputs[0])?;
+    RATE.check_column(&rate)?;
+    Ok(rate.into_series())
 }
 
 /// Crossover of [`derive_cdf`], in units of `t = rate * x`.
@@ -311,19 +311,12 @@ fn draw(dist: &Exp, rng: &mut impl rand::Rng) -> f64 {
 #[polars_expr(output_type=Float64)]
 fn exponential_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let rate = inputs[0].cast(&DataType::Float64)?;
+    let rate = coerce_f64(&inputs[0])?;
     let index = inputs[1].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    RATE.check_column(rate.f64()?)?;
+    RATE.check_column(&rate)?;
 
-    sample_per_row_binary(
-        name,
-        rate.f64()?,
-        index.u64()?,
-        kwargs.seed,
-        build_dist,
-        draw,
-    )
+    sample_per_row_binary(name, &rate, index.u64()?, kwargs.seed, build_dist, draw)
 }
 
 /// Constant-rate fast path for [`exponential_sample`].
@@ -362,12 +355,12 @@ fn exponential_samples_scalar(
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn exponential_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let rate = inputs[0].cast(&DataType::Float64)?;
+    let rate = coerce_f64(&inputs[0])?;
     let index = inputs[1].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    RATE.check_column(rate.f64()?)?;
+    RATE.check_column(&rate)?;
 
-    let rows = binary_param_rows(rate.f64()?, index.u64()?, build_dist);
+    let rows = binary_param_rows(&rate, index.u64()?, build_dist);
 
     samples_per_row(name, rows, kwargs.seed, kwargs.size, draw)
 }

--- a/src/distributions/geometric.rs
+++ b/src/distributions/geometric.rs
@@ -4,7 +4,7 @@ use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::Geometric;
 
 use crate::distributions::{
-    align_inputs, expm1, ln_abs_expm1, on_unit_interval, value_keyed_derived_per_row,
+    align_inputs, coerce_f64, expm1, ln_abs_expm1, on_unit_interval, value_keyed_derived_per_row,
     value_keyed_derived_scalar, ParamDomain, Sides,
 };
 use crate::rng::{
@@ -66,9 +66,9 @@ impl GeometricParamsKwargs {
 /// invalid `p` raises as it does from `geometric_sample`.
 #[polars_expr(output_type=Float64)]
 fn geometric_p(inputs: &[Series]) -> PolarsResult<Series> {
-    let proba = inputs[0].cast(&DataType::Float64)?;
-    P.check_column(proba.f64()?)?;
-    Ok(proba)
+    let proba = coerce_f64(&inputs[0])?;
+    P.check_column(&proba)?;
+    Ok(proba.into_series())
 }
 
 /// Crossover of [`derive_cdf`], in units of `ln(sf)`.
@@ -402,19 +402,12 @@ fn draw(ln_failure: &f64, rng: &mut impl rand::Rng) -> u64 {
 #[polars_expr(output_type=UInt64)]
 fn geometric_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let proba = inputs[0].cast(&DataType::Float64)?;
+    let proba = coerce_f64(&inputs[0])?;
     let index = inputs[1].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    P.check_column(proba.f64()?)?;
+    P.check_column(&proba)?;
 
-    sample_per_row_binary(
-        name,
-        proba.f64()?,
-        index.u64()?,
-        kwargs.seed,
-        build_sampler,
-        draw,
-    )
+    sample_per_row_binary(name, &proba, index.u64()?, kwargs.seed, build_sampler, draw)
 }
 
 /// Constant-parameter fast path for [`geometric_sample`].
@@ -453,12 +446,12 @@ fn geometric_samples_scalar(
 #[polars_expr(output_type_func_with_kwargs=samples_u64_output)]
 fn geometric_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let proba = inputs[0].cast(&DataType::Float64)?;
+    let proba = coerce_f64(&inputs[0])?;
     let index = inputs[1].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    P.check_column(proba.f64()?)?;
+    P.check_column(&proba)?;
 
-    let rows = binary_param_rows(proba.f64()?, index.u64()?, build_sampler);
+    let rows = binary_param_rows(&proba, index.u64()?, build_sampler);
 
     samples_per_row(name, rows, kwargs.seed, kwargs.size, draw)
 }

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -5,7 +5,7 @@ use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::{Continuous, ContinuousCDF, LogNormal, Normal};
 
 use crate::distributions::{
-    align_inputs, normal, value_keyed_per_row, value_keyed_scalar, ParamDomain,
+    align_inputs, coerce_f64, normal, value_keyed_per_row, value_keyed_scalar, ParamDomain,
 };
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
@@ -72,19 +72,12 @@ where
     F: Fn(&LogNormal, f64) -> Option<f64>,
 {
     let inputs = align_inputs(inputs)?;
-    let value = inputs[0].cast(&DataType::Float64)?;
-    let mu = inputs[1].cast(&DataType::Float64)?;
-    let sigma = inputs[2].cast(&DataType::Float64)?;
-    check_params(mu.f64()?, sigma.f64()?)?;
+    let value = coerce_f64(&inputs[0])?;
+    let mu = coerce_f64(&inputs[1])?;
+    let sigma = coerce_f64(&inputs[2])?;
+    check_params(&mu, &sigma)?;
 
-    value_keyed_per_row(
-        value.f64()?,
-        mu.f64()?,
-        sigma.f64()?,
-        inputs[0].name().clone(),
-        build_dist,
-        f,
-    )
+    value_keyed_per_row(&value, &mu, &sigma, inputs[0].name().clone(), build_dist, f)
 }
 
 /// `sigma` where both of `(mu, sigma)` are present, null elsewhere, after [`check_params`].
@@ -95,15 +88,14 @@ where
 #[polars_expr(output_type=Float64)]
 fn lognormal_sigma(inputs: &[Series]) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let mu = inputs[0].cast(&DataType::Float64)?;
-    let sigma = inputs[1].cast(&DataType::Float64)?;
-    check_params(mu.f64()?, sigma.f64()?)?;
+    let mu = coerce_f64(&inputs[0])?;
+    let sigma = coerce_f64(&inputs[1])?;
+    check_params(&mu, &sigma)?;
 
-    let ca: Float64Chunked = binary_elementwise(
-        mu.f64()?,
-        sigma.f64()?,
-        |mu: Option<f64>, sigma: Option<f64>| mu.and(sigma),
-    );
+    let ca: Float64Chunked =
+        binary_elementwise(&mu, &sigma, |mu: Option<f64>, sigma: Option<f64>| {
+            mu.and(sigma)
+        });
     Ok(ca.into_series())
 }
 
@@ -123,16 +115,16 @@ fn draw(dist: &LogNormal, rng: &mut impl rand::Rng) -> f64 {
 #[polars_expr(output_type=Float64)]
 fn lognormal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let mu = inputs[0].cast(&DataType::Float64)?;
-    let sigma = inputs[1].cast(&DataType::Float64)?;
+    let mu = coerce_f64(&inputs[0])?;
+    let sigma = coerce_f64(&inputs[1])?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    check_params(mu.f64()?, sigma.f64()?)?;
+    check_params(&mu, &sigma)?;
 
     sample_per_row_ternary(
         name,
-        mu.f64()?,
-        sigma.f64()?,
+        &mu,
+        &sigma,
         index.u64()?,
         kwargs.seed,
         build_dist,
@@ -176,13 +168,13 @@ fn lognormal_samples_scalar(
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn lognormal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let mu = inputs[0].cast(&DataType::Float64)?;
-    let sigma = inputs[1].cast(&DataType::Float64)?;
+    let mu = coerce_f64(&inputs[0])?;
+    let sigma = coerce_f64(&inputs[1])?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    check_params(mu.f64()?, sigma.f64()?)?;
+    check_params(&mu, &sigma)?;
 
-    let rows = ternary_param_rows(mu.f64()?, sigma.f64()?, index.u64()?, build_dist);
+    let rows = ternary_param_rows(&mu, &sigma, index.u64()?, build_dist);
 
     samples_per_row(name, rows, kwargs.seed, kwargs.size, draw)
 }

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -60,6 +60,20 @@ pub(crate) fn align_inputs(inputs: &[Series]) -> PolarsResult<Cow<'_, [Series]>>
     ))
 }
 
+/// The dtype gate for every evaluation point and float parameter: `Int*`, `UInt*`, `Float*` and
+/// `Decimal` cast to `Float64`, a `Null`-typed column casts to all-null, and any other dtype raises
+/// `ComputeError` naming the input. Polars' own cast is no gate: it reads `Boolean` as `0` / `1`,
+/// parses `String` non-strictly and takes a temporal dtype's integer representation.
+pub(crate) fn coerce_f64(input: &Series) -> PolarsResult<Float64Chunked> {
+    let dtype = input.dtype();
+    polars_ensure!(
+        dtype.is_numeric() || dtype.is_null(),
+        ComputeError: "'{}' must be a numeric column (Int*, UInt*, Float*, Decimal), got {}",
+        input.name(), dtype
+    );
+    Ok(input.cast(&DataType::Float64)?.f64()?.clone())
+}
+
 /// What one float parameter must satisfy on its own, checked once per call: [`Self::check`] on a
 /// constant, [`Self::check_column`] over the whole column before any row is built.
 ///
@@ -166,11 +180,10 @@ pub(crate) fn value_keyed_scalar<F>(value: &Series, f: F) -> PolarsResult<Series
 where
     F: Fn(f64) -> Option<f64>,
 {
-    let value = value.cast(&DataType::Float64)?;
-    let value_ca = value.f64()?;
-    let name = value_ca.name().clone();
+    let value = coerce_f64(value)?;
+    let name = value.name().clone();
 
-    let ca: Float64Chunked = unary_elementwise(value_ca, |opt| {
+    let ca: Float64Chunked = unary_elementwise(&value, |opt| {
         opt.and_then(|v| if v.is_nan() { Some(f64::NAN) } else { f(v) })
     });
     Ok(ca.with_name(name).into_series())
@@ -279,13 +292,12 @@ where
     Select: Fn(&Branches, f64) -> Option<f64>,
 {
     let inputs = align_inputs(inputs)?;
-    let value = inputs[0].cast(&DataType::Float64)?;
-    let param = inputs[1].cast(&DataType::Float64)?;
-    let param_ca = param.f64()?;
+    let value = coerce_f64(&inputs[0])?;
+    let param = coerce_f64(&inputs[1])?;
     let name = inputs[0].name().clone();
-    domain.check_column(param_ca)?;
+    domain.check_column(&param)?;
 
-    let ca: Float64Chunked = binary_elementwise(value.f64()?, param_ca, |value_opt, param_opt| {
+    let ca: Float64Chunked = binary_elementwise(&value, &param, |value_opt, param_opt| {
         let param = param_opt?;
         let value = value_opt?;
         if value.is_nan() {
@@ -377,15 +389,14 @@ where
     Select: Fn(&Branches, f64) -> Option<f64>,
 {
     let inputs = align_inputs(inputs)?;
-    let value = inputs[0].cast(&DataType::Float64)?;
-    let param_a = inputs[1].cast(&DataType::Float64)?;
-    let param_b = inputs[2].cast(&DataType::Float64)?;
-    let (a_ca, b_ca) = (param_a.f64()?, param_b.f64()?);
+    let value = coerce_f64(&inputs[0])?;
+    let param_a = coerce_f64(&inputs[1])?;
+    let param_b = coerce_f64(&inputs[2])?;
     let name = inputs[0].name().clone();
-    check_params(a_ca, b_ca)?;
+    check_params(&param_a, &param_b)?;
 
     let ca: Float64Chunked =
-        ternary_elementwise(value.f64()?, a_ca, b_ca, |value_opt, a_opt, b_opt| {
+        ternary_elementwise(&value, &param_a, &param_b, |value_opt, a_opt, b_opt| {
             let (a, b) = (a_opt?, b_opt?);
             let value = value_opt?;
             if value.is_nan() {

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -60,10 +60,10 @@ pub(crate) fn align_inputs(inputs: &[Series]) -> PolarsResult<Cow<'_, [Series]>>
     ))
 }
 
-/// The dtype gate for every evaluation point and float parameter: `Int*`, `UInt*`, `Float*` and
-/// `Decimal` cast to `Float64`, a `Null`-typed column casts to all-null, and any other dtype raises
-/// `ComputeError` naming the input. Polars' own cast is no gate: it reads `Boolean` as `0` / `1`,
-/// parses `String` non-strictly and takes a temporal dtype's integer representation.
+/// The dtype gate every evaluation point and float parameter passes: `Int*`, `UInt*`, `Float*` and
+/// `Decimal` cast to `Float64`, a `Null`-typed column to all-null, anything else raises `ComputeError`
+/// naming the input. Polars' own cast would read `Boolean` as `0` / `1`, parse `String` and take a
+/// temporal dtype's integer representation.
 pub(crate) fn coerce_f64(input: &Series) -> PolarsResult<Float64Chunked> {
     let dtype = input.dtype();
     polars_ensure!(
@@ -217,8 +217,9 @@ where
 /// per-method body the fast path applies (`cdf_value`, `ppf_value`, ...), so the two paths cannot
 /// drift and agree bit for bit.
 ///
-/// The caller does the cast and the accessor (`.f64()` / `.u64()`), which fixes `A` and `B`, so a
-/// mixed `(u64, f64)` parameterisation (Binomial's `UInt64` `n` beside its `Float64` `p`) fits, as in
+/// The caller passes each parameter through its own coercer (`coerce_f64`, `coerce_n`,
+/// `coerce_bound`), which fixes `A` and `B`, so a mixed `(u64, f64)` parameterisation (Binomial's
+/// `UInt64` `n` beside its `Float64` `p`) fits, as in
 /// [`ternary_param_rows`](crate::rng::ternary_param_rows). `S` needs no trait bound: it is whatever
 /// `build` returns.
 ///

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -266,10 +266,10 @@ fn ppf_value(dist: &Normal, q: f64) -> Option<f64> {
 /// Inverse survival function, `mu + sigma * sqrt(2) * erfc_inv(2q)`, solved on `q` rather than on
 /// its complement.
 ///
-/// Deliberately not `ppf(1 - q)`, the base-class default: that composes `statrs`' `inverse_cdf`
-/// into `erfc_inv(2 - 2q)`, whose argument resolves to `2.2e-16` absolute, so the tail mass is
-/// quantised before the inverse runs. The symmetry `z_(1-q) = -z_q` puts the sign on the scale
-/// instead, leaving the exact power-of-two `2q` as the only thing the inverse sees.
+/// Not `ppf(1 - q)`: that composes `statrs`' `inverse_cdf` into `erfc_inv(2 - 2q)`, whose argument
+/// resolves to `2.2e-16` absolute, so the tail mass is quantised before the inverse runs. The
+/// symmetry `z_(1-q) = -z_q` puts the sign on the scale instead, leaving the exact power-of-two `2q`
+/// as the only thing the inverse sees.
 ///
 /// Contract mirrors [`ppf_value`]: `null` outside `[0, 1]`, closed endpoints to the infinite tails
 /// (`isf(0) = +inf`, `isf(1) = -inf`, the reverse of `ppf`). `pub(crate)` so `LogNormal` composes it.

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -8,7 +8,9 @@ use statrs::distribution::{Continuous, ContinuousCDF, Normal};
 use statrs::function::erf;
 use statrs::statistics::Distribution as StatrsDistribution;
 
-use crate::distributions::{align_inputs, value_keyed_per_row, value_keyed_scalar, ParamDomain};
+use crate::distributions::{
+    align_inputs, coerce_f64, value_keyed_per_row, value_keyed_scalar, ParamDomain,
+};
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
     ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
@@ -64,15 +66,14 @@ impl NormalParamsKwargs {
 #[polars_expr(output_type=Float64)]
 fn normal_sigma(inputs: &[Series]) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let mu = inputs[0].cast(&DataType::Float64)?;
-    let sigma = inputs[1].cast(&DataType::Float64)?;
-    check_params(mu.f64()?, sigma.f64()?)?;
+    let mu = coerce_f64(&inputs[0])?;
+    let sigma = coerce_f64(&inputs[1])?;
+    check_params(&mu, &sigma)?;
 
-    let ca: Float64Chunked = binary_elementwise(
-        mu.f64()?,
-        sigma.f64()?,
-        |mu: Option<f64>, sigma: Option<f64>| mu.and(sigma),
-    );
+    let ca: Float64Chunked =
+        binary_elementwise(&mu, &sigma, |mu: Option<f64>, sigma: Option<f64>| {
+            mu.and(sigma)
+        });
     Ok(ca.into_series())
 }
 
@@ -83,19 +84,12 @@ where
     F: Fn(&Normal, f64) -> Option<f64>,
 {
     let inputs = align_inputs(inputs)?;
-    let value = inputs[0].cast(&DataType::Float64)?;
-    let mu = inputs[1].cast(&DataType::Float64)?;
-    let sigma = inputs[2].cast(&DataType::Float64)?;
-    check_params(mu.f64()?, sigma.f64()?)?;
+    let value = coerce_f64(&inputs[0])?;
+    let mu = coerce_f64(&inputs[1])?;
+    let sigma = coerce_f64(&inputs[2])?;
+    check_params(&mu, &sigma)?;
 
-    value_keyed_per_row(
-        value.f64()?,
-        mu.f64()?,
-        sigma.f64()?,
-        inputs[0].name().clone(),
-        build_dist,
-        f,
-    )
+    value_keyed_per_row(&value, &mu, &sigma, inputs[0].name().clone(), build_dist, f)
 }
 
 /// One Normal draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
@@ -114,16 +108,16 @@ fn draw(dist: &Normal, rng: &mut impl rand::Rng) -> f64 {
 #[polars_expr(output_type=Float64)]
 fn normal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let mu = inputs[0].cast(&DataType::Float64)?;
-    let sigma = inputs[1].cast(&DataType::Float64)?;
+    let mu = coerce_f64(&inputs[0])?;
+    let sigma = coerce_f64(&inputs[1])?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    check_params(mu.f64()?, sigma.f64()?)?;
+    check_params(&mu, &sigma)?;
 
     sample_per_row_ternary(
         name,
-        mu.f64()?,
-        sigma.f64()?,
+        &mu,
+        &sigma,
         index.u64()?,
         kwargs.seed,
         build_dist,
@@ -167,13 +161,13 @@ fn normal_samples_scalar(
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn normal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let mu = inputs[0].cast(&DataType::Float64)?;
-    let sigma = inputs[1].cast(&DataType::Float64)?;
+    let mu = coerce_f64(&inputs[0])?;
+    let sigma = coerce_f64(&inputs[1])?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    check_params(mu.f64()?, sigma.f64()?)?;
+    check_params(&mu, &sigma)?;
 
-    let rows = ternary_param_rows(mu.f64()?, sigma.f64()?, index.u64()?, build_dist);
+    let rows = ternary_param_rows(&mu, &sigma, index.u64()?, build_dist);
 
     samples_per_row(name, rows, kwargs.seed, kwargs.size, draw)
 }

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -4,8 +4,8 @@ use pyo3_polars::derive::polars_expr;
 use rand::distr::{Distribution, StandardUniform};
 
 use crate::distributions::{
-    align_inputs, on_unit_interval, value_keyed_derived_pair_per_row, value_keyed_scalar,
-    PairDomain, ParamDomain,
+    align_inputs, coerce_f64, on_unit_interval, value_keyed_derived_pair_per_row,
+    value_keyed_scalar, PairDomain, ParamDomain,
 };
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
@@ -389,16 +389,16 @@ fn draw_half_open(lo: f64, hi: f64, rng: &mut impl rand::Rng) -> f64 {
 #[polars_expr(output_type=Float64)]
 fn uniform_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let min = inputs[0].cast(&DataType::Float64)?;
-    let max = inputs[1].cast(&DataType::Float64)?;
+    let min = coerce_f64(&inputs[0])?;
+    let max = coerce_f64(&inputs[1])?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    check_params(min.f64()?, max.f64()?)?;
+    check_params(&min, &max)?;
 
     sample_per_row_ternary(
         name,
-        min.f64()?,
-        max.f64()?,
+        &min,
+        &max,
         index.u64()?,
         kwargs.seed,
         checked_bounds,
@@ -445,13 +445,13 @@ fn uniform_samples_scalar(
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn uniform_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let min = inputs[0].cast(&DataType::Float64)?;
-    let max = inputs[1].cast(&DataType::Float64)?;
+    let min = coerce_f64(&inputs[0])?;
+    let max = coerce_f64(&inputs[1])?;
     let index = inputs[2].cast(&DataType::UInt64)?;
     let name = inputs[0].name().clone();
-    check_params(min.f64()?, max.f64()?)?;
+    check_params(&min, &max)?;
 
-    let rows = ternary_param_rows(min.f64()?, max.f64()?, index.u64()?, checked_bounds);
+    let rows = ternary_param_rows(&min, &max, index.u64()?, checked_bounds);
 
     samples_per_row(name, rows, kwargs.seed, kwargs.size, |&(lo, hi), rng| {
         draw_half_open(lo, hi, rng)
@@ -469,14 +469,12 @@ fn uniform_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Ser
 #[polars_expr(output_type=Float64)]
 fn uniform_range(inputs: &[Series]) -> PolarsResult<Series> {
     let inputs = align_inputs(inputs)?;
-    let min = inputs[0].cast(&DataType::Float64)?;
-    let max = inputs[1].cast(&DataType::Float64)?;
-    check_params(min.f64()?, max.f64()?)?;
+    let min = coerce_f64(&inputs[0])?;
+    let max = coerce_f64(&inputs[1])?;
+    check_params(&min, &max)?;
 
-    let ca: Float64Chunked = binary_elementwise(
-        min.f64()?,
-        max.f64()?,
-        |lo: Option<f64>, hi: Option<f64>| Some(hi? - lo?),
-    );
+    let ca: Float64Chunked = binary_elementwise(&min, &max, |lo: Option<f64>, hi: Option<f64>| {
+        Some(hi? - lo?)
+    });
     Ok(ca.into_series())
 }

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -218,10 +218,10 @@ where
 /// contracts throughout.
 ///
 /// The two parameter dtypes are independent, so a mixed `(u64, f64)` parameterisation (Binomial's
-/// `UInt64` `n` beside its `Float64` `p`) fits, as in [`ternary_param_rows`]: the caller does the
-/// cast and the accessor (`.f64()` / `.u64()`), which fixes `A` and `B`. `S` is whatever `build`
-/// returns, the built distribution for most callers but Uniform's raw `(f64, f64)` bounds for the
-/// one that validates then discards.
+/// `UInt64` `n` beside its `Float64` `p`) fits, as in [`ternary_param_rows`]: each parameter arrives
+/// through its own coercer, which fixes `A` and `B`. `S` is whatever `build` returns, the built
+/// distribution for most callers but Uniform's raw `(f64, f64)` bounds for the one that validates
+/// then discards.
 #[inline]
 pub(crate) fn sample_per_row_ternary<V, A, B, S, Build, Draw>(
     name: PlSmallStr,

--- a/tests/distributions/base_defaults_test.py
+++ b/tests/distributions/base_defaults_test.py
@@ -40,6 +40,9 @@ class _UnitUniform(ContinuousDistribution):
     def _ppf(self, quantile: pl.Expr) -> pl.Expr:
         return quantile
 
+    def _isf(self, quantile: pl.Expr) -> pl.Expr:
+        return 1 - quantile
+
     def mean(self) -> pl.Expr:
         return pl.lit(0.5)
 
@@ -70,6 +73,9 @@ class _FairCoin(DiscreteDistribution):
 
     def _ppf(self, quantile: pl.Expr) -> pl.Expr:
         return (quantile > _MEDIAN_QUANTILE).cast(pl.Float64)
+
+    def _isf(self, quantile: pl.Expr) -> pl.Expr:
+        return (quantile < _MEDIAN_QUANTILE).cast(pl.Float64)
 
     def mean(self) -> pl.Expr:
         return pl.lit(0.5)
@@ -166,8 +172,8 @@ def test_the_default_log_density_is_the_log_of_the_density(toy: _Toy) -> None:
 
 
 def test_the_minimal_surface_is_coherent(toy: _Toy) -> None:
-    # The remaining defaults a distribution inherits for free: `_isf` as `ppf(1 - q)`, `std` as
-    # `sqrt(variance)`, `median` as `ppf(0.5)`.
+    # The remaining defaults a distribution inherits for free: `std` as `sqrt(variance)`, `median` as
+    # `ppf(0.5)`.
     dist = toy.dist
     got = pl.DataFrame({"q": [toy.quantile]}).select(
         ppf=dist.ppf(pl.col("q")),

--- a/tests/distributions/bernoulli/isf_test.py
+++ b/tests/distributions/bernoulli/isf_test.py
@@ -11,7 +11,6 @@ from polars_stats import Bernoulli
 
 @pytest.mark.parametrize("q", [0.1, 0.5, 0.9])
 def test_isf_is_ppf_of_complement(unit_frame: pl.DataFrame, q: float) -> None:
-    # isf(q) == ppf(1 - q) by base-class default.
     p = 0.3
     isf = unit_frame.select(v=Bernoulli(p=p).isf(q)).item(0, "v")
     ppf_comp = unit_frame.select(v=Bernoulli(p=p).ppf(1 - q)).item(0, "v")

--- a/tests/distributions/null_nan_contract_test.py
+++ b/tests/distributions/null_nan_contract_test.py
@@ -8,6 +8,10 @@ row is built, so it cannot depend on what else is null on the row.
 A null parameter is answered before the evaluation point is read, so every method nulls at a finite,
 `NaN`, null and off-support point alike.
 
+A column that is not numeric (`Int*`, `UInt*`, `Float*`, `Decimal`, or `Null`-typed) is refused in either
+position before any row is built, with a `ComputeError` naming the column and its dtype; `Decimal` computes
+as its `Float64` cast.
+
 Value-keyed methods go through the private `_x` hooks: on polars >= 1.44 the public wrapper
 `propagate_null_and_nan` masks the plugin out of the null and `NaN` rows before it can validate.
 Moments and samplers have no wrapper and go through the public API.
@@ -33,6 +37,7 @@ from polars_stats import (
     Uniform,
 )
 from polars_stats.distributions._base import DiscreteDistribution, _UnivariateDistribution
+from tests._polars_compat import assert_series_equal
 
 
 @dataclass(frozen=True)
@@ -109,9 +114,10 @@ def _report(frame: pl.DataFrame, expr: pl.Expr) -> str | None:
     return None
 
 
-def _probes(
-    dist: _Dist, overrides: dict[str, float | None], points: tuple[float | None, ...]
-) -> list[tuple[str, pl.DataFrame, pl.Expr]]:
+_Probes = list[tuple[str, pl.DataFrame, pl.Expr]]
+
+
+def _probes(dist: _Dist, overrides: dict[str, float | None], points: tuple[float | None, ...]) -> _Probes:
     """Every value-keyed hook at every point, then the moments and both samplers, as `(label, frame, expr)`."""
     probes = [
         (f"{hook}(x={x})", dist.frame(overrides, x), getattr(dist.dist, hook)(pl.col("x")))
@@ -172,3 +178,73 @@ def test_null_parameter_nulls_every_method(dist: _Dist, slot: str) -> None:
     """Off-support constants and the `NaN` short-circuit included."""
     answered = _non_null_answers(dist, slot)
     assert not answered, f"{dist.name} answered with a null `{slot}`: {answered}"
+
+
+_REFUSED_DTYPES = (pl.Boolean(), pl.String(), pl.Date())
+"""One per family polars' own cast would silently accept: `Boolean` as `0` / `1`, `String` parsed, `Date` as days."""
+
+
+def _hooks(dist: _Dist) -> _Probes:
+    """The value-keyed probes alone; the moments and samplers never read `x`."""
+    return [probe for probe in _probes(dist, {}, (0.5,)) if probe[0].startswith("_")]
+
+
+def _refusal(frame: pl.DataFrame, expr: pl.Expr) -> str | None:
+    """The refusal as `<type>: <message>`, or `None` when the query computed."""
+    try:
+        frame.select(r=expr)
+    except (pl.exceptions.ComputeError, pl.exceptions.InvalidOperationError) as err:
+        return f"{type(err).__name__}: {err}"
+    return None
+
+
+def _accepted(column: str, dtype: pl.DataType, probes: _Probes) -> list[tuple[str, str]]:
+    """Every probe that computes, or raises without naming `column`, with `column` recast to `dtype`.
+
+    `InvalidOperationError` is a refusal too: a closed-form moment's own arithmetic (`n * p` on a `String`
+    `p`) meets the column before the plugin does, and nothing computes there either.
+    """
+    fragment = f"'{column}' must be a numeric column"
+    refusals = [
+        (label, _refusal(frame.with_columns(pl.col(column).cast(pl.Int64).cast(dtype)), expr))
+        for label, frame, expr in probes
+    ]
+    return [
+        (label, refusal or "computed")
+        for label, refusal in refusals
+        if refusal is None or (fragment not in refusal and not refusal.startswith("InvalidOperationError"))
+    ]
+
+
+@pytest.mark.parametrize("dtype", _REFUSED_DTYPES, ids=str)
+@pytest.mark.parametrize("dist", _DISTS, ids=lambda dist: dist.name)
+def test_non_numeric_evaluation_point_raises_on_every_hook(dist: _Dist, dtype: pl.DataType) -> None:
+    accepted = _accepted("x", dtype, _hooks(dist))
+    assert not accepted, f"{dist.name} took a {dtype} evaluation point: {accepted}"
+
+
+@pytest.mark.parametrize("dtype", _REFUSED_DTYPES, ids=str)
+@pytest.mark.parametrize(
+    ("dist", "slot"),
+    [pytest.param(dist, slot, id=f"{dist.name}.{slot}") for dist in _DISTS for slot in dist.float_slots],
+)
+def test_non_numeric_parameter_raises_on_every_method(dist: _Dist, slot: str, dtype: pl.DataType) -> None:
+    """Float slots only: `n` and `DiscreteUniform`'s bounds keep their own, stricter integer gate."""
+    accepted = _accepted(slot, dtype, _probes(dist, {}, (0.5,)))
+    assert not accepted, f"{dist.name} took a {dtype} `{slot}`: {accepted}"
+
+
+@pytest.mark.parametrize(
+    ("dist", "column"),
+    [pytest.param(dist, column, id=f"{dist.name}.{column}") for dist in _DISTS for column in ("x", *dist.float_slots)],
+)
+def test_decimal_column_computes_as_its_float64_cast(dist: _Dist, column: str) -> None:
+    """Hooks and samplers only: the closed-form moments are polars arithmetic on the parameter itself, and
+    polars has no `pow` for `Decimal`. The samplers never read `x`, so a recast `x` probes the hooks alone.
+    """
+    probes = (
+        _hooks(dist) if column == "x" else [probe for probe in _probes(dist, {}, (0.5,)) if probe[0] not in _MOMENTS]
+    )
+    for _label, frame, expr in probes:
+        decimal = frame.with_columns(pl.col(column).cast(pl.Decimal(10, 2)))
+        assert_series_equal(decimal.select(r=expr)["r"], frame.select(r=expr)["r"], check_exact=True)

--- a/tests/distributions/null_nan_contract_test.py
+++ b/tests/distributions/null_nan_contract_test.py
@@ -10,7 +10,7 @@ A null parameter is answered before the evaluation point is read, so every metho
 
 A column that is not numeric (`Int*`, `UInt*`, `Float*`, `Decimal`, or `Null`-typed) is refused in either
 position before any row is built, with a `ComputeError` naming the column and its dtype; `Decimal` computes
-as its `Float64` cast.
+as its `Float64` cast and a `Null`-typed column as all-null.
 
 Value-keyed methods go through the private `_x` hooks: on polars >= 1.44 the public wrapper
 `propagate_null_and_nan` masks the plugin out of the null and `NaN` rows before it can validate.
@@ -105,35 +105,44 @@ def _value_hooks(dist: _UnivariateDistribution) -> tuple[str, ...]:
     return (*density, "_cdf", "_log_cdf", "_sf", "_log_sf", "_ppf", "_isf")
 
 
-def _report(frame: pl.DataFrame, expr: pl.Expr) -> str | None:
-    """The `ComputeError` message, or `None` when the query computed."""
+def _refusal(frame: pl.DataFrame, expr: pl.Expr) -> str | None:
+    """The refusal as `<type>: <message>`, or `None` when the query computed."""
     try:
         frame.select(r=expr)
-    except pl.exceptions.ComputeError as err:
-        return str(err)
+    except (pl.exceptions.ComputeError, pl.exceptions.InvalidOperationError) as err:
+        return f"{type(err).__name__}: {err}"
     return None
 
 
 _Probes = list[tuple[str, pl.DataFrame, pl.Expr]]
+_Overrides = dict[str, float | None]
 
 
-def _probes(dist: _Dist, overrides: dict[str, float | None], points: tuple[float | None, ...]) -> _Probes:
-    """Every value-keyed hook at every point, then the moments and both samplers, as `(label, frame, expr)`."""
-    probes = [
+def _hook_probes(dist: _Dist, overrides: _Overrides, points: tuple[float | None, ...]) -> _Probes:
+    """Every value-keyed hook at every point, as `(label, frame, expr)`."""
+    return [
         (f"{hook}(x={x})", dist.frame(overrides, x), getattr(dist.dist, hook)(pl.col("x")))
         for x in points
         for hook in _value_hooks(dist.dist)
     ]
+
+
+def _sampler_probes(dist: _Dist, overrides: _Overrides) -> _Probes:
     row = dist.frame(overrides, 0.5)
-    probes += [(method, row, getattr(dist.dist, method)()) for method in _MOMENTS]
-    probes += [("sample", row, dist.dist.sample(seed=0)), ("samples", row, dist.dist.samples(3, seed=0))]
-    return probes
+    return [("sample", row, dist.dist.sample(seed=0)), ("samples", row, dist.dist.samples(3, seed=0))]
 
 
-def _unreported(dist: _Dist, overrides: dict[str, float | None], slot: str) -> list[tuple[str, str | None]]:
+def _probes(dist: _Dist, overrides: _Overrides, points: tuple[float | None, ...]) -> _Probes:
+    """The hooks at every point, then the moments and both samplers."""
+    row = dist.frame(overrides, 0.5)
+    moments = [(method, row, getattr(dist.dist, method)()) for method in _MOMENTS]
+    return _hook_probes(dist, overrides, points) + moments + _sampler_probes(dist, overrides)
+
+
+def _unreported(dist: _Dist, overrides: _Overrides, slot: str) -> list[tuple[str, str | None]]:
     """Every method that computes, or raises without naming `slot`, with what it reported."""
     fragment = f"{slot} must be"
-    reports = [(label, _report(frame, expr)) for label, frame, expr in _probes(dist, overrides, (0.5, math.nan, None))]
+    reports = [(label, _refusal(frame, expr)) for label, frame, expr in _probes(dist, overrides, (0.5, math.nan, None))]
     return [(label, report) for label, report in reports if report is None or fragment not in report]
 
 
@@ -184,25 +193,11 @@ _REFUSED_DTYPES = (pl.Boolean(), pl.String(), pl.Date())
 """One per family polars' own cast would silently accept: `Boolean` as `0` / `1`, `String` parsed, `Date` as days."""
 
 
-def _hooks(dist: _Dist) -> _Probes:
-    """The value-keyed probes alone; the moments and samplers never read `x`."""
-    return [probe for probe in _probes(dist, {}, (0.5,)) if probe[0].startswith("_")]
-
-
-def _refusal(frame: pl.DataFrame, expr: pl.Expr) -> str | None:
-    """The refusal as `<type>: <message>`, or `None` when the query computed."""
-    try:
-        frame.select(r=expr)
-    except (pl.exceptions.ComputeError, pl.exceptions.InvalidOperationError) as err:
-        return f"{type(err).__name__}: {err}"
-    return None
-
-
 def _accepted(column: str, dtype: pl.DataType, probes: _Probes) -> list[tuple[str, str]]:
     """Every probe that computes, or raises without naming `column`, with `column` recast to `dtype`.
 
-    `InvalidOperationError` is a refusal too: a closed-form moment's own arithmetic (`n * p` on a `String`
-    `p`) meets the column before the plugin does, and nothing computes there either.
+    A moment may refuse with polars' own `InvalidOperationError` instead: its closed-form arithmetic (`n * p`
+    on a `String` `p`) meets the column before the plugin does. Hooks and samplers reach the plugin first.
     """
     fragment = f"'{column}' must be a numeric column"
     refusals = [
@@ -212,14 +207,15 @@ def _accepted(column: str, dtype: pl.DataType, probes: _Probes) -> list[tuple[st
     return [
         (label, refusal or "computed")
         for label, refusal in refusals
-        if refusal is None or (fragment not in refusal and not refusal.startswith("InvalidOperationError"))
+        if refusal is None
+        or (fragment not in refusal and not (label in _MOMENTS and refusal.startswith("InvalidOperationError")))
     ]
 
 
 @pytest.mark.parametrize("dtype", _REFUSED_DTYPES, ids=str)
 @pytest.mark.parametrize("dist", _DISTS, ids=lambda dist: dist.name)
 def test_non_numeric_evaluation_point_raises_on_every_hook(dist: _Dist, dtype: pl.DataType) -> None:
-    accepted = _accepted("x", dtype, _hooks(dist))
+    accepted = _accepted("x", dtype, _hook_probes(dist, {}, (0.5,)))
     assert not accepted, f"{dist.name} took a {dtype} evaluation point: {accepted}"
 
 
@@ -234,17 +230,33 @@ def test_non_numeric_parameter_raises_on_every_method(dist: _Dist, slot: str, dt
     assert not accepted, f"{dist.name} took a {dtype} `{slot}`: {accepted}"
 
 
-@pytest.mark.parametrize(
-    ("dist", "column"),
-    [pytest.param(dist, column, id=f"{dist.name}.{column}") for dist in _DISTS for column in ("x", *dist.float_slots)],
-)
-def test_decimal_column_computes_as_its_float64_cast(dist: _Dist, column: str) -> None:
-    """Hooks and samplers only: the closed-form moments are polars arithmetic on the parameter itself, and
-    polars has no `pow` for `Decimal`. The samplers never read `x`, so a recast `x` probes the hooks alone.
+_COLUMNS = [
+    pytest.param(dist, column, id=f"{dist.name}.{column}") for dist in _DISTS for column in ("x", *dist.float_slots)
+]
+"""Every column the gate sees: the evaluation point and each float parameter slot."""
+
+
+def _gate_probes(dist: _Dist, column: str) -> _Probes:
+    """The probes where the gate alone stands between `column` and the answer: the hooks, and for a parameter
+    the samplers too. The closed-form moments are polars arithmetic on the parameter itself, so their dtype
+    behaviour is polars' (a missing kernel raises, a bare parameter keeps its dtype), not the gate's.
     """
-    probes = (
-        _hooks(dist) if column == "x" else [probe for probe in _probes(dist, {}, (0.5,)) if probe[0] not in _MOMENTS]
-    )
-    for _label, frame, expr in probes:
+    return _hook_probes(dist, {}, (0.5,)) + ([] if column == "x" else _sampler_probes(dist, {}))
+
+
+@pytest.mark.parametrize(("dist", "column"), _COLUMNS)
+def test_decimal_column_computes_as_its_float64_cast(dist: _Dist, column: str) -> None:
+    for _label, frame, expr in _gate_probes(dist, column):
         decimal = frame.with_columns(pl.col(column).cast(pl.Decimal(10, 2)))
         assert_series_equal(decimal.select(r=expr)["r"], frame.select(r=expr)["r"], check_exact=True)
+
+
+@pytest.mark.parametrize(("dist", "column"), _COLUMNS)
+def test_null_dtype_column_nulls_every_answer(dist: _Dist, column: str) -> None:
+    """A `Null`-typed column passes the gate as all-null `Float64`."""
+    answered = [
+        label
+        for label, frame, expr in _gate_probes(dist, column)
+        if frame.with_columns(pl.lit(None).alias(column)).select(r=expr)["r"].item() is not None
+    ]
+    assert not answered, f"{dist.name} answered with a Null-typed `{column}`: {answered}"

--- a/tests/property/value_dtype_test.py
+++ b/tests/property/value_dtype_test.py
@@ -15,6 +15,9 @@ version (1.15.0 through current) and pinned here so a regression in either direc
   statrs-backed paths (both a Python-side `cast` and the plugin's internal Rust cast would
   otherwise accept it).
 
+Below the guard, Rust refuses every non-numeric dtype with a `ComputeError` in both positions; parameters
+have no Python guard, so that is their whole contract. `Decimal` is numeric to Rust and computes in both.
+
 Whether a dtype reaches either half at all is `tests/plugin_boundary_dtype_test.py`'s question.
 """
 
@@ -125,7 +128,7 @@ _REFUSED_VALUES = (
     pl.Series("x", [1, 2], dtype=pl.Int64).cast(pl.Duration("us")),
     pl.Series("x", [1, 2], dtype=pl.Int64).cast(pl.Time),
 )
-"""Every dtype an evaluation point may not be. `Decimal` is numeric but `is_nan` has no `NaN` to test on it."""
+"""Every dtype the public guard refuses in the value position. `Decimal` is numeric, but `is_nan` has no `NaN` on it."""
 
 
 @pytest.mark.parametrize(
@@ -146,12 +149,8 @@ def test_non_numeric_value_column_raises(dist: _UnivariateDistribution, series: 
         series.to_frame().select(dist.cdf(pl.col("x")))
 
 
-_REFUSED_PARAMETERS = (
-    pl.Series("mu", ["a", "b"], dtype=pl.Categorical),
-    pl.Series("mu", ["a", "b"], dtype=pl.Enum(["a", "b"])),
-    pl.Series("mu", [{"a": 1}, {"a": 2}], dtype=pl.Struct({"a": pl.Int64})),
-)
-"""Parameter dtypes the Rust cast refuses; `Boolean`, `String` and the temporal dtypes survive it and compute."""
+_REFUSED_PARAMETERS = tuple(series.rename("mu") for series in _REFUSED_VALUES if not series.dtype.is_decimal())
+"""Every non-numeric dtype; Rust refuses each as a parameter where polars' own cast would compute."""
 
 
 @pytest.mark.parametrize("series", _REFUSED_PARAMETERS, ids=lambda s: str(s.dtype))
@@ -160,8 +159,33 @@ def test_refused_parameter_column_raises_from_the_plugin(series: pl.Series, meth
     """A refused *parameter* raises `ComputeError` from Rust: no Python-side guard sees a parameter column."""
     dist = Normal(mu="mu", sigma=1.0)
     expr = dist.mean() if method == "mean" else dist.sample(seed=0)
-    with pytest.raises(pl.exceptions.ComputeError):
+    with pytest.raises(pl.exceptions.ComputeError, match="'mu' must be a numeric column"):
         series.to_frame().select(r=expr)
+
+
+@pytest.mark.parametrize(
+    "dist",
+    [Normal(mu=0.0, sigma=1.0), Uniform(min=0.0, max=1.0)],
+    ids=["normal", "uniform"],
+)
+@pytest.mark.parametrize("series", _REFUSED_PARAMETERS, ids=lambda s: str(s.dtype))
+def test_non_numeric_value_column_raises_from_the_plugin(dist: _UnivariateDistribution, series: pl.Series) -> None:
+    """Below the public guard, the funnel refuses a non-numeric evaluation point: nothing parses, nothing computes."""
+    with pytest.raises(pl.exceptions.ComputeError, match="'x' must be a numeric column"):
+        series.rename("x").to_frame().select(dist._cdf(pl.col("x")))
+
+
+@pytest.mark.parametrize(
+    "dist",
+    [Normal(mu=0.0, sigma=1.0), Uniform(min=0.0, max=1.0)],
+    ids=["normal", "uniform"],
+)
+def test_decimal_value_column_computes_through_the_hook(dist: _UnivariateDistribution) -> None:
+    """A `Decimal` evaluation point is numeric to the funnel and evaluates as its `Float64` cast."""
+    frame = pl.Series("x", [Decimal("0.50"), Decimal("0.25"), None], dtype=pl.Decimal(10, 2)).to_frame()
+    narrow = frame.select(r=dist._cdf(pl.col("x")))["r"]
+    wide = frame.select(r=dist._cdf(pl.col("x").cast(pl.Float64())))["r"]
+    assert_series_equal(narrow, wide, check_exact=True)
 
 
 @pytest.mark.parametrize("dtype", [*available_dtypes("Int128", "UInt128", "Float16"), pl.Decimal(10, 2)], ids=str)

--- a/tests/property/value_dtype_test.py
+++ b/tests/property/value_dtype_test.py
@@ -84,7 +84,7 @@ def test_narrow_value_column_matches_float64(spec: DistSpec, dtype: pl.DataType,
     dist = spec.make(params)
     lo, hi = spec.eval_range(params)
     values = pl.Series("x", _int_grid(lo, hi, dtype)).cast(dtype).to_frame()
-    q_grid = [0, 1, None] if dtype.is_integer() else [0.0, 0.25, 0.5, 0.75, 1.0, None]
+    q_grid = [0, 1, None] if dtype.is_integer() else [0.0, 0.1, 0.25, 0.5, 0.75, 1.0, None]
     quantiles = pl.Series("q", q_grid).cast(dtype).to_frame()
 
     x, q = pl.col("x"), pl.col("q")
@@ -149,18 +149,18 @@ def test_non_numeric_value_column_raises(dist: _UnivariateDistribution, series: 
         series.to_frame().select(dist.cdf(pl.col("x")))
 
 
-_REFUSED_PARAMETERS = tuple(series.rename("mu") for series in _REFUSED_VALUES if not series.dtype.is_decimal())
-"""Every non-numeric dtype; Rust refuses each as a parameter where polars' own cast would compute."""
+_NON_NUMERIC = tuple(series for series in _REFUSED_VALUES if not series.dtype.is_decimal())
+"""Every dtype the Rust gate refuses, in either position, where polars' own cast would compute."""
 
 
-@pytest.mark.parametrize("series", _REFUSED_PARAMETERS, ids=lambda s: str(s.dtype))
+@pytest.mark.parametrize("series", _NON_NUMERIC, ids=lambda s: str(s.dtype))
 @pytest.mark.parametrize("method", ["mean", "sample"], ids=str)
-def test_refused_parameter_column_raises_from_the_plugin(series: pl.Series, method: str) -> None:
-    """A refused *parameter* raises `ComputeError` from Rust: no Python-side guard sees a parameter column."""
+def test_non_numeric_parameter_column_raises_from_the_plugin(series: pl.Series, method: str) -> None:
+    """A non-numeric *parameter* raises `ComputeError` from Rust: no Python-side guard sees a parameter column."""
     dist = Normal(mu="mu", sigma=1.0)
     expr = dist.mean() if method == "mean" else dist.sample(seed=0)
     with pytest.raises(pl.exceptions.ComputeError, match="'mu' must be a numeric column"):
-        series.to_frame().select(r=expr)
+        series.rename("mu").to_frame().select(r=expr)
 
 
 @pytest.mark.parametrize(
@@ -168,11 +168,11 @@ def test_refused_parameter_column_raises_from_the_plugin(series: pl.Series, meth
     [Normal(mu=0.0, sigma=1.0), Uniform(min=0.0, max=1.0)],
     ids=["normal", "uniform"],
 )
-@pytest.mark.parametrize("series", _REFUSED_PARAMETERS, ids=lambda s: str(s.dtype))
+@pytest.mark.parametrize("series", _NON_NUMERIC, ids=lambda s: str(s.dtype))
 def test_non_numeric_value_column_raises_from_the_plugin(dist: _UnivariateDistribution, series: pl.Series) -> None:
     """Below the public guard, the funnel refuses a non-numeric evaluation point: nothing parses, nothing computes."""
     with pytest.raises(pl.exceptions.ComputeError, match="'x' must be a numeric column"):
-        series.rename("x").to_frame().select(dist._cdf(pl.col("x")))
+        series.to_frame().select(dist._cdf(pl.col("x")))
 
 
 @pytest.mark.parametrize(

--- a/tests/scipy_parity/exponential_test.py
+++ b/tests/scipy_parity/exponential_test.py
@@ -108,9 +108,9 @@ def test_ppf_keeps_tiny_quantiles(rate: float, q: float) -> None:
 def test_isf_is_exact_rather_than_ppf_of_the_complement(rate: float, q: float) -> None:
     """`isf(q)` is `-log(q) / rate`, never routed through `ppf(1 - q)`.
 
-    The base-class default builds `1 - q`, whose absolute resolution is `1.1e-16`, so a small `q`
-    was quantised (relative error `~1.1e-16 / q`, `1.4e-9` at `q = 1e-9`) and saturated below
-    `1e-16`. The exponential has a closed-form inverse survival function, so it overrides.
+    Routing through `1 - q` would quantise a small `q` at the complement's `1.1e-16` absolute
+    resolution (relative error `~1.1e-16 / q`, `1.4e-9` at `q = 1e-9`) and saturate below `1e-16`;
+    the exponential has a closed-form inverse survival function instead.
     """
     got = pl.DataFrame({"q": [q]}).select(r=Exponential(rate=rate).isf(pl.col("q")))["r"].item()
     assert got == pytest.approx(-math.log(q) / rate, rel=1e-15)


### PR DESCRIPTION
One Rust gate, `coerce_f64`, now sits on every evaluation point and float parameter: `Int*`, `UInt*`, `Float*`, `Decimal` and `Null`-typed columns cast to `Float64`, anything else raises `ComputeError` naming the column, so a `String` parameter no longer parses and a `Boolean` no longer computes as `0` / `1`. Beta and Binomial `isf` move to Rust and the base-class `ppf(1 - q)` fallback is gone (`_isf` is abstract), since polars formed `1 - q` before the gate saw the column. The public value-position error stays polars' `InvalidOperationError` until the wrapper is deleted in the next PR; `Beta` and `Binomial` `isf` on Float32 / Float16 quantile columns now widen before the complement, a small favourable change.
