### PR TITLE
feat: add is_discrete / is_continuous as narrowing type guards

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -57,6 +57,15 @@ it; otherwise the composing defaults apply (`sf = 1 - cdf`, `log_pdf = pdf().log
 Argument-free statistics return one value per row of parameters: with column-valued parameters, `mean()` yields the
 mean of a different distribution on every row.
 
+## Type guards
+
+Two module-level guards say which kind a distribution is, for code that accepts either and has to pick between
+`pmf` and `pdf`. Both narrow the argument's type, so the branch body needs no cast.
+
+::: polars_stats.is_discrete
+
+::: polars_stats.is_continuous
+
 ## Compatibility
 
 | Dimension | Values |

--- a/polars_stats/__init__.py
+++ b/polars_stats/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from polars_stats._internal import __version__ as __version__
-from polars_stats.distributions._base import ContinuousDistribution, DiscreteDistribution
+from polars_stats.distributions._base import ContinuousDistribution, DiscreteDistribution, is_continuous, is_discrete
 from polars_stats.distributions._bernoulli import Bernoulli
 from polars_stats.distributions._beta import Beta
 from polars_stats.distributions._binomial import Binomial
@@ -25,4 +25,6 @@ __all__ = (
     "Normal",
     "Uniform",
     "__version__",
+    "is_continuous",
+    "is_discrete",
 )

--- a/polars_stats/distributions/_base.py
+++ b/polars_stats/distributions/_base.py
@@ -13,6 +13,8 @@ from polars_stats._lib import LIB
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
 
+    from typing_extensions import TypeIs
+
     from polars_stats._typing import IntoExprColumn, PolarsDataType
 
 _LITERAL_LEN_IN_AGG = tuple(int(part) for part in pl.__version__.split(".", 2)[:2]) >= (1, 35)
@@ -686,3 +688,72 @@ class ContinuousDistribution(_UnivariateDistribution, ABC):
 
     def _log_pdf(self, value: pl.Expr) -> pl.Expr:
         return self._pdf(value).log()
+
+
+def is_discrete(obj: object, /) -> TypeIs[DiscreteDistribution]:
+    """Whether ``obj`` is a discrete distribution.
+
+    Narrowing guard: on the true branch a type checker sees ``obj`` as a
+    ``DiscreteDistribution``, so ``pmf`` / ``log_pmf`` are reachable without a cast, and on the
+    false branch it drops ``DiscreteDistribution`` from the type.
+
+    Arguments:
+        obj: Any object.
+
+    Returns:
+        ``True`` if ``obj`` is an instance of ``DiscreteDistribution``.
+
+    Examples:
+        >>> import polars_stats as ps
+        >>> ps.is_discrete(ps.Binomial(10, 0.5))
+        True
+        >>> ps.is_discrete(ps.Normal())
+        False
+
+        Dispatching on the kind picks the density method that exists:
+
+        >>> import polars as pl
+        >>> def density(dist: ps.DiscreteDistribution | ps.ContinuousDistribution, value: str):
+        ...     return dist.pmf(value) if ps.is_discrete(dist) else dist.pdf(value)
+        >>> pl.DataFrame({"x": [0.0, 1.0]}).select(density(ps.Binomial(10, 0.5), "x"))
+        shape: (2, 1)
+        ┌──────────┐
+        │ x        │
+        │ ---      │
+        │ f64      │
+        ╞══════════╡
+        │ 0.000977 │
+        │ 0.009766 │
+        └──────────┘
+    """
+    return isinstance(obj, DiscreteDistribution)
+
+
+def is_continuous(obj: object, /) -> TypeIs[ContinuousDistribution]:
+    """Whether ``obj`` is a continuous distribution.
+
+    The counterpart of [`is_discrete`][polars_stats.is_discrete]: the two kinds are disjoint, so
+    exactly one of the guards holds for any distribution in this package.
+
+    Arguments:
+        obj: Any object.
+
+    Returns:
+        ``True`` if ``obj`` is an instance of ``ContinuousDistribution``.
+
+    Examples:
+        >>> import polars_stats as ps
+        >>> ps.is_continuous(ps.Normal())
+        True
+        >>> ps.is_continuous(ps.Binomial(10, 0.5))
+        False
+
+        The guard narrows, so ``pdf`` type checks inside the branch:
+
+        >>> import polars as pl
+        >>> dist = ps.Normal(mu=0.0, sigma=1.0)
+        >>> if ps.is_continuous(dist):
+        ...     print(round(pl.DataFrame({"x": [0.0]}).select(dist.pdf("x")).item(), 6))
+        0.398942
+    """
+    return isinstance(obj, ContinuousDistribution)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ typing = [
     "pyrefly>=0.62.0",
     "pyright>=1.1.409",
     "scipy-stubs>=1.15.3.0",
+    "typing-extensions>=4.16.0",
     {include-group = "audit"},
     {include-group = "benchmarks"},
     {include-group = "testing"},

--- a/tests/type_guard_test.py
+++ b/tests/type_guard_test.py
@@ -1,0 +1,41 @@
+"""`is_discrete` / `is_continuous`: the two kinds partition the catalogue, and nothing else."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pytest
+
+import polars_stats as ps
+from tests.property._specs import ALL_SPECS
+
+if TYPE_CHECKING:
+    from tests.property._specs import DistSpec
+
+
+@pytest.mark.parametrize("spec", ALL_SPECS, ids=lambda s: s.name)
+def test_every_distribution_answers_exactly_one_guard(spec: DistSpec) -> None:
+    """The guards agree with the spec's own `continuous` flag, and never both hold."""
+    dist = spec.make(spec.example)
+
+    assert ps.is_continuous(dist) is spec.continuous
+    assert ps.is_discrete(dist) is not spec.continuous
+
+
+@pytest.mark.parametrize(
+    "obj",
+    [
+        None,
+        0.0,
+        "Normal",
+        pl.col("x"),
+        # The class, not an instance: a guard takes an object, so an untyped caller can pass either.
+        ps.Normal,
+        ps.Binomial,
+    ],
+    ids=repr,
+)
+def test_non_distributions_answer_neither_guard(obj: object) -> None:
+    assert ps.is_discrete(obj) is False
+    assert ps.is_continuous(obj) is False

--- a/uv.lock
+++ b/uv.lock
@@ -1328,6 +1328,7 @@ typing = [
     { name = "scipy-stubs", version = "1.15.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy-stubs", version = "1.17.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "scipy-stubs", version = "1.18.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions" },
 ]
 
 [package.metadata]
@@ -1371,6 +1372,7 @@ typing = [
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "rich", specifier = ">=15.0.0" },
     { name = "scipy-stubs", specifier = ">=1.15.3.0" },
+    { name = "typing-extensions", specifier = ">=4.16.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Two module-level `TypeIs` guards for code that accepts either kind of distribution and has to pick between `pmf` and `pdf`: the true branch narrows to `DiscreteDistribution` / `ContinuousDistribution`, so the branch body needs no cast. 

Closes #22 