### PR TITLE
refactor(distributions): drop the null/NaN wrapper, the plugin owns every row

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,9 @@ Run `prek` through `make lint`, and do not pass `--no-verify` unless asked.
   [Contributing > Adding a distribution](./docs/contributing.md#adding-a-distribution), step 3.
 * **Write the scipy-parity test first**, then the implementation, then iterate until it passes within a tolerance you
   can justify.
-* **Override the private `_x` hook, never the public method.** The public methods add the null and `NaN` contract, and
-  the composing defaults call the hooks, so a public override is bypassed by everything built on it.
+* **Override the private `_x` hook, never the public method.** The public methods only coerce the argument, and the
+  composing defaults (`_sf`, the `_log_*` family, `median`) call the hooks, so a public override is bypassed by
+  everything built on it.
 * **Priorities, in order: correctness, ergonomics, maintainability, performance.** Performance is last on purpose:
   the polars engine carries large frames, so a clear formula beats a fast one. Reject a choice on performance grounds
   only when it is clearly suboptimal (an `O(n)` draw per row, a per-draw rebuild), never to shave constants.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -58,7 +58,7 @@ polars-stats/
 │   ├── __init__.py           # public exports
 │   ├── _lib.py               # plugin path resolution
 │   └── distributions/
-│       ├── _base.py          # ABCs + coercion / null helpers
+│       ├── _base.py          # ABCs + coercion helpers
 │       └── _<name>.py        # one Python class per distribution
 ├── tests/
 │   ├── distributions/<name>/ # one folder per distribution, one file per method

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -23,11 +23,12 @@ The method surface (`pdf`/`pmf`, `cdf`, `sf`, `ppf`, `isf`, the `log_*` family, 
 `entropy`, `sample`, `samples`) is defined on the abstract base classes `ContinuousDistribution` and
 `DiscreteDistribution`. The catalogue and the full table live in the [API reference](../reference/index.md#method-surface).
 
-**Template-method split**: every value-keyed method is *concrete in the base*: it coerces the argument with `as_expr`,
-applies `propagate_null_and_nan`, then delegates the maths to a private hook (`_pdf`, `_cdf`, `_ppf`, ...). **Subclasses
-implement and override the `_x` hooks, never the public methods.** The hook receives an already-coerced `pl.Expr` and
-returns the formula with no null or NaN handling; the base guarantees the input contract uniformly (null in, null out;
-`NaN` in, `NaN` out, matching scipy) along with input coercion.
+**Template-method split**: every value-keyed method is *concrete in the base*: it coerces the argument with `as_expr`
+and delegates everything else to a private hook (`_pdf`, `_cdf`, `_ppf`, ...). **Subclasses implement and override the
+`_x` hooks, never the public methods.** The hook receives an already-coerced `pl.Expr` and owns the whole per-row
+contract, the null and `NaN` rows included (null in, null out; `NaN` in, `NaN` out, matching scipy). Nothing sits
+between the hook and the caller; [Design notes](design.md#one-rust-file-per-distribution-one-plugin-function-per-method-that-needs-rust)
+explain why a `when` / `then` / `otherwise` above it could not be trusted with those rows.
 
 Composing defaults live in the base and call the other hooks:
 

--- a/docs/how-to/nulls-and-errors.md
+++ b/docs/how-to/nulls-and-errors.md
@@ -29,8 +29,9 @@ null parameter nulls the row even where the evaluation point alone would have se
 
 ## Find the rows that would raise
 
-An invalid parameter *value* (`sigma <= 0`, `max <= min`, `p` outside `[0, 1]`) fails the whole evaluation with a
-`ComputeError`. Locate the offending rows with an ordinary filter before scoring:
+An invalid parameter *value* (`sigma <= 0`, `max <= min`, `p` outside `[0, 1]`, a `NaN` or an infinity) fails the
+whole evaluation with a `ComputeError`, whatever else is on the row. Locate the offending rows with an ordinary filter
+before scoring:
 
 ```python exec="yes" source="above" session="nulls-and-errors" result="python"
 frame = pl.DataFrame(

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -65,23 +65,3 @@ mean of a different distribution on every row.
 | Polars | `>=1.15` (the `pyo3-polars` ABI floor) |
 | OS | wheels for Linux x86_64/aarch64, macOS arm64/x86_64, Windows x86_64 |
 | Runtime dependencies | `polars` only |
-
-!!! warning "Known limitation on polars >= 1.44"
-
-    On polars 1.44.0 and newer, an invalid parameter goes unreported on a row whose **evaluation point
-    is null or `NaN`**, for every distribution and both parameter spellings, scalar included.
-
-    Polars 1.44.0 ([pola-rs/polars#28498](https://github.com/pola-rs/polars/pull/28498)) masks the arms
-    of a `when/then/otherwise` to null on the rows an arm does not select. Every value-keyed method
-    validates inside the Rust plugin that computes it, but the wrapper that gives you `null -> null` and
-    `NaN -> NaN` sits one level above, and it masks those rows out of the plugin's input before it can
-    validate. With a column parameter that is per row; with a scalar one it takes the whole batch, so
-    `Bernoulli(p=1.5).pmf(col)` returns `[nan, nan]` over an all-`NaN` column but still raises as soon
-    as one evaluation point is finite.
-
-    **Not affected:** every finite evaluation point, on every method of every distribution, and every
-    *valid* computation, whose results are unchanged.
-
-    **Workarounds:** pin `polars<1.44` yourself, or validate column parameters before passing them.
-
-    Tracked as [pola-rs/polars#29005](https://github.com/pola-rs/polars/issues/29005).

--- a/docs/reference/parameters-and-contracts.md
+++ b/docs/reference/parameters-and-contracts.md
@@ -67,9 +67,7 @@ are cast to `Float64` at evaluation, so an integer column works wherever a float
 That cast is the plugin's. The closed-form moments are polars arithmetic on the parameter itself, so there polars
 decides: a moment that is the parameter (`Normal(mu="mu").mean()`) keeps the column's dtype, and a `Decimal` or
 `Null`-typed `sigma` raises `InvalidOperationError` where polars has no kernel for it on the bare column (`pow`,
-`log`, `exp`: `Normal`'s `variance` and `entropy`, `LogNormal`'s `mean`, `variance`, `std` and `entropy`). `Decimal`
-is also the one numeric dtype refused as an *evaluation point*: the null/`NaN` guard applied to the value column has
-no `NaN` to test for on a decimal and raises `InvalidOperationError`.
+`log`, `exp`: `Normal`'s `variance` and `entropy`, `LogNormal`'s `mean`, `variance`, `std` and `entropy`).
 
 The integer parameters are the exception to the cast: the count `n` and `DiscreteUniform`'s bounds must already hold
 integers, of any integer dtype, because casting a float one would silently truncate. `n` widens to `UInt64` and the
@@ -77,17 +75,13 @@ bounds to `Int64`, so a `UInt64` bound *value* above `i64::MAX` raises rather th
 dtype, so a float column raises even when every value in it is null; a `Null`-dtype column
 propagates nulls like any other parameter.
 
-In **evaluation-point** position every non-numeric dtype is rejected: Polars fails the query with
-`InvalidOperationError`. That covers `Boolean`, `String`, `Categorical`, `Enum`, `Struct`, `Object` and the temporal
-dtypes, plus `Decimal`. Nothing silently parses and nothing silently nulls. (On polars older than 1.25, an `Object`
-column in either position raises `PanicException` from polars' own arrow export instead.)
-
-In **parameter** position the Rust plugin enforces the same rule on every method: a `Boolean`, `String`,
-`Categorical`, `Enum`, `Struct`, `Object` or temporal column raises `ComputeError` naming the column and the dtype
-the plugin received (`Object` arrives as `binary`), and no row computes. Nothing is parsed and nothing is read as
-`0` / `1`. The one variation is the exception type: where a closed-form moment's own polars arithmetic meets the
+In **either position** the Rust plugin enforces that rule on every method: a `Boolean`, `String`, `Categorical`,
+`Enum`, `Struct`, `Object` or temporal column raises `ComputeError` naming the column and the dtype the plugin
+received (`Object` arrives as `binary`), and no row computes. Nothing is parsed and nothing is read as `0` / `1`.
+The one variation is the exception type: where a closed-form moment's own polars arithmetic meets a parameter
 column before the plugin does (`n * p` on a `String` `p`), polars raises `InvalidOperationError` instead. Cast a
-parameter to `Float64` when you mean a number.
+column to `Float64` when you mean a number. (On polars older than 1.25, an `Object` column in either position raises
+`PanicException` from polars' own arrow export instead.)
 
 ## Parameter validity
 
@@ -109,8 +103,8 @@ may hold any count its dtype can, up to `UInt64`.
 | `Geometric(p)` | `0 < p <= 1` | `p = 0` rejected, unlike `Bernoulli` |
 
 A violation raises `ComputeError` and fails the whole evaluation. The check runs over each parameter column before
-any row computes, so an invalid value raises even on a row whose other parameter is null. See
-[nulls, NaNs and errors](#nulls-nans-and-errors) below.
+any row computes, so an invalid value raises even on a row whose other parameter is null or whose evaluation point
+is null or `NaN`. See [nulls, NaNs and errors](#nulls-nans-and-errors) below.
 
 ## Sampling
 
@@ -146,15 +140,17 @@ Element dtype is per distribution and is not normalised to `Float64`:
 **`null` is reserved for missing inputs; an invalid parameter raises.** A silent null from a bad parameter would be
 indistinguishable from a legitimately missing input, and would propagate wrong answers downstream.
 
+The rows are in precedence order: per row, the first that applies decides, so a raise outranks a null and a null
+parameter outranks a `NaN` evaluation point. "Present" means non-null.
+
 | Situation | When detected | Behaviour |
 |---|---|---|
 | Wrong parameter *type* (a `list`, an `int` for a float parameter, a `bool`) | Python `__init__` | `TypeError`, no query runs |
-| Invalid parameter *value*, scalar or one column row | Rust evaluation | `ComputeError`, fails the whole evaluation, never silently nulls (one exception on polars >= 1.44, see [Known limitation](index.md#compatibility)) |
+| Non-numeric column in either position (`Boolean`, `String`, `Categorical`, `Enum`, `Struct`, `Object`, temporal) | Rust evaluation | `ComputeError` naming the column and its dtype, no row computes; polars' `InvalidOperationError` where a closed-form moment's arithmetic meets a parameter column first (see [Accepted inputs](#accepted-inputs)) |
+| Invalid *present* parameter value: outside its domain, `NaN`, `+inf` or `-inf`, as a scalar or on any column row | Rust evaluation | `ComputeError`, fails the whole evaluation, never silently nulls, whatever else is on the row: a null sibling parameter, a null or `NaN` evaluation point |
+| `null` parameter on a row | per row | `null` on that row, on every method and at every evaluation point, `NaN` and off-support included (see below) |
 | `null` value or quantile argument on a row | per row | `null` on that row |
-| `null` parameter on a row | per row | `null` on that row, on every method and off the support too, no error (see below) |
-| `NaN` value or quantile argument on a row | per row | `NaN` on that row (matches scipy) |
-| Non-numeric column as an *argument* | evaluation | Polars raises `InvalidOperationError` |
-| Non-numeric column as a *parameter* | Rust evaluation | `ComputeError` naming the column and its dtype; polars' `InvalidOperationError` where a closed-form moment's arithmetic meets the column first. Nothing computes either way (see [Accepted inputs](#accepted-inputs)) |
+| `NaN` value or quantile argument on a row | per row | `NaN` on that row, `ppf` / `isf` included (matches scipy) |
 | `q` outside `[0, 1]` in `ppf` / `isf` | per row | `null`, guaranteed for every distribution and both parameter regimes (pinned by `tests/property/ppf_domain_test.py`). `q` exactly `0` or `1` is in range and maps to a support bound |
 | `x` outside the support (e.g. `pdf` below a `Uniform`'s `min`) | per row | `0.0` (matches scipy) |
 | `pmf(3.5)` for a discrete distribution | per row | `0.0` (matches scipy) |

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -277,16 +277,6 @@ def register_plugin(
     )
 
 
-def propagate_null_and_nan(value: pl.Expr, result: pl.Expr) -> pl.Expr:
-    """Return `result`, overridden to null/NaN where `value` is null/NaN respectively.
-
-    Applied by every public value-keyed wrapper (scipy semantics: null in, null out; `NaN` in, `NaN` out).
-    """
-    guarded = pl.when(value.is_null()).then(pl.lit(None)).when(value.is_nan()).then(float("nan")).otherwise(result)
-    name = value.meta.output_name(raise_if_undetermined=False)
-    return guarded if name is None else guarded.alias(name)
-
-
 _LN_2 = math.log(2.0)
 """`log(2)`, the leading term of `log_abs_expm1`."""
 
@@ -329,6 +319,9 @@ class _UnivariateDistribution(ABC):
     row (e.g. `Normal(mu=pl.col("mu"), sigma=1.0)`).
 
     The interface mirrors `scipy.stats.rv_continuous` / `rv_discrete` but returns `pl.Expr` instead of NumPy arrays.
+
+    A public value-keyed method only coerces its argument; the `_x` hook it calls answers every row, the null and
+    `NaN` rows included.
     """
 
     _plugin_prefix: ClassVar[str]
@@ -540,17 +533,15 @@ class _UnivariateDistribution(ABC):
 
     def cdf(self, value: float | IntoExprColumn) -> pl.Expr:
         """Cumulative distribution function, `P(X <= value)`. Nulls and NaNs in `value` are propagated."""
-        v = as_expr(value)
-        return propagate_null_and_nan(v, self._cdf(v))
+        return self._cdf(as_expr(value))
 
     @abstractmethod
     def _cdf(self, value: pl.Expr) -> pl.Expr:
-        """Core cdf formula on a coerced expr; null handling is applied by `cdf`."""
+        """Core cdf formula on a coerced expr."""
 
     def log_cdf(self, value: float | IntoExprColumn) -> pl.Expr:
         """Natural logarithm of the cdf. Nulls and NaNs in `value` are propagated."""
-        v = as_expr(value)
-        return propagate_null_and_nan(v, self._log_cdf(v))
+        return self._log_cdf(as_expr(value))
 
     def _log_cdf(self, value: pl.Expr) -> pl.Expr:
         """Default `log(cdf)`; underflows to `-inf` once `cdf` rounds to `0` deep in the left tail.
@@ -563,17 +554,15 @@ class _UnivariateDistribution(ABC):
 
     def sf(self, value: float | IntoExprColumn) -> pl.Expr:
         """Survival function, `P(X > value) = 1 - cdf(value)`. Nulls and NaNs in `value` are propagated."""
-        v = as_expr(value)
-        return propagate_null_and_nan(v, self._sf(v))
+        return self._sf(as_expr(value))
 
     def _sf(self, value: pl.Expr) -> pl.Expr:
-        """Default `1 - cdf`; subclasses override when a closed form is more accurate in the upper tail."""
-        return 1 - self._cdf(value)
+        """Default `1 - cdf`, spelled `-cdf + 1` so the output keeps `_cdf`'s name; override for a stabler tail."""
+        return self._cdf(value).neg() + 1
 
     def log_sf(self, value: float | IntoExprColumn) -> pl.Expr:
         """Natural logarithm of the survival function. Nulls and NaNs in `value` are propagated."""
-        v = as_expr(value)
-        return propagate_null_and_nan(v, self._log_sf(v))
+        return self._log_sf(as_expr(value))
 
     def _log_sf(self, value: pl.Expr) -> pl.Expr:
         """Default `log(sf)`; underflows to `-inf` once `sf` rounds to `0` deep in the right tail.
@@ -591,12 +580,11 @@ class _UnivariateDistribution(ABC):
 
         Nulls are propagated and a `NaN` quantile yields `NaN`, matching scipy.
         """
-        q = as_expr(quantile)
-        return propagate_null_and_nan(q, self._ppf(q))
+        return self._ppf(as_expr(quantile))
 
     @abstractmethod
     def _ppf(self, quantile: pl.Expr) -> pl.Expr:
-        """Core inverse-cdf formula on a coerced expr; null handling is applied by `ppf`."""
+        """Core inverse-cdf formula on a coerced expr."""
 
     def isf(self, quantile: float | IntoExprColumn) -> pl.Expr:
         """Inverse survival function, the value `x` with `sf(x) == quantile`.
@@ -604,12 +592,11 @@ class _UnivariateDistribution(ABC):
         Same domain contract as `ppf`, with the endpoints reversed: `quantile` outside `[0, 1]` yields
         null, nulls propagate, `NaN` yields `NaN`.
         """
-        q = as_expr(quantile)
-        return propagate_null_and_nan(q, self._isf(q))
+        return self._isf(as_expr(quantile))
 
     @abstractmethod
     def _isf(self, quantile: pl.Expr) -> pl.Expr:
-        """Core inverse-survival formula on a coerced expr; null handling is applied by `isf`.
+        """Core inverse-survival formula on a coerced expr.
 
         No `ppf(1 - quantile)` default: the complement quantises a small quantile before the inverse
         runs, and polars would form it ahead of the Rust dtype gate. Solve against `quantile` itself.
@@ -656,7 +643,7 @@ class _UnivariateDistribution(ABC):
 
     def median(self) -> pl.Expr:
         """Median, `ppf(0.5)`."""
-        return self.ppf(0.5)
+        return self._ppf(as_expr(0.5))
 
     @abstractmethod
     def entropy(self) -> pl.Expr:
@@ -668,17 +655,15 @@ class DiscreteDistribution(_UnivariateDistribution, ABC):
 
     def pmf(self, value: float | IntoExprColumn) -> pl.Expr:
         """Probability mass function, `P(X = value)`. Nulls and NaNs in `value` are propagated."""
-        v = as_expr(value)
-        return propagate_null_and_nan(v, self._pmf(v))
+        return self._pmf(as_expr(value))
 
     @abstractmethod
     def _pmf(self, value: pl.Expr) -> pl.Expr:
-        """Core pmf formula on a coerced expr; null handling is applied by `pmf`."""
+        """Core pmf formula on a coerced expr."""
 
     def log_pmf(self, value: float | IntoExprColumn) -> pl.Expr:
         """Natural logarithm of the pmf. Nulls and NaNs in `value` are propagated."""
-        v = as_expr(value)
-        return propagate_null_and_nan(v, self._log_pmf(v))
+        return self._log_pmf(as_expr(value))
 
     def _log_pmf(self, value: pl.Expr) -> pl.Expr:
         return self._pmf(value).log()
@@ -689,17 +674,15 @@ class ContinuousDistribution(_UnivariateDistribution, ABC):
 
     def pdf(self, value: float | IntoExprColumn) -> pl.Expr:
         """Probability density function evaluated at `value`. Nulls and NaNs in `value` are propagated."""
-        v = as_expr(value)
-        return propagate_null_and_nan(v, self._pdf(v))
+        return self._pdf(as_expr(value))
 
     @abstractmethod
     def _pdf(self, value: pl.Expr) -> pl.Expr:
-        """Core pdf formula on a coerced expr; null handling is applied by `pdf`."""
+        """Core pdf formula on a coerced expr."""
 
     def log_pdf(self, value: float | IntoExprColumn) -> pl.Expr:
         """Natural logarithm of the pdf. Nulls and NaNs in `value` are propagated."""
-        v = as_expr(value)
-        return propagate_null_and_nan(v, self._log_pdf(v))
+        return self._log_pdf(as_expr(value))
 
     def _log_pdf(self, value: pl.Expr) -> pl.Expr:
         return self._pdf(value).log()

--- a/tests/_polars_compat.py
+++ b/tests/_polars_compat.py
@@ -11,9 +11,6 @@ forwarded untouched.
 `linear_space` backfills `polars.linear_space`, which is missing on older supported polars; the implementation here
 reproduces its evenly spaced, inclusive-endpoint grid on every supported version.
 
-`ARM_MASKING_HIDES_VALIDATION` gates the validation contract at a null or `NaN` evaluation point, which
-polars 1.44 breaks by masking the `propagate_null_and_nan` wrapper's arms before the plugin can validate.
-
 `available_dtypes` drops the dtypes an older supported polars has no name for.
 
 `arr_explode` wraps `Series.arr.explode`: polars 1.36 added the `empty_as_null` flag and 1.42 deprecated its
@@ -33,7 +30,6 @@ if TYPE_CHECKING:
     from polars import Series
 
 __all__ = (
-    "ARM_MASKING_HIDES_VALIDATION",
     "LITERAL_DISPLAYS_AS_VALUE",
     "PARTITIONED_BROADCAST_AVAILABLE",
     "arr_explode",
@@ -77,17 +73,6 @@ upstream defects are the reason the partition suites are gated rather than the b
 Both are polars defects, not plugin defects: the same expressions are correct on 1.34 and above with
 an unchanged plugin. Documented for users in `docs/reference/parameters-and-contracts.md`.
 When the polars floor reaches 1.34 this constant and every gate on it can be deleted.
-"""
-
-
-ARM_MASKING_HIDES_VALIDATION = Version("1.44.0") <= PL_VERSION
-"""Whether a validating plugin inside a `when/then/otherwise` arm stops seeing the rows the arm skips.
-
-Polars 1.44 (pola-rs/polars#28498) masks the **arms** of a `when/then/otherwise` to null on the rows
-the arm does not select. It does not mask the **condition**. So a validator reached only from inside
-`.then(...)` / `.otherwise(...)` never sees an invalid row and never raises, while a validator in the
-`when(...)` condition, or one called unconditionally from inside the plugin that computes the answer,
-still does.
 """
 
 

--- a/tests/distributions/base_defaults_test.py
+++ b/tests/distributions/base_defaults_test.py
@@ -32,7 +32,7 @@ class _UnitUniform(ContinuousDistribution):
         return ()
 
     def _pdf(self, value: pl.Expr) -> pl.Expr:
-        return pl.when(value.is_between(0.0, 1.0)).then(1.0).otherwise(0.0)
+        return value.is_between(0.0, 1.0).cast(pl.Float64)
 
     def _cdf(self, value: pl.Expr) -> pl.Expr:
         return value.clip(0.0, 1.0)
@@ -66,10 +66,20 @@ class _FairCoin(DiscreteDistribution):
         return ()
 
     def _pmf(self, value: pl.Expr) -> pl.Expr:
-        return pl.when(value.is_in([0.0, 1.0])).then(0.5).otherwise(0.0)
+        return value.is_in([0.0, 1.0]).cast(pl.Float64) * 0.5
 
     def _cdf(self, value: pl.Expr) -> pl.Expr:
-        return pl.when(value < 0).then(0.0).when(value < 1).then(0.5).otherwise(1.0)
+        # A null or `NaN` point answers itself, first so the output keeps the value's name; the bare
+        # chain would answer `1.0` on both.
+        return (
+            pl.when(value.is_null() | value.is_nan())
+            .then(value)
+            .when(value < 0)
+            .then(0.0)
+            .when(value < 1)
+            .then(0.5)
+            .otherwise(1.0)
+        )
 
     def _ppf(self, quantile: pl.Expr) -> pl.Expr:
         return (quantile > _MEDIAN_QUANTILE).cast(pl.Float64)
@@ -150,8 +160,7 @@ def test_the_default_sf_is_the_complement_of_cdf(toy: _Toy) -> None:
 
 
 def test_the_default_sf_keeps_the_null_and_nan_contract(toy: _Toy) -> None:
-    # `sf` wraps the hook in `propagate_null_and_nan`, so the default inherits the contract. Only the
-    # null and `NaN` rows are asserted here; the value is the test above.
+    # `1 - _cdf` passes the hook's null and `NaN` rows through; the value is the test above.
     frame = pl.DataFrame({"x": [toy.quantile, None, float("nan")]}, schema={"x": pl.Float64})
 
     got = frame.select(r=toy.dist.sf(pl.col("x")))["r"].to_list()
@@ -159,6 +168,14 @@ def test_the_default_sf_keeps_the_null_and_nan_contract(toy: _Toy) -> None:
     assert got[0] is not None
     assert got[1] is None
     assert math.isnan(got[2])
+
+
+def test_the_defaults_keep_the_hook_output_name(toy: _Toy) -> None:
+    # Polars names arithmetic after its left operand, so a default spelled `1 - hook` would be `"literal"`.
+    # Both toys name their hooks after the value, as the Rust plugins do.
+    frame = pl.DataFrame({"x": toy.grid})
+    for method in ("sf", f"log_{toy.density}", "log_cdf", "log_sf"):
+        assert frame.select(getattr(toy.dist, method)(pl.col("x"))).columns == ["x"], method
 
 
 def test_the_default_log_density_is_the_log_of_the_density(toy: _Toy) -> None:

--- a/tests/distributions/null_nan_contract_test.py
+++ b/tests/distributions/null_nan_contract_test.py
@@ -11,10 +11,6 @@ A null parameter is answered before the evaluation point is read, so every metho
 A column that is not numeric (`Int*`, `UInt*`, `Float*`, `Decimal`, or `Null`-typed) is refused in either
 position before any row is built, with a `ComputeError` naming the column and its dtype; `Decimal` computes
 as its `Float64` cast and a `Null`-typed column as all-null.
-
-Value-keyed methods go through the private `_x` hooks: on polars >= 1.44 the public wrapper
-`propagate_null_and_nan` masks the plugin out of the null and `NaN` rows before it can validate.
-Moments and samplers have no wrapper and go through the public API.
 """
 
 from __future__ import annotations
@@ -100,9 +96,9 @@ _OUT_OF_DOMAIN: tuple[tuple[str, str, float], ...] = (
 )
 
 
-def _value_hooks(dist: _UnivariateDistribution) -> tuple[str, ...]:
-    density = ("_pmf", "_log_pmf") if isinstance(dist, DiscreteDistribution) else ("_pdf", "_log_pdf")
-    return (*density, "_cdf", "_log_cdf", "_sf", "_log_sf", "_ppf", "_isf")
+def _value_keyed_methods(dist: _UnivariateDistribution) -> tuple[str, ...]:
+    density = ("pmf", "log_pmf") if isinstance(dist, DiscreteDistribution) else ("pdf", "log_pdf")
+    return (*density, "cdf", "log_cdf", "sf", "log_sf", "ppf", "isf")
 
 
 def _refusal(frame: pl.DataFrame, expr: pl.Expr) -> str | None:
@@ -118,12 +114,12 @@ _Probes = list[tuple[str, pl.DataFrame, pl.Expr]]
 _Overrides = dict[str, float | None]
 
 
-def _hook_probes(dist: _Dist, overrides: _Overrides, points: tuple[float | None, ...]) -> _Probes:
-    """Every value-keyed hook at every point, as `(label, frame, expr)`."""
+def _value_keyed_probes(dist: _Dist, overrides: _Overrides, points: tuple[float | None, ...]) -> _Probes:
+    """Every value-keyed method at every point, as `(label, frame, expr)`."""
     return [
-        (f"{hook}(x={x})", dist.frame(overrides, x), getattr(dist.dist, hook)(pl.col("x")))
+        (f"{method}(x={x})", dist.frame(overrides, x), getattr(dist.dist, method)(pl.col("x")))
         for x in points
-        for hook in _value_hooks(dist.dist)
+        for method in _value_keyed_methods(dist.dist)
     ]
 
 
@@ -133,10 +129,10 @@ def _sampler_probes(dist: _Dist, overrides: _Overrides) -> _Probes:
 
 
 def _probes(dist: _Dist, overrides: _Overrides, points: tuple[float | None, ...]) -> _Probes:
-    """The hooks at every point, then the moments and both samplers."""
+    """The value-keyed methods at every point, then the moments and both samplers."""
     row = dist.frame(overrides, 0.5)
     moments = [(method, row, getattr(dist.dist, method)()) for method in _MOMENTS]
-    return _hook_probes(dist, overrides, points) + moments + _sampler_probes(dist, overrides)
+    return _value_keyed_probes(dist, overrides, points) + moments + _sampler_probes(dist, overrides)
 
 
 def _unreported(dist: _Dist, overrides: _Overrides, slot: str) -> list[tuple[str, str | None]]:
@@ -197,7 +193,8 @@ def _accepted(column: str, dtype: pl.DataType, probes: _Probes) -> list[tuple[st
     """Every probe that computes, or raises without naming `column`, with `column` recast to `dtype`.
 
     A moment may refuse with polars' own `InvalidOperationError` instead: its closed-form arithmetic (`n * p`
-    on a `String` `p`) meets the column before the plugin does. Hooks and samplers reach the plugin first.
+    on a `String` `p`) meets the column before the plugin does. Value-keyed methods and samplers reach the plugin
+    first.
     """
     fragment = f"'{column}' must be a numeric column"
     refusals = [
@@ -214,8 +211,8 @@ def _accepted(column: str, dtype: pl.DataType, probes: _Probes) -> list[tuple[st
 
 @pytest.mark.parametrize("dtype", _REFUSED_DTYPES, ids=str)
 @pytest.mark.parametrize("dist", _DISTS, ids=lambda dist: dist.name)
-def test_non_numeric_evaluation_point_raises_on_every_hook(dist: _Dist, dtype: pl.DataType) -> None:
-    accepted = _accepted("x", dtype, _hook_probes(dist, {}, (0.5,)))
+def test_non_numeric_evaluation_point_raises_on_every_method(dist: _Dist, dtype: pl.DataType) -> None:
+    accepted = _accepted("x", dtype, _value_keyed_probes(dist, {}, (0.5,)))
     assert not accepted, f"{dist.name} took a {dtype} evaluation point: {accepted}"
 
 
@@ -237,11 +234,12 @@ _COLUMNS = [
 
 
 def _gate_probes(dist: _Dist, column: str) -> _Probes:
-    """The probes where the gate alone stands between `column` and the answer: the hooks, and for a parameter
-    the samplers too. The closed-form moments are polars arithmetic on the parameter itself, so their dtype
+    """The probes where only the gate stands between `column` and the answer.
+
+    The closed-form moments are left out: they are polars arithmetic on the parameter itself, so their dtype
     behaviour is polars' (a missing kernel raises, a bare parameter keeps its dtype), not the gate's.
     """
-    return _hook_probes(dist, {}, (0.5,)) + ([] if column == "x" else _sampler_probes(dist, {}))
+    return _value_keyed_probes(dist, {}, (0.5,)) + ([] if column == "x" else _sampler_probes(dist, {}))
 
 
 @pytest.mark.parametrize(("dist", "column"), _COLUMNS)

--- a/tests/distributions/output_name_test.py
+++ b/tests/distributions/output_name_test.py
@@ -6,9 +6,7 @@ name). With column-valued parameters the output keeps polars root-name semantics
 the first parameter expression, which is what lets multi-column parameters (`pl.col("p1", "p2")`)
 and `.name.*` modifiers work.
 
-Value-keyed methods are named after the evaluation column: `propagate_null_and_nan` re-aliases its
-output to `value`'s resolved name, since its leading `pl.lit(None)` branch would otherwise name
-every value-keyed output `"literal"`.
+Value-keyed methods are named after the evaluation column, the plugin's first input.
 
 The parameter validators follow the same first-parameter rule. Polars resolves a plugin
 expression's output name from its first input, which is why the validator drivers set no name of
@@ -87,15 +85,19 @@ def test_samples_with_column_params_keeps_root_name(dist: _UnivariateDistributio
     assert _FRAME.select(dist.samples(size=3, seed=0)).columns == [root]
 
 
+# The methods every family has; `pdf` / `pmf` are the same plugin shape as `cdf`.
+_VALUE_KEYED_METHODS = ("cdf", "log_cdf", "sf", "log_sf", "ppf", "isf")
+
+
+@pytest.mark.parametrize("method", _VALUE_KEYED_METHODS)
 @pytest.mark.parametrize("dist", _SCALAR_PARAMS.values(), ids=list(_SCALAR_PARAMS))
-def test_value_keyed_keeps_value_root_name(dist: _UnivariateDistribution) -> None:
-    """`cdf(pl.col("p"))` is named `"p"` via the guard's alias.
+def test_value_keyed_keeps_value_root_name(dist: _UnivariateDistribution, method: str) -> None:
+    """`cdf(pl.col("p"))` is named `"p"`.
 
     Only the output name is pinned: how a downstream `.name.*` modifier resolves it is polars'
-    call and differs across supported versions (old polars resolves the *root* name, which for the
-    closed-form hooks is a scalar parameter's `pl.lit`).
+    call and differs across supported versions.
     """
-    assert _FRAME.select(dist.cdf(pl.col("p"))).columns == ["p"]
+    assert _FRAME.select(getattr(dist, method)(pl.col("p"))).columns == ["p"]
 
 
 # Every second parameter carries a different column name from its first, which is what makes these

--- a/tests/distributions/plugin_nan_test.py
+++ b/tests/distributions/plugin_nan_test.py
@@ -1,16 +1,10 @@
-"""The raw value-keyed plugins propagate a `NaN` evaluation point as `NaN`, `ppf` / `isf` included.
+"""Every value-keyed method propagates a `NaN` evaluation point as `NaN`, `ppf` / `isf` included.
 
-The public wrappers overlay `propagate_null_and_nan` (`_base.py`), which rewrites `NaN` rows
-regardless of what the plugins return, so this Rust-level contract is invisible through the public
-API; it is exercised here through the private `_x` hooks, which for the statrs-backed
-distributions are bare plugin calls. The `NaN` short-circuit lives centrally in the shared drivers
-(`value_keyed_scalar` / `value_keyed_per_row` in `src/distributions/mod.rs`) and is load-bearing
-in two places:
+The `NaN` short-circuit lives in the shared drivers (`value_keyed_scalar` / `value_keyed_per_row` in
+`src/distributions/mod.rs`) and is load-bearing in two places:
 
-* `Beta` `cdf` / `sf`: statrs' regularized incomplete beta panics on a `NaN` evaluation point, and
-  polars evaluates every `when`/`then`/`otherwise` branch over the full column, so the plugin runs
-  on `NaN` rows even though the Python guard discards their output there; without the
-  short-circuit the whole query aborts.
+* `Beta` `cdf` / `sf`: statrs' regularized incomplete beta panics on a `NaN` evaluation point, so
+  without the short-circuit the whole query aborts.
 * `Binomial`: `NaN < 0.0` is false and `NaN.floor() as u64` saturates to `0`, so unguarded bodies
   would return a confident `P(X <= 0)` (and a `pmf` of `0.0`).
 
@@ -65,17 +59,17 @@ _CASES = [
 ]
 
 
-def _value_hooks(dist: _UnivariateDistribution) -> tuple[str, ...]:
-    """Every value-keyed `_x` hook of `dist`, density methods named by family."""
-    density = ("_pmf", "_log_pmf") if isinstance(dist, DiscreteDistribution) else ("_pdf", "_log_pdf")
-    return (*density, "_cdf", "_log_cdf", "_sf", "_log_sf", "_ppf", "_isf")
+def _value_keyed_methods(dist: _UnivariateDistribution) -> tuple[str, ...]:
+    """Every value-keyed method of `dist`, density methods named by family."""
+    density = ("pmf", "log_pmf") if isinstance(dist, DiscreteDistribution) else ("pdf", "log_pdf")
+    return (*density, "cdf", "log_cdf", "sf", "log_sf", "ppf", "isf")
 
 
 @pytest.mark.parametrize(("label", "dist"), _CASES, ids=[label for label, _ in _CASES])
-def test_raw_plugin_propagates_nan(label: str, dist: _UnivariateDistribution) -> None:
-    """Each hook yields `NaN` (not null, not a confident constant) for a `NaN` evaluation point."""
+def test_value_keyed_method_propagates_nan(label: str, dist: _UnivariateDistribution) -> None:
+    """Each method yields `NaN` (not null, not a confident constant) for a `NaN` evaluation point."""
     frame = pl.DataFrame({"x": [float("nan")]})
-    for hook in _value_hooks(dist):
-        out = frame.select(r=getattr(dist, hook)(pl.col("x")))["r"]
-        assert out.null_count() == 0, f"{label}.{hook} nulled a NaN evaluation point"
-        assert math.isnan(out.item()), f"{label}.{hook} did not propagate NaN"
+    for method in _value_keyed_methods(dist):
+        out = frame.select(r=getattr(dist, method)(pl.col("x")))["r"]
+        assert out.null_count() == 0, f"{label}.{method} nulled a NaN evaluation point"
+        assert math.isnan(out.item()), f"{label}.{method} did not propagate NaN"

--- a/tests/distributions/validation_contract_test.py
+++ b/tests/distributions/validation_contract_test.py
@@ -1,10 +1,8 @@
-"""Every value-keyed method reports an invalid parameterisation, whichever branch the value selects.
+"""Every value-keyed method reports an invalid parameterisation, whatever the evaluation point holds.
 
-Two axes, one contract. The first test sweeps the *evaluation value* across every branch of every
-method, which holds because every value-keyed method validates inside the Rust plugin that computes
-it. The second holds the value at `NaN` and targets `propagate_null_and_nan` instead, a
-`when/then/otherwise` wrapped around every public value-keyed method: a second place the validator
-can sit inside an arm, one level above the distribution.
+The first test sweeps the *evaluation value* across every branch of every method, which holds because
+every value-keyed method validates inside the Rust plugin that computes it. The other two hold the
+value at `NaN` and at null, the rows a validator inside a `when` arm would never see.
 """
 
 from __future__ import annotations
@@ -26,7 +24,6 @@ from polars_stats import (
     Normal,
     Uniform,
 )
-from tests._polars_compat import ARM_MASKING_HIDES_VALIDATION
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -69,7 +66,7 @@ _CASES: tuple[_Case, ...] = (
     _Case("Uniform", Uniform(min=pl.col("lo"), max=pl.col("hi")), {"lo": [0.0, 5.0], "hi": [1.0, 2.0]}, "max must be"),
 )
 
-_VALUE_METHODS = ("pdf", "log_pdf", "pmf", "log_pmf", "cdf", "log_cdf", "sf", "log_sf")
+_SUPPORT_POINT_METHODS = ("pdf", "log_pdf", "pmf", "log_pmf", "cdf", "log_cdf", "sf", "log_sf")
 """Support-point methods. `pdf` / `pmf` are family-specific, so a missing one is skipped, not failed."""
 
 _QUANTILE_METHODS = ("ppf", "isf")
@@ -81,12 +78,12 @@ _QUANTILES = (-0.5, 0.001, 0.5, 0.999, 1.5)
 """In-range quantiles plus the two out-of-range values, which take the guard branch instead of computing.
 
 A `None` quantile is not probed here. It is not a statement about which branch the value selects, so
-it gets its own test below, alongside the `NaN` point that leaks through the same wrapper.
+it gets its own test below, alongside the `NaN` point.
 """
 
 
 _METHOD_VALUES: tuple[tuple[str, tuple[float, ...]], ...] = (
-    *((method, _SUPPORT_POINTS) for method in _VALUE_METHODS),
+    *((method, _SUPPORT_POINTS) for method in _SUPPORT_POINT_METHODS),
     *((method, _QUANTILES) for method in _QUANTILE_METHODS),
 )
 """Each method paired with the whole value sweep it is contracted to raise on."""
@@ -129,39 +126,32 @@ def test_invalid_parameter_raises_whichever_branch_the_value_selects(
     assert not misnamed, f"{case.name}.{method} raised without naming `{case.fragment}` at {misnamed}"
 
 
-_NAN_METHODS = (*_VALUE_METHODS, *_QUANTILE_METHODS)
-"""Every value-keyed method, since the wrapper below sits on all of them identically."""
+_VALUE_KEYED_METHODS = (*_SUPPORT_POINT_METHODS, *_QUANTILE_METHODS)
+"""All ten; the `NaN` and null points below are probed on every one."""
+
+
+def _unreported_at(case: _Case, point: float | None) -> list[str]:
+    """Every method that computes at `point`, or raises without naming `case.fragment`."""
+    probed = [(method, fn) for method in _VALUE_KEYED_METHODS if (fn := getattr(case.dist, method, None)) is not None]
+    # Eight of the ten always resolve; the other two are the wrong-family `pdf` / `pmf` pair. Asserted
+    # so a renamed method shrinks the sweep loudly instead of silently.
+    assert len(probed) == len(_VALUE_KEYED_METHODS) - 2
+    reports = [(method, _report(case, fn, point)) for method, fn in probed]
+    # Silence and a misnamed message both mean the invalid row went unreported.
+    return [method for method, report in reports if report is None or case.fragment not in report]
 
 
 @pytest.mark.parametrize("case", _CASES, ids=_ids)
-def test_invalid_parameter_raises_at_a_nan_evaluation_point(case: _Case, request: pytest.FixtureRequest) -> None:
+def test_invalid_parameter_raises_at_a_nan_evaluation_point(case: _Case) -> None:
     """One assertion per distribution, over every value-keyed method, at a `NaN` evaluation point.
 
-    The methods are looped inside rather than parametrised over, unlike the test above: leakage there
-    varies by method, so its gate needs method precision, while here all 72 (distribution, method)
-    pairs leak on polars 1.44.1 and all 72 raise on 1.43.2. One item per distribution matches that
-    shape and keeps the gate to one marker instead of seventy-two.
+    Looped, not parametrised: the point is the same for every method, so one item per distribution is
+    the claim.
 
-    The leak is in `propagate_null_and_nan` (`_base.py`), not in any distribution: it spells the
-    null/`NaN` overlay as `when(...).then(...).otherwise(result)`, so from polars 1.44 the plugin in
-    `result` is masked out on exactly the `NaN` rows and never validates. Bypassing the wrapper makes
-    the same call raise, which is why `Bernoulli` and `DiscreteUniform` leak here despite computing
-    entirely in Rust. Porting a distribution does not fix this one; deleting the wrapper does.
+    From polars 1.44 a `when` arm is masked to null on the rows it does not select, so a validator
+    reachable only from inside an arm never sees a `NaN` row; the plugin has to answer that row itself.
     """
-    # Passed as the marker's own condition rather than an `if`, since it is true for every item here:
-    # a Python-level branch would leave its false side unexecuted on polars >= 1.44.
-    reason = "pola-rs/polars#29005, at the wrapper rather than the hook"
-    request.applymarker(pytest.mark.xfail(ARM_MASKING_HIDES_VALIDATION, reason=reason))
-
-    probed = [(method, fn) for method in _NAN_METHODS if (fn := getattr(case.dist, method, None)) is not None]
-    # Eight of the ten always resolve; the other two are the wrong-family `pdf` / `pmf` pair. Asserted
-    # so a renamed method shrinks the sweep loudly instead of silently.
-    assert len(probed) == len(_NAN_METHODS) - 2
-    reports = [(method, _report(case, fn, float("nan"))) for method, fn in probed]
-    # Silence and a misnamed message are merged into one predicate, where the test above keeps them
-    # apart. Every probe here leaks on the gated version, so a second assertion would be a line no
-    # supported polars ever reaches.
-    unreported = [method for method, report in reports if report is None or case.fragment not in report]
+    unreported = _unreported_at(case, float("nan"))
     assert not unreported, f"{case.name} did not report the invalid `{case.fragment}` at a NaN point in {unreported}"
 
 
@@ -171,15 +161,7 @@ def test_invalid_parameter_raises_at_a_null_evaluation_point(case: _Case) -> Non
 
     A null *value* propagates to null, but it never downgrades an invalid parameterisation to one.
     That is what separates it from a null *parameter*, where there is nothing to reject and the row
-    nulls. Every per-row driver validates before it reads the value, so this holds on every supported
-    polars, which is why it needs no gate where the two tests above do.
-
-    Probed through the private hooks: `propagate_null_and_nan` spells the null overlay as the same
-    `when(...).then(...).otherwise(result)` the `NaN` test above indicts, so the public wrappers still
-    mask this from polars 1.44. Deleting the wrapper is what closes that half.
+    nulls. Every per-row driver validates before it reads the value.
     """
-    probed = [(method, fn) for method in _NAN_METHODS if (fn := getattr(case.dist, f"_{method}", None)) is not None]
-    assert len(probed) == len(_NAN_METHODS) - 2
-    reports = [(method, _report(case, fn, None)) for method, fn in probed]
-    unreported = [method for method, report in reports if report is None or case.fragment not in report]
+    unreported = _unreported_at(case, None)
     assert not unreported, f"{case.name} did not report the invalid `{case.fragment}` at a null point in {unreported}"

--- a/tests/property/value_dtype_test.py
+++ b/tests/property/value_dtype_test.py
@@ -1,30 +1,22 @@
-"""Value-keyed methods accept narrow numeric evaluation points; non-numeric dtypes fail fast.
+"""Value-keyed methods accept every numeric evaluation-point dtype; non-numeric dtypes fail fast.
 
-`propagate_null_and_nan` in `_base.py` applies `is_nan` to the coerced value expression as-is,
-with no `Float64` cast. That relies on two polars behaviours, both verified on every supported
-version (1.15.0 through current) and pinned here so a regression in either direction surfaces:
+The public methods hand the coerced value expression to the Rust plugin as-is, with no `Float64` cast
+in Python. The plugin's dtype gate casts every numeric dtype (`Int*`, `UInt*`, `Float*`, `Decimal`) to
+`Float64` and refuses everything else with a `ComputeError`, in both positions. Pinned here so a
+regression in either direction surfaces:
 
-* `is_nan` returns `False` for integer dtypes (an integer can never hold a `NaN`), so an
-  integer-typed value column, or the integer literal a scalar like `cdf(0)` coerces to,
-  flows through the guard and must evaluate exactly as its `Float64`-cast equivalent. The Rust
-  plugins cast the evaluation point to `Float64` internally; the closed-form hooks combine it
-  under polars supertype rules; both are exact for the grids used here.
-* `is_nan` raises `InvalidOperationError` for non-numeric dtypes (`Boolean`, `String`, temporal),
-  so an invalid value column is rejected up front, before any hook or plugin sees it. This is the
-  strict half of the contract: a numeric `String` column must not silently parse through the
-  statrs-backed paths (both a Python-side `cast` and the plugin's internal Rust cast would
-  otherwise accept it).
+* a narrow value column, or the integer literal a scalar like `cdf(0)` coerces to, must evaluate
+  exactly as its `Float64`-cast equivalent; every grid here is exact in every dtype it is cast to.
+* a non-numeric value column (`Boolean`, `String`, temporal, nested) is rejected before any row
+  computes: a numeric `String` column must not silently parse, and a `Boolean` one must not compute
+  as `0` / `1`, which is what polars' own cast would do with both.
 
-Below the guard, Rust refuses every non-numeric dtype with a `ComputeError` in both positions; parameters
-have no Python guard, so that is their whole contract. `Decimal` is numeric to Rust and computes in both.
-
-Whether a dtype reaches either half at all is `tests/plugin_boundary_dtype_test.py`'s question.
+Whether a dtype reaches the plugin at all is `tests/plugin_boundary_dtype_test.py`'s question.
 """
 
 from __future__ import annotations
 
 import math
-from decimal import Decimal
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -41,8 +33,15 @@ if TYPE_CHECKING:
     from polars_stats.distributions._base import _UnivariateDistribution
     from tests.property._specs import DistSpec
 
-_VALUE_DTYPES = (pl.Int64(), pl.UInt32(), pl.Float32(), *available_dtypes("Int128", "UInt128", "Float16"))
-"""`Int64` and `UInt32` cover the contract; `Int128`, `UInt128` and `Float16` each need a polars build feature."""
+_VALUE_DTYPES = (
+    pl.Int64(),
+    pl.UInt32(),
+    pl.Float32(),
+    pl.Decimal(10, 2),
+    *available_dtypes("Int128", "UInt128", "Float16"),
+)
+"""`Int64` and `UInt32` cover the integer contract and `Decimal` is the one numeric dtype that is neither integer nor
+float; `Int128`, `UInt128` and `Float16` each need a polars build feature."""
 
 _MAX_GRID = 16
 
@@ -107,8 +106,8 @@ def test_narrow_value_column_matches_float64(spec: DistSpec, dtype: pl.DataType,
 def test_integer_scalar_value_matches_float_scalar(spec: DistSpec, data: st.DataObject) -> None:
     """`cdf(1)` (coerced by `as_expr` to a length-1 integer literal) equals `cdf(1.0)`.
 
-    One method suffices: the `as_expr` coercion and the `propagate_null_and_nan` guard this scalar
-    routes through are shared by every value-keyed method.
+    One method suffices: the `as_expr` coercion this scalar routes through, and the plugin gate that
+    casts it, are shared by every value-keyed method.
     """
     params = data.draw(spec.params)
     dist = spec.make(params)
@@ -116,10 +115,9 @@ def test_integer_scalar_value_matches_float_scalar(spec: DistSpec, data: st.Data
     assert_series_equal(frame.select(r=dist.cdf(1))["r"], frame.select(r=dist.cdf(1.0))["r"], check_exact=True)
 
 
-_REFUSED_VALUES = (
+_NON_NUMERIC_COLUMNS = (
     pl.Series("x", [True, False]),
     pl.Series("x", ["0.5", "1.0"]),
-    pl.Series("x", [Decimal("0.50"), Decimal("1.00")], dtype=pl.Decimal(10, 2)),
     pl.Series("x", ["a", "b"], dtype=pl.Categorical),
     pl.Series("x", ["a", "b"], dtype=pl.Enum(["a", "b"])),
     pl.Series("x", [{"a": 1}, {"a": 2}], dtype=pl.Struct({"a": pl.Int64})),
@@ -128,7 +126,7 @@ _REFUSED_VALUES = (
     pl.Series("x", [1, 2], dtype=pl.Int64).cast(pl.Duration("us")),
     pl.Series("x", [1, 2], dtype=pl.Int64).cast(pl.Time),
 )
-"""Every dtype the public guard refuses in the value position. `Decimal` is numeric, but `is_nan` has no `NaN` on it."""
+"""Every dtype the Rust gate refuses, in either position, where polars' own cast would compute."""
 
 
 @pytest.mark.parametrize(
@@ -136,56 +134,21 @@ _REFUSED_VALUES = (
     [Normal(mu=0.0, sigma=1.0), Uniform(min=0.0, max=1.0)],
     ids=["normal", "uniform"],
 )
-@pytest.mark.parametrize("series", _REFUSED_VALUES, ids=lambda s: str(s.dtype))
+@pytest.mark.parametrize("series", _NON_NUMERIC_COLUMNS, ids=lambda s: str(s.dtype))
 def test_non_numeric_value_column_raises(dist: _UnivariateDistribution, series: pl.Series) -> None:
-    """A non-numeric value column is rejected up front, plugin-backed or closed-form alike.
-
-    Only the exception type is pinned, not the message: whether the guard's `is_nan` or a hook
-    operation (e.g. `Uniform`'s division on a `String`) resolves first is a polars
-    schema-resolution ordering detail. The contract is that the query errors instead of silently
-    computing (`InvalidOperationError` on every supported polars for both operators).
-    """
-    with pytest.raises(pl.exceptions.InvalidOperationError):
+    """A non-numeric evaluation point is refused before any row computes."""
+    with pytest.raises(pl.exceptions.ComputeError, match="'x' must be a numeric column"):
         series.to_frame().select(dist.cdf(pl.col("x")))
 
 
-_NON_NUMERIC = tuple(series for series in _REFUSED_VALUES if not series.dtype.is_decimal())
-"""Every dtype the Rust gate refuses, in either position, where polars' own cast would compute."""
-
-
-@pytest.mark.parametrize("series", _NON_NUMERIC, ids=lambda s: str(s.dtype))
+@pytest.mark.parametrize("series", _NON_NUMERIC_COLUMNS, ids=lambda s: str(s.dtype))
 @pytest.mark.parametrize("method", ["mean", "sample"], ids=str)
 def test_non_numeric_parameter_column_raises_from_the_plugin(series: pl.Series, method: str) -> None:
-    """A non-numeric *parameter* raises `ComputeError` from Rust: no Python-side guard sees a parameter column."""
+    """A non-numeric *parameter* raises `ComputeError` from Rust, on a moment and on a sampler alike."""
     dist = Normal(mu="mu", sigma=1.0)
     expr = dist.mean() if method == "mean" else dist.sample(seed=0)
     with pytest.raises(pl.exceptions.ComputeError, match="'mu' must be a numeric column"):
         series.rename("mu").to_frame().select(r=expr)
-
-
-@pytest.mark.parametrize(
-    "dist",
-    [Normal(mu=0.0, sigma=1.0), Uniform(min=0.0, max=1.0)],
-    ids=["normal", "uniform"],
-)
-@pytest.mark.parametrize("series", _NON_NUMERIC, ids=lambda s: str(s.dtype))
-def test_non_numeric_value_column_raises_from_the_plugin(dist: _UnivariateDistribution, series: pl.Series) -> None:
-    """Below the public guard, the funnel refuses a non-numeric evaluation point: nothing parses, nothing computes."""
-    with pytest.raises(pl.exceptions.ComputeError, match="'x' must be a numeric column"):
-        series.to_frame().select(dist._cdf(pl.col("x")))
-
-
-@pytest.mark.parametrize(
-    "dist",
-    [Normal(mu=0.0, sigma=1.0), Uniform(min=0.0, max=1.0)],
-    ids=["normal", "uniform"],
-)
-def test_decimal_value_column_computes_through_the_hook(dist: _UnivariateDistribution) -> None:
-    """A `Decimal` evaluation point is numeric to the funnel and evaluates as its `Float64` cast."""
-    frame = pl.Series("x", [Decimal("0.50"), Decimal("0.25"), None], dtype=pl.Decimal(10, 2)).to_frame()
-    narrow = frame.select(r=dist._cdf(pl.col("x")))["r"]
-    wide = frame.select(r=dist._cdf(pl.col("x").cast(pl.Float64())))["r"]
-    assert_series_equal(narrow, wide, check_exact=True)
 
 
 @pytest.mark.parametrize("dtype", [*available_dtypes("Int128", "UInt128", "Float16"), pl.Decimal(10, 2)], ids=str)


### PR DESCRIPTION
Deletes `propagate_null_and_nan` and its ten call sites so every public value-keyed method is coercion plus hook, with the Rust plugin answering the null and NaN rows itself; this closes the polars >= 1.44 arm-masking leak, and an invalid parameter now raises at a null or NaN evaluation point (`xfail` removed). A non-numeric value column now raises `ComputeError` instead of `InvalidOperationError` and a `Decimal` evaluation point computes. Also fixes the base default _sf naming its output "literal" and pins output names across the value-keyed surface.