### PR TITLE
test(distributions): pin the value-name and scalar-point

### DIFF
--- a/tests/distributions/base_defaults_test.py
+++ b/tests/distributions/base_defaults_test.py
@@ -1,3 +1,18 @@
+"""The composing defaults a subclass gets for free, and the two toys that exercise them.
+
+Every shipped distribution overrides `_sf`, `_log_pdf` and `_log_pmf` with a form that keeps precision
+in a tail, so the defaults have no caller in the library. They are still what a new distribution
+inherits until it needs the accurate form.
+
+The toys pin the output-name contract only. Their hooks name their output after the value as a Rust
+plugin does, but of the eight only `_FairCoin._cdf` answers a null or `NaN` point the way a real hook
+must, which is what the `sf`-default test needs. Polars propagates a null through comparison and cast,
+so every hook is right there; it orders `NaN` above every float, so `_UnitUniform._pdf` and
+`_FairCoin._pmf` answer `0.0` on a `NaN` point, `_FairCoin._ppf` / `_isf` answer `1.0` / `0.0`. That
+contract is pinned on all nine real distributions in `null_nan_contract_test.py` and
+`plugin_nan_test.py`.
+"""
+
 from __future__ import annotations
 
 import math
@@ -11,10 +26,6 @@ from polars_stats.distributions._base import ContinuousDistribution, DiscreteDis
 
 if TYPE_CHECKING:
     from polars_stats.distributions._base import _UnivariateDistribution
-
-# Every shipped distribution overrides `_sf`, `_log_pdf` and `_log_pmf` with a form that keeps
-# precision in a tail, so the composing defaults have no caller in the library. They are still what a
-# new distribution inherits until it needs the accurate form.
 
 _MEDIAN_QUANTILE = 0.5
 
@@ -41,7 +52,8 @@ class _UnitUniform(ContinuousDistribution):
         return quantile
 
     def _isf(self, quantile: pl.Expr) -> pl.Expr:
-        return 1 - quantile
+        # `-q + 1`, not `1 - q`: polars names arithmetic after its left operand.
+        return quantile.neg() + 1
 
     def mean(self) -> pl.Expr:
         return pl.lit(0.5)
@@ -170,12 +182,19 @@ def test_the_default_sf_keeps_the_null_and_nan_contract(toy: _Toy) -> None:
     assert math.isnan(got[2])
 
 
-def test_the_defaults_keep_the_hook_output_name(toy: _Toy) -> None:
-    # Polars names arithmetic after its left operand, so a default spelled `1 - hook` would be `"literal"`.
-    # Both toys name their hooks after the value, as the Rust plugins do.
-    frame = pl.DataFrame({"x": toy.grid})
-    for method in ("sf", f"log_{toy.density}", "log_cdf", "log_sf"):
+def test_every_value_keyed_method_keeps_the_value_name(toy: _Toy) -> None:
+    """Defaults and hooks alike name their output after the value column.
+
+    Polars names arithmetic after its *left* operand, so `1 - hook` is named `"literal"`. The base
+    `_sf` did that until the wrapper's `alias` stopped hiding it, and `_isf` here is the same trap one
+    layer down.
+    """
+    frame = pl.DataFrame({"x": toy.grid, "q": [0.25] * len(toy.grid)})
+
+    for method in ("sf", f"log_{toy.density}", "log_cdf", "log_sf", toy.density, "cdf"):
         assert frame.select(getattr(toy.dist, method)(pl.col("x"))).columns == ["x"], method
+    for method in ("ppf", "isf"):
+        assert frame.select(getattr(toy.dist, method)(pl.col("q"))).columns == ["q"], method
 
 
 def test_the_default_log_density_is_the_log_of_the_density(toy: _Toy) -> None:

--- a/tests/distributions/broadcast_test.py
+++ b/tests/distributions/broadcast_test.py
@@ -67,7 +67,7 @@ _needs_partitioned_broadcast = pytest.mark.skipif(
 """Gate for the two partition suites below. The plain-`select` suites run on every supported version."""
 
 
-def _call(spec: DistSpec, dist: _UnivariateDistribution, method: str, value: pl.Expr | None) -> pl.Expr:
+def _call(spec: DistSpec, dist: _UnivariateDistribution, method: str, value: pl.Expr | float | None) -> pl.Expr:
     """One public method by name: a value-keyed call on `value`, or a seeded draw when `value` is `None`."""
     if value is None:
         return dist.sample(seed=0) if method == "sample" else dist.samples(size=3, seed=0)
@@ -80,7 +80,7 @@ def _call(spec: DistSpec, dist: _UnivariateDistribution, method: str, value: pl.
             return dist.log_pmf(value)
         msg = f"unsupported distribution family: {type(dist)}"  # pragma: no cover
         raise TypeError(msg)  # pragma: no cover
-    call: Callable[[pl.Expr], pl.Expr] = getattr(dist, method)
+    call: Callable[[pl.Expr | float], pl.Expr] = getattr(dist, method)
     return call(value)
 
 
@@ -138,6 +138,25 @@ def test_length_one_value_broadcasts(spec: DistSpec, method: str, column: str) -
         _call(spec, dist, method, pl.repeat(scalar, n=pl.len())),
         height=_ROWS,
     )
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+@pytest.mark.parametrize(("method", "column"), _VALUE_METHODS)
+def test_a_scalar_point_broadcasts_to_the_frame_height(spec: DistSpec, method: str, column: str) -> None:
+    """A Python scalar point with all-scalar parameters is full height under `with_columns`, as `Float64`.
+
+    Nothing else in this file reaches that shape: every other case keeps one full-length input, so the
+    height comes from that input rather than from polars broadcasting a wholly length-1 expression.
+    Under `select` the same expression is one row, which is `pl.lit`'s own semantics.
+    """
+    frame = _FRAMES[spec.name]
+    dist = spec.make_literals(spec.example)
+    point = float(frame[column][0])
+
+    widened = frame.with_columns(r=_call(spec, dist, method, point))["r"]
+    assert widened.len() == _ROWS, f"{method} collapsed a scalar point to {widened.len()} rows"
+    assert widened.dtype == pl.Float64, f"{method} returned {widened.dtype}"
+    assert frame.select(r=_call(spec, dist, method, point)).height == 1
 
 
 @pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)

--- a/tests/property/_specs.py
+++ b/tests/property/_specs.py
@@ -86,8 +86,8 @@ class DistSpec:
         make_series: Like `make_columns`, but every parameter is a `SERIES_ROWS`-long `pl.Series` literal, so
             the parameters outrun the frame and set the call's row count.
         example: One valid parameterisation, for tests that need a fixed frame rather than a sweep.
-        density: `pdf` or `pmf` as `(dist, expr) -> expr`. Typed loosely because the method differs by family;
-            the concrete distribution is fixed per spec.
+        density: `pdf` or `pmf` as `(dist, value) -> expr`, `value` an expression or a scalar. Typed
+            loosely because the method differs by family; the concrete distribution is fixed per spec.
         eval_range: `(lo, hi)` finite window for evaluating cdf / density on a grid.
         integration_bounds: `(lo, hi)` over which the pdf integrates to ~1 (continuous only);
             the normal is truncated to a wide multiple of `std`. `None` for discrete.
@@ -103,7 +103,7 @@ class DistSpec:
     make_literals: Callable[[tuple[float, ...]], _UnivariateDistribution]
     make_series: Callable[[tuple[float, ...]], _UnivariateDistribution]
     example: tuple[float, ...]
-    density: Callable[[Any, pl.Expr], pl.Expr]
+    density: Callable[[Any, pl.Expr | float], pl.Expr]
     eval_range: Callable[[tuple[float, ...]], tuple[float, float]]
     integration_bounds: Callable[[tuple[float, ...]], tuple[float, float]] | None = None
     support: Callable[[tuple[float, ...]], list[float]] | None = None


### PR DESCRIPTION
`_UnitUniform._isf` was `1 - quantile`, so it named its output "literal" rather than after the value column: the same defect the review of #88 fixed in the base `_sf`, still live in the fixture that exists to demonstrate the rule. Nothing caught it, because the name test covered only the four composing defaults.