### PR TITLE
perf(distributions): stop treating a length-1 parameter as a column

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -126,7 +126,9 @@ code rather than halfway through, write the scipy-parity test first, and keep a 
 
     * **`align_inputs(inputs)?` first, before any cast**, for any plugin with more than one input. Polars broadcasts
       nothing into a plugin and `try_*_elementwise` truncates to its shortest input, so skipping it silently drops
-      every row past the first. `tests/distributions/broadcast_test.py` catches a missed one.
+      every row past the first. `tests/distributions/broadcast_test.py` catches a missed one. The value-keyed drivers
+      in `mod.rs` are the one exception, and you get it by routing through them rather than by writing it: when
+      *every* parameter is length 1 they cast and check those length-1 columns and skip the expansion entirely.
     * **`is_elementwise=True`**, which the shared `register_plugin` shim fixes for you. An aggregating plugin would
       break `over` and `group_by`, so it is a guard rather than a default.
     * **Null in, null out.** The `try_*_elementwise` drivers give you that; a raw `.into_iter()` over chunks does not,
@@ -185,9 +187,11 @@ code rather than halfway through, write the scipy-parity test first, and keep a 
           is a column.
         * A one-parameter distribution pairs those two through `value_keyed_derived_per_row` and
           `value_keyed_derived_scalar` in `src/distributions/mod.rs`. A two-parameter one takes
-          `value_keyed_derived_pair_per_row` beside them, and keeps its constant-parameter twin local
-          (`UniformParamsKwargs::value_keyed`) until a second distribution needs it; both plugin shells are still one
-          line and neither names a driver internal. They are not `value_keyed_per_row`, which builds a `statrs`
+          `value_keyed_derived_pair_per_row` and `value_keyed_derived_pair_scalar` instead; both plugin shells are
+          still one line and neither names a driver internal. The `_pair_scalar` twin validates nothing, because a
+          pair's rule is the distribution's own `check_params` rather than a `ParamDomain`, so its caller owes it a
+          checked `(a, b)`: `constant_pair` for a length-1 parameterisation, `<Name>ParamsKwargs`' own check for
+          kwargs. They are not `value_keyed_per_row`, which builds a `statrs`
           distribution per row: `derive` takes plain `f64`s and hoists the parameter-only terms out of the loop.
           Every driver nulls a row on any null parameter, before it reads the evaluation point.
     * State each parameter's domain once as a `ParamDomain` constant (`ParamDomain::finite("mu")`,

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -127,8 +127,8 @@ code rather than halfway through, write the scipy-parity test first, and keep a 
     * **`align_inputs(inputs)?` first, before any cast**, for any plugin with more than one input. Polars broadcasts
       nothing into a plugin and `try_*_elementwise` truncates to its shortest input, so skipping it silently drops
       every row past the first. `tests/distributions/broadcast_test.py` catches a missed one. The value-keyed drivers
-      in `mod.rs` are the one exception, and you get it by routing through them rather than by writing it: when
-      *every* parameter is length 1 they cast and check those length-1 columns and skip the expansion entirely.
+      in `mod.rs` skip it when *every* parameter is length 1: they check the constant once and never expand it. Route
+      through them rather than writing that branch yourself.
     * **`is_elementwise=True`**, which the shared `register_plugin` shim fixes for you. An aggregating plugin would
       break `over` and `group_by`, so it is a guard rather than a default.
     * **Null in, null out.** The `try_*_elementwise` drivers give you that; a raw `.into_iter()` over chunks does not,
@@ -186,14 +186,14 @@ code rather than halfway through, write the scipy-parity test first, and keep a 
           up to 195% at 10M rows. `derive` runs once per call on the constant path and once per row when a parameter
           is a column.
         * A one-parameter distribution pairs those two through `value_keyed_derived_per_row` and
-          `value_keyed_derived_scalar` in `src/distributions/mod.rs`. A two-parameter one takes
-          `value_keyed_derived_pair_per_row` and `value_keyed_derived_pair_scalar` instead; both plugin shells are
-          still one line and neither names a driver internal. The `_pair_scalar` twin validates nothing, because a
-          pair's rule is the distribution's own `check_params` rather than a `ParamDomain`, so its caller owes it a
-          checked `(a, b)`: `constant_pair` for a length-1 parameterisation, `<Name>ParamsKwargs`' own check for
-          kwargs. They are not `value_keyed_per_row`, which builds a `statrs`
-          distribution per row: `derive` takes plain `f64`s and hoists the parameter-only terms out of the loop.
-          Every driver nulls a row on any null parameter, before it reads the evaluation point.
+          `value_keyed_derived_scalar` in `src/distributions/mod.rs`; a two-parameter one takes
+          `value_keyed_derived_pair_per_row` and `value_keyed_derived_pair_scalar`. Both plugin shells are still one
+          line and neither names a driver internal. The `_scalar` twins derive and map only; their caller owns the
+          check (`<Name>ParamsKwargs::value_keyed` for kwargs, the driver's column pass for a length-1
+          parameterisation), and both call the twin rather than spelling its two lines, so the two spellings run one
+          instantiation and cannot drift in output or in machine code. They are not `value_keyed_per_row`, which
+          builds a `statrs` distribution per row: `derive` takes plain `f64`s and hoists the parameter-only terms out
+          of the loop. Every driver nulls a row on any null parameter, before it reads the evaluation point.
     * State each parameter's domain once as a `ParamDomain` constant (`ParamDomain::finite("mu")`,
       `ParamDomain::positive("sigma")`, `ParamDomain::probability("p")`, or a literal for any other rule) and a joint
       constraint as a `PairDomain`. Every column-parameter plugin runs `check_column` / `check_columns` over its

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -50,7 +50,8 @@ parameters like Binomial's `n`). The accepted inputs and their coercions are tab
 A scalar becomes `pl.lit(value)`, a length-1 scalar column, and Rust owns row-alignment: polars broadcasts nothing
 into a plugin, so `align_inputs` broadcasts every length-1 input up to the call's row count before any cast. It
 aligns by *length*, not by expression kind, so a user-written `.first()` or `.max()` parameter is handled like a
-literal.
+literal. The value-keyed drivers take one shortcut ahead of that. When *every* parameter is length 1 they validate and
+build it once and never expand it, so a `pl.lit` or an aggregate parameter costs what a Python scalar does.
 
 An expression whose inputs are *all* constant is therefore a scalar column, so `df.select(Normal(0.0, 1.0).mean())`
 is one row; any column-valued input sets the length instead. See

--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -120,6 +120,14 @@ It is the same "constant parameters take a fast path" idea as the sampler, appli
 and the raise contract is unchanged (pinned by `moment_test.py` and the `*_scalar` validation tests). For a constant,
 "per row" and "once" are the same check.
 
+The value-keyed methods do the same, and they reach it by *length* rather than by expression kind. A Python scalar
+rides in `kwargs`, but `pl.lit(0.3)` and `pl.col("x").min()` arrive as ordinary length-1 inputs whose length polars
+only knows once the aggregate has run. When every parameter is length 1 the driver casts and checks those length-1
+columns, builds once, and maps the method body over the value column, so the parameters are never expanded to full
+height and never re-validated per row. The one observable consequence is on a 0-row frame, where the check now runs
+with no row to observe it; see
+[Parameters and contracts](../reference/parameters-and-contracts.md#nulls-nans-and-errors).
+
 ### `samples` draws each row's array in one native call
 
 `sample_iter` was rejected for the multi-draw loop body: it advances a single stream in row order, which couples rows

--- a/docs/explanation/design.md
+++ b/docs/explanation/design.md
@@ -124,9 +124,8 @@ The value-keyed methods do the same, and they reach it by *length* rather than b
 rides in `kwargs`, but `pl.lit(0.3)` and `pl.col("x").min()` arrive as ordinary length-1 inputs whose length polars
 only knows once the aggregate has run. When every parameter is length 1 the driver casts and checks those length-1
 columns, builds once, and maps the method body over the value column, so the parameters are never expanded to full
-height and never re-validated per row. The one observable consequence is on a 0-row frame, where the check now runs
-with no row to observe it; see
-[Parameters and contracts](../reference/parameters-and-contracts.md#nulls-nans-and-errors).
+height and never re-validated per row. What that changes for the caller (a 0-row frame, and which of two simultaneous
+errors is reported) is in [Parameters and contracts](../reference/parameters-and-contracts.md#nulls-nans-and-errors).
 
 ### `samples` draws each row's array in one native call
 

--- a/docs/reference/parameters-and-contracts.md
+++ b/docs/reference/parameters-and-contracts.md
@@ -169,7 +169,8 @@ a length-1 expression (`pl.lit(5.0)`, `pl.col("x").min()`) are one parameterisat
 any row is read, so `Uniform(5.0, 2.0)` and `Uniform(pl.lit(5.0), pl.lit(2.0))` both raise on an empty frame. A
 parameter column is validated over its values, and an empty column has none, so `Uniform(pl.col("lo"), pl.col("hi"))`
 returns an empty result instead. This applies to a value the strict cast refuses (`Binomial(n=pl.lit(-5))`) as much as
-to one outside its domain.
+to one outside its domain. The same once-per-call check runs before the value column's dtype gate, so when both are
+invalid a constant parameterisation reports the parameter and a parameter column reports the value column.
 
 Every distribution shipped today has finite moments on its valid parameter range, so this contract is exhaustive for
 them. The policy for distributions whose moments can be undefined is in

--- a/docs/reference/parameters-and-contracts.md
+++ b/docs/reference/parameters-and-contracts.md
@@ -148,6 +148,7 @@ parameter outranks a `NaN` evaluation point. "Present" means non-null.
 | Wrong parameter *type* (a `list`, an `int` for a float parameter, a `bool`) | Python `__init__` | `TypeError`, no query runs |
 | Non-numeric column in either position (`Boolean`, `String`, `Categorical`, `Enum`, `Struct`, `Object`, temporal) | Rust evaluation | `ComputeError` naming the column and its dtype, no row computes; polars' `InvalidOperationError` where a closed-form moment's arithmetic meets a parameter column first (see [Accepted inputs](#accepted-inputs)) |
 | Invalid *present* parameter value: outside its domain, `NaN`, `+inf` or `-inf`, as a scalar or on any column row | Rust evaluation | `ComputeError`, fails the whole evaluation, never silently nulls, whatever else is on the row: a null sibling parameter, a null or `NaN` evaluation point |
+| The same, on a **0-row** frame | Rust evaluation | A *constant* parameterisation still raises; a parameter *column* returns an empty result (see below) |
 | `null` parameter on a row | per row | `null` on that row, on every method and at every evaluation point, `NaN` and off-support included (see below) |
 | `null` value or quantile argument on a row | per row | `null` on that row |
 | `NaN` value or quantile argument on a row | per row | `NaN` on that row, `ppf` / `isf` included (matches scipy) |
@@ -162,6 +163,13 @@ parameter outranks a `NaN` evaluation point. "Present" means non-null.
 per bound for `Uniform`, whose two bounds might otherwise have settled the answer between them: on a row whose `min`
 is null and whose `max` is `1.0`, `pdf(5.0)` and `cdf(5.0)` are both `null`, as is every method at `0.5`. Both
 inverses null at every quantile under either null bound, in range and out.
+
+**On a 0-row frame, a constant parameterisation is still checked and a parameter column is not.** A Python scalar and
+a length-1 expression (`pl.lit(5.0)`, `pl.col("x").min()`) are one parameterisation, validated once per call before
+any row is read, so `Uniform(5.0, 2.0)` and `Uniform(pl.lit(5.0), pl.lit(2.0))` both raise on an empty frame. A
+parameter column is validated over its values, and an empty column has none, so `Uniform(pl.col("lo"), pl.col("hi"))`
+returns an empty result instead. This applies to a value the strict cast refuses (`Binomial(n=pl.lit(-5))`) as much as
+to one outside its domain.
 
 Every distribution shipped today has finite moments on its valid parameter range, so this contract is exhaustive for
 them. The policy for distributions whose moments can be undefined is in

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -32,15 +32,15 @@ impl BernoulliParamsKwargs {
         build_dist(self.p)
     }
 
-    /// Binds the constant parameter and its domain into [`value_keyed_derived_scalar`], which
-    /// validates and derives once per call rather than per row.
+    /// Validates once per call, then derives and maps through [`value_keyed_derived_scalar`].
     fn value_keyed<Branches>(
         &self,
         value: &Series,
         derive: impl Fn(f64) -> Branches,
         select: impl Fn(&Branches, f64) -> Option<f64>,
     ) -> PolarsResult<Series> {
-        value_keyed_derived_scalar(value, self.p, &P, derive, select)
+        P.check(self.p)?;
+        value_keyed_derived_scalar(value, self.p, derive, select)
     }
 }
 

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -77,13 +77,7 @@ fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
 where
     F: Fn(&Beta, f64) -> Option<f64>,
 {
-    let inputs = align_inputs(inputs)?;
-    let value = coerce_f64(&inputs[0])?;
-    let a = coerce_f64(&inputs[1])?;
-    let b = coerce_f64(&inputs[2])?;
-    check_params(&a, &b)?;
-
-    value_keyed_per_row(&value, &a, &b, inputs[0].name().clone(), build_dist, f)
+    value_keyed_per_row(inputs, coerce_f64, coerce_f64, check_params, build_dist, f)
 }
 
 /// Apply a parameter-keyed moment `f(dist)` element-wise over `(a, b)`.

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -137,13 +137,14 @@ fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
 where
     F: Fn(&Binomial, f64) -> Option<f64>,
 {
-    let inputs = align_inputs(inputs)?;
-    let value = coerce_f64(&inputs[0])?;
-    let n = coerce_n(&inputs[1])?;
-    let p = coerce_f64(&inputs[2])?;
-    P.check_column(&p)?;
-
-    value_keyed_per_row(&value, &n, &p, inputs[0].name().clone(), build_dist, f)
+    value_keyed_per_row(
+        inputs,
+        coerce_n,
+        coerce_f64,
+        |_, p| P.check_column(p),
+        build_dist,
+        f,
+    )
 }
 
 /// Apply a parameter-keyed moment `f(dist)` element-wise over `(n, p)`.

--- a/src/distributions/discrete_uniform.rs
+++ b/src/distributions/discrete_uniform.rs
@@ -5,7 +5,8 @@ use rand::distr::Distribution;
 use statrs::distribution::DiscreteUniform;
 
 use crate::distributions::{
-    align_inputs, coerce_f64, constant_pair, value_keyed_per_row, value_keyed_scalar, PairDomain,
+    align_inputs, coerce_f64, params_are_constant, value_keyed_per_row, value_keyed_scalar,
+    PairDomain,
 };
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_i64_output, samples_per_row,
@@ -29,9 +30,7 @@ fn build_dist(min: i64, max: i64) -> PolarsResult<DiscreteUniform> {
     DiscreteUniform::new(min, max).map_err(|e| polars_err!(ComputeError: "{e}"))
 }
 
-/// [`BOUNDS`]'s column pass as a `fn` item, which is what the drivers take. A method cannot be
-/// passed as one.
-fn check_bounds(min: &Int64Chunked, max: &Int64Chunked) -> PolarsResult<()> {
+fn check_params(min: &Int64Chunked, max: &Int64Chunked) -> PolarsResult<()> {
     BOUNDS.check_columns(min, max)
 }
 
@@ -75,7 +74,6 @@ impl DiscreteUniformParamsKwargs {
         build_dist(self.min, self.max)
     }
 
-    /// Binds the constant bounds into [`du_value_keyed_scalar`].
     fn value_keyed<F>(&self, value: &Series, f: F) -> PolarsResult<Series>
     where
         F: Fn(&Support, Point) -> Option<f64>,
@@ -334,23 +332,27 @@ fn coerce_points(value: &Series) -> PolarsResult<Points> {
 }
 
 /// Apply a closed-form `f(support, point)` element-wise over `(value, min, max)`; shared by the
-/// six value-keyed plugins with an integer-exact path. Null and `NaN` contracts follow
-/// [`value_keyed_per_row`]: a null bound nulls the row without building, an invalid
+/// six value-keyed plugins with an integer-exact path. Null, `NaN` and constant-parameter contracts
+/// follow [`value_keyed_per_row`]: a null bound nulls the row without building, an invalid
 /// parameterisation raises from [`BOUNDS`]'s column pass whatever the row's point is, and constant
-/// bounds ([`constant_pair`]) take [`du_value_keyed_scalar`] after the same pass.
+/// bounds take [`du_value_keyed_scalar`] after the same pass.
 fn du_value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
 where
     F: Fn(&Support, Point) -> Option<f64>,
 {
-    if let Some((min, max)) = constant_pair(inputs, coerce_bound, coerce_bound, check_bounds)? {
-        return du_value_keyed_scalar(&inputs[0], min, max, f);
+    if params_are_constant(inputs) {
+        let (min, max) = (coerce_bound(&inputs[1])?, coerce_bound(&inputs[2])?);
+        check_params(&min, &max)?;
+        if let Some((min, max)) = min.get(0).zip(max.get(0)) {
+            return du_value_keyed_scalar(&inputs[0], min, max, f);
+        }
     }
 
     let inputs = align_inputs(inputs)?;
     let name = inputs[0].name().clone();
     let min = coerce_bound(&inputs[1])?;
     let max = coerce_bound(&inputs[2])?;
-    check_bounds(&min, &max)?;
+    check_params(&min, &max)?;
 
     let ca: Float64Chunked = match coerce_points(&inputs[0])? {
         Points::Float(v) => try_ternary_elementwise(&v, &min, &max, |v, lo, hi| {
@@ -436,7 +438,7 @@ fn discreteuniform_ppf(inputs: &[Series]) -> PolarsResult<Series> {
         inputs,
         coerce_bound,
         coerce_bound,
-        check_bounds,
+        check_params,
         build_support,
         ppf_value,
     )
@@ -449,7 +451,7 @@ fn discreteuniform_isf(inputs: &[Series]) -> PolarsResult<Series> {
         inputs,
         coerce_bound,
         coerce_bound,
-        check_bounds,
+        check_params,
         build_support,
         isf_value,
     )

--- a/src/distributions/discrete_uniform.rs
+++ b/src/distributions/discrete_uniform.rs
@@ -5,7 +5,7 @@ use rand::distr::Distribution;
 use statrs::distribution::DiscreteUniform;
 
 use crate::distributions::{
-    align_inputs, coerce_f64, value_keyed_per_row, value_keyed_scalar, PairDomain,
+    align_inputs, coerce_f64, constant_pair, value_keyed_per_row, value_keyed_scalar, PairDomain,
 };
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_i64_output, samples_per_row,
@@ -27,6 +27,12 @@ const BOUNDS: PairDomain<i64> = PairDomain {
 fn build_dist(min: i64, max: i64) -> PolarsResult<DiscreteUniform> {
     BOUNDS.check(min, max)?;
     DiscreteUniform::new(min, max).map_err(|e| polars_err!(ComputeError: "{e}"))
+}
+
+/// [`BOUNDS`]'s column pass as a `fn` item, which is what the drivers take. A method cannot be
+/// passed as one.
+fn check_bounds(min: &Int64Chunked, max: &Int64Chunked) -> PolarsResult<()> {
+    BOUNDS.check_columns(min, max)
 }
 
 /// Widen a bound column to the `Int64` both distribution types take.
@@ -69,34 +75,42 @@ impl DiscreteUniformParamsKwargs {
         build_dist(self.min, self.max)
     }
 
-    /// Constant-parameter twin of the per-row [`du_value_keyed`], sharing its `<method>_point`
-    /// bodies: validate and size the support once per call, then map `f` over the evaluation-point
-    /// column in its own arithmetic (see [`coerce_points`]).
+    /// Binds the constant bounds into [`du_value_keyed_scalar`].
     fn value_keyed<F>(&self, value: &Series, f: F) -> PolarsResult<Series>
     where
         F: Fn(&Support, Point) -> Option<f64>,
     {
-        let support = build_support(self.min, self.max)?;
-        let name = value.name().clone();
-        let ca: Float64Chunked = match coerce_points(value)? {
-            Points::Float(v) => unary_elementwise(&v, |opt| {
-                opt.and_then(|v| {
-                    if v.is_nan() {
-                        Some(f64::NAN)
-                    } else {
-                        f(&support, Point::Float(v))
-                    }
-                })
-            }),
-            Points::Int(v) => unary_elementwise(&v, |opt| {
-                opt.and_then(|v| f(&support, Point::Int(v.into())))
-            }),
-            Points::Wide(v) => unary_elementwise(&v, |opt| {
-                opt.and_then(|v| f(&support, Point::Int(v.into())))
-            }),
-        };
-        Ok(ca.with_name(name).into_series())
+        du_value_keyed_scalar(value, self.min, self.max, f)
     }
+}
+
+/// Constant-bounds twin of the per-row [`du_value_keyed`], sharing its `<method>_point` bodies:
+/// validate and size the support once per call, then map `f` over the evaluation-point column in
+/// its own arithmetic (see [`coerce_points`]).
+fn du_value_keyed_scalar<F>(value: &Series, min: i64, max: i64, f: F) -> PolarsResult<Series>
+where
+    F: Fn(&Support, Point) -> Option<f64>,
+{
+    let support = build_support(min, max)?;
+    let name = value.name().clone();
+    let ca: Float64Chunked = match coerce_points(value)? {
+        Points::Float(v) => unary_elementwise(&v, |opt| {
+            opt.and_then(|v| {
+                if v.is_nan() {
+                    Some(f64::NAN)
+                } else {
+                    f(&support, Point::Float(v))
+                }
+            })
+        }),
+        Points::Int(v) => unary_elementwise(&v, |opt| {
+            opt.and_then(|v| f(&support, Point::Int(v.into())))
+        }),
+        Points::Wide(v) => unary_elementwise(&v, |opt| {
+            opt.and_then(|v| f(&support, Point::Int(v.into())))
+        }),
+    };
+    Ok(ca.with_name(name).into_series())
 }
 
 /// The validated support, with the count precomputed: the state every closed-form body reads.
@@ -321,17 +335,22 @@ fn coerce_points(value: &Series) -> PolarsResult<Points> {
 
 /// Apply a closed-form `f(support, point)` element-wise over `(value, min, max)`; shared by the
 /// six value-keyed plugins with an integer-exact path. Null and `NaN` contracts follow
-/// [`value_keyed_per_row`]: a null bound nulls the row without building, and an invalid
-/// parameterisation raises from [`BOUNDS`]'s column pass whatever the row's point is.
+/// [`value_keyed_per_row`]: a null bound nulls the row without building, an invalid
+/// parameterisation raises from [`BOUNDS`]'s column pass whatever the row's point is, and constant
+/// bounds ([`constant_pair`]) take [`du_value_keyed_scalar`] after the same pass.
 fn du_value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
 where
     F: Fn(&Support, Point) -> Option<f64>,
 {
+    if let Some((min, max)) = constant_pair(inputs, coerce_bound, coerce_bound, check_bounds)? {
+        return du_value_keyed_scalar(&inputs[0], min, max, f);
+    }
+
     let inputs = align_inputs(inputs)?;
     let name = inputs[0].name().clone();
     let min = coerce_bound(&inputs[1])?;
     let max = coerce_bound(&inputs[2])?;
-    BOUNDS.check_columns(&min, &max)?;
+    check_bounds(&min, &max)?;
 
     let ca: Float64Chunked = match coerce_points(&inputs[0])? {
         Points::Float(v) => try_ternary_elementwise(&v, &min, &max, |v, lo, hi| {
@@ -413,16 +432,11 @@ fn discreteuniform_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
 /// See [`ppf_value`] for the correction and endpoint contract.
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_ppf(inputs: &[Series]) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let value = coerce_f64(&inputs[0])?;
-    let min = coerce_bound(&inputs[1])?;
-    let max = coerce_bound(&inputs[2])?;
-    BOUNDS.check_columns(&min, &max)?;
     value_keyed_per_row(
-        &value,
-        &min,
-        &max,
-        inputs[0].name().clone(),
+        inputs,
+        coerce_bound,
+        coerce_bound,
+        check_bounds,
         build_support,
         ppf_value,
     )
@@ -431,16 +445,11 @@ fn discreteuniform_ppf(inputs: &[Series]) -> PolarsResult<Series> {
 /// Element-wise inverse survival function; see [`isf_value`] for the two-sided correction.
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let value = coerce_f64(&inputs[0])?;
-    let min = coerce_bound(&inputs[1])?;
-    let max = coerce_bound(&inputs[2])?;
-    BOUNDS.check_columns(&min, &max)?;
     value_keyed_per_row(
-        &value,
-        &min,
-        &max,
-        inputs[0].name().clone(),
+        inputs,
+        coerce_bound,
+        coerce_bound,
+        check_bounds,
         build_support,
         isf_value,
     )

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -33,15 +33,15 @@ impl ExponentialParamsKwargs {
         build_dist(self.rate)
     }
 
-    /// Binds the constant rate and its domain into [`value_keyed_derived_scalar`], which
-    /// validates and derives once per call rather than per row.
+    /// Validates once per call, then derives and maps through [`value_keyed_derived_scalar`].
     fn value_keyed<Branches>(
         &self,
         value: &Series,
         derive: impl Fn(f64) -> Branches,
         select: impl Fn(&Branches, f64) -> Option<f64>,
     ) -> PolarsResult<Series> {
-        value_keyed_derived_scalar(value, self.rate, &RATE, derive, select)
+        RATE.check(self.rate)?;
+        value_keyed_derived_scalar(value, self.rate, derive, select)
     }
 }
 

--- a/src/distributions/geometric.rs
+++ b/src/distributions/geometric.rs
@@ -50,15 +50,15 @@ impl GeometricParamsKwargs {
         build_sampler(self.p)
     }
 
-    /// Binds the constant `p` and its domain into [`value_keyed_derived_scalar`], which validates
-    /// and derives once per call rather than per row.
+    /// Validates once per call, then derives and maps through [`value_keyed_derived_scalar`].
     fn value_keyed<Branches>(
         &self,
         value: &Series,
         derive: impl Fn(f64) -> Branches,
         select: impl Fn(&Branches, f64) -> Option<f64>,
     ) -> PolarsResult<Series> {
-        value_keyed_derived_scalar(value, self.p, &P, derive, select)
+        P.check(self.p)?;
+        value_keyed_derived_scalar(value, self.p, derive, select)
     }
 }
 

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -71,13 +71,7 @@ fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
 where
     F: Fn(&LogNormal, f64) -> Option<f64>,
 {
-    let inputs = align_inputs(inputs)?;
-    let value = coerce_f64(&inputs[0])?;
-    let mu = coerce_f64(&inputs[1])?;
-    let sigma = coerce_f64(&inputs[2])?;
-    check_params(&mu, &sigma)?;
-
-    value_keyed_per_row(&value, &mu, &sigma, inputs[0].name().clone(), build_dist, f)
+    value_keyed_per_row(inputs, coerce_f64, coerce_f64, check_params, build_dist, f)
 }
 
 /// `sigma` where both of `(mu, sigma)` are present, null elsewhere, after [`check_params`].

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -60,6 +60,46 @@ pub(crate) fn align_inputs(inputs: &[Series]) -> PolarsResult<Cow<'_, [Series]>>
     ))
 }
 
+/// Whether every parameter (every input after the evaluation point) arrived as a length-1 Series: a
+/// `pl.lit`, or an aggregate whose length polars only knows once it has run.
+///
+/// One length-1 parameter beside a column is *not* constant. It still aligns, so a column that fits
+/// neither the frame nor its sibling is still reported by [`align_inputs`].
+fn constant_params(inputs: &[Series]) -> bool {
+    inputs[1..].iter().all(|param| param.len() == 1)
+}
+
+/// The one parameterisation a two-parameter call carries, or `None` when the row loop must run.
+///
+/// `None` means either that a parameter is a column, or that a length-1 parameter is null and has no
+/// value to build from; both fall through to the caller's row loop, which nulls every row and keeps
+/// the evaluation point's own dtype gate.
+///
+/// Coercing and checking here rather than after [`align_inputs`] is what makes a constant
+/// parameterisation raise once per call, before any row is read and even on a zero-row frame. The
+/// check runs *before* the null test so the four drivers cannot drift on that ordering again.
+pub(crate) fn constant_pair<A, B, CoerceP1, CoerceP2, Check>(
+    inputs: &[Series],
+    coerce_p1: CoerceP1,
+    coerce_p2: CoerceP2,
+    check: Check,
+) -> PolarsResult<Option<(A::Native, B::Native)>>
+where
+    A: PolarsNumericType,
+    B: PolarsNumericType,
+    CoerceP1: Fn(&Series) -> PolarsResult<ChunkedArray<A>>,
+    CoerceP2: Fn(&Series) -> PolarsResult<ChunkedArray<B>>,
+    Check: Fn(&ChunkedArray<A>, &ChunkedArray<B>) -> PolarsResult<()>,
+{
+    if !constant_params(inputs) {
+        return Ok(None);
+    }
+    let p1 = coerce_p1(&inputs[1])?;
+    let p2 = coerce_p2(&inputs[2])?;
+    check(&p1, &p2)?;
+    Ok(p1.get(0).zip(p2.get(0)))
+}
+
 /// The dtype gate every evaluation point and float parameter passes: `Int*`, `UInt*`, `Float*` and
 /// `Decimal` cast to `Float64`, a `Null`-typed column to all-null, anything else raises `ComputeError`
 /// naming the input. Polars' own cast would read `Boolean` as `0` / `1`, parse `String` and take a
@@ -165,7 +205,9 @@ impl<N: Copy + std::fmt::Display> PairDomain<N> {
 /// distribution parameter is a Python scalar, the caller validates them and builds the
 /// distribution **once**, and only the evaluation-point column crosses FFI. This maps `f` over
 /// that single column, where `f` is the same per-method body the per-row path uses, so the two
-/// paths cannot drift and output is bit-identical.
+/// paths cannot drift and output is bit-identical. The per-row drivers hand off here as well when
+/// every parameter arrives as a length-1 Series, so a `pl.lit` or an aggregate parameter costs what
+/// a Python scalar does.
 ///
 /// Null contract: `value` is the only nullable input this driver sees; a null `value` propagates,
 /// and `f` returning `None` nulls the row on the method's own terms (`ppf` outside `[0, 1]`).
@@ -210,6 +252,27 @@ where
     value_keyed_scalar(value, |v| select(&branches, v))
 }
 
+/// Constant-parameter twin of [`value_keyed_derived_pair_per_row`], over [`value_keyed_scalar`].
+///
+/// Derives once per call, so the parameter-only terms `derive` hoists (`Uniform`'s `1 / range`,
+/// `-ln(range)`) are computed once instead of per row. Unlike [`value_keyed_derived_scalar`] it
+/// validates nothing: a pair's rule is the distribution's own `check_params`, not a [`ParamDomain`],
+/// so `(a, b)` must already have passed it (via [`constant_pair`] or a kwargs struct's own check).
+pub(crate) fn value_keyed_derived_pair_scalar<Branches, Derive, Select>(
+    value: &Series,
+    a: f64,
+    b: f64,
+    derive: Derive,
+    select: Select,
+) -> PolarsResult<Series>
+where
+    Derive: Fn(f64, f64) -> Branches,
+    Select: Fn(&Branches, f64) -> Option<f64>,
+{
+    let branches = derive(a, b);
+    value_keyed_scalar(value, |v| select(&branches, v))
+}
+
 /// Shared driver for the column-parameter value-keyed per-row paths.
 ///
 /// The column-parameter counterpart of [`value_keyed_scalar`]: at least one distribution parameter
@@ -217,38 +280,56 @@ where
 /// per-method body the fast path applies (`cdf_value`, `ppf_value`, ...), so the two paths cannot
 /// drift and agree bit for bit.
 ///
-/// The caller passes each parameter through its own coercer (`coerce_f64`, `coerce_n`,
+/// `coerce_p1` and `coerce_p2` are each parameter's own coercer (`coerce_f64`, `coerce_n`,
 /// `coerce_bound`), which fixes `A` and `B`, so a mixed `(u64, f64)` parameterisation (Binomial's
 /// `UInt64` `n` beside its `Float64` `p`) fits, as in
 /// [`ternary_param_rows`](crate::rng::ternary_param_rows). `S` needs no trait bound: it is whatever
 /// `build` returns.
 ///
-/// The caller has run the parameter columns through their [`ParamDomain`]s, so `build` cannot fail
-/// here; it stays `PolarsResult` because the `statrs` constructors are.
+/// `check_params` is the caller's pass over the two parameter columns, run once before any row is
+/// built, so `build` cannot fail here; it stays `PolarsResult` because the `statrs` constructors are.
+///
+/// A constant parameterisation ([`constant_pair`]) builds once and hands the value column to
+/// [`value_keyed_scalar`], expanding nothing.
 ///
 /// Null contract: any null among `(value, p1, p2)` nulls the row without calling `build`, matching
 /// the samplers. `NaN` contract: as in [`value_keyed_scalar`].
 ///
 /// Keep `build` and `f` generic `Fn`s: they monomorphise into the row loop, where a `&dyn Fn` or a
 /// `fn` pointer would cost an indirect call per row.
-pub(crate) fn value_keyed_per_row<A, B, S, Build, F>(
-    value: &Float64Chunked,
-    p1: &ChunkedArray<A>,
-    p2: &ChunkedArray<B>,
-    name: PlSmallStr,
+pub(crate) fn value_keyed_per_row<A, B, S, CoerceP1, CoerceP2, CheckParams, Build, F>(
+    inputs: &[Series],
+    coerce_p1: CoerceP1,
+    coerce_p2: CoerceP2,
+    check_params: CheckParams,
     build: Build,
     f: F,
 ) -> PolarsResult<Series>
 where
     A: PolarsNumericType,
     B: PolarsNumericType,
+    CoerceP1: Fn(&Series) -> PolarsResult<ChunkedArray<A>>,
+    CoerceP2: Fn(&Series) -> PolarsResult<ChunkedArray<B>>,
+    CheckParams: Fn(&ChunkedArray<A>, &ChunkedArray<B>) -> PolarsResult<()>,
     Build: Fn(A::Native, B::Native) -> PolarsResult<S>,
     F: Fn(&S, f64) -> Option<f64>,
 {
+    if let Some((p1, p2)) = constant_pair(inputs, &coerce_p1, &coerce_p2, &check_params)? {
+        let dist = build(p1, p2)?;
+        return value_keyed_scalar(&inputs[0], |v| f(&dist, v));
+    }
+
+    let inputs = align_inputs(inputs)?;
+    let value = coerce_f64(&inputs[0])?;
+    let p1 = coerce_p1(&inputs[1])?;
+    let p2 = coerce_p2(&inputs[2])?;
+    let name = inputs[0].name().clone();
+    check_params(&p1, &p2)?;
+
     let ca: Float64Chunked = try_ternary_elementwise(
-        value,
-        p1,
-        p2,
+        &value,
+        &p1,
+        &p2,
         |value_opt, p1_opt, p2_opt| -> PolarsResult<Option<f64>> {
             let (Some(value), Some(p1), Some(p2)) = (value_opt, p1_opt, p2_opt) else {
                 return Ok(None);
@@ -274,6 +355,9 @@ where
 /// `domain`'s column pass runs once before any row is built, so nothing inside the row loop
 /// validates.
 ///
+/// A length-1 parameter takes [`value_keyed_derived_scalar`] instead, checked and derived once and
+/// never expanded. A null one falls through to the row loop, which nulls every row.
+///
 /// Null contract: a null parameter nulls the row before the evaluation point is read; then a null
 /// value nulls it. `select` returning `None` nulls it on the method's own terms (`ppf` outside
 /// `[0, 1]`).
@@ -292,6 +376,12 @@ where
     Derive: Fn(f64) -> Branches,
     Select: Fn(&Branches, f64) -> Option<f64>,
 {
+    if constant_params(inputs) {
+        if let Some(param) = coerce_f64(&inputs[1])?.get(0) {
+            return value_keyed_derived_scalar(&inputs[0], param, domain, derive, select);
+        }
+    }
+
     let inputs = align_inputs(inputs)?;
     let value = coerce_f64(&inputs[0])?;
     let param = coerce_f64(&inputs[1])?;
@@ -377,7 +467,8 @@ pub(crate) fn on_unit_interval<Arm: Fn(f64) -> f64>(arm: &Arm, quantile: f64) ->
 ///
 /// `check_params` is the caller's column pass over the two parameter columns, each alone and the
 /// pair together, run once before any row is built. Null and `NaN` contracts as in
-/// [`value_keyed_derived_per_row`]: a null in either parameter nulls the row.
+/// [`value_keyed_derived_per_row`]: a null in either parameter nulls the row, and a constant
+/// parameterisation ([`constant_pair`]) takes [`value_keyed_derived_pair_scalar`] after the same check.
 pub(crate) fn value_keyed_derived_pair_per_row<Branches, CheckParams, Derive, Select>(
     inputs: &[Series],
     check_params: CheckParams,
@@ -389,6 +480,10 @@ where
     Derive: Fn(f64, f64) -> Branches,
     Select: Fn(&Branches, f64) -> Option<f64>,
 {
+    if let Some((a, b)) = constant_pair(inputs, coerce_f64, coerce_f64, &check_params)? {
+        return value_keyed_derived_pair_scalar(&inputs[0], a, b, derive, select);
+    }
+
     let inputs = align_inputs(inputs)?;
     let value = coerce_f64(&inputs[0])?;
     let param_a = coerce_f64(&inputs[1])?;

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -60,44 +60,11 @@ pub(crate) fn align_inputs(inputs: &[Series]) -> PolarsResult<Cow<'_, [Series]>>
     ))
 }
 
-/// Whether every parameter (every input after the evaluation point) arrived as a length-1 Series: a
-/// `pl.lit`, or an aggregate whose length polars only knows once it has run.
-///
-/// One length-1 parameter beside a column is *not* constant. It still aligns, so a column that fits
-/// neither the frame nor its sibling is still reported by [`align_inputs`].
-fn constant_params(inputs: &[Series]) -> bool {
+/// Every parameter (every input after the evaluation point) is a length-1 Series: a `pl.lit`, or an
+/// aggregate whose length polars only knows once it has run. One length-1 parameter beside a column
+/// is not constant; it still aligns, so a mismatched column is still reported by [`align_inputs`].
+pub(crate) fn params_are_constant(inputs: &[Series]) -> bool {
     inputs[1..].iter().all(|param| param.len() == 1)
-}
-
-/// The one parameterisation a two-parameter call carries, or `None` when the row loop must run.
-///
-/// `None` means either that a parameter is a column, or that a length-1 parameter is null and has no
-/// value to build from; both fall through to the caller's row loop, which nulls every row and keeps
-/// the evaluation point's own dtype gate.
-///
-/// Coercing and checking here rather than after [`align_inputs`] is what makes a constant
-/// parameterisation raise once per call, before any row is read and even on a zero-row frame. The
-/// check runs *before* the null test so the four drivers cannot drift on that ordering again.
-pub(crate) fn constant_pair<A, B, CoerceP1, CoerceP2, Check>(
-    inputs: &[Series],
-    coerce_p1: CoerceP1,
-    coerce_p2: CoerceP2,
-    check: Check,
-) -> PolarsResult<Option<(A::Native, B::Native)>>
-where
-    A: PolarsNumericType,
-    B: PolarsNumericType,
-    CoerceP1: Fn(&Series) -> PolarsResult<ChunkedArray<A>>,
-    CoerceP2: Fn(&Series) -> PolarsResult<ChunkedArray<B>>,
-    Check: Fn(&ChunkedArray<A>, &ChunkedArray<B>) -> PolarsResult<()>,
-{
-    if !constant_params(inputs) {
-        return Ok(None);
-    }
-    let p1 = coerce_p1(&inputs[1])?;
-    let p2 = coerce_p2(&inputs[2])?;
-    check(&p1, &p2)?;
-    Ok(p1.get(0).zip(p2.get(0)))
 }
 
 /// The dtype gate every evaluation point and float parameter passes: `Int*`, `UInt*`, `Float*` and
@@ -201,13 +168,11 @@ impl<N: Copy + std::fmt::Display> PairDomain<N> {
 
 /// Shared driver for the constant-parameter value-keyed fast paths.
 ///
-/// The constant-parameter counterpart of each distribution's `value_keyed` helper: when every
-/// distribution parameter is a Python scalar, the caller validates them and builds the
-/// distribution **once**, and only the evaluation-point column crosses FFI. This maps `f` over
-/// that single column, where `f` is the same per-method body the per-row path uses, so the two
-/// paths cannot drift and output is bit-identical. The per-row drivers hand off here as well when
-/// every parameter arrives as a length-1 Series, so a `pl.lit` or an aggregate parameter costs what
-/// a Python scalar does.
+/// The constant-parameter counterpart of each distribution's `value_keyed` helper: the parameters are
+/// Python scalars in kwargs, or every one is a length-1 Series ([`params_are_constant`]), so the
+/// caller validates them and builds the distribution **once** and this maps `f` over the
+/// evaluation-point column. `f` is the same per-method body the per-row path uses, so the two paths
+/// cannot drift and output is bit-identical.
 ///
 /// Null contract: `value` is the only nullable input this driver sees; a null `value` propagates,
 /// and `f` returning `None` nulls the row on the method's own terms (`ppf` outside `[0, 1]`).
@@ -231,15 +196,16 @@ where
     Ok(ca.with_name(name).into_series())
 }
 
-/// Constant-parameter twin of [`value_keyed_derived_per_row`], over [`value_keyed_scalar`].
+/// Constant-parameter twin of [`value_keyed_derived_per_row`], over [`value_keyed_scalar`]: derives
+/// once per call, so the parameter-only terms `derive` hoists (`Bernoulli`'s `1 - p`, `Exponential`'s
+/// `ln(rate)`) are computed once instead of per row. The caller has already checked `param`.
 ///
-/// Checks the parameter against `domain` and derives once per call, then maps `select` over the
-/// evaluation-point column, so the parameter-only terms `derive` hoists (`Bernoulli`'s `1 - p`,
-/// `Exponential`'s `ln(rate)`) are computed once instead of per row.
+/// The kwargs plugins and the driver's length-1 branch both call this rather than spelling the two
+/// lines themselves, so the two spellings share one instantiation: same output bit for bit, and the
+/// same machine code (separate copies of the closure measured 7% apart on one method, 28% on another).
 pub(crate) fn value_keyed_derived_scalar<Branches, Derive, Select>(
     value: &Series,
     param: f64,
-    domain: &ParamDomain,
     derive: Derive,
     select: Select,
 ) -> PolarsResult<Series>
@@ -247,17 +213,12 @@ where
     Derive: Fn(f64) -> Branches,
     Select: Fn(&Branches, f64) -> Option<f64>,
 {
-    domain.check(param)?;
     let branches = derive(param);
     value_keyed_scalar(value, |v| select(&branches, v))
 }
 
-/// Constant-parameter twin of [`value_keyed_derived_pair_per_row`], over [`value_keyed_scalar`].
-///
-/// Derives once per call, so the parameter-only terms `derive` hoists (`Uniform`'s `1 / range`,
-/// `-ln(range)`) are computed once instead of per row. Unlike [`value_keyed_derived_scalar`] it
-/// validates nothing: a pair's rule is the distribution's own `check_params`, not a [`ParamDomain`],
-/// so `(a, b)` must already have passed it (via [`constant_pair`] or a kwargs struct's own check).
+/// Two-parameter sibling of [`value_keyed_derived_scalar`], shared by the same two spellings for the
+/// same reason. The caller has already checked `(a, b)`.
 pub(crate) fn value_keyed_derived_pair_scalar<Branches, Derive, Select>(
     value: &Series,
     a: f64,
@@ -289,8 +250,9 @@ where
 /// `check_params` is the caller's pass over the two parameter columns, run once before any row is
 /// built, so `build` cannot fail here; it stays `PolarsResult` because the `statrs` constructors are.
 ///
-/// A constant parameterisation ([`constant_pair`]) builds once and hands the value column to
-/// [`value_keyed_scalar`], expanding nothing.
+/// Constant parameters ([`params_are_constant`]) are checked and built once, before any row is read
+/// and even on a 0-row frame, and the value column takes [`value_keyed_scalar`]. A null constant
+/// falls through to the row loop, which nulls every row and keeps the value column's dtype gate.
 ///
 /// Null contract: any null among `(value, p1, p2)` nulls the row without calling `build`, matching
 /// the samplers. `NaN` contract: as in [`value_keyed_scalar`].
@@ -314,9 +276,13 @@ where
     Build: Fn(A::Native, B::Native) -> PolarsResult<S>,
     F: Fn(&S, f64) -> Option<f64>,
 {
-    if let Some((p1, p2)) = constant_pair(inputs, &coerce_p1, &coerce_p2, &check_params)? {
-        let dist = build(p1, p2)?;
-        return value_keyed_scalar(&inputs[0], |v| f(&dist, v));
+    if params_are_constant(inputs) {
+        let (p1, p2) = (coerce_p1(&inputs[1])?, coerce_p2(&inputs[2])?);
+        check_params(&p1, &p2)?;
+        if let Some((p1, p2)) = p1.get(0).zip(p2.get(0)) {
+            let dist = build(p1, p2)?;
+            return value_keyed_scalar(&inputs[0], |v| f(&dist, v));
+        }
     }
 
     let inputs = align_inputs(inputs)?;
@@ -355,8 +321,8 @@ where
 /// `domain`'s column pass runs once before any row is built, so nothing inside the row loop
 /// validates.
 ///
-/// A length-1 parameter takes [`value_keyed_derived_scalar`] instead, checked and derived once and
-/// never expanded. A null one falls through to the row loop, which nulls every row.
+/// A constant parameter ([`params_are_constant`]) is checked and derived once, as in
+/// [`value_keyed_per_row`]; a null one falls through to the row loop, which nulls every row.
 ///
 /// Null contract: a null parameter nulls the row before the evaluation point is read; then a null
 /// value nulls it. `select` returning `None` nulls it on the method's own terms (`ppf` outside
@@ -376,9 +342,11 @@ where
     Derive: Fn(f64) -> Branches,
     Select: Fn(&Branches, f64) -> Option<f64>,
 {
-    if constant_params(inputs) {
-        if let Some(param) = coerce_f64(&inputs[1])?.get(0) {
-            return value_keyed_derived_scalar(&inputs[0], param, domain, derive, select);
+    if params_are_constant(inputs) {
+        let param = coerce_f64(&inputs[1])?;
+        domain.check_column(&param)?;
+        if let Some(param) = param.get(0) {
+            return value_keyed_derived_scalar(&inputs[0], param, derive, select);
         }
     }
 
@@ -466,9 +434,8 @@ pub(crate) fn on_unit_interval<Arm: Fn(f64) -> f64>(arm: &Arm, quantile: f64) ->
 /// three `Series`.
 ///
 /// `check_params` is the caller's column pass over the two parameter columns, each alone and the
-/// pair together, run once before any row is built. Null and `NaN` contracts as in
-/// [`value_keyed_derived_per_row`]: a null in either parameter nulls the row, and a constant
-/// parameterisation ([`constant_pair`]) takes [`value_keyed_derived_pair_scalar`] after the same check.
+/// pair together, run once before any row is built. Null, `NaN` and constant-parameter contracts as
+/// in [`value_keyed_derived_per_row`]; a null in either parameter nulls the row.
 pub(crate) fn value_keyed_derived_pair_per_row<Branches, CheckParams, Derive, Select>(
     inputs: &[Series],
     check_params: CheckParams,
@@ -480,8 +447,12 @@ where
     Derive: Fn(f64, f64) -> Branches,
     Select: Fn(&Branches, f64) -> Option<f64>,
 {
-    if let Some((a, b)) = constant_pair(inputs, coerce_f64, coerce_f64, &check_params)? {
-        return value_keyed_derived_pair_scalar(&inputs[0], a, b, derive, select);
+    if params_are_constant(inputs) {
+        let (a, b) = (coerce_f64(&inputs[1])?, coerce_f64(&inputs[2])?);
+        check_params(&a, &b)?;
+        if let Some((a, b)) = a.get(0).zip(b.get(0)) {
+            return value_keyed_derived_pair_scalar(&inputs[0], a, b, derive, select);
+        }
     }
 
     let inputs = align_inputs(inputs)?;

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -83,13 +83,7 @@ fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
 where
     F: Fn(&Normal, f64) -> Option<f64>,
 {
-    let inputs = align_inputs(inputs)?;
-    let value = coerce_f64(&inputs[0])?;
-    let mu = coerce_f64(&inputs[1])?;
-    let sigma = coerce_f64(&inputs[2])?;
-    check_params(&mu, &sigma)?;
-
-    value_keyed_per_row(&value, &mu, &sigma, inputs[0].name().clone(), build_dist, f)
+    value_keyed_per_row(inputs, coerce_f64, coerce_f64, check_params, build_dist, f)
 }
 
 /// One Normal draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -45,8 +45,7 @@ struct UniformParamsKwargs {
 }
 
 impl UniformParamsKwargs {
-    /// Binds the kwargs bounds into [`value_keyed_derived_pair_scalar`] behind [`checked_bounds`],
-    /// which is that driver's required check.
+    /// Validates once per call, then derives and maps through [`value_keyed_derived_pair_scalar`].
     fn value_keyed<Branches>(
         &self,
         value: &Series,

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -5,7 +5,7 @@ use rand::distr::{Distribution, StandardUniform};
 
 use crate::distributions::{
     align_inputs, coerce_f64, on_unit_interval, value_keyed_derived_pair_per_row,
-    value_keyed_scalar, PairDomain, ParamDomain,
+    value_keyed_derived_pair_scalar, PairDomain, ParamDomain,
 };
 use crate::rng::{
     sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
@@ -45,9 +45,8 @@ struct UniformParamsKwargs {
 }
 
 impl UniformParamsKwargs {
-    /// Constant-bounds twin of [`value_keyed_derived_pair_per_row`]: validates and derives once per
-    /// call, then maps `select` over the evaluation-point column, so the bound-only terms `derive`
-    /// hoists (`1 / range`, `-ln(range)`) are computed once instead of per row.
+    /// Binds the kwargs bounds into [`value_keyed_derived_pair_scalar`] behind [`checked_bounds`],
+    /// which is that driver's required check.
     fn value_keyed<Branches>(
         &self,
         value: &Series,
@@ -55,8 +54,7 @@ impl UniformParamsKwargs {
         select: impl Fn(&Branches, f64) -> Option<f64>,
     ) -> PolarsResult<Series> {
         checked_bounds(self.min, self.max)?;
-        let branches = derive(self.min, self.max);
-        value_keyed_scalar(value, |v| select(&branches, v))
+        value_keyed_derived_pair_scalar(value, self.min, self.max, derive, select)
     }
 }
 

--- a/tests/distributions/broadcast_test.py
+++ b/tests/distributions/broadcast_test.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pytest
 
-from polars_stats import Binomial, Normal
+from polars_stats import Binomial, DiscreteUniform, Exponential, Normal, Uniform
 from polars_stats.distributions._base import ContinuousDistribution, DiscreteDistribution
 from tests._polars_compat import (
     PARTITIONED_BROADCAST_AVAILABLE,
@@ -222,6 +222,47 @@ def test_reduced_value_expressions_broadcast(reducer: str) -> None:
     )
 
 
+_REDUCED_PARAMETERS: dict[str, tuple[_UnivariateDistribution, _UnivariateDistribution]] = {
+    "normal": (
+        Normal(mu=pl.col("lo").first(), sigma=pl.col("hi").max()),
+        Normal(mu=pl.repeat(1.0, n=pl.len()), sigma=pl.repeat(6.0, n=pl.len())),
+    ),
+    "exponential": (Exponential(rate=pl.col("hi").max()), Exponential(rate=pl.repeat(6.0, n=pl.len()))),
+    "uniform": (
+        Uniform(min=pl.col("lo").first(), max=pl.col("hi").max()),
+        Uniform(min=pl.repeat(1.0, n=pl.len()), max=pl.repeat(6.0, n=pl.len())),
+    ),
+    "discreteuniform": (
+        DiscreteUniform(min=pl.col("n_lo").min(), max=pl.col("n_hi").max()),
+        DiscreteUniform(min=pl.repeat(0, n=pl.len(), dtype=pl.Int64), max=pl.repeat(7, n=pl.len(), dtype=pl.Int64)),
+    ),
+}
+"""One distribution per Rust driver: parameters reduced from a column, beside the same constants at full length."""
+
+
+@pytest.mark.parametrize(("reduced", "full_length"), _REDUCED_PARAMETERS.values(), ids=list(_REDUCED_PARAMETERS))
+def test_reduced_parameter_expressions_broadcast(
+    reduced: _UnivariateDistribution, full_length: _UnivariateDistribution
+) -> None:
+    """A parameter reduced from a column is length 1 only once it has run, and is handled like a literal.
+
+    On a 0-row frame the reduction is null, so the call is a null constant and the result stays empty.
+    """
+    frame = pl.DataFrame(
+        {
+            "x": [0.5, 1.0, 2.0, 3.0],
+            "lo": [1.0, 2.0, 0.5, 1.5],
+            "hi": [4.0, 6.0, 5.0, 4.5],
+            "n_lo": [1, 2, 0, 1],
+            "n_hi": [6, 7, 5, 6],
+        }
+    )
+    x = pl.col("x")
+
+    _assert_same_rows(frame, reduced.cdf(x), full_length.cdf(x), height=frame.height, exact=True)
+    assert frame.head(0).select(r=reduced.cdf(x)).height == 0
+
+
 @pytest.mark.parametrize("moment", ["mean", "variance", "std", "median", "entropy"])
 def test_length_one_parameter_beside_a_column_moment(moment: str) -> None:
     """A length-1 parameter beside a full-length one gives a full-length moment.
@@ -327,12 +368,9 @@ def test_multi_chunk_frame_broadcasts() -> None:
     ],
 )
 def test_broadcast_n_still_rejects_a_bad_dtype(n: pl.Expr, message: str) -> None:
-    """A length-1 `n` beside a column `p` is the mixed shape, so alignment runs *before* the cast and
-    `coerce_n` judges the expanded column, still rejecting it.
+    """A length-1 `n` beside a column `p` aligns before the cast, so `coerce_n` judges the expanded column.
 
-    `n` is the one parameter whose cast can reject, so it is the one place the order is observable. An
-    *all*-length-1 call casts first instead, pinned by
-    `value_keyed_fast_path_test.py::test_a_constant_the_cast_rejects_also_raises_on_an_empty_frame`.
+    `n` is the one parameter whose cast can reject, so it is the one place the order is observable.
     """
     frame = pl.DataFrame({"x": [0.0, 1.0, 2.0, 3.0], "p": [0.5] * 4})
 

--- a/tests/distributions/broadcast_test.py
+++ b/tests/distributions/broadcast_test.py
@@ -327,9 +327,12 @@ def test_multi_chunk_frame_broadcasts() -> None:
     ],
 )
 def test_broadcast_n_still_rejects_a_bad_dtype(n: pl.Expr, message: str) -> None:
-    """Alignment runs *before* the cast, so `coerce_n` judges the expanded column and still rejects it.
+    """A length-1 `n` beside a column `p` is the mixed shape, so alignment runs *before* the cast and
+    `coerce_n` judges the expanded column, still rejecting it.
 
-    `n` is the one parameter whose cast can reject, so it is the one place the order is observable.
+    `n` is the one parameter whose cast can reject, so it is the one place the order is observable. An
+    *all*-length-1 call casts first instead, pinned by
+    `value_keyed_fast_path_test.py::test_a_constant_the_cast_rejects_also_raises_on_an_empty_frame`.
     """
     frame = pl.DataFrame({"x": [0.0, 1.0, 2.0, 3.0], "p": [0.5] * 4})
 

--- a/tests/distributions/value_keyed_fast_path_test.py
+++ b/tests/distributions/value_keyed_fast_path_test.py
@@ -13,10 +13,12 @@ routing are pinned here, both of which the bit-equality property test
   must produce identical output. A non-finite parameter is invalid by the library's own check,
   whether or not `statrs` would accept it. The fast path cannot quietly accept or reject something
   the per-row path does not.
-* **The fast path validates up front.** The scalar check runs once before any value is touched, so
-  invalid scalar parameters raise even on a zero-row frame; the per-row path's column pass sees no
-  value on an empty frame, so it returns empty. This divergence is intentional (validate-once,
-  mirroring the sampler fast path) and pinned so it cannot regress silently.
+* **Constants validate up front, columns validate value by value.** A Python scalar rides in kwargs
+  and a length-1 expression (`pl.lit`, an aggregate) arrives as a length-1 input. Both are one
+  parameterisation, checked once before any value is read, so an invalid one raises even on a
+  zero-row frame, whether a domain or the strict cast rejects it. A parameter *column* is checked
+  over its values, and an empty column has none, so it returns empty. Only an all-length-1 call takes
+  that branch; one constant beside a column still aligns, and a mismatched column is still reported.
 
 A Python `None` parameter cannot reach either path: `coerce_param` rejects it as a `TypeError` at construction, covered
 by each distribution's `construct_test.py`. So there is no "null scalar parameter" case to test here, and none for
@@ -138,18 +140,130 @@ def test_scalar_and_column_paths_agree_on_validation(
         assert_series_equal(fast, per_row, check_exact=True)
 
 
-def test_scalar_fast_path_validates_on_empty_input() -> None:
-    """The fast path raises on invalid scalar params even with no rows; the per-row path returns empty.
+_INT = pl.Int64()
 
-    The scalar check runs once up front on the fast path, so an invalid scale is caught regardless
-    of input length. The per-row path's column pass sees no value on a zero-row frame, so it
-    produces an empty result instead. Pinned because it is the one intended observable difference
-    between the two paths.
+# One invalid parameterisation per Rust driver, spelled three ways: Python scalar, length-1 literal,
+# full-length column. id -> (scalar, literal, column, message fragment)
+_INVALID_PER_DRIVER: dict[
+    str, tuple[_UnivariateDistribution, _UnivariateDistribution, _UnivariateDistribution, str]
+] = {
+    "exponential rate=-1": (Exponential(-1.0), Exponential(pl.lit(-1.0)), Exponential(_col(-1.0)), "rate must be"),
+    "uniform max<min": (
+        Uniform(5.0, 2.0),
+        Uniform(pl.lit(5.0), pl.lit(2.0)),
+        Uniform(_col(5.0), _col(2.0)),
+        "max must be",
+    ),
+    "normal std=-1": (
+        Normal(0.0, -1.0),
+        Normal(pl.lit(0.0), pl.lit(-1.0)),
+        Normal(_col(0.0), _col(-1.0)),
+        "sigma must be",
+    ),
+    "discreteuniform min>max": (
+        DiscreteUniform(6, 1),
+        DiscreteUniform(pl.lit(6, dtype=_INT), pl.lit(1, dtype=_INT)),
+        DiscreteUniform(_col(6, _INT), _col(1, _INT)),
+        "max must be",
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    ("scalar", "literal", "column", "fragment"), _INVALID_PER_DRIVER.values(), ids=list(_INVALID_PER_DRIVER)
+)
+def test_constant_parameters_validate_on_empty_input(
+    scalar: _UnivariateDistribution, literal: _UnivariateDistribution, column: _UnivariateDistribution, fragment: str
+) -> None:
+    """A constant parameterisation raises when invalid even with no rows to observe it; an empty column returns empty.
+
+    Python scalars and length-1 literals are both constants, checked once per call before any value is
+    read. A parameter column is checked value by value, and a zero-row column has none.
     """
     empty = pl.DataFrame({"x": []}, schema={"x": pl.Float64})
 
-    with pytest.raises(pl.exceptions.ComputeError, match="sigma must be finite and strictly positive"):
-        empty.select(r=Normal(0.0, -1.0).pdf(pl.col("x")))
+    for constant in (scalar, literal):
+        with pytest.raises(pl.exceptions.ComputeError, match=fragment):
+            empty.select(r=_density(constant, pl.col("x")))
 
-    per_row = empty.select(r=Normal(_col(0.0), _col(-1.0)).pdf(pl.col("x")))
-    assert per_row.height == 0
+    assert empty.select(r=_density(column, pl.col("x"))).height == 0
+
+
+def test_a_constant_the_cast_rejects_also_raises_on_an_empty_frame() -> None:
+    """The zero-row change reaches cast rejections, not only parameter domains.
+
+    `n = -5` never gets as far as a domain check: `coerce_n`'s strict `Int64 -> UInt64` cast refuses it,
+    and on the length-1 path that cast now runs before any row. A negative Python-scalar `n` has no
+    spelling here, `coerce_n` rejects it as a `ValueError` at construction.
+    """
+    empty = pl.DataFrame({"x": []}, schema={"x": pl.Float64})
+
+    with pytest.raises(pl.exceptions.PolarsError, match="n must be a non-negative integer"):
+        empty.select(r=Binomial(n=pl.lit(-5, dtype=_INT), p=pl.lit(0.5)).pmf(pl.col("x")))
+
+    assert empty.select(r=Binomial(n=_col(-5, _INT), p=_col(0.5)).pmf(pl.col("x"))).height == 0
+
+
+@pytest.mark.parametrize(
+    "dist",
+    [
+        Exponential(pl.lit(None, dtype=pl.Float64)),
+        Uniform(pl.lit(None, dtype=pl.Float64), pl.lit(1.0)),
+        Normal(pl.lit(0.0), pl.lit(None, dtype=pl.Float64)),
+        DiscreteUniform(pl.lit(None, dtype=_INT), pl.lit(6, dtype=_INT)),
+    ],
+    ids=["exponential", "uniform", "normal", "discreteuniform"],
+)
+def test_a_null_constant_parameter_nulls_every_row(dist: _UnivariateDistribution) -> None:
+    """A null length-1 parameter is one parameterisation with nothing to build from.
+
+    Each driver declines it and falls back to the row loop rather than raising, so every row is null,
+    as it is for a null parameter column. One case per driver.
+    """
+    frame = pl.DataFrame({"x": [0.5, 1.0, 2.0]})
+
+    result = frame.select(r=_density(dist, pl.col("x")))["r"]
+
+    assert result.len() == frame.height
+    assert result.null_count() == frame.height
+
+
+def test_a_null_constant_parameter_still_gates_the_value_dtype() -> None:
+    """Declining the fast path must not skip the evaluation point's dtype gate.
+
+    The row loop the null falls back to coerces the value column, so a `String` one is still refused.
+    Short-circuiting a null parameterisation straight to all-nulls would lose that.
+    """
+    strings = pl.DataFrame({"x": ["a", "b"]})
+
+    with pytest.raises(pl.exceptions.ComputeError, match="must be a numeric column"):
+        strings.select(r=Normal(pl.lit(0.0), pl.lit(None, dtype=pl.Float64)).pdf(pl.col("x")))
+
+
+@pytest.mark.parametrize("dtype", [pl.Int64, pl.UInt64, pl.Int32])
+def test_discreteuniform_integer_points_agree_across_bound_spellings(dtype: pl.DataType) -> None:
+    """The fast path keeps DiscreteUniform's integer-exact point dispatch.
+
+    `du_value_keyed_scalar` re-dispatches on the value dtype, so its `Int` and `Wide` arms are reached
+    only from an integer value column. `UInt64` is the only dtype that reaches the `Wide` arm.
+    """
+    frame = pl.DataFrame({"x": [0, 1, 3, 6, 7]}, schema={"x": dtype})
+    expected = frame.select(r=DiscreteUniform(1, 6).pmf(pl.col("x")))["r"]
+
+    literal = DiscreteUniform(pl.lit(1, dtype=_INT), pl.lit(6, dtype=_INT))
+    column = DiscreteUniform(_col(1, _INT), _col(6, _INT))
+    for dist in (literal, column):
+        assert_series_equal(frame.select(r=dist.pmf(pl.col("x")))["r"], expected, check_exact=True)
+
+
+def test_one_constant_beside_a_mismatched_column_still_raises() -> None:
+    """One length-1 parameter does not make the call constant; the other is still aligned, and reported.
+
+    Which layer reports the mismatch moves with the polars version, as in
+    `broadcast_test.py::test_mismatched_lengths_raise`, so the message is matched loosely.
+    """
+    frame = pl.DataFrame({"x": [0.0, 1.0, 2.0, 3.0]})
+    mismatched = Binomial(n=pl.lit(5, dtype=_INT), p=pl.Series("p", [0.5, 0.5, 0.5])).pmf(pl.col("x"))
+
+    with pytest.raises(pl.exceptions.PolarsError, match=r"incompatible lengths|non-equal length"):
+        frame.select(mismatched)

--- a/tests/distributions/value_keyed_fast_path_test.py
+++ b/tests/distributions/value_keyed_fast_path_test.py
@@ -13,12 +13,11 @@ routing are pinned here, both of which the bit-equality property test
   must produce identical output. A non-finite parameter is invalid by the library's own check,
   whether or not `statrs` would accept it. The fast path cannot quietly accept or reject something
   the per-row path does not.
-* **Constants validate up front, columns validate value by value.** A Python scalar rides in kwargs
-  and a length-1 expression (`pl.lit`, an aggregate) arrives as a length-1 input. Both are one
-  parameterisation, checked once before any value is read, so an invalid one raises even on a
-  zero-row frame, whether a domain or the strict cast rejects it. A parameter *column* is checked
-  over its values, and an empty column has none, so it returns empty. Only an all-length-1 call takes
-  that branch; one constant beside a column still aligns, and a mismatched column is still reported.
+* **Constants validate up front, columns validate value by value.** A Python scalar in kwargs and a
+  length-1 expression (`pl.lit`, an aggregate) are one parameterisation, checked once before any value
+  is read, so an invalid one raises even on a zero-row frame. A parameter *column* is checked over its
+  values, and an empty column has none, so it returns empty. One constant beside a column still
+  aligns, and a mismatched column is still reported.
 
 A Python `None` parameter cannot reach either path: `coerce_param` rejects it as a `TypeError` at construction, covered
 by each distribution's `construct_test.py`. So there is no "null scalar parameter" case to test here, and none for
@@ -175,11 +174,7 @@ _INVALID_PER_DRIVER: dict[
 def test_constant_parameters_validate_on_empty_input(
     scalar: _UnivariateDistribution, literal: _UnivariateDistribution, column: _UnivariateDistribution, fragment: str
 ) -> None:
-    """A constant parameterisation raises when invalid even with no rows to observe it; an empty column returns empty.
-
-    Python scalars and length-1 literals are both constants, checked once per call before any value is
-    read. A parameter column is checked value by value, and a zero-row column has none.
-    """
+    """An invalid constant raises with no rows to observe it; an invalid empty column returns empty."""
     empty = pl.DataFrame({"x": []}, schema={"x": pl.Float64})
 
     for constant in (scalar, literal):
@@ -190,11 +185,9 @@ def test_constant_parameters_validate_on_empty_input(
 
 
 def test_a_constant_the_cast_rejects_also_raises_on_an_empty_frame() -> None:
-    """The zero-row change reaches cast rejections, not only parameter domains.
+    """`n = -5` is refused by the strict `Int64 -> UInt64` cast, not a domain check, and still before any row.
 
-    `n = -5` never gets as far as a domain check: `coerce_n`'s strict `Int64 -> UInt64` cast refuses it,
-    and on the length-1 path that cast now runs before any row. A negative Python-scalar `n` has no
-    spelling here, `coerce_n` rejects it as a `ValueError` at construction.
+    A negative Python-scalar `n` has no spelling here: `coerce_n` rejects it at construction.
     """
     empty = pl.DataFrame({"x": []}, schema={"x": pl.Float64})
 
@@ -204,22 +197,19 @@ def test_a_constant_the_cast_rejects_also_raises_on_an_empty_frame() -> None:
     assert empty.select(r=Binomial(n=_col(-5, _INT), p=_col(0.5)).pmf(pl.col("x"))).height == 0
 
 
-@pytest.mark.parametrize(
-    "dist",
-    [
-        Exponential(pl.lit(None, dtype=pl.Float64)),
-        Uniform(pl.lit(None, dtype=pl.Float64), pl.lit(1.0)),
-        Normal(pl.lit(0.0), pl.lit(None, dtype=pl.Float64)),
-        DiscreteUniform(pl.lit(None, dtype=_INT), pl.lit(6, dtype=_INT)),
-    ],
-    ids=["exponential", "uniform", "normal", "discreteuniform"],
-)
-def test_a_null_constant_parameter_nulls_every_row(dist: _UnivariateDistribution) -> None:
-    """A null length-1 parameter is one parameterisation with nothing to build from.
+# One null length-1 parameterisation per Rust driver, plus Binomial, whose `n` has its own coercer.
+_NULL_CONSTANT_PER_DRIVER: dict[str, _UnivariateDistribution] = {
+    "exponential": Exponential(pl.lit(None, dtype=pl.Float64)),
+    "uniform": Uniform(pl.lit(None, dtype=pl.Float64), pl.lit(1.0)),
+    "normal": Normal(pl.lit(0.0), pl.lit(None, dtype=pl.Float64)),
+    "binomial": Binomial(n=pl.lit(None, dtype=_INT), p=pl.lit(0.5)),
+    "discreteuniform": DiscreteUniform(pl.lit(None, dtype=_INT), pl.lit(6, dtype=_INT)),
+}
 
-    Each driver declines it and falls back to the row loop rather than raising, so every row is null,
-    as it is for a null parameter column. One case per driver.
-    """
+
+@pytest.mark.parametrize("dist", _NULL_CONSTANT_PER_DRIVER.values(), ids=list(_NULL_CONSTANT_PER_DRIVER))
+def test_a_null_constant_parameter_nulls_every_row(dist: _UnivariateDistribution) -> None:
+    """A null length-1 parameter nulls every row, as a null parameter column does."""
     frame = pl.DataFrame({"x": [0.5, 1.0, 2.0]})
 
     result = frame.select(r=_density(dist, pl.col("x")))["r"]
@@ -228,25 +218,18 @@ def test_a_null_constant_parameter_nulls_every_row(dist: _UnivariateDistribution
     assert result.null_count() == frame.height
 
 
-def test_a_null_constant_parameter_still_gates_the_value_dtype() -> None:
-    """Declining the fast path must not skip the evaluation point's dtype gate.
-
-    The row loop the null falls back to coerces the value column, so a `String` one is still refused.
-    Short-circuiting a null parameterisation straight to all-nulls would lose that.
-    """
+@pytest.mark.parametrize("dist", _NULL_CONSTANT_PER_DRIVER.values(), ids=list(_NULL_CONSTANT_PER_DRIVER))
+def test_a_null_constant_parameter_still_gates_the_value_dtype(dist: _UnivariateDistribution) -> None:
+    """A null length-1 parameter does not skip the value column's dtype gate: a `String` column is still refused."""
     strings = pl.DataFrame({"x": ["a", "b"]})
 
     with pytest.raises(pl.exceptions.ComputeError, match="must be a numeric column"):
-        strings.select(r=Normal(pl.lit(0.0), pl.lit(None, dtype=pl.Float64)).pdf(pl.col("x")))
+        strings.select(r=_density(dist, pl.col("x")))
 
 
 @pytest.mark.parametrize("dtype", [pl.Int64, pl.UInt64, pl.Int32])
 def test_discreteuniform_integer_points_agree_across_bound_spellings(dtype: pl.DataType) -> None:
-    """The fast path keeps DiscreteUniform's integer-exact point dispatch.
-
-    `du_value_keyed_scalar` re-dispatches on the value dtype, so its `Int` and `Wide` arms are reached
-    only from an integer value column. `UInt64` is the only dtype that reaches the `Wide` arm.
-    """
+    """Integer points stay exact under every bound spelling; `UInt64` is the one dtype with its own arm."""
     frame = pl.DataFrame({"x": [0, 1, 3, 6, 7]}, schema={"x": dtype})
     expected = frame.select(r=DiscreteUniform(1, 6).pmf(pl.col("x")))["r"]
 

--- a/tests/property/value_keyed_test.py
+++ b/tests/property/value_keyed_test.py
@@ -1,11 +1,12 @@
-"""Bit-equality of the constant-parameter value-keyed fast path against the per-row path.
+"""Bit-equality of the three parameter spellings on every value-keyed method.
 
 Constant scalar parameters route the value-keyed methods (density, log-density, cdf, log-cdf, sf,
 log-sf, ppf, isf) through a dedicated ``<name>_<method>_scalar`` plugin: parameters are validated once and
-passed as kwargs, with only the value column crossing FFI. Column parameters take the general per-row plugin.
-In Rust both plugins call the same named per-method body, so for any parameterisation the two paths
-must agree bit for bit, including null propagation and ppf's null-outside-``[0, 1]`` contract. A
-divergence (e.g. a parameter-order swap in a scalar kwargs struct) must fail here.
+passed as kwargs, with only the value column crossing FFI. Expression parameters take the general per-row
+plugin, which validates and builds once per call when every parameter is length 1 (a `pl.lit`, an aggregate)
+and once per row otherwise. In Rust all three spellings call the same named per-method body, so for any
+parameterisation they must agree bit for bit, including null propagation and ppf's null-outside-``[0, 1]``
+contract. A divergence (e.g. a parameter-order swap in a scalar kwargs struct) must fail here.
 
 The comparison is bit-exact for every spec.
 """
@@ -24,6 +25,8 @@ from tests._polars_compat import assert_series_equal, linear_space
 from tests.property._specs import ALL_SPECS
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from polars_stats.distributions._base import _UnivariateDistribution
     from tests.property._specs import DistSpec
 
@@ -49,10 +52,11 @@ def _log_density(dist: _UnivariateDistribution, value: pl.Expr) -> pl.Expr:
 @pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
 @given(data=st.data())
 def test_value_keyed_scalar_fast_path_matches_per_row(spec: DistSpec, data: st.DataObject) -> None:
-    """Constant scalar parameters and the equivalent per-row columns evaluate identically."""
+    """Constant scalar parameters, length-1 literals and the equivalent per-row columns evaluate identically."""
     params = data.draw(spec.params)
     scalar = spec.make(params)
     per_row = spec.make_columns(params)
+    literal = spec.make_literals(params)
 
     lo, hi = spec.eval_range(params)
     values = pl.DataFrame({"x": [*linear_space(lo, hi, _GRID_SIZE), None, float("nan")]}, schema={"x": pl.Float64})
@@ -62,17 +66,17 @@ def test_value_keyed_scalar_fast_path_matches_per_row(spec: DistSpec, data: st.D
     )
 
     x, q = pl.col("x"), pl.col("q")
-    cases = [
-        (values, spec.density(scalar, x), spec.density(per_row, x)),
-        (values, _log_density(scalar, x), _log_density(per_row, x)),
-        (values, scalar.cdf(x), per_row.cdf(x)),
-        (values, scalar.log_cdf(x), per_row.log_cdf(x)),
-        (values, scalar.sf(x), per_row.sf(x)),
-        (values, scalar.log_sf(x), per_row.log_sf(x)),
-        (quantiles, scalar.ppf(q), per_row.ppf(q)),
-        (quantiles, scalar.isf(q), per_row.isf(q)),
+    cases: list[tuple[pl.DataFrame, Callable[[_UnivariateDistribution], pl.Expr]]] = [
+        (values, lambda d: spec.density(d, x)),
+        (values, lambda d: _log_density(d, x)),
+        (values, lambda d: d.cdf(x)),
+        (values, lambda d: d.log_cdf(x)),
+        (values, lambda d: d.sf(x)),
+        (values, lambda d: d.log_sf(x)),
+        (quantiles, lambda d: d.ppf(q)),
+        (quantiles, lambda d: d.isf(q)),
     ]
-    for frame, fast_expr, per_row_expr in cases:
-        fast = frame.select(r=fast_expr)["r"]
-        slow = frame.select(r=per_row_expr)["r"]
-        assert_series_equal(fast, slow, check_exact=True)
+    for frame, method in cases:
+        fast = frame.select(r=method(scalar))["r"]
+        for spelling in (per_row, literal):
+            assert_series_equal(fast, frame.select(r=method(spelling))["r"], check_exact=True)


### PR DESCRIPTION
A `pl.lit` or aggregate parameter (`pl.col("x").min()`) reaches the value-keyed plugins as a length-1 Series and was expanded to full height and re-validated per row. The four shared drivers now detect an all-length-1 parameterisation, check and build it once, and map the method body over the value column through the same `_scalar` twins the Python-scalar path uses, so the two spellings share one instantiation.

Length-1 parameters now cost what Python scalars do (2x to 6x speedup at 10M rows); the column and sampler paths are unchanged. One behaviour change: an invalid constant parameterisation raises on a 0-row frame where the length-1 spelling used to return an empty result, matching the Python-scalar spelling.
