### PR TITLE
refactor(rust): one generic driver per input arity, no closed-form loop family

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -133,29 +133,30 @@ code rather than halfway through, write the scipy-parity test first, and keep a 
       break `over` and `group_by`, so it is a guard rather than a default.
     * **Null in, null out.** The `try_*_elementwise` drivers give you that; a raw `.into_iter()` over chunks does not,
       which is the one way to lose the contract while writing ordinary-looking Rust.
-    * Always the samplers. Every one is a shell over a driver in `src/rng.rs`; none resolves a seed or writes a row
-      loop itself, which is what keeps seeding, `null` propagation (a `null` in any input nulls the row) and the
-      invalid-parameter error contract in one place. The per-row `<name>_sample` / `<name>_samples` (multi-draw,
-      backing `samples`) take the parameter columns plus a row index as the last input: `<name>_sample` calls
-      `sample_per_row_binary` (one parameter column) or `sample_per_row_ternary` (two), passing a `build` that
-      constructs the row's draw state; `<name>_samples` feeds `binary_param_rows` /
-      `ternary_param_rows` into `samples_per_row`. The constant-parameter fast paths `<name>_sample_scalar` /
-      `<name>_samples_scalar` are shells over `sample_by_index` / `samples_by_index`, taking
-      `SampleScalarKwargs<<Name>ParamsKwargs>` / `SamplesScalarKwargs<<Name>ParamsKwargs>` so the parameters are
-      validated once. All five drivers share the argument order `name, inputs, seed, [size], closures` and take the
-      output dtype from what `draw` returns, so no call site names a polars type. The per-row drivers want the index
-      pre-cast (`index.u64()?`, since `*_param_rows` hands back a borrowing iterator); the fast-path drivers take the
-      raw `&inputs[0]` and cast it themselves. Give the distribution one named `fn draw` and call it from the
-      per-row plugin and both shells; that shared call, not a test, is what keeps the three byte-identical.
+    * Always the samplers. Every one is a one-line shell over a driver in `src/rng.rs`; none resolves a seed, coerces
+      an input or writes a row loop itself, which is what keeps seeding, `null` propagation (a `null` in any input
+      nulls the row) and the invalid-parameter error contract in one place. The per-row `<name>_sample` /
+      `<name>_samples` (multi-draw, backing `samples`) take the parameter columns plus a row index as the last input
+      and call `sample_per_row_binary` / `samples_per_row_binary` (one parameter, passing its `ParamDomain`) or
+      `sample_per_row_ternary` / `samples_per_row_ternary` (two, passing each parameter's coercer and the
+      `check_params` pass), plus a `build` that constructs the row's draw state. The constant-parameter fast paths
+      `<name>_sample_scalar` / `<name>_samples_scalar` build once from `SampleScalarKwargs<<Name>Params>` /
+      `SamplesScalarKwargs<<Name>Params>` and hand `sample_by_index` / `samples_by_index` the row index and a draw
+      closure. Every driver takes its output dtype from what `draw` returns, so no call site names a polars type.
+      Give the distribution one named `fn draw` and call it from all four shells; that shared call, not a test, is
+      what keeps them byte-identical.
     * When a method needs a **special function** (`erf`, log-gamma, regularized incomplete beta/gamma, ...) or has
       no elementary closed form: bind it in `statrs` (`pdf` / `pmf`, `cdf`, `ppf`, `ln_pdf` / `ln_pmf`, native `sf`,
-      native `median`). Each shares one named `*_value` body between the per-row `value_keyed` helper (a hand-written
-      shell over the `value_keyed_per_row` driver in `src/distributions/mod.rs`) and the constant-parameter
-      `<name>_<method>_scalar` twin, so the two paths are byte-identical by construction. Write each twin as a
-      one-line `#[polars_expr]` shell over `kwargs.value_keyed(&inputs[0], <method>_value)`, an inherent method on
-      the distribution's `<Name>ParamsKwargs` struct that validates and builds the distribution once per call and
-      then maps the body through the shared `value_keyed_scalar` driver. Putting the driver on the kwargs struct is
-      what makes the hoist structural: a shell cannot build the distribution itself, so it cannot rebuild per row.
+      native `median`). Write one named `*_value` body per method, `fn cdf_value(dist: &Dist, v: f64) -> Option<f64>`,
+      and call it from two one-line shells: the per-row `<name>_<method>` over the distribution's own `value_keyed`
+      helper (itself one line over `value_keyed_ternary` in `src/distributions/mod.rs`, or `value_keyed_binary` for
+      one parameter, passing the coercers, `check_params` and `build_dist`), and the constant-parameter
+      `<name>_<method>_scalar` over `kwargs.value_keyed(&inputs[0], <method>_value)`, an inherent method on the
+      distribution's `<Name>Params` struct that builds once through `Self::build` and maps the body through
+      `value_keyed_scalar`. The driver's constant branch (every parameter length 1) calls the same `value_keyed_scalar`
+      with the same body, so a Python scalar and a length-1 literal or aggregate run one instantiation and agree bit
+      for bit. Putting the builder on the kwargs struct is what makes the hoist structural: a shell cannot build the
+      distribution itself, so it cannot rebuild per row.
     * When a method is an **elementary** closed form (no special function: a Normal's
       `0.5*log(2*pi*e*sigma^2)`, a Bernoulli's `1 - p` at 0, `mean = n*p`, ...), the test is **whether every row
       reaches the validator**, not whether Polars can express the arithmetic:
@@ -179,24 +180,20 @@ code rather than halfway through, write the scipy-parity test first, and keep a 
           `uniform.rs`'s `Density::pdf`); where a branch still depends on the evaluation point, the table carries an
           `Arm` type parameter and `derive` is a free function (`exponential.rs`'s and `geometric.rs`'s `derive_cdf`
           over the shared `Sides<Arm, FLOOR>` in `mod.rs`, `uniform.rs`'s `derive_cdf` / `Regions::at`). An inverse
-          needs no table at all: `derive` returns the arm and `select` is the shared `on_unit_interval`. The Polars
-          expression it replaces computed `1 - p` once on a
-          length-1 literal and broadcast it; a body that recomputes per row regressed the constant-parameter path by
-          up to 195% at 10M rows. `derive` runs once per call on the constant path and once per row when a parameter
-          is a column.
-        * A one-parameter distribution pairs those two through `value_keyed_derived_per_row` and
-          `value_keyed_derived_scalar` in `src/distributions/mod.rs`; a two-parameter one takes
-          `value_keyed_derived_pair_per_row` and `value_keyed_derived_pair_scalar`. Both plugin shells are still one
-          line and neither names a driver internal. The `_scalar` twins derive and map only; their caller owns the
-          check (`<Name>ParamsKwargs::value_keyed` for kwargs, the driver's column pass for a length-1
-          parameterisation), and both call the twin rather than spelling its two lines, so the two spellings run one
-          instantiation and cannot drift in output or in machine code. They are not `value_keyed_per_row`, which
-          builds a `statrs` distribution per row: `derive` takes plain `f64`s and hoists the parameter-only terms out
-          of the loop. Every driver nulls a row on any null parameter, before it reads the evaluation point.
+          needs no table at all: `derive` returns the arm and `select` is the shared `on_unit_interval`. `derive`
+          runs once per call on the constant path and once per row when a parameter is a column; a body that
+          recomputed the parameter-only terms per row regressed the constant-parameter path by up to 195% at 10M
+          rows.
+        * The per-row shell is one line over `value_keyed_derived_binary(inputs, &DOMAIN, derive, select)` (one
+          parameter) or `value_keyed_derived_ternary(inputs, check_params, derive, select)` (two); these wrap
+          `value_keyed_binary` / `value_keyed_ternary` with `derive` as an infallible `build`, so there is one row loop
+          per arity in the crate. The `_scalar` twin is `kwargs.value_keyed(&inputs[0], derive, select)`, an inherent
+          method that checks the constant and calls `value_keyed_scalar(value, &derive(p), select)`, the same call the
+          driver's constant branch makes.
     * State each parameter's domain once as a `ParamDomain` constant (`ParamDomain::finite("mu")`,
       `ParamDomain::positive("sigma")`, `ParamDomain::probability("p")`, or a literal for any other rule) and a joint
       constraint as a `PairDomain`. Every column-parameter plugin runs `check_column` / `check_columns` over its
-      parameter columns before its row loop, and every `<Name>ParamsKwargs::build` runs `check` once, so an invalid
+      parameter columns before its row loop, and every `<Name>Params::build` runs `check` once, so an invalid
       parameter raises the same `ComputeError` in both regimes whatever else its row holds. Keep a
       `build_dist(...) -> PolarsResult<Dist>` around the `statrs` constructor for the row loops; behind the pass it
       cannot fail.
@@ -218,10 +215,13 @@ code rather than halfway through, write the scipy-parity test first, and keep a 
     * `_validated_params`, the validating plugin call the moments gate on. In Rust, a plugin returning a reused
       quantity that raises on invalid parameters and nulls on a null one (`uniform_range` returns `max - min`,
       `normal_sigma` the validated `sigma`); its suffix must be in `ParamFunction`. Cast each input, run the domain
-      pass, then return the quantity: the checked column itself for one parameter (`bernoulli_proba`), or a
-      `binary_elementwise` over both columns that nulls where either is null. It takes no output name: polars resolves
-      an expression's output name from its first input. In Python, `_validated_params` is
-      `self._validated("<suffix>", <the same quantity as a polars expr>)`, which runs the plugin per row for column
+      pass, then return the quantity: `validated_param(inputs, &DOMAIN)` returns the checked column itself for one
+      parameter (`bernoulli_proba`); `validated_pair(inputs, coerce_a, check_params)` returns the second parameter
+      where both are present (`normal_sigma`, `beta_params`); `param_keyed(inputs, coerce_a, coerce_b, check_params,
+      |a, b| ...)` returns any other per-row quantity, null where either parameter is null (`uniform_range`,
+      `beta_entropy`). It takes no output name: polars resolves an expression's output name from its first input. In
+      Python, `_validated_params` is `self._validated("<suffix>", <the same quantity as a polars expr>)`, which runs
+      the plugin per row for column
       parameters and once, on length-1 literals, for constants; or `self._param_plugin("<suffix>")` when the plugin's
       own output is the answer on both routings (`DiscreteUniform.support_size`, whose `Float64` count must not be
       recomputed in polars).

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -117,10 +117,10 @@ index crosses FFI, instead of one broadcast column per parameter that the genera
 on every row. The shared `sample_by_index` helper in `rng.rs` resolves the seed once and maps the dense,
 non-null index straight into the typed output. Each distribution writes the two fast-path shells by hand over
 `sample_by_index` / `samples_by_index`, carrying its parameters in `SampleScalarKwargs<P>` / `SamplesScalarKwargs<P>`,
-the generic `seed` / `size` wrappers in `rng.rs` around the distribution's own `<Name>ParamsKwargs`. The shells reuse
+the generic `seed` / `size` wrappers in `rng.rs` around the distribution's own `<Name>Params`. The shells reuse
 the same `(root_seed, row_index)` seeding and call the same named `draw` as the per-row path, so output is
 byte-identical for the same seed (a property test pins that equality); column-valued parameters still take the general
-per-row plugin, itself a shell over the `sample_per_row_*` / `samples_per_row` drivers in the same file.
+per-row plugin, itself a shell over the `sample_per_row_*` / `samples_per_row_*` drivers in the same file.
 
 !!! info "Earlier `ChaCha20` design (removed)"
 

--- a/src/distributions/bernoulli.rs
+++ b/src/distributions/bernoulli.rs
@@ -4,35 +4,31 @@ use rand::distr::Distribution;
 use statrs::distribution::Bernoulli;
 
 use crate::distributions::{
-    align_inputs, coerce_f64, on_unit_interval, value_keyed_derived_per_row,
-    value_keyed_derived_scalar, ParamDomain,
+    on_unit_interval, validated_param, value_keyed_derived_binary, value_keyed_scalar, ParamDomain,
 };
 use crate::rng::{
-    binary_param_rows, sample_by_index, sample_per_row_binary, samples_bool_output,
-    samples_by_index, samples_per_row, SampleKwargs, SampleScalarKwargs, SamplesKwargs,
-    SamplesScalarKwargs,
+    sample_by_index, sample_per_row_binary, samples_bool_output, samples_by_index,
+    samples_per_row_binary, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
 const P: ParamDomain = ParamDomain::probability("p");
 
-/// Cannot fail behind [`P`]'s pass; the `statrs` error is kept as the backstop.
-fn build_dist(proba: f64) -> PolarsResult<Bernoulli> {
-    Bernoulli::new(proba).map_err(|e| polars_err!(ComputeError: "{e}"))
+fn build_dist(p: f64) -> PolarsResult<Bernoulli> {
+    Bernoulli::new(p).map_err(|e| polars_err!(ComputeError: "{e}"))
 }
 
-/// Bernoulli's constant success probability, deserialised once per call.
+/// Constant parameter, deserialised once per call; every `_scalar` twin checks it once here.
 #[derive(serde::Deserialize)]
-struct BernoulliParamsKwargs {
+struct BernoulliParams {
     p: f64,
 }
 
-impl BernoulliParamsKwargs {
+impl BernoulliParams {
     fn build(&self) -> PolarsResult<Bernoulli> {
         P.check(self.p)?;
         build_dist(self.p)
     }
 
-    /// Validates once per call, then derives and maps through [`value_keyed_derived_scalar`].
     fn value_keyed<Branches>(
         &self,
         value: &Series,
@@ -40,25 +36,19 @@ impl BernoulliParamsKwargs {
         select: impl Fn(&Branches, f64) -> Option<f64>,
     ) -> PolarsResult<Series> {
         P.check(self.p)?;
-        value_keyed_derived_scalar(value, self.p, derive, select)
+        value_keyed_scalar(value, &derive(self.p), select)
     }
 }
 
-/// `p` unchanged after [`P`]'s column pass, `null` included. The moments derive from this so an
-/// invalid `p` raises as it does from `bernoulli_sample`, instead of computing a negative variance.
 #[polars_expr(output_type=Float64)]
 fn bernoulli_proba(inputs: &[Series]) -> PolarsResult<Series> {
-    let proba = coerce_f64(&inputs[0])?;
-    P.check_column(&proba)?;
-    Ok(proba.into_series())
+    validated_param(inputs, &P)
 }
 
-// Per-method bodies, shared by the per-row plugins and their `*_scalar` twins. Each method pairs a
-// `derive` that turns `p` into its branch answers with an `at` that picks one by where the value
-// sits. `derive` runs once per call on the constant path and once per row only when `p` is a column,
-// which is what keeps the constant path from recomputing a logarithm 10M times.
+// Each method pairs a `derive` that turns `p` into its branch answers with an `at` that picks one by
+// where the point sits; `derive` runs once per call on a constant `p`, once per row on a column.
 
-/// `pmf` / `log_pmf`: the answer at each of the two support points, and off the support.
+/// `pmf` / `log_pmf`: the answer at each support point, and off the support.
 struct Mass {
     at_zero: f64,
     at_one: f64,
@@ -66,7 +56,6 @@ struct Mass {
 }
 
 impl Mass {
-    /// `1 - p` at 0, `p` at 1, `0` off the support.
     fn pmf(p: f64) -> Self {
         Mass {
             at_zero: 1.0 - p,
@@ -75,11 +64,7 @@ impl Mass {
         }
     }
 
-    /// `ln_1p(-p)` at 0, `ln(p)` at 1, `-inf` off the support.
-    ///
-    /// `ln_1p`, not `ln(1 - p)`: the latter collapses to `0.0` below `p ~ 1.1e-16`. Both logarithms
-    /// are derived where a row reads one, which costs the column path a spare `ln` and saves the
-    /// constant path a per-row one.
+    /// `ln_1p(-p)`, not `ln(1 - p)`, which collapses to `0.0` below `p ~ 1.1e-16`.
     fn ln_pmf(p: f64) -> Self {
         Mass {
             at_zero: (-p).ln_1p(),
@@ -88,8 +73,7 @@ impl Mass {
         }
     }
 
-    /// Exact `f64` equality, never a cast to an integer type, so a non-integral value is off the
-    /// support rather than an error: `pmf(0.5)` is `0.0`.
+    /// Exact `f64` equality, never an integer cast: `pmf(0.5)` is `0.0`, not an error.
     fn at(&self, value: f64) -> Option<f64> {
         Some(if value == 0.0 {
             self.at_zero
@@ -109,7 +93,6 @@ struct Steps {
 }
 
 impl Steps {
-    /// `0` below 0, `1 - p` on `[0, 1)`, `1` at or above 1.
     fn cdf(p: f64) -> Self {
         Steps {
             below_zero: 0.0,
@@ -118,8 +101,6 @@ impl Steps {
         }
     }
 
-    /// `-inf` below 0, `ln_1p(-p)` on `[0, 1)`, `0` at or above 1; same `ln_1p` reason as
-    /// [`Mass::ln_pmf`].
     fn ln_cdf(p: f64) -> Self {
         Steps {
             below_zero: f64::NEG_INFINITY,
@@ -128,10 +109,8 @@ impl Steps {
         }
     }
 
-    /// `1` below 0, `p` on `[0, 1)`, `0` at or above 1.
-    ///
-    /// Read straight off `p`, never as `1 - cdf`: that recomputes `p` as `1 - (1 - p)` and so
-    /// quantises it to the `1.1e-16` spacing of `1.0`, reaching `0.0` below that.
+    /// Read off `p` directly, never as `1 - cdf`, which quantises `p` to the `1.1e-16` spacing of
+    /// `1.0` and reaches `0.0` below that.
     fn sf(p: f64) -> Self {
         Steps {
             below_zero: 1.0,
@@ -140,8 +119,6 @@ impl Steps {
         }
     }
 
-    /// The plain log of [`Steps::sf`], slot for slot: `ln(1) = 0` and `ln(0) = -inf` are exact, and
-    /// the middle slot is `p` itself, so there is no complement for an `ln_1p` to rescue.
     fn ln_sf(p: f64) -> Self {
         Steps {
             below_zero: 0.0,
@@ -161,11 +138,11 @@ impl Steps {
     }
 }
 
-/// `ppf`: the cdf step the quantile is compared against, and the answer at `q == 1`.
+/// `ppf`: the one cdf step, and the answer at `q == 1`.
 struct PpfCutoffs {
-    /// `1 - p`, the only step in the cdf.
     step: f64,
-    /// `1.0` unless the mass at 1 is zero, in which case `0.0`.
+    /// `1.0` unless the mass at 1 is zero. `1 - p` rounds to exactly `1.0` below `p ~ 1.1e-16`, so
+    /// `q > step` would answer `0.0` at `q = 1` where `1.0` is the only correct answer.
     at_quantile_one: f64,
 }
 
@@ -177,13 +154,8 @@ impl PpfCutoffs {
         }
     }
 
-    /// Smallest `x` with `cdf(x) >= q`: `0.0` if `q <= 1 - p` else `1.0`; `None` (null) outside
-    /// `[0, 1]`. The support point is a `Float64`, not a `Boolean`, so `NaN` stays representable.
-    ///
-    /// `q == 1` is a separate branch because `1 - p` rounds to exactly `1.0` below `p ~ 1.1e-16`,
-    /// which made `q > 1 - p` false and answered `0.0` where `1.0` is the only correct answer. Every
-    /// representable `q < 1` is safely below the true `1 - p` for such a `p`, so the branch is
-    /// needed only at the endpoint; `p == 0` keeps `0.0`.
+    /// Smallest `x` with `cdf(x) >= q`, as `Float64` so `NaN` stays representable; null outside
+    /// `[0, 1]`.
     fn at(&self, quantile: f64) -> Option<f64> {
         (0.0..=1.0).contains(&quantile).then(|| {
             if quantile == 1.0 {
@@ -195,188 +167,121 @@ impl PpfCutoffs {
     }
 }
 
-/// Smallest `x` with `sf(x) <= q`: `1.0` if `p > q` else `0.0`; null outside `[0, 1]`.
-///
-/// Compared against `q` itself, never as `ppf(1 - q)`: `sf(0)` *is* `p`, so this comparison forms no
-/// complement, while `ppf(1 - q)` forms two and loses the answer whenever either saturates
-/// (`Bernoulli(1e-17).isf(1e-20)` gave `0.0` against a true `1.0`). So `isf` reads `p` directly and
-/// hoists nothing.
+/// Smallest `x` with `sf(x) <= q`, compared against `q` itself: `sf(0)` is `p`, so no complement is
+/// formed, where `ppf(1 - q)` forms two and loses the answer once either saturates.
 fn derive_isf(p: f64) -> impl Fn(f64) -> f64 {
     move |quantile: f64| f64::from(p > quantile)
 }
 
-/// Element-wise pmf: `1 - p` at 0, `p` at 1, `0` off the support.
-/// See [`value_keyed_derived_per_row`] for the null/error contract.
 #[polars_expr(output_type=Float64)]
 fn bernoulli_pmf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, Mass::pmf, Mass::at)
+    value_keyed_derived_binary(inputs, &P, Mass::pmf, Mass::at)
 }
 
-/// Element-wise log-pmf; see [`Mass::ln_pmf`] for the `ln_1p` reason.
 #[polars_expr(output_type=Float64)]
 fn bernoulli_ln_pmf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, Mass::ln_pmf, Mass::at)
+    value_keyed_derived_binary(inputs, &P, Mass::ln_pmf, Mass::at)
 }
 
-/// Element-wise cdf `P(X <= value)`; see [`Steps::cdf`].
 #[polars_expr(output_type=Float64)]
 fn bernoulli_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, Steps::cdf, Steps::at)
+    value_keyed_derived_binary(inputs, &P, Steps::cdf, Steps::at)
 }
 
-/// Element-wise log-cdf; see [`Steps::ln_cdf`].
 #[polars_expr(output_type=Float64)]
 fn bernoulli_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, Steps::ln_cdf, Steps::at)
+    value_keyed_derived_binary(inputs, &P, Steps::ln_cdf, Steps::at)
 }
 
-/// Element-wise survival function `P(X > value)`; see [`Steps::sf`] for why it is not `1 - cdf`.
 #[polars_expr(output_type=Float64)]
 fn bernoulli_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, Steps::sf, Steps::at)
+    value_keyed_derived_binary(inputs, &P, Steps::sf, Steps::at)
 }
 
-/// Element-wise log-sf; see [`Steps::ln_sf`].
 #[polars_expr(output_type=Float64)]
 fn bernoulli_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, Steps::ln_sf, Steps::at)
+    value_keyed_derived_binary(inputs, &P, Steps::ln_sf, Steps::at)
 }
 
-/// Element-wise ppf (inverse cdf), returning the support point as `f64`; see [`PpfCutoffs::at`].
 #[polars_expr(output_type=Float64)]
 fn bernoulli_ppf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, PpfCutoffs::derive, PpfCutoffs::at)
+    value_keyed_derived_binary(inputs, &P, PpfCutoffs::derive, PpfCutoffs::at)
 }
 
-/// Element-wise inverse survival function; see [`derive_isf`] for why it never forms a complement.
 #[polars_expr(output_type=Float64)]
 fn bernoulli_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, derive_isf, on_unit_interval)
+    value_keyed_derived_binary(inputs, &P, derive_isf, on_unit_interval)
 }
 
-/// Constant-parameter fast path for [`bernoulli_pmf`].
 #[polars_expr(output_type=Float64)]
-fn bernoulli_pmf_scalar(inputs: &[Series], kwargs: BernoulliParamsKwargs) -> PolarsResult<Series> {
+fn bernoulli_pmf_scalar(inputs: &[Series], kwargs: BernoulliParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], Mass::pmf, Mass::at)
 }
 
-/// Constant-parameter fast path for [`bernoulli_ln_pmf`].
 #[polars_expr(output_type=Float64)]
-fn bernoulli_ln_pmf_scalar(
-    inputs: &[Series],
-    kwargs: BernoulliParamsKwargs,
-) -> PolarsResult<Series> {
+fn bernoulli_ln_pmf_scalar(inputs: &[Series], kwargs: BernoulliParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], Mass::ln_pmf, Mass::at)
 }
 
-/// Constant-parameter fast path for [`bernoulli_cdf`].
 #[polars_expr(output_type=Float64)]
-fn bernoulli_cdf_scalar(inputs: &[Series], kwargs: BernoulliParamsKwargs) -> PolarsResult<Series> {
+fn bernoulli_cdf_scalar(inputs: &[Series], kwargs: BernoulliParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], Steps::cdf, Steps::at)
 }
 
-/// Constant-parameter fast path for [`bernoulli_ln_cdf`].
 #[polars_expr(output_type=Float64)]
-fn bernoulli_ln_cdf_scalar(
-    inputs: &[Series],
-    kwargs: BernoulliParamsKwargs,
-) -> PolarsResult<Series> {
+fn bernoulli_ln_cdf_scalar(inputs: &[Series], kwargs: BernoulliParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], Steps::ln_cdf, Steps::at)
 }
 
-/// Constant-parameter fast path for [`bernoulli_sf`].
 #[polars_expr(output_type=Float64)]
-fn bernoulli_sf_scalar(inputs: &[Series], kwargs: BernoulliParamsKwargs) -> PolarsResult<Series> {
+fn bernoulli_sf_scalar(inputs: &[Series], kwargs: BernoulliParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], Steps::sf, Steps::at)
 }
 
-/// Constant-parameter fast path for [`bernoulli_ln_sf`].
 #[polars_expr(output_type=Float64)]
-fn bernoulli_ln_sf_scalar(
-    inputs: &[Series],
-    kwargs: BernoulliParamsKwargs,
-) -> PolarsResult<Series> {
+fn bernoulli_ln_sf_scalar(inputs: &[Series], kwargs: BernoulliParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], Steps::ln_sf, Steps::at)
 }
 
-/// Constant-parameter fast path for [`bernoulli_ppf`].
 #[polars_expr(output_type=Float64)]
-fn bernoulli_ppf_scalar(inputs: &[Series], kwargs: BernoulliParamsKwargs) -> PolarsResult<Series> {
+fn bernoulli_ppf_scalar(inputs: &[Series], kwargs: BernoulliParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], PpfCutoffs::derive, PpfCutoffs::at)
 }
 
-/// Constant-parameter fast path for [`bernoulli_isf`].
 #[polars_expr(output_type=Float64)]
-fn bernoulli_isf_scalar(inputs: &[Series], kwargs: BernoulliParamsKwargs) -> PolarsResult<Series> {
+fn bernoulli_isf_scalar(inputs: &[Series], kwargs: BernoulliParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_isf, on_unit_interval)
 }
 
-/// One Bernoulli draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
-///
-/// Every Bernoulli sampler draws through here, per-row and fast path alike, so their bit-equality is
-/// structural rather than only sampled by `sample_test.py`.
 #[inline]
 fn draw(dist: &Bernoulli, rng: &mut impl rand::Rng) -> bool {
     <Bernoulli as Distribution<bool>>::sample(dist, rng)
 }
 
-/// Element-wise Bernoulli sampler over `(p, row_index)`, returning `Boolean`.
-///
-/// Per row, `null` propagates; an invalid `p` raises from [`P`]'s column pass first. Seeding and
-/// chunk-invariance follow [`sample_per_row_binary`].
 #[polars_expr(output_type=Boolean)]
 fn bernoulli_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let proba = coerce_f64(&inputs[0])?;
-    let index = inputs[1].cast(&DataType::UInt64)?;
-    let name = inputs[0].name().clone();
-    P.check_column(&proba)?;
-
-    sample_per_row_binary(name, &proba, index.u64()?, kwargs.seed, build_dist, draw)
+    sample_per_row_binary(inputs, kwargs, &P, build_dist, draw)
 }
 
-/// Constant-parameter fast path for [`bernoulli_sample`].
 #[polars_expr(output_type=Boolean)]
 fn bernoulli_sample_scalar(
     inputs: &[Series],
-    kwargs: SampleScalarKwargs<BernoulliParamsKwargs>,
+    kwargs: SampleScalarKwargs<BernoulliParams>,
 ) -> PolarsResult<Series> {
     let dist = kwargs.params.build()?;
-    let name = inputs[0].name().clone();
-
-    sample_by_index(name, &inputs[0], kwargs.seed, |rng| draw(&dist, rng))
+    sample_by_index(&inputs[0], kwargs.seed, |rng| draw(&dist, rng))
 }
 
-/// Constant-parameter multi-draw fast path: the `samples` twin of [`bernoulli_sample_scalar`].
-///
-/// `size` consecutive draws from each row's stream, so `samples(size=1)` matches `sample` bit for
-/// bit and the distribution is built once per call. Returns `Array(Boolean, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_bool_output)]
 fn bernoulli_samples_scalar(
     inputs: &[Series],
-    kwargs: SamplesScalarKwargs<BernoulliParamsKwargs>,
+    kwargs: SamplesScalarKwargs<BernoulliParams>,
 ) -> PolarsResult<Series> {
     let dist = kwargs.params.build()?;
-    let name = inputs[0].name().clone();
-
-    samples_by_index(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
-        draw(&dist, rng)
-    })
+    samples_by_index(&inputs[0], kwargs.seed, kwargs.size, |rng| draw(&dist, rng))
 }
 
-/// Element-wise multi-draw Bernoulli sampler: `size` draws per row in one call, the distribution
-/// built once per row. Returns `Array(Boolean, size)`.
-///
-/// Seeding and the null/error contract follow [`samples_per_row`] and [`bernoulli_sample`].
 #[polars_expr(output_type_func_with_kwargs=samples_bool_output)]
 fn bernoulli_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let proba = coerce_f64(&inputs[0])?;
-    let index = inputs[1].cast(&DataType::UInt64)?;
-    let name = inputs[0].name().clone();
-    P.check_column(&proba)?;
-
-    let rows = binary_param_rows(&proba, index.u64()?, build_dist);
-
-    samples_per_row(name, rows, kwargs.seed, kwargs.size, draw)
+    samples_per_row_binary(inputs, kwargs, &P, build_dist, draw)
 }

--- a/src/distributions/beta.rs
+++ b/src/distributions/beta.rs
@@ -1,4 +1,3 @@
-use polars::prelude::arity::{binary_elementwise, try_binary_elementwise};
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution as RandDistribution;
@@ -6,11 +5,11 @@ use statrs::distribution::{Beta, Continuous, ContinuousCDF};
 use statrs::statistics::Distribution as StatrsDistribution;
 
 use crate::distributions::{
-    align_inputs, coerce_f64, value_keyed_per_row, value_keyed_scalar, ParamDomain,
+    coerce_f64, param_keyed, validated_pair, value_keyed_scalar, value_keyed_ternary, ParamDomain,
 };
 use crate::rng::{
-    sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
-    ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
+    sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output,
+    samples_per_row_ternary, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
 const A: ParamDomain = ParamDomain::positive("a");
@@ -21,166 +20,100 @@ fn check_params(a: &Float64Chunked, b: &Float64Chunked) -> PolarsResult<()> {
     B.check_column(b)
 }
 
-/// Cannot fail behind [`A`] and [`B`]'s pass; the `statrs` error is kept as the backstop.
 fn build_dist(a: f64, b: f64) -> PolarsResult<Beta> {
     Beta::new(a, b).map_err(|e| polars_err!(ComputeError: "{e}"))
 }
 
-/// Beta's constant shapes, deserialised once per call.
-///
-/// The one place this file spells `(a, b)`: every fast path, sampler or value-keyed, reaches the
-/// constructor through [`Self::build`], so the order cannot drift between them.
+/// Constant parameters, deserialised once per call. Every `_scalar` twin builds through
+/// [`Self::build`], so it cannot rebuild per row.
 #[derive(serde::Deserialize)]
-struct BetaParamsKwargs {
+struct BetaParams {
     a: f64,
     b: f64,
 }
 
-impl BetaParamsKwargs {
+impl BetaParams {
     fn build(&self) -> PolarsResult<Beta> {
         A.check(self.a)?;
         B.check(self.b)?;
         build_dist(self.a, self.b)
     }
 
-    /// Constant-parameter twin of the per-row [`value_keyed`], sharing its `<method>_value`
-    /// bodies: build once per call, then map `f` over the evaluation-point column.
-    fn value_keyed<F>(&self, value: &Series, f: F) -> PolarsResult<Series>
+    fn value_keyed<Body>(&self, value: &Series, body: Body) -> PolarsResult<Series>
     where
-        F: Fn(&Beta, f64) -> Option<f64>,
+        Body: Fn(&Beta, f64) -> Option<f64>,
     {
-        let dist = self.build()?;
-        value_keyed_scalar(value, |v| f(&dist, v))
+        value_keyed_scalar(value, &self.build()?, body)
     }
 }
 
-/// Validate the `(a, b)` parameterisation and return the validated `b`.
-///
-/// `inputs[0]` is `a`, `inputs[1]` is `b`. The Python closed-form moments (`mean = a / (a + b)`,
-/// `variance = a * b / ((a + b)^2 * (a + b + 1))`) are gated on this single FFI round-trip, so
-/// they raise on an invalid parameterisation exactly like the value-keyed methods. `null` in
-/// either input propagates.
+fn value_keyed<Body>(inputs: &[Series], body: Body) -> PolarsResult<Series>
+where
+    Body: Fn(&Beta, f64) -> Option<f64>,
+{
+    value_keyed_ternary(
+        inputs,
+        coerce_f64,
+        coerce_f64,
+        check_params,
+        build_dist,
+        body,
+    )
+}
+
 #[polars_expr(output_type=Float64)]
 fn beta_params(inputs: &[Series]) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let a = coerce_f64(&inputs[0])?;
-    let b = coerce_f64(&inputs[1])?;
-    check_params(&a, &b)?;
-
-    let ca: Float64Chunked = binary_elementwise(&a, &b, |a: Option<f64>, b: Option<f64>| a.and(b));
-    Ok(ca.into_series())
+    validated_pair(inputs, coerce_f64, check_params)
 }
 
-/// Apply a value-keyed `f(dist, value)` element-wise over `(value, a, b)`; shared by `pdf`,
-/// `ln_pdf`, `cdf`, `sf`, `ppf`. Null and `NaN` contracts in [`value_keyed_per_row`].
-fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
-where
-    F: Fn(&Beta, f64) -> Option<f64>,
-{
-    value_keyed_per_row(inputs, coerce_f64, coerce_f64, check_params, build_dist, f)
-}
-
-/// Apply a parameter-keyed moment `f(dist)` element-wise over `(a, b)`.
-///
-/// `inputs[0]` is `a`, `inputs[1]` is `b`. `null` in either propagates; an invalid shape raises
-/// from [`check_params`]. Only `entropy` routes through here (the one moment without an elementary
-/// closed form); `mean` and `variance` are closed forms computed in Polars and gated on
-/// [`beta_params`].
-fn params_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
-where
-    F: Fn(&Beta) -> f64,
-{
-    let inputs = align_inputs(inputs)?;
-    let a = coerce_f64(&inputs[0])?;
-    let b = coerce_f64(&inputs[1])?;
-    check_params(&a, &b)?;
-
-    let ca: Float64Chunked = try_binary_elementwise(&a, &b, |a, b| -> PolarsResult<Option<f64>> {
-        match (a, b) {
-            (Some(a), Some(b)) => Ok(Some(f(&build_dist(a, b)?))),
-            _ => Ok(None),
-        }
-    })?;
-    Ok(ca.into_series())
-}
-
-/// One Beta draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
-///
-/// Every Beta sampler draws through here, per-row and fast path alike, so their bit-equality is
-/// structural rather than only sampled by `sample_test.py`.
 #[inline]
 fn draw(dist: &Beta, rng: &mut impl rand::Rng) -> f64 {
     RandDistribution::sample(dist, rng)
 }
 
-/// Element-wise Beta sampler over `(a, b, row_index)`, returning `Float64`.
-///
-/// Per row, `null` propagates; an invalid shape raises from [`check_params`] first. Seeding and
-/// chunk-invariance follow [`sample_per_row_ternary`].
-///
-/// The draw keeps `statrs` (two `O(1)`-amortised Gamma draws, normalised); routing it through
-/// `rand_distr` would buy nothing, since that is already the algorithm class it uses (unlike the
-/// binomial draw, see docs/explanation/design.md).
 #[polars_expr(output_type=Float64)]
 fn beta_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let a = coerce_f64(&inputs[0])?;
-    let b = coerce_f64(&inputs[1])?;
-    let index = inputs[2].cast(&DataType::UInt64)?;
-    let name = inputs[0].name().clone();
-    check_params(&a, &b)?;
-
-    sample_per_row_ternary(name, &a, &b, index.u64()?, kwargs.seed, build_dist, draw)
+    sample_per_row_ternary(
+        inputs,
+        kwargs,
+        coerce_f64,
+        coerce_f64,
+        check_params,
+        build_dist,
+        draw,
+    )
 }
 
-/// Constant-parameter fast path for [`beta_sample`].
 #[polars_expr(output_type=Float64)]
 fn beta_sample_scalar(
     inputs: &[Series],
-    kwargs: SampleScalarKwargs<BetaParamsKwargs>,
+    kwargs: SampleScalarKwargs<BetaParams>,
 ) -> PolarsResult<Series> {
     let dist = kwargs.params.build()?;
-    let name = inputs[0].name().clone();
-
-    sample_by_index(name, &inputs[0], kwargs.seed, |rng| draw(&dist, rng))
+    sample_by_index(&inputs[0], kwargs.seed, |rng| draw(&dist, rng))
 }
 
-/// Constant-parameter multi-draw fast path: the `samples` twin of [`beta_sample_scalar`].
-///
-/// `size` consecutive draws from each row's stream, so `samples(size=1)` matches `sample` bit for
-/// bit and the distribution is built once per call. Returns `Array(Float64, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn beta_samples_scalar(
     inputs: &[Series],
-    kwargs: SamplesScalarKwargs<BetaParamsKwargs>,
+    kwargs: SamplesScalarKwargs<BetaParams>,
 ) -> PolarsResult<Series> {
     let dist = kwargs.params.build()?;
-    let name = inputs[0].name().clone();
-
-    samples_by_index(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
-        draw(&dist, rng)
-    })
+    samples_by_index(&inputs[0], kwargs.seed, kwargs.size, |rng| draw(&dist, rng))
 }
 
-/// Element-wise multi-draw Beta sampler: `size` draws per row in one call, the distribution built
-/// once per row. Returns `Array(Float64, size)`.
-///
-/// Seeding and the null/error contract follow [`samples_per_row`] and [`beta_sample`].
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn beta_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let a = coerce_f64(&inputs[0])?;
-    let b = coerce_f64(&inputs[1])?;
-    let index = inputs[2].cast(&DataType::UInt64)?;
-    let name = inputs[0].name().clone();
-    check_params(&a, &b)?;
-
-    let rows = ternary_param_rows(&a, &b, index.u64()?, build_dist);
-
-    samples_per_row(name, rows, kwargs.seed, kwargs.size, draw)
+    samples_per_row_ternary(
+        inputs,
+        kwargs,
+        coerce_f64,
+        coerce_f64,
+        check_params,
+        build_dist,
+        draw,
+    )
 }
-
-// Per-method bodies, shared by the per-row plugins and their `*_scalar` twins.
 
 fn pdf_value(dist: &Beta, v: f64) -> Option<f64> {
     Some(dist.pdf(v))
@@ -190,9 +123,8 @@ fn ln_pdf_value(dist: &Beta, v: f64) -> Option<f64> {
     Some(dist.ln_pdf(v))
 }
 
-// `cdf` / `sf` rely on the shared drivers' `NaN` short-circuit (see `value_keyed_scalar` in
-// `mod.rs`): unlike `pdf` / `ln_pdf`, which compute through to `NaN`, the regularized incomplete
-// beta behind them panics on a `NaN` evaluation point, which would abort the whole query.
+// The regularized incomplete beta behind `cdf` / `sf` panics on a `NaN` point; the drivers'
+// short-circuit is what keeps it out.
 
 fn cdf_value(dist: &Beta, v: f64) -> Option<f64> {
     Some(dist.cdf(v))
@@ -202,9 +134,7 @@ fn sf_value(dist: &Beta, v: f64) -> Option<f64> {
     Some(dist.sf(v))
 }
 
-/// A quantile outside `[0, 1]` yields `null` (statrs' `inverse_cdf` panics there, so the guard is
-/// load-bearing); the endpoints map to the support bounds (`ppf(0) = 0`, `ppf(1) = 1`), matching
-/// `scipy.stats.beta.ppf`.
+/// Null outside `[0, 1]`; `statrs` panics there. The endpoints map to the support bounds.
 fn ppf_value(dist: &Beta, q: f64) -> Option<f64> {
     if !(0.0..=1.0).contains(&q) {
         None
@@ -213,102 +143,77 @@ fn ppf_value(dist: &Beta, q: f64) -> Option<f64> {
     }
 }
 
-/// Element-wise pdf via `statrs` `Continuous::pdf` (Beta function); `0` outside `[0, 1]`, and
-/// divergent (`inf`) at a boundary whose shape is `< 1`. See [`value_keyed`] for the null/error
-/// contract.
+fn isf_value(dist: &Beta, q: f64) -> Option<f64> {
+    ppf_value(dist, 1.0 - q)
+}
+
 #[polars_expr(output_type=Float64)]
 fn beta_pdf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, pdf_value)
 }
 
-/// Element-wise log-pdf via native `Continuous::ln_pdf` (more accurate than `pdf().ln()`);
-/// `-inf` outside `[0, 1]`.
 #[polars_expr(output_type=Float64)]
 fn beta_ln_pdf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, ln_pdf_value)
 }
 
-/// Element-wise cdf via `statrs` `ContinuousCDF::cdf` (regularized incomplete beta); `0` below the
-/// support, `1` at/above `1`, `NaN` for a `NaN` value (short-circuited in the shared drivers:
-/// statrs panics on it).
 #[polars_expr(output_type=Float64)]
 fn beta_cdf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, cdf_value)
 }
 
-/// Element-wise survival function via native `ContinuousCDF::sf` (accurate in the upper tail);
-/// `1` below the support, `0` at/above `1`, `NaN` for a `NaN` value (short-circuited in the shared
-/// drivers: statrs panics on it).
 #[polars_expr(output_type=Float64)]
 fn beta_sf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, sf_value)
 }
 
-/// Element-wise ppf via the closed-form `ContinuousCDF::inverse_cdf` (inverse regularized
-/// incomplete beta). See [`ppf_value`] for the endpoint and out-of-range contract.
 #[polars_expr(output_type=Float64)]
 fn beta_ppf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, ppf_value)
 }
 
-/// `ppf(1 - q)`, so the endpoints reverse (`isf(0) = 1`, `isf(1) = 0`) and `q` outside `[0, 1]`
-/// yields `null` through [`ppf_value`].
-fn isf_value(dist: &Beta, q: f64) -> Option<f64> {
-    ppf_value(dist, 1.0 - q)
-}
-
-/// Element-wise inverse survival function; see [`isf_value`].
 #[polars_expr(output_type=Float64)]
 fn beta_isf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, isf_value)
 }
 
-/// Constant-parameter fast path for [`beta_pdf`].
 #[polars_expr(output_type=Float64)]
-fn beta_pdf_scalar(inputs: &[Series], kwargs: BetaParamsKwargs) -> PolarsResult<Series> {
+fn beta_pdf_scalar(inputs: &[Series], kwargs: BetaParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], pdf_value)
 }
 
-/// Constant-parameter fast path for [`beta_ln_pdf`].
 #[polars_expr(output_type=Float64)]
-fn beta_ln_pdf_scalar(inputs: &[Series], kwargs: BetaParamsKwargs) -> PolarsResult<Series> {
+fn beta_ln_pdf_scalar(inputs: &[Series], kwargs: BetaParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], ln_pdf_value)
 }
 
-/// Constant-parameter fast path for [`beta_cdf`].
 #[polars_expr(output_type=Float64)]
-fn beta_cdf_scalar(inputs: &[Series], kwargs: BetaParamsKwargs) -> PolarsResult<Series> {
+fn beta_cdf_scalar(inputs: &[Series], kwargs: BetaParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], cdf_value)
 }
 
-/// Constant-parameter fast path for [`beta_sf`].
 #[polars_expr(output_type=Float64)]
-fn beta_sf_scalar(inputs: &[Series], kwargs: BetaParamsKwargs) -> PolarsResult<Series> {
+fn beta_sf_scalar(inputs: &[Series], kwargs: BetaParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], sf_value)
 }
 
-/// Constant-parameter fast path for [`beta_ppf`].
 #[polars_expr(output_type=Float64)]
-fn beta_ppf_scalar(inputs: &[Series], kwargs: BetaParamsKwargs) -> PolarsResult<Series> {
+fn beta_ppf_scalar(inputs: &[Series], kwargs: BetaParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], ppf_value)
 }
 
-/// Constant-parameter fast path for [`beta_isf`].
 #[polars_expr(output_type=Float64)]
-fn beta_isf_scalar(inputs: &[Series], kwargs: BetaParamsKwargs) -> PolarsResult<Series> {
+fn beta_isf_scalar(inputs: &[Series], kwargs: BetaParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], isf_value)
 }
 
-/// Element-wise differential entropy (in nats) via `statrs` `Distribution::entropy`:
-/// `ln B(a, b) - (a - 1) psi(a) - (b - 1) psi(b) + (a + b - 2) psi(a + b)`.
-///
-/// Kept in Rust, unlike `mean` / `variance`: the beta entropy needs log-Beta and digamma, which
-/// have no elementary closed form, so there is no numerically equivalent Polars expression to move
-/// it to (the same reasoning as `binomial_entropy`).
+/// Differential entropy (nats), `ln B(a, b) - (a - 1) psi(a) - (b - 1) psi(b) + (a + b - 2) psi(a + b)`:
+/// log-Beta and digamma have no Polars expression to move to.
 #[polars_expr(output_type=Float64)]
 fn beta_entropy(inputs: &[Series]) -> PolarsResult<Series> {
-    params_keyed(inputs, |dist| {
-        dist.entropy()
-            .expect("Beta::entropy is Some for every valid (a, b)")
+    param_keyed(inputs, coerce_f64, coerce_f64, check_params, |a, b| {
+        Ok(build_dist(a, b)?
+            .entropy()
+            .expect("Beta::entropy is Some for every valid (a, b)"))
     })
 }

--- a/src/distributions/binomial.rs
+++ b/src/distributions/binomial.rs
@@ -1,4 +1,3 @@
-use polars::prelude::arity::{binary_elementwise, try_binary_elementwise};
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution as RandDistribution;
@@ -7,61 +6,42 @@ use statrs::distribution::{Binomial, Discrete, DiscreteCDF};
 use statrs::statistics::Distribution as StatrsDistribution;
 
 use crate::distributions::{
-    align_inputs, coerce_f64, value_keyed_per_row, value_keyed_scalar, ParamDomain,
+    coerce_f64, param_keyed, validated_pair, value_keyed_scalar, value_keyed_ternary, ParamDomain,
 };
 use crate::rng::{
-    sample_by_index, sample_per_row_ternary, samples_by_index, samples_per_row, samples_u64_output,
-    ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
+    sample_by_index, sample_per_row_ternary, samples_by_index, samples_per_row_ternary,
+    samples_u64_output, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
 /// `n` has no rule of its own beyond the `u64` [`coerce_n`] makes it.
 const P: ParamDomain = ParamDomain::probability("p");
 
+fn check_params(_n: &UInt64Chunked, p: &Float64Chunked) -> PolarsResult<()> {
+    P.check_column(p)
+}
+
 /// `statrs::Binomial::new(p, n)` takes the arguments in the opposite order to this crate's `(n, p)`.
-/// Its `n` is a `u64` and so is this one, so no row converts a trial count and a negative cannot
-/// arrive here at all; behind [`P`]'s pass this cannot fail.
 fn build_dist(n: u64, p: f64) -> PolarsResult<Binomial> {
     Binomial::new(p, n).map_err(|e| polars_err!(ComputeError: "{e}"))
 }
 
-/// Construct a `rand_distr::Binomial` for sampling, mirroring [`build_dist`]'s validation contract.
-///
-/// `statrs`' `Distribution<u64>` draw for `Binomial` is `(0..n).fold(...)`: one uniform per trial, so
-/// `O(n)` draws per sampled row. `rand_distr`'s sampler is `O(1)`-amortised (inversion for small
-/// `n*p`, BTPE otherwise), so the sampler builds *this* distribution rather than the `statrs` one.
-/// The accepted/rejected parameter set is identical to [`build_dist`]: the same `u64` `n`, and `p`
-/// finite in `[0, 1]` (`rand_distr` rejects `NaN` via `!(p >= 0.0)`). The error messages share the
-/// same prefixes, so validation behaviour is unchanged from the value-keyed methods. The value-keyed
-/// methods keep building the `statrs` distribution; only the sampler uses this.
+/// The samplers draw from `rand_distr::Binomial`, `O(1)`-amortised (inversion for small `n p`, BTPE
+/// otherwise), where `statrs`' draw is one uniform per trial. Both accept the same parameter set.
 fn build_sampler(n: u64, p: f64) -> PolarsResult<BinomialSampler> {
     BinomialSampler::new(n, p).map_err(|e| {
         PolarsError::InvalidOperation(format!("p must be in [0, 1], got {p}: {e}").into())
     })
 }
 
-/// Widen an `n` column to the `UInt64` both distribution types take. The Rust half of `coerce_n`, and
-/// the single place an `n` *column* becomes a `u64`, so no row converts one again.
+/// An `n` column as the `UInt64` both distribution types take. A float dtype is refused rather than
+/// cast, since a cast would truncate `2.7` to `2` while the Python closed-form moments keep `2.7`;
+/// the strict cast reports a negative `n`, where the default cast would null the row. Widening to
+/// `UInt64` rather than `Int64` keeps the whole `u64` range reachable.
 ///
-/// A float dtype is refused rather than cast: a bare `cast(&DataType::Int64)` would truncate `2.7`
-/// to `2` here while the Python closed-form moments keep `2.7`. Refusing leaves the caller to say
-/// how a fraction rounds, and matches `coerce_n`, which refuses a scalar `2.0` on type.
-///
-/// The sign comes free from a *strict* cast, since a negative has no `u64` to widen to; the
-/// default `cast` is `NonStrict` and would null the row instead. Polars' message names the column and
-/// every offending value. Unlike the row loops this reads the whole column, so a negative `n` raises
-/// even on a row another parameter nulls; a null `n` still propagates.
-///
-/// Widening rather than narrowing is also what lets the whole `u64` range reach `statrs`: funnelling
-/// through `Int64` maps anything above `i64::MAX` to `null`, turning a trial count `statrs` accepts
-/// into a silent null row. A `UInt64` column costs nothing, since an equal-dtype cast is a clone;
-/// any other width pays one pass, measurable only on `mean` / `variance` (~5% at 1M rows) and
-/// cheaper than the `max()` scan plus down-cast that narrowing would need.
+/// A `Null`-dtype column widens to all-null so null-in-null-out holds; the dtype gate stays
+/// column-level, so a float column is refused even when every value in it is null.
 fn coerce_n(n: &Series) -> PolarsResult<UInt64Chunked> {
     let dtype = n.dtype();
-    // A `Null`-dtype column (e.g. `pl.DataFrame({"n": [None]})`) has no values the integer rule
-    // could protect; it widens to all-null `UInt64` so null-in-null-out holds, exactly as every
-    // other parameter's cast treats it. The dtype gate below stays column-level: a *float* column
-    // is refused even when every value in it is null.
     if dtype == &DataType::Null {
         return Ok(n.cast(&DataType::UInt64)?.u64()?.clone());
     }
@@ -79,49 +59,44 @@ fn coerce_n(n: &Series) -> PolarsResult<UInt64Chunked> {
     Ok(widened.u64()?.clone())
 }
 
-/// Binomial's constant parameters, deserialised once per call.
-///
-/// The one place this file spells `(n, p)`. The two families build different types from it: the
-/// value-keyed twins take the `statrs` distribution via [`Self::build`], the samplers take the
-/// `rand_distr` sampler via [`Self::build_sampler`]. `n` arrives as the `u64` both of them want:
-/// `coerce_n` refuses a negative Python constant before it reaches the wire, so nothing converts it
-/// here, and a negative would fail deserialisation rather than reach a message.
+/// Constant parameters, deserialised once per call. The value-keyed `_scalar` twins build the
+/// `statrs` distribution through [`Self::build`], the samplers the `rand_distr` sampler through
+/// [`Self::build_sampler`]; neither can rebuild per row. Swapping `(n, p)` is a compile error.
 #[derive(serde::Deserialize)]
-struct BinomialParamsKwargs {
+struct BinomialParams {
     n: u64,
     p: f64,
 }
 
-impl BinomialParamsKwargs {
-    /// The `statrs` distribution, for the value-keyed methods.
+impl BinomialParams {
     fn build(&self) -> PolarsResult<Binomial> {
         P.check(self.p)?;
         build_dist(self.n, self.p)
     }
 
-    /// The `rand_distr` sampler, for the samplers. The free [`build_sampler`] carries the note on
-    /// why the two families use different distribution types.
     fn build_sampler(&self) -> PolarsResult<BinomialSampler> {
         P.check(self.p)?;
         build_sampler(self.n, self.p)
     }
 
-    /// Constant-parameter twin of the per-row [`value_keyed`], sharing its `<method>_value`
-    /// bodies: build once per call, then map `f` over the evaluation-point column.
-    fn value_keyed<F>(&self, value: &Series, f: F) -> PolarsResult<Series>
+    fn value_keyed<Body>(&self, value: &Series, body: Body) -> PolarsResult<Series>
     where
-        F: Fn(&Binomial, f64) -> Option<f64>,
+        Body: Fn(&Binomial, f64) -> Option<f64>,
     {
-        let dist = self.build()?;
-        value_keyed_scalar(value, |v| f(&dist, v))
+        value_keyed_scalar(value, &self.build()?, body)
     }
 }
 
-/// `value` as a binomial support point: `Some(k)` when `value` is a non-negative integer, else
-/// `None` (off the support, where the mass is zero). `value > n` still maps to `Some`; `statrs`
-/// returns zero mass there, so the check need only reject negatives and non-integers. The `as`
-/// cast saturates to `u64::MAX` for values beyond the integer range, which `statrs` then treats as
-/// `> n`.
+fn value_keyed<Body>(inputs: &[Series], body: Body) -> PolarsResult<Series>
+where
+    Body: Fn(&Binomial, f64) -> Option<f64>,
+{
+    value_keyed_ternary(inputs, coerce_n, coerce_f64, check_params, build_dist, body)
+}
+
+/// `Some(k)` for a non-negative integer point, `None` off the support. `value > n` still maps to
+/// `Some`; `statrs` returns zero mass there. The cast saturates to `u64::MAX` beyond the integer
+/// range, which `statrs` treats as `> n`.
 #[inline]
 fn support_point(value: f64) -> Option<u64> {
     if value < 0.0 || value.fract() != 0.0 {
@@ -131,136 +106,57 @@ fn support_point(value: f64) -> Option<u64> {
     }
 }
 
-/// Apply a value-keyed `f(dist, value)` element-wise over `(value, n, p)`; shared by `pmf`,
-/// `ln_pmf`, `cdf`, `sf`, `ppf`. Null and `NaN` contracts in [`value_keyed_per_row`].
-fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
-where
-    F: Fn(&Binomial, f64) -> Option<f64>,
-{
-    value_keyed_per_row(
-        inputs,
-        coerce_n,
-        coerce_f64,
-        |_, p| P.check_column(p),
-        build_dist,
-        f,
-    )
-}
-
-/// Apply a parameter-keyed moment `f(dist)` element-wise over `(n, p)`.
-///
-/// `inputs[0]` is `n`, `inputs[1]` is `p`. `null` in either propagates; an invalid `p` raises from
-/// [`P`]'s column pass. Only `entropy` routes through here (the one moment without an
-/// elementary closed form); `mean` and `variance` are closed forms computed in Polars and gated on
-/// [`binomial_params`].
-///
-/// `n == u64::MAX` is refused here rather than in [`build_dist`]: it is a valid trial count for
-/// every other method, but `statrs` evaluates the support-sum moments by iterating `(0..n + 1)`,
-/// which wraps to an empty range at `u64::MAX` in release and returns a confident `0.0` entropy.
-fn params_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
-where
-    F: Fn(&Binomial) -> f64,
-{
-    let inputs = align_inputs(inputs)?;
-    let n = coerce_n(&inputs[0])?;
-    let p = coerce_f64(&inputs[1])?;
-    P.check_column(&p)?;
-
-    let ca: Float64Chunked = try_binary_elementwise(&n, &p, |n, p| -> PolarsResult<Option<f64>> {
-        let (Some(n), Some(p)) = (n, p) else {
-            return Ok(None);
-        };
-        // TODO(FBruzzesi): Remove `n == u64::MAX` guard once fixed upstream in statrs
-        polars_ensure!(
-            n != u64::MAX,
-            ComputeError: "n = {} overflows the entropy support sum: statrs iterates 0..=n via n + 1, which wraps at u64::MAX", n
-        );
-        Ok(Some(f(&build_dist(n, p)?)))
-    })?;
-    Ok(ca.into_series())
-}
-
-/// One Binomial draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
-///
-/// The state is a [`BinomialSampler`] (`rand_distr`), built by [`build_sampler`] and not by
-/// [`build_dist`]. Every Binomial sampler draws through here, per-row and fast path alike, so their
-/// bit-equality is structural rather than only sampled by `sample_test.py`.
 #[inline]
 fn draw(dist: &BinomialSampler, rng: &mut impl rand::Rng) -> u64 {
     dist.sample(rng)
 }
 
-/// Element-wise Binomial sampler over `(n, p, row_index)`, returning `UInt64`.
-///
-/// Per row, `null` propagates; an invalid `p` raises from [`P`]'s column pass first.
-/// Seeding and chunk-invariance follow [`sample_per_row_ternary`].
 #[polars_expr(output_type=UInt64)]
 fn binomial_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let n = coerce_n(&inputs[0])?;
-    let p = coerce_f64(&inputs[1])?;
-    let index = inputs[2].cast(&DataType::UInt64)?;
-    let name = inputs[0].name().clone();
-    P.check_column(&p)?;
-
-    sample_per_row_ternary(name, &n, &p, index.u64()?, kwargs.seed, build_sampler, draw)
+    sample_per_row_ternary(
+        inputs,
+        kwargs,
+        coerce_n,
+        coerce_f64,
+        check_params,
+        build_sampler,
+        draw,
+    )
 }
 
-/// Constant-parameter fast path for [`binomial_sample`], on the same [`build_sampler`].
 #[polars_expr(output_type=UInt64)]
 fn binomial_sample_scalar(
     inputs: &[Series],
-    kwargs: SampleScalarKwargs<BinomialParamsKwargs>,
+    kwargs: SampleScalarKwargs<BinomialParams>,
 ) -> PolarsResult<Series> {
     let dist = kwargs.params.build_sampler()?;
-    let name = inputs[0].name().clone();
-
-    sample_by_index(name, &inputs[0], kwargs.seed, |rng| draw(&dist, rng))
+    sample_by_index(&inputs[0], kwargs.seed, |rng| draw(&dist, rng))
 }
 
-/// Constant-parameter multi-draw fast path: the `samples` twin of [`binomial_sample_scalar`].
-///
-/// `size` consecutive draws from each row's stream, so `samples(size=1)` matches `sample` bit for
-/// bit and the sampler (whose BINV/BTPE setup is the expensive part) is built once per call rather
-/// than once per draw. Returns `Array(UInt64, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_u64_output)]
 fn binomial_samples_scalar(
     inputs: &[Series],
-    kwargs: SamplesScalarKwargs<BinomialParamsKwargs>,
+    kwargs: SamplesScalarKwargs<BinomialParams>,
 ) -> PolarsResult<Series> {
     let dist = kwargs.params.build_sampler()?;
-    let name = inputs[0].name().clone();
-
-    samples_by_index(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
-        draw(&dist, rng)
-    })
+    samples_by_index(&inputs[0], kwargs.seed, kwargs.size, |rng| draw(&dist, rng))
 }
 
-/// Element-wise multi-draw Binomial sampler: `size` draws per row in one call, the `rand_distr`
-/// sampler (whose BINV/BTPE setup is the expensive part) built once per row.
-/// Returns `Array(UInt64, size)`.
-///
-/// Seeding and the null/error contract follow [`samples_per_row`] and [`binomial_sample`].
 #[polars_expr(output_type_func_with_kwargs=samples_u64_output)]
 fn binomial_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let n = coerce_n(&inputs[0])?;
-    let p = coerce_f64(&inputs[1])?;
-    let index = inputs[2].cast(&DataType::UInt64)?;
-    let name = inputs[0].name().clone();
-    P.check_column(&p)?;
-
-    let rows = ternary_param_rows(&n, &p, index.u64()?, build_sampler);
-
-    samples_per_row(name, rows, kwargs.seed, kwargs.size, draw)
+    samples_per_row_ternary(
+        inputs,
+        kwargs,
+        coerce_n,
+        coerce_f64,
+        check_params,
+        build_sampler,
+        draw,
+    )
 }
 
-// Per-method bodies, shared by the per-row plugins and their `*_scalar` twins.
-//
-// The bodies never see a `NaN` value: the shared drivers short-circuit it to `NaN` first (see
-// `value_keyed_scalar` in `mod.rs`). That guard is load-bearing here: `NaN < 0.0` is false and
-// `NaN.floor() as u64` saturates to `0`, so an unguarded body would confidently return
-// `P(X <= 0)` (and `pmf` a confident `0.0`) instead of propagating `NaN` (scipy semantics).
+// The bodies never see a `NaN` point: `NaN < 0.0` is false and `NaN.floor() as u64` is `0`, so an
+// unguarded `cdf` would answer a confident `P(X <= 0)`. The drivers' short-circuit keeps it out.
 
 fn pmf_value(dist: &Binomial, v: f64) -> Option<f64> {
     Some(support_point(v).map_or(0.0, |k| dist.pmf(k)))
@@ -286,52 +182,14 @@ fn sf_value(dist: &Binomial, v: f64) -> Option<f64> {
     }
 }
 
-/// Element-wise pmf via `statrs` `Discrete::pmf`; zero off the integer support (`value < 0`,
-/// non-integer, or `value > n`), `NaN` for a `NaN` value. See [`value_keyed`] for the null/error
-/// contract.
-#[polars_expr(output_type=Float64)]
-fn binomial_pmf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed(inputs, pmf_value)
-}
-
-/// Element-wise log-pmf via native `Discrete::ln_pmf` (more accurate than `pmf().ln()`);
-/// `-inf` off the integer support, `NaN` for a `NaN` value.
-#[polars_expr(output_type=Float64)]
-fn binomial_ln_pmf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed(inputs, ln_pmf_value)
-}
-
-/// Element-wise cdf `P(X <= floor(value))` via `statrs` `DiscreteCDF::cdf`; `0` for `value < 0`,
-/// `1` for `value >= n`, `NaN` for a `NaN` value.
-#[polars_expr(output_type=Float64)]
-fn binomial_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed(inputs, cdf_value)
-}
-
-/// Element-wise survival function `P(X > floor(value))` via native `DiscreteCDF::sf` (accurate in
-/// the upper tail); `1` for `value < 0`, `0` for `value >= n`, `NaN` for a `NaN` value.
-#[polars_expr(output_type=Float64)]
-fn binomial_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed(inputs, sf_value)
-}
-
-/// Slack absorbing the rounding error in `statrs`' regularized-incomplete-beta cdf when comparing
-/// against a quantile that sits exactly on a cdf step. The cdf is accurate to a few ULP (~1e-15),
-/// so 1e-12 reliably treats `cdf(k) == q` as satisfied (matching scipy's integer-valued ppf) while
-/// staying far below the gap between distinct adjacent cdf values at any quantile a caller would
-/// pass.
+/// Relative slack on the cdf-step comparison in [`inverse_cdf`]. The regularized-incomplete-beta
+/// cdf is accurate to a few ulp (`~1e-15`), so `1e-12` treats `cdf(k) == q` as satisfied (scipy's
+/// integer-valued `ppf`) while staying far below the gap between adjacent cdf values. Relative, not
+/// absolute: an absolute slack exceeds every quantile below it and would collapse the search to `0`.
 const PPF_CDF_TOL: f64 = 1e-12;
 
-/// Smallest support point `k in {0, ..., n}` with `cdf(k) >= q`, by binary search over the bounded
-/// discrete CDF.
-///
-/// This is the inverse-cdf statrs documents for `Binomial` (a search over the CDF), reimplemented
-/// here so the cdf-step comparison carries the **relative** slack below, which `statrs`' generic
-/// `DiscreteCDF::inverse_cdf` does not provide.
-///
-/// The step slack is **relative** ([`PPF_CDF_TOL`] scaled by `q`), not absolute: an absolute slack
-/// exceeds every quantile below it, so `cdf(0) + tol >= q` would hold for any `q <= 1e-12`,
-/// collapsing the search to `0`. The caller maps the closed endpoints, so `q` here is interior.
+/// Smallest `k in {0, ..., n}` with `cdf(k) >= q (1 - tol)`, by binary search; the caller maps the
+/// closed endpoints, so `q` here is interior.
 fn inverse_cdf(dist: &Binomial, q: f64) -> u64 {
     let threshold = q * (1.0 - PPF_CDF_TOL);
     let mut lo = 0u64;
@@ -347,12 +205,9 @@ fn inverse_cdf(dist: &Binomial, q: f64) -> u64 {
     lo
 }
 
-/// A quantile outside `[0, 1]` yields `null`. At the endpoints this returns the support bounds
-/// (`ppf(0) = 0`, `ppf(1) = n`); scipy's below-support sentinel `ppf(0) = -1` is not reproduced, so
-/// parity comparisons restrict to interior quantiles.
-///
-/// `q == 1` is mapped here rather than left to the search: `cdf(k)` reaches `1.0` a long way below
-/// `n` once the upper tail underflows, so the search would stop at the first such `k`.
+/// Null outside `[0, 1]`; the endpoints map to the support bounds (`ppf(0) = 0`, `ppf(1) = n`),
+/// not scipy's `-1` sentinel. `q == 1` is mapped here because `cdf(k)` reaches `1.0` far below `n`
+/// once the upper tail underflows, and the search would stop there.
 fn ppf_value(dist: &Binomial, q: f64) -> Option<f64> {
     if !(0.0..=1.0).contains(&q) {
         None
@@ -365,88 +220,89 @@ fn ppf_value(dist: &Binomial, q: f64) -> Option<f64> {
     }
 }
 
-/// Element-wise ppf (inverse cdf), returning the integer support point as `f64`.
-/// See [`ppf_value`] for the endpoint and out-of-range contract.
+fn isf_value(dist: &Binomial, q: f64) -> Option<f64> {
+    ppf_value(dist, 1.0 - q)
+}
+
+#[polars_expr(output_type=Float64)]
+fn binomial_pmf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, pmf_value)
+}
+
+#[polars_expr(output_type=Float64)]
+fn binomial_ln_pmf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, ln_pmf_value)
+}
+
+#[polars_expr(output_type=Float64)]
+fn binomial_cdf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, cdf_value)
+}
+
+#[polars_expr(output_type=Float64)]
+fn binomial_sf(inputs: &[Series]) -> PolarsResult<Series> {
+    value_keyed(inputs, sf_value)
+}
+
 #[polars_expr(output_type=Float64)]
 fn binomial_ppf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, ppf_value)
 }
 
-/// `ppf(1 - q)`, so the endpoints reverse (`isf(0) = n`, `isf(1) = 0`) and `q` outside `[0, 1]`
-/// yields `null` through [`ppf_value`].
-fn isf_value(dist: &Binomial, q: f64) -> Option<f64> {
-    ppf_value(dist, 1.0 - q)
-}
-
-/// Element-wise inverse survival function; see [`isf_value`].
 #[polars_expr(output_type=Float64)]
 fn binomial_isf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, isf_value)
 }
 
-/// Constant-parameter fast path for [`binomial_pmf`].
 #[polars_expr(output_type=Float64)]
-fn binomial_pmf_scalar(inputs: &[Series], kwargs: BinomialParamsKwargs) -> PolarsResult<Series> {
+fn binomial_pmf_scalar(inputs: &[Series], kwargs: BinomialParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], pmf_value)
 }
 
-/// Constant-parameter fast path for [`binomial_ln_pmf`].
 #[polars_expr(output_type=Float64)]
-fn binomial_ln_pmf_scalar(inputs: &[Series], kwargs: BinomialParamsKwargs) -> PolarsResult<Series> {
+fn binomial_ln_pmf_scalar(inputs: &[Series], kwargs: BinomialParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], ln_pmf_value)
 }
 
-/// Constant-parameter fast path for [`binomial_cdf`].
 #[polars_expr(output_type=Float64)]
-fn binomial_cdf_scalar(inputs: &[Series], kwargs: BinomialParamsKwargs) -> PolarsResult<Series> {
+fn binomial_cdf_scalar(inputs: &[Series], kwargs: BinomialParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], cdf_value)
 }
 
-/// Constant-parameter fast path for [`binomial_sf`].
 #[polars_expr(output_type=Float64)]
-fn binomial_sf_scalar(inputs: &[Series], kwargs: BinomialParamsKwargs) -> PolarsResult<Series> {
+fn binomial_sf_scalar(inputs: &[Series], kwargs: BinomialParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], sf_value)
 }
 
-/// Constant-parameter fast path for [`binomial_ppf`].
 #[polars_expr(output_type=Float64)]
-fn binomial_ppf_scalar(inputs: &[Series], kwargs: BinomialParamsKwargs) -> PolarsResult<Series> {
+fn binomial_ppf_scalar(inputs: &[Series], kwargs: BinomialParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], ppf_value)
 }
 
-/// Constant-parameter fast path for [`binomial_isf`].
 #[polars_expr(output_type=Float64)]
-fn binomial_isf_scalar(inputs: &[Series], kwargs: BinomialParamsKwargs) -> PolarsResult<Series> {
+fn binomial_isf_scalar(inputs: &[Series], kwargs: BinomialParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], isf_value)
 }
 
-/// Validate the `(n, p)` parameterisation and return the validated `p`.
-///
-/// `inputs[0]` is `n`, `inputs[1]` is `p`. The Python closed-form moments (`mean = n * p`,
-/// `variance = n * p * (1 - p)`) are gated on this single FFI round-trip, so they raise on an
-/// invalid parameterisation exactly like the value-keyed methods. `null` in either input
-/// propagates.
 #[polars_expr(output_type=Float64)]
 fn binomial_params(inputs: &[Series]) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let n = coerce_n(&inputs[0])?;
-    let p = coerce_f64(&inputs[1])?;
-    P.check_column(&p)?;
-
-    let ca: Float64Chunked = binary_elementwise(&n, &p, |n: Option<u64>, p: Option<f64>| n.and(p));
-    Ok(ca.into_series())
+    validated_pair(inputs, coerce_n, check_params)
 }
 
-/// Element-wise Shannon entropy (in nats) via `statrs` `Distribution::entropy`, the exact support
-/// sum `-sum_k pmf(k) ln pmf(k)`; `0` at the degenerate endpoints `p in {0, 1}`.
-///
-/// Kept in Rust, unlike `mean` / `variance`: the binomial entropy has no elementary closed form (it
-/// is a sum over the whole `{0, ..., n}` support, which scipy also evaluates exactly), so there is no
-/// numerically equivalent Polars expression to move it to.
+/// Shannon entropy (nats) as the exact support sum `-sum_k pmf(k) ln pmf(k)`, which has no Polars
+/// expression to move to. `n == u64::MAX` is refused here and nowhere else: it is a valid trial count
+/// for every other method, but `statrs` iterates `0..n + 1`, which wraps to an empty range and returns
+/// a confident `0.0`.
 #[polars_expr(output_type=Float64)]
 fn binomial_entropy(inputs: &[Series]) -> PolarsResult<Series> {
-    params_keyed(inputs, |dist| {
-        dist.entropy()
-            .expect("Binomial::entropy is Some for every valid (n, p)")
+    param_keyed(inputs, coerce_n, coerce_f64, check_params, |n, p| {
+        // TODO(FBruzzesi): Remove once fixed upstream in statrs
+        polars_ensure!(
+            n != u64::MAX,
+            ComputeError: "n = {} overflows the entropy support sum: statrs iterates 0..=n via n + 1, which wraps at u64::MAX", n
+        );
+        Ok(build_dist(n, p)?
+            .entropy()
+            .expect("Binomial::entropy is Some for every valid (n, p)"))
     })
 }

--- a/src/distributions/discrete_uniform.rs
+++ b/src/distributions/discrete_uniform.rs
@@ -1,30 +1,28 @@
-use polars::prelude::arity::{binary_elementwise, try_ternary_elementwise, unary_elementwise};
+use polars::prelude::arity::{try_ternary_elementwise, unary_elementwise};
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution;
 use statrs::distribution::DiscreteUniform;
 
 use crate::distributions::{
-    align_inputs, coerce_f64, params_are_constant, value_keyed_per_row, value_keyed_scalar,
-    PairDomain,
+    align_inputs, coerce_f64, param_keyed, params_are_constant, value_keyed_scalar,
+    value_keyed_ternary, PairDomain,
 };
 use crate::rng::{
-    sample_by_index, sample_per_row_ternary, samples_by_index, samples_i64_output, samples_per_row,
-    ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
+    sample_by_index, sample_per_row_ternary, samples_by_index, samples_i64_output,
+    samples_per_row_ternary, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
 /// `min == max` is the legitimate one-point mass. Every closed form divides by the count
-/// `max - min + 1`, so it must fit `i64`; the width is computed in `i128` so the check itself
-/// cannot wrap. The bounds have no rule of their own: an integer column is one by dtype, through
-/// [`coerce_bound`].
+/// `max - min + 1`, so it must fit `i64`; the width is computed in `i128` so the check cannot wrap.
+/// The bounds have no rule of their own: an integer column is one by dtype, through [`coerce_bound`].
 const BOUNDS: PairDomain<i64> = PairDomain {
     names: ("min", "max"),
     rule: "greater than or equal to min, with a support width max - min + 1 that fits in i64",
     accepts: |min, max| min <= max && i64::try_from(i128::from(max) - i128::from(min) + 1).is_ok(),
 };
 
-/// The constant regime's once-per-call check, and the row loops' backstop. `statrs` itself only
-/// rejects `max < min`, so behind [`BOUNDS`] its error is unreachable and kept as is.
+/// `statrs` itself only rejects `max < min`, so behind [`BOUNDS`] its error is unreachable.
 fn build_dist(min: i64, max: i64) -> PolarsResult<DiscreteUniform> {
     BOUNDS.check(min, max)?;
     DiscreteUniform::new(min, max).map_err(|e| polars_err!(ComputeError: "{e}"))
@@ -34,13 +32,10 @@ fn check_params(min: &Int64Chunked, max: &Int64Chunked) -> PolarsResult<()> {
     BOUNDS.check_columns(min, max)
 }
 
-/// Widen a bound column to the `Int64` both distribution types take.
-///
-/// The signed counterpart of binomial's `coerce_n`: a float dtype is refused rather than cast
-/// (a bare cast would silently truncate `2.7` to `2`), and the strict cast to `Int64` is what
-/// reports values outside the range. A `Null`-dtype column widens to all-null so null-in-null-out
-/// holds; the dtype gate stays column-level, so a *float* column is refused even when every value
-/// in it is null.
+/// A bound column as `Int64`: the signed counterpart of binomial's `coerce_n`. A float dtype is
+/// refused rather than cast (a cast would truncate `2.7` to `2`); the strict cast reports values
+/// outside the range. A `Null`-dtype column widens to all-null so null-in-null-out holds; the dtype
+/// gate stays column-level, so a float column is refused even when every value in it is null.
 fn coerce_bound(bound: &Series) -> PolarsResult<Int64Chunked> {
     let dtype = bound.dtype();
     if dtype == &DataType::Null {
@@ -62,66 +57,42 @@ fn coerce_bound(bound: &Series) -> PolarsResult<Int64Chunked> {
     Ok(cast.i64()?.clone())
 }
 
-/// DiscreteUniform's constant bounds, deserialised once per call.
+/// Constant parameters, deserialised once per call; every `_scalar` twin builds once through here.
 #[derive(serde::Deserialize)]
-struct DiscreteUniformParamsKwargs {
+struct DiscreteUniformParams {
     min: i64,
     max: i64,
 }
 
-impl DiscreteUniformParamsKwargs {
+impl DiscreteUniformParams {
     fn build(&self) -> PolarsResult<DiscreteUniform> {
         build_dist(self.min, self.max)
     }
 
-    fn value_keyed<F>(&self, value: &Series, f: F) -> PolarsResult<Series>
+    fn point_keyed<Body>(&self, value: &Series, body: Body) -> PolarsResult<Series>
     where
-        F: Fn(&Support, Point) -> Option<f64>,
+        Body: Fn(&Support, Point) -> Option<f64>,
     {
-        du_value_keyed_scalar(value, self.min, self.max, f)
+        point_keyed_scalar(value, self.min, self.max, body)
+    }
+
+    fn value_keyed<Body>(&self, value: &Series, body: Body) -> PolarsResult<Series>
+    where
+        Body: Fn(&Support, f64) -> Option<f64>,
+    {
+        value_keyed_scalar(value, &build_support(self.min, self.max)?, body)
     }
 }
 
-/// Constant-bounds twin of the per-row [`du_value_keyed`], sharing its `<method>_point` bodies:
-/// validate and size the support once per call, then map `f` over the evaluation-point column in
-/// its own arithmetic (see [`coerce_points`]).
-fn du_value_keyed_scalar<F>(value: &Series, min: i64, max: i64, f: F) -> PolarsResult<Series>
-where
-    F: Fn(&Support, Point) -> Option<f64>,
-{
-    let support = build_support(min, max)?;
-    let name = value.name().clone();
-    let ca: Float64Chunked = match coerce_points(value)? {
-        Points::Float(v) => unary_elementwise(&v, |opt| {
-            opt.and_then(|v| {
-                if v.is_nan() {
-                    Some(f64::NAN)
-                } else {
-                    f(&support, Point::Float(v))
-                }
-            })
-        }),
-        Points::Int(v) => unary_elementwise(&v, |opt| {
-            opt.and_then(|v| f(&support, Point::Int(v.into())))
-        }),
-        Points::Wide(v) => unary_elementwise(&v, |opt| {
-            opt.and_then(|v| f(&support, Point::Int(v.into())))
-        }),
-    };
-    Ok(ca.with_name(name).into_series())
-}
-
-/// The validated support, with the count precomputed: the state every closed-form body reads.
-///
-/// `n` is `(max - min + 1) as f64`, computed in `i128` exactly as [`discreteuniform_range`]
-/// returns it, so the Rust bodies and the Python moments read the same rounded count.
+/// The validated support with its count precomputed. `n` is `(max - min + 1) as f64`, computed in
+/// `i128` exactly as [`discreteuniform_range`] returns it, so the Rust bodies and the Python moments
+/// read the same rounded count.
 struct Support {
     min: i64,
     max: i64,
     n: f64,
 }
 
-/// Size the support once, behind [`build_dist`].
 fn build_support(min: i64, max: i64) -> PolarsResult<Support> {
     build_dist(min, max)?;
     let n = (max as i128 - min as i128 + 1) as f64;
@@ -129,34 +100,25 @@ fn build_support(min: i64, max: i64) -> PolarsResult<Support> {
 }
 
 /// An evaluation point in its own arithmetic: `f64` for float columns, exact `i128` for integer
-/// columns. The integer side is what keeps an `int` spelling exact on supports a `Float64` cannot
-/// address (documented in docs/explanation/accuracy.md), and `i128` is wide enough that a `UInt64`
-/// point above `i64::MAX` still compares exactly instead of wrapping.
-///
-/// [`Point`], [`Placement`] and [`coerce_points`] stay private to this file on purpose:
-/// DiscreteUniform is their only consumer today. Geometric is the one remaining catalogue entry
-/// with closed forms over an integer support, so hoist the trio into `mod.rs` when its port makes
-/// it a second consumer, not before.
+/// columns, so an `int` spelling stays exact on supports a `Float64` cannot address and a `UInt64`
+/// point above `i64::MAX` compares exactly instead of wrapping.
 #[derive(Clone, Copy)]
 enum Point {
     Float(f64),
     Int(i128),
 }
 
-/// Where a point sits relative to the support, with the two counts the closed forms read.
-///
-/// The float side compares and counts against `Float64`-cast bounds, mirroring how polars promotes
-/// a mixed `Float64`/`Int64` operation; the integer side stays exact. The mirror is a snapshot,
-/// not a dependency: the promotion rule is frozen here, so a future polars change to its supertype
-/// rules moves nothing in this file. `count` and `tail` are only read where the branches keep them
-/// in `[1, N - 1]`; elsewhere they are computed but discarded.
+/// Where a point sits relative to the support, with the two counts the closed forms read. The float
+/// side compares against `Float64`-cast bounds, as polars promotes a mixed `Float64`/`Int64`
+/// operation; the integer side stays exact. `count` and `tail` are only read where the branches keep
+/// them in `[1, N - 1]`.
 struct Placement {
     below: bool,
     at_or_above_max: bool,
     on_support: bool,
-    /// `floor(value) - min + 1`, the support points at or below the point, as `Float64`.
+    /// `floor(value) - min + 1`, the support points at or below the point.
     count: f64,
-    /// `max - floor(value)`, the support points strictly above the point, as `Float64`.
+    /// `max - floor(value)`, the support points strictly above the point.
     tail: f64,
 }
 
@@ -185,17 +147,12 @@ fn place(s: &Support, point: Point) -> Placement {
     }
 }
 
-// Per-method bodies, shared by the per-row plugins and their `*_scalar` twins. The drivers
-// short-circuit a `NaN` float point to `NaN` before these run, matching `value_keyed_scalar`.
-
-/// `1 / N` on the integer support, `0` off it.
 fn pmf_point(s: &Support, point: Point) -> Option<f64> {
     let pos = place(s, point);
     Some(if pos.on_support { 1.0 / s.n } else { 0.0 })
 }
 
-/// `-ln(N)` on the integer support, `-inf` off it: the mass is exactly `1 / N`, so its log reads
-/// straight off the count instead of a rounded quotient.
+/// `-ln(N)` straight off the count, not the log of the rounded quotient `1 / N`.
 fn ln_pmf_point(s: &Support, point: Point) -> Option<f64> {
     let pos = place(s, point);
     Some(if pos.on_support {
@@ -205,10 +162,9 @@ fn ln_pmf_point(s: &Support, point: Point) -> Option<f64> {
     })
 }
 
-/// `count * (1 / N)` inside the support, `0` below `min`, `1` from `max` up.
-///
-/// The explicit endpoints make `cdf(max) == 1` an answer rather than the limit of a clamp:
-/// `N * (1 / N)` is not `1.0` for 483 of the first 4000 support counts.
+/// `count / N` inside the support, `0` below `min`, `1` from `max` up. The explicit endpoint makes
+/// `cdf(max) == 1` an answer rather than the limit of a clamp: `N * (1 / N)` is not `1.0` for 483
+/// of the first 4000 support counts.
 fn cdf_point(s: &Support, point: Point) -> Option<f64> {
     let pos = place(s, point);
     Some(if pos.below {
@@ -220,9 +176,7 @@ fn cdf_point(s: &Support, point: Point) -> Option<f64> {
     })
 }
 
-/// `tail * (1 / N)` inside the support, `1` below `min`, `0` from `max` up: a direct count of the
-/// points above the value, not `1 - cdf`, whose subtraction absorbs the tail once the cdf rounds
-/// towards `1`.
+/// `tail / N`, a direct count of the points above the value, not `1 - cdf`.
 fn sf_point(s: &Support, point: Point) -> Option<f64> {
     let pos = place(s, point);
     Some(if pos.below {
@@ -235,8 +189,7 @@ fn sf_point(s: &Support, point: Point) -> Option<f64> {
 }
 
 /// `ln(count / N)`, through `ln_1p` of the survival ratio once the cdf passes one half: the naive
-/// log's relative error one point below the top grows with `N` (`8.7e-16` at `N = 1e3` but
-/// `2.8e-08` at `N = 1e9`).
+/// log's relative error one point below the top grows with `N` (`2.8e-08` at `N = 1e9`).
 fn ln_cdf_point(s: &Support, point: Point) -> Option<f64> {
     let pos = place(s, point);
     Some(if pos.below {
@@ -264,12 +217,9 @@ fn ln_sf_point(s: &Support, point: Point) -> Option<f64> {
     })
 }
 
-/// `min + ceil(q * N) - 1`, corrected and clamped; `None` (null) outside `[0, 1]`.
-///
-/// Matches scipy's `randint.ppf` including its correction step, which probes the point below and
-/// keeps it whenever that point's cdf already reaches `q`, settling the step boundaries where an
-/// ulp of noise in `q * N` would skip a support point. Both inverses lose support points above
-/// `2**53`; see docs/explanation/accuracy.md.
+/// `min + ceil(q * N) - 1`, with scipy's correction step (keep the point below when its cdf already
+/// reaches `q`, so an ulp of noise in `q * N` cannot skip a support point) and clamped; null outside
+/// `[0, 1]`. Both inverses lose support points above `2**53`.
 fn ppf_value(s: &Support, q: f64) -> Option<f64> {
     if !(0.0..=1.0).contains(&q) {
         return None;
@@ -286,14 +236,10 @@ fn ppf_value(s: &Support, q: f64) -> Option<f64> {
     Some(chosen.clamp(lo, hi))
 }
 
-/// The smallest support point whose survival mass is at most `q`, from `max - floor(q * N)`
-/// corrected on both sides and clamped; `None` (null) outside `[0, 1]`.
-///
-/// Entered against `q` itself rather than `ppf(1 - q)`: the complement rounds before the inverse
-/// runs, and the survival steps sit at multiples of `1 / N`, exactly where `1 - q` has spent its
-/// precision. A rounded `q * N` can floor one point off in either direction, so the correction
-/// probes both neighbours and keeps the smallest one whose survival mass `(max - x) / N` is still
-/// at most `q`.
+/// The smallest support point whose survival mass is at most `q`, from `max - floor(q * N)`, solved
+/// on `q` itself: the survival steps sit at multiples of `1 / N`, exactly where `1 - q` has spent its
+/// precision. A rounded `q * N` can floor one point off in either direction, so both neighbours are
+/// probed; null outside `[0, 1]`.
 fn isf_value(s: &Support, q: f64) -> Option<f64> {
     if !(0.0..=1.0).contains(&q) {
         return None;
@@ -312,8 +258,7 @@ fn isf_value(s: &Support, q: f64) -> Option<f64> {
 }
 
 /// The evaluation-point column in the arithmetic its dtype earns: integer dtypes stay exact, with
-/// `UInt64` on its own accessor so a value above `i64::MAX` reaches [`Point::Int`] via `i128`;
-/// everything else goes through [`coerce_f64`].
+/// `UInt64` on its own accessor so a value above `i64::MAX` reaches [`Point::Int`] via `i128`.
 enum Points {
     Float(Float64Chunked),
     Int(Int64Chunked),
@@ -331,110 +276,120 @@ fn coerce_points(value: &Series) -> PolarsResult<Points> {
     Ok(Points::Float(coerce_f64(value)?))
 }
 
-/// Apply a closed-form `f(support, point)` element-wise over `(value, min, max)`; shared by the
-/// six value-keyed plugins with an integer-exact path. Null, `NaN` and constant-parameter contracts
-/// follow [`value_keyed_per_row`]: a null bound nulls the row without building, an invalid
-/// parameterisation raises from [`BOUNDS`]'s column pass whatever the row's point is, and constant
-/// bounds take [`du_value_keyed_scalar`] after the same pass.
-fn du_value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
+/// Constant-bounds path of [`point_keyed`]: size the support once, then map `body` over the point
+/// column in its own arithmetic. A `NaN` float point is `NaN` before `body` runs.
+fn point_keyed_scalar<Body>(value: &Series, min: i64, max: i64, body: Body) -> PolarsResult<Series>
 where
-    F: Fn(&Support, Point) -> Option<f64>,
+    Body: Fn(&Support, Point) -> Option<f64>,
+{
+    let support = build_support(min, max)?;
+    let out: Float64Chunked = match coerce_points(value)? {
+        Points::Float(v) => unary_elementwise(&v, |opt| {
+            opt.and_then(|v| {
+                if v.is_nan() {
+                    Some(f64::NAN)
+                } else {
+                    body(&support, Point::Float(v))
+                }
+            })
+        }),
+        Points::Int(v) => unary_elementwise(&v, |opt| {
+            opt.and_then(|v| body(&support, Point::Int(v.into())))
+        }),
+        Points::Wide(v) => unary_elementwise(&v, |opt| {
+            opt.and_then(|v| body(&support, Point::Int(v.into())))
+        }),
+    };
+    Ok(out.into_series())
+}
+
+/// `value_keyed_ternary` with the point kept in its own arithmetic, for the six methods with an
+/// integer-exact path; same null, `NaN` and constant-parameter contracts.
+fn point_keyed<Body>(inputs: &[Series], body: Body) -> PolarsResult<Series>
+where
+    Body: Fn(&Support, Point) -> Option<f64>,
 {
     if params_are_constant(inputs) {
         let (min, max) = (coerce_bound(&inputs[1])?, coerce_bound(&inputs[2])?);
         check_params(&min, &max)?;
         if let Some((min, max)) = min.get(0).zip(max.get(0)) {
-            return du_value_keyed_scalar(&inputs[0], min, max, f);
+            return point_keyed_scalar(&inputs[0], min, max, body);
         }
     }
 
     let inputs = align_inputs(inputs)?;
-    let name = inputs[0].name().clone();
     let min = coerce_bound(&inputs[1])?;
     let max = coerce_bound(&inputs[2])?;
     check_params(&min, &max)?;
 
-    let ca: Float64Chunked = match coerce_points(&inputs[0])? {
+    let out: Float64Chunked = match coerce_points(&inputs[0])? {
         Points::Float(v) => try_ternary_elementwise(&v, &min, &max, |v, lo, hi| {
-            per_row(v.map(Point::Float), lo, hi, &f)
+            per_row(v.map(Point::Float), lo, hi, &body)
         })?,
         Points::Int(v) => try_ternary_elementwise(&v, &min, &max, |v, lo, hi| {
-            per_row(v.map(|v| Point::Int(v.into())), lo, hi, &f)
+            per_row(v.map(|v| Point::Int(v.into())), lo, hi, &body)
         })?,
         Points::Wide(v) => try_ternary_elementwise(&v, &min, &max, |v, lo, hi| {
-            per_row(v.map(|v| Point::Int(v.into())), lo, hi, &f)
+            per_row(v.map(|v| Point::Int(v.into())), lo, hi, &body)
         })?,
     };
-    Ok(ca.with_name(name).into_series())
+    Ok(out.into_series())
 }
 
-/// One row of [`du_value_keyed`]: build before the point is read, so an invalid parameterisation
-/// raises whatever the row's point is, exactly as [`value_keyed_per_row`] orders it.
 #[inline]
-fn per_row<F>(
+fn per_row<Body>(
     point: Option<Point>,
     min: Option<i64>,
     max: Option<i64>,
-    f: &F,
+    body: &Body,
 ) -> PolarsResult<Option<f64>>
 where
-    F: Fn(&Support, Point) -> Option<f64>,
+    Body: Fn(&Support, Point) -> Option<f64>,
 {
-    let (Some(min), Some(max)) = (min, max) else {
+    let (Some(min), Some(max), Some(point)) = (min, max, point) else {
         return Ok(None);
     };
-    let support = build_support(min, max)?;
-    let Some(point) = point else {
-        return Ok(None);
-    };
-    Ok(match point {
-        Point::Float(v) if v.is_nan() => Some(f64::NAN),
-        _ => f(&support, point),
-    })
+    if let Point::Float(v) = point {
+        if v.is_nan() {
+            return Ok(Some(f64::NAN));
+        }
+    }
+    Ok(body(&build_support(min, max)?, point))
 }
 
-/// Element-wise pmf: `1 / N` on the integer support, `0` off it, `NaN` for a `NaN` value.
-/// See [`du_value_keyed`] for the null/error contract.
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_pmf(inputs: &[Series]) -> PolarsResult<Series> {
-    du_value_keyed(inputs, pmf_point)
+    point_keyed(inputs, pmf_point)
 }
 
-/// Element-wise log-pmf: `-ln(N)` on the integer support, `-inf` off it.
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_ln_pmf(inputs: &[Series]) -> PolarsResult<Series> {
-    du_value_keyed(inputs, ln_pmf_point)
+    point_keyed(inputs, ln_pmf_point)
 }
 
-/// Element-wise cdf `P(X <= floor(value))`; see [`cdf_point`] for the endpoint contract.
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    du_value_keyed(inputs, cdf_point)
+    point_keyed(inputs, cdf_point)
 }
 
-/// Element-wise survival function `P(X > floor(value))`; see [`sf_point`].
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    du_value_keyed(inputs, sf_point)
+    point_keyed(inputs, sf_point)
 }
 
-/// Element-wise log-cdf, `ln_1p`-stable near the top of the support; see [`ln_cdf_point`].
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    du_value_keyed(inputs, ln_cdf_point)
+    point_keyed(inputs, ln_cdf_point)
 }
 
-/// Element-wise log-sf, `ln_1p`-stable near the bottom of the support; see [`ln_sf_point`].
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    du_value_keyed(inputs, ln_sf_point)
+    point_keyed(inputs, ln_sf_point)
 }
 
-/// Element-wise ppf (inverse cdf), returning the integer support point as `f64`.
-/// See [`ppf_value`] for the correction and endpoint contract.
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_ppf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_per_row(
+    value_keyed_ternary(
         inputs,
         coerce_bound,
         coerce_bound,
@@ -444,10 +399,9 @@ fn discreteuniform_ppf(inputs: &[Series]) -> PolarsResult<Series> {
     )
 }
 
-/// Element-wise inverse survival function; see [`isf_value`] for the two-sided correction.
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_per_row(
+    value_keyed_ternary(
         inputs,
         coerce_bound,
         coerce_bound,
@@ -457,184 +411,133 @@ fn discreteuniform_isf(inputs: &[Series]) -> PolarsResult<Series> {
     )
 }
 
-/// Constant-parameter fast path for [`discreteuniform_pmf`].
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_pmf_scalar(
     inputs: &[Series],
-    kwargs: DiscreteUniformParamsKwargs,
+    kwargs: DiscreteUniformParams,
 ) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], pmf_point)
+    kwargs.point_keyed(&inputs[0], pmf_point)
 }
 
-/// Constant-parameter fast path for [`discreteuniform_ln_pmf`].
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_ln_pmf_scalar(
     inputs: &[Series],
-    kwargs: DiscreteUniformParamsKwargs,
+    kwargs: DiscreteUniformParams,
 ) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], ln_pmf_point)
+    kwargs.point_keyed(&inputs[0], ln_pmf_point)
 }
 
-/// Constant-parameter fast path for [`discreteuniform_cdf`].
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_cdf_scalar(
     inputs: &[Series],
-    kwargs: DiscreteUniformParamsKwargs,
+    kwargs: DiscreteUniformParams,
 ) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], cdf_point)
+    kwargs.point_keyed(&inputs[0], cdf_point)
 }
 
-/// Constant-parameter fast path for [`discreteuniform_sf`].
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_sf_scalar(
     inputs: &[Series],
-    kwargs: DiscreteUniformParamsKwargs,
+    kwargs: DiscreteUniformParams,
 ) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], sf_point)
+    kwargs.point_keyed(&inputs[0], sf_point)
 }
 
-/// Constant-parameter fast path for [`discreteuniform_ln_cdf`].
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_ln_cdf_scalar(
     inputs: &[Series],
-    kwargs: DiscreteUniformParamsKwargs,
+    kwargs: DiscreteUniformParams,
 ) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], ln_cdf_point)
+    kwargs.point_keyed(&inputs[0], ln_cdf_point)
 }
 
-/// Constant-parameter fast path for [`discreteuniform_ln_sf`].
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_ln_sf_scalar(
     inputs: &[Series],
-    kwargs: DiscreteUniformParamsKwargs,
+    kwargs: DiscreteUniformParams,
 ) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], ln_sf_point)
+    kwargs.point_keyed(&inputs[0], ln_sf_point)
 }
 
-/// Constant-parameter fast path for [`discreteuniform_ppf`].
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_ppf_scalar(
     inputs: &[Series],
-    kwargs: DiscreteUniformParamsKwargs,
+    kwargs: DiscreteUniformParams,
 ) -> PolarsResult<Series> {
-    let support = build_support(kwargs.min, kwargs.max)?;
-    value_keyed_scalar(&inputs[0], |q| ppf_value(&support, q))
+    kwargs.value_keyed(&inputs[0], ppf_value)
 }
 
-/// Constant-parameter fast path for [`discreteuniform_isf`].
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_isf_scalar(
     inputs: &[Series],
-    kwargs: DiscreteUniformParamsKwargs,
+    kwargs: DiscreteUniformParams,
 ) -> PolarsResult<Series> {
-    let support = build_support(kwargs.min, kwargs.max)?;
-    value_keyed_scalar(&inputs[0], |q| isf_value(&support, q))
+    kwargs.value_keyed(&inputs[0], isf_value)
 }
 
-/// Element-wise validation of the `(min, max)` parameterisation: returns the support count
-/// `N = max - min + 1` as `Float64`, raising if `max < min` or the width overflows `i64`.
-/// `null` propagates.
+/// The support count `N = max - min + 1` as `Float64`, which the Python moments divide by.
 ///
-/// Every closed-form Python method divides by this count, so routing it through Rust is what lets
-/// them report an invalid parameterisation consistently with `discreteuniform_sample`, instead of
-/// silently dividing by zero or a negative.
-///
-/// Callers that need one count *per row* rather than a broadcast scalar append a third input, whose
-/// height [`align_inputs`] broadcasts the bounds up to; the closure never reads it. `_ppf` and `_isf`
-/// need that, because their step-boundary correction divides by the count and compares against the
-/// quantile with no slack: a length-1 count makes polars see a broadcast-scalar division, which the
-/// in-memory engine evaluates as a reciprocal multiply, one ulp from the true division and exactly at
-/// the steps where that flips the comparison to the wrong side of a support point.
+/// Callers that need one count per row rather than a broadcast scalar append a third input whose
+/// height the bounds broadcast up to; the body never reads it. `_ppf` and `_isf` need that: their
+/// step-boundary correction divides by the count and compares against the quantile with no slack,
+/// and a length-1 count makes the in-memory engine evaluate the division as a reciprocal multiply,
+/// one ulp from the true division and exactly at the steps where that flips a support point.
 #[polars_expr(output_type=Float64)]
 fn discreteuniform_range(inputs: &[Series]) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let min = coerce_bound(&inputs[0])?;
-    let max = coerce_bound(&inputs[1])?;
-    BOUNDS.check_columns(&min, &max)?;
-
-    let ca: Float64Chunked = binary_elementwise(&min, &max, |lo: Option<i64>, hi: Option<i64>| {
-        Some((i128::from(hi?) - i128::from(lo?) + 1) as f64)
-    });
-    Ok(ca.into_series())
+    param_keyed(
+        inputs,
+        coerce_bound,
+        coerce_bound,
+        check_params,
+        |lo, hi| Ok((i128::from(hi) - i128::from(lo) + 1) as f64),
+    )
 }
 
-/// One DiscreteUniform draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
-///
-/// Every sampler draws through here, per-row and fast path alike, so their bit-equality is
-/// structural rather than only sampled by `sample_test.py`.
 #[inline]
 fn draw(dist: &DiscreteUniform, rng: &mut impl rand::Rng) -> i64 {
     <DiscreteUniform as Distribution<i64>>::sample(dist, rng)
 }
 
-/// Element-wise DiscreteUniform sampler over `(min, max, row_index)`, returning `Int64`.
-///
-/// Per row, `null` propagates; an invalid parameterisation raises from [`BOUNDS`]'s column pass.
-/// Seeding and chunk-invariance follow [`sample_per_row_ternary`].
 #[polars_expr(output_type=Int64)]
 fn discreteuniform_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let min = coerce_bound(&inputs[0])?;
-    let max = coerce_bound(&inputs[1])?;
-    let index = inputs[2].cast(&DataType::UInt64)?;
-    let name = inputs[0].name().clone();
-    BOUNDS.check_columns(&min, &max)?;
-
     sample_per_row_ternary(
-        name,
-        &min,
-        &max,
-        index.u64()?,
-        kwargs.seed,
+        inputs,
+        kwargs,
+        coerce_bound,
+        coerce_bound,
+        check_params,
         build_dist,
         draw,
     )
 }
 
-/// Constant-parameter fast path for [`discreteuniform_sample`].
 #[polars_expr(output_type=Int64)]
 fn discreteuniform_sample_scalar(
     inputs: &[Series],
-    kwargs: SampleScalarKwargs<DiscreteUniformParamsKwargs>,
+    kwargs: SampleScalarKwargs<DiscreteUniformParams>,
 ) -> PolarsResult<Series> {
     let dist = kwargs.params.build()?;
-    let name = inputs[0].name().clone();
-
-    sample_by_index(name, &inputs[0], kwargs.seed, |rng| draw(&dist, rng))
+    sample_by_index(&inputs[0], kwargs.seed, |rng| draw(&dist, rng))
 }
 
-/// Constant-parameter multi-draw fast path: the `samples` twin of
-/// [`discreteuniform_sample_scalar`].
-///
-/// `size` consecutive draws from each row's stream, so `samples(size=1)` matches `sample` bit for
-/// bit and the distribution is built once per call. Returns `Array(Int64, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_i64_output)]
 fn discreteuniform_samples_scalar(
     inputs: &[Series],
-    kwargs: SamplesScalarKwargs<DiscreteUniformParamsKwargs>,
+    kwargs: SamplesScalarKwargs<DiscreteUniformParams>,
 ) -> PolarsResult<Series> {
     let dist = kwargs.params.build()?;
-    let name = inputs[0].name().clone();
-
-    samples_by_index(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
-        draw(&dist, rng)
-    })
+    samples_by_index(&inputs[0], kwargs.seed, kwargs.size, |rng| draw(&dist, rng))
 }
 
-/// Element-wise multi-draw DiscreteUniform sampler: `size` draws per row in one call, the
-/// distribution built once per row. Returns `Array(Int64, size)`.
-///
-/// Seeding and the null/error contract follow [`samples_per_row`] and [`discreteuniform_sample`].
 #[polars_expr(output_type_func_with_kwargs=samples_i64_output)]
 fn discreteuniform_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let min = coerce_bound(&inputs[0])?;
-    let max = coerce_bound(&inputs[1])?;
-    let index = inputs[2].cast(&DataType::UInt64)?;
-    let name = inputs[0].name().clone();
-    BOUNDS.check_columns(&min, &max)?;
-
-    let rows = ternary_param_rows(&min, &max, index.u64()?, build_dist);
-
-    samples_per_row(name, rows, kwargs.seed, kwargs.size, draw)
+    samples_per_row_ternary(
+        inputs,
+        kwargs,
+        coerce_bound,
+        coerce_bound,
+        check_params,
+        build_dist,
+        draw,
+    )
 }

--- a/src/distributions/exponential.rs
+++ b/src/distributions/exponential.rs
@@ -4,36 +4,32 @@ use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::Exp;
 
 use crate::distributions::{
-    align_inputs, coerce_f64, expm1, on_unit_interval, value_keyed_derived_per_row,
-    value_keyed_derived_scalar, ParamDomain, Sides,
+    expm1, on_unit_interval, validated_param, value_keyed_derived_binary, value_keyed_scalar,
+    ParamDomain, Sides,
 };
 use crate::rng::{
-    binary_param_rows, sample_by_index, sample_per_row_binary, samples_by_index,
-    samples_f64_output, samples_per_row, SampleKwargs, SampleScalarKwargs, SamplesKwargs,
-    SamplesScalarKwargs,
+    sample_by_index, sample_per_row_binary, samples_by_index, samples_f64_output,
+    samples_per_row_binary, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
 const RATE: ParamDomain = ParamDomain::positive("rate");
 
-/// `statrs::Exp::new` accepts a positive-infinite rate (a degenerate point mass at 0), so [`RATE`]
-/// is what refuses it; behind its pass this cannot fail.
 fn build_dist(rate: f64) -> PolarsResult<Exp> {
     Exp::new(rate).map_err(|e| polars_err!(ComputeError: "{e}"))
 }
 
-/// Exponential's constant rate, deserialised once per call.
+/// Constant parameter, deserialised once per call; every `_scalar` twin checks it once here.
 #[derive(serde::Deserialize)]
-struct ExponentialParamsKwargs {
+struct ExponentialParams {
     rate: f64,
 }
 
-impl ExponentialParamsKwargs {
+impl ExponentialParams {
     fn build(&self) -> PolarsResult<Exp> {
         RATE.check(self.rate)?;
         build_dist(self.rate)
     }
 
-    /// Validates once per call, then derives and maps through [`value_keyed_derived_scalar`].
     fn value_keyed<Branches>(
         &self,
         value: &Series,
@@ -41,32 +37,23 @@ impl ExponentialParamsKwargs {
         select: impl Fn(&Branches, f64) -> Option<f64>,
     ) -> PolarsResult<Series> {
         RATE.check(self.rate)?;
-        value_keyed_derived_scalar(value, self.rate, derive, select)
+        value_keyed_scalar(value, &derive(self.rate), select)
     }
 }
 
-/// `rate` unchanged after [`RATE`]'s column pass, `null` included. The moments derive from this so
-/// an invalid rate raises as it does from `exponential_sample`.
 #[polars_expr(output_type=Float64)]
 fn exponential_rate(inputs: &[Series]) -> PolarsResult<Series> {
-    let rate = coerce_f64(&inputs[0])?;
-    RATE.check_column(&rate)?;
-    Ok(rate.into_series())
+    validated_param(inputs, &RATE)
 }
 
-/// Crossover of [`derive_cdf`], in units of `t = rate * x`.
-///
-/// Above `t = 1` the plain `1 - exp(-t)` is already exact, and the [`expm1`] identity that replaces
-/// it below would overflow past `t ~ 1420`. The two branches agree to `1e-16` here.
+/// Crossover of [`derive_cdf`] in units of `t = rate * x`: above it the plain `1 - exp(-t)` is
+/// already exact, and the [`expm1`] identity below it would overflow past `t ~ 1420`. The two
+/// branches agree to `1e-16` here.
 const CDF_SINH_MAX: f64 = 1.0;
 
-/// `rate * exp(-rate * x)` on `x >= 0`, `0` below, keeping the subnormal range exact.
-///
-/// Reassociated as `(rate * exp(-rate * x / 2)) * exp(-rate * x / 2)`: the same product with the
-/// rounding moved to the end. Written literally, `exp(-rate * x)` rounds into the gradual-underflow
-/// range while the scale is still to be applied, and the final multiply then magnifies what the
-/// subnormal threw away. Halving the exponent keeps the intermediate normal, at the cost of one
-/// multiply and no branch.
+/// `rate * exp(-rate * x)` on `x >= 0`, `0` below, as `(rate * exp(-t / 2)) * exp(-t / 2)`: written
+/// literally, `exp(-t)` rounds into the subnormal range before the scale is applied and the final
+/// multiply magnifies what was thrown away.
 fn derive_pdf(rate: f64) -> Sides<impl Fn(f64) -> f64, 0> {
     Sides {
         below_support: 0.0,
@@ -77,8 +64,7 @@ fn derive_pdf(rate: f64) -> Sides<impl Fn(f64) -> f64, 0> {
     }
 }
 
-/// `ln(rate) - rate * x` on `x >= 0`, `-inf` below. `ln(rate)` is the only term the rate alone fixes,
-/// so it is the only one [`value_keyed_derived_scalar`] can lift out of the loop.
+/// `ln(rate) - rate * x` on `x >= 0`, `-inf` below; `ln(rate)` is hoisted out of the row loop.
 fn derive_ln_pdf(rate: f64) -> Sides<impl Fn(f64) -> f64, 0> {
     Sides {
         below_support: f64::NEG_INFINITY,
@@ -89,10 +75,8 @@ fn derive_ln_pdf(rate: f64) -> Sides<impl Fn(f64) -> f64, 0> {
     }
 }
 
-/// `1 - exp(-rate * x)` on `x >= 0`, `0` below, keeping the left tail exact.
-///
-/// `1 - exp(-t)` cancels to `0` below `t ~ 1.1e-16`, so the small branch reads it as `-expm1(-t)`;
-/// see [`CDF_SINH_MAX`] for why the crossover is where it is.
+/// `1 - exp(-rate * x)` on `x >= 0`, `0` below. `1 - exp(-t)` cancels to `0` below `t ~ 1.1e-16`,
+/// so the small side reads `-expm1(-t)`.
 fn derive_cdf(rate: f64) -> Sides<impl Fn(f64) -> f64, 0> {
     Sides {
         below_support: 0.0,
@@ -107,16 +91,10 @@ fn derive_cdf(rate: f64) -> Sides<impl Fn(f64) -> f64, 0> {
     }
 }
 
-/// `ln(cdf)` in the left tail, `ln_1p(-sf)` in the right; `-inf` below the support.
-///
-/// As `cdf -> 1` the cdf rounds to ~1 and its log to a tiny, inaccurate value, so that side goes
-/// through `ln_1p` of the small `sf`. As `cdf -> 0` the log is well conditioned and [`derive_cdf`] is
-/// exact there, so that side is its log.
-///
-/// The predicate `rate * x < 1` says where `ln(cdf)` is well conditioned; it is not a comparison
-/// against the computed cdf. It coincides with [`CDF_SINH_MAX`] rather than deriving from it, which
-/// is what lets the left arm inline [`derive_cdf`]'s `expm1` branch: on the support and below
-/// `t = 1` that is the only branch it would take.
+/// `ln(cdf)` where `t < 1`, `ln_1p(-sf)` above; `-inf` below the support. As `cdf -> 1` its log
+/// rounds to a tiny inaccurate value, so that side goes through `ln_1p` of the small `sf`; the
+/// predicate says where `ln(cdf)` is well conditioned and coincides with [`CDF_SINH_MAX`], which is
+/// what lets the left arm inline [`derive_cdf`]'s `expm1` branch.
 fn derive_ln_cdf(rate: f64) -> Sides<impl Fn(f64) -> f64, 0> {
     Sides {
         below_support: f64::NEG_INFINITY,
@@ -131,10 +109,8 @@ fn derive_ln_cdf(rate: f64) -> Sides<impl Fn(f64) -> f64, 0> {
     }
 }
 
-/// `exp(-rate * x)` on `x >= 0`, `1` below.
-///
-/// The closed form, never `1 - cdf`: the complement quantises the upper tail to the `1.1e-16`
-/// spacing of `1.0` and reaches `0.0` below that.
+/// `exp(-rate * x)` on `x >= 0`, `1` below; never `1 - cdf`, which quantises the upper tail to the
+/// `1.1e-16` spacing of `1.0`.
 fn derive_sf(rate: f64) -> Sides<impl Fn(f64) -> f64, 0> {
     Sides {
         below_support: 1.0,
@@ -142,7 +118,6 @@ fn derive_sf(rate: f64) -> Sides<impl Fn(f64) -> f64, 0> {
     }
 }
 
-/// `-rate * x` on `x >= 0`, `0` below: the plain log of [`derive_sf`].
 fn derive_ln_sf(rate: f64) -> Sides<impl Fn(f64) -> f64, 0> {
     Sides {
         below_support: 0.0,
@@ -150,217 +125,127 @@ fn derive_ln_sf(rate: f64) -> Sides<impl Fn(f64) -> f64, 0> {
     }
 }
 
-/// `-ln_1p(-q) / rate`, the exact inverse cdf; null outside `[0, 1]`.
-///
-/// Through `ln_1p` rather than `ln(1 - q)`: the latter rounds `1 - q` to exactly `1` below
-/// `q ~ 1.1e-16` and collapses to `-0.0`.
-///
-/// The rate is divided by, never reciprocated: `x * (1 / rate)` rounds twice where `x / rate` rounds
-/// once, and at a subnormal rate the reciprocal reaches `inf` and `NaN` where the division stays
-/// finite. So neither inverse hoists anything into its `derive`.
+/// `-ln_1p(-q) / rate`; `ln(1 - q)` rounds `1 - q` to exactly `1` below `q ~ 1.1e-16`. The rate is
+/// divided by, never reciprocated: `x * (1 / rate)` rounds twice, and at a subnormal rate the
+/// reciprocal reaches `inf` where the division stays finite.
 fn derive_ppf(rate: f64) -> impl Fn(f64) -> f64 {
     move |quantile: f64| (-((-quantile).ln_1p())) / rate
 }
 
-/// `-ln(q) / rate`, the exact inverse survival function; null outside `[0, 1]`.
-///
-/// Never `ppf(1 - q)`: that forms the complement and then undoes it, losing the answer whenever
-/// either step saturates.
+/// `-ln(q) / rate`, solved on `q` itself rather than as `ppf(1 - q)`.
 fn derive_isf(rate: f64) -> impl Fn(f64) -> f64 {
     move |quantile: f64| (-quantile.ln()) / rate
 }
 
-/// Element-wise pdf; see [`derive_pdf`] for the subnormal reassociation.
-/// See [`value_keyed_derived_per_row`] for the null/error contract.
 #[polars_expr(output_type=Float64)]
 fn exponential_pdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &RATE, derive_pdf, Sides::at)
+    value_keyed_derived_binary(inputs, &RATE, derive_pdf, Sides::at)
 }
 
-/// Element-wise log-pdf; see [`derive_ln_pdf`].
 #[polars_expr(output_type=Float64)]
 fn exponential_ln_pdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &RATE, derive_ln_pdf, Sides::at)
+    value_keyed_derived_binary(inputs, &RATE, derive_ln_pdf, Sides::at)
 }
 
-/// Element-wise cdf `P(X <= value)`; see [`derive_cdf`] and [`CDF_SINH_MAX`].
 #[polars_expr(output_type=Float64)]
 fn exponential_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &RATE, derive_cdf, Sides::at)
+    value_keyed_derived_binary(inputs, &RATE, derive_cdf, Sides::at)
 }
 
-/// Element-wise log-cdf; see [`derive_ln_cdf`].
 #[polars_expr(output_type=Float64)]
 fn exponential_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &RATE, derive_ln_cdf, Sides::at)
+    value_keyed_derived_binary(inputs, &RATE, derive_ln_cdf, Sides::at)
 }
 
-/// Element-wise survival function `P(X > value)`; see [`derive_sf`] for why it is not `1 - cdf`.
 #[polars_expr(output_type=Float64)]
 fn exponential_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &RATE, derive_sf, Sides::at)
+    value_keyed_derived_binary(inputs, &RATE, derive_sf, Sides::at)
 }
 
-/// Element-wise log-sf; see [`derive_ln_sf`].
 #[polars_expr(output_type=Float64)]
 fn exponential_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &RATE, derive_ln_sf, Sides::at)
+    value_keyed_derived_binary(inputs, &RATE, derive_ln_sf, Sides::at)
 }
 
-/// Element-wise ppf (inverse cdf); see [`derive_ppf`].
 #[polars_expr(output_type=Float64)]
 fn exponential_ppf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &RATE, derive_ppf, on_unit_interval)
+    value_keyed_derived_binary(inputs, &RATE, derive_ppf, on_unit_interval)
 }
 
-/// Element-wise inverse survival function; see [`derive_isf`] for why it never forms a complement.
 #[polars_expr(output_type=Float64)]
 fn exponential_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &RATE, derive_isf, on_unit_interval)
+    value_keyed_derived_binary(inputs, &RATE, derive_isf, on_unit_interval)
 }
 
-/// Constant-rate fast path for [`exponential_pdf`].
 #[polars_expr(output_type=Float64)]
-fn exponential_pdf_scalar(
-    inputs: &[Series],
-    kwargs: ExponentialParamsKwargs,
-) -> PolarsResult<Series> {
+fn exponential_pdf_scalar(inputs: &[Series], kwargs: ExponentialParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_pdf, Sides::at)
 }
 
-/// Constant-rate fast path for [`exponential_ln_pdf`].
 #[polars_expr(output_type=Float64)]
-fn exponential_ln_pdf_scalar(
-    inputs: &[Series],
-    kwargs: ExponentialParamsKwargs,
-) -> PolarsResult<Series> {
+fn exponential_ln_pdf_scalar(inputs: &[Series], kwargs: ExponentialParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_ln_pdf, Sides::at)
 }
 
-/// Constant-rate fast path for [`exponential_cdf`].
 #[polars_expr(output_type=Float64)]
-fn exponential_cdf_scalar(
-    inputs: &[Series],
-    kwargs: ExponentialParamsKwargs,
-) -> PolarsResult<Series> {
+fn exponential_cdf_scalar(inputs: &[Series], kwargs: ExponentialParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_cdf, Sides::at)
 }
 
-/// Constant-rate fast path for [`exponential_ln_cdf`].
 #[polars_expr(output_type=Float64)]
-fn exponential_ln_cdf_scalar(
-    inputs: &[Series],
-    kwargs: ExponentialParamsKwargs,
-) -> PolarsResult<Series> {
+fn exponential_ln_cdf_scalar(inputs: &[Series], kwargs: ExponentialParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_ln_cdf, Sides::at)
 }
 
-/// Constant-rate fast path for [`exponential_sf`].
 #[polars_expr(output_type=Float64)]
-fn exponential_sf_scalar(
-    inputs: &[Series],
-    kwargs: ExponentialParamsKwargs,
-) -> PolarsResult<Series> {
+fn exponential_sf_scalar(inputs: &[Series], kwargs: ExponentialParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_sf, Sides::at)
 }
 
-/// Constant-rate fast path for [`exponential_ln_sf`].
 #[polars_expr(output_type=Float64)]
-fn exponential_ln_sf_scalar(
-    inputs: &[Series],
-    kwargs: ExponentialParamsKwargs,
-) -> PolarsResult<Series> {
+fn exponential_ln_sf_scalar(inputs: &[Series], kwargs: ExponentialParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_ln_sf, Sides::at)
 }
 
-/// Constant-rate fast path for [`exponential_ppf`].
 #[polars_expr(output_type=Float64)]
-fn exponential_ppf_scalar(
-    inputs: &[Series],
-    kwargs: ExponentialParamsKwargs,
-) -> PolarsResult<Series> {
+fn exponential_ppf_scalar(inputs: &[Series], kwargs: ExponentialParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_ppf, on_unit_interval)
 }
 
-/// Constant-rate fast path for [`exponential_isf`].
 #[polars_expr(output_type=Float64)]
-fn exponential_isf_scalar(
-    inputs: &[Series],
-    kwargs: ExponentialParamsKwargs,
-) -> PolarsResult<Series> {
+fn exponential_isf_scalar(inputs: &[Series], kwargs: ExponentialParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_isf, on_unit_interval)
 }
 
-/// One Exponential draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
-///
-/// Every Exponential sampler draws through here, per-row and fast path alike, so their bit-equality is
-/// structural rather than only sampled by `sample_test.py`.
 #[inline]
 fn draw(dist: &Exp, rng: &mut impl rand::Rng) -> f64 {
     RandDistribution::sample(dist, rng)
 }
 
-/// Element-wise Exponential sampler over `(rate, row_index)`, returning `Float64`.
-///
-/// Per row, `null` propagates; an invalid rate raises from [`RATE`]'s column pass first. Seeding
-/// and chunk-invariance follow [`sample_per_row_binary`].
-///
-/// The draw keeps `statrs` (`O(1)` ziggurat: `sample_exp_1(rng) / rate`); routing it through
-/// `rand_distr` would buy nothing, since that is already the algorithm class `statrs` uses (unlike
-/// the binomial draw, see docs/explanation/design.md).
 #[polars_expr(output_type=Float64)]
 fn exponential_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let rate = coerce_f64(&inputs[0])?;
-    let index = inputs[1].cast(&DataType::UInt64)?;
-    let name = inputs[0].name().clone();
-    RATE.check_column(&rate)?;
-
-    sample_per_row_binary(name, &rate, index.u64()?, kwargs.seed, build_dist, draw)
+    sample_per_row_binary(inputs, kwargs, &RATE, build_dist, draw)
 }
 
-/// Constant-rate fast path for [`exponential_sample`].
 #[polars_expr(output_type=Float64)]
 fn exponential_sample_scalar(
     inputs: &[Series],
-    kwargs: SampleScalarKwargs<ExponentialParamsKwargs>,
+    kwargs: SampleScalarKwargs<ExponentialParams>,
 ) -> PolarsResult<Series> {
     let dist = kwargs.params.build()?;
-    let name = inputs[0].name().clone();
-
-    sample_by_index(name, &inputs[0], kwargs.seed, |rng| draw(&dist, rng))
+    sample_by_index(&inputs[0], kwargs.seed, |rng| draw(&dist, rng))
 }
 
-/// Constant-parameter multi-draw fast path: the `samples` twin of [`exponential_sample_scalar`].
-///
-/// `size` consecutive draws from each row's stream, so `samples(size=1)` matches `sample` bit for
-/// bit and the distribution is built once per call. Returns `Array(Float64, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn exponential_samples_scalar(
     inputs: &[Series],
-    kwargs: SamplesScalarKwargs<ExponentialParamsKwargs>,
+    kwargs: SamplesScalarKwargs<ExponentialParams>,
 ) -> PolarsResult<Series> {
     let dist = kwargs.params.build()?;
-    let name = inputs[0].name().clone();
-
-    samples_by_index(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
-        draw(&dist, rng)
-    })
+    samples_by_index(&inputs[0], kwargs.seed, kwargs.size, |rng| draw(&dist, rng))
 }
 
-/// Element-wise multi-draw Exponential sampler: `size` draws per row in one call, the distribution
-/// built once per row. Returns `Array(Float64, size)`.
-///
-/// Seeding and the null/error contract follow [`samples_per_row`] and [`exponential_sample`].
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn exponential_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let rate = coerce_f64(&inputs[0])?;
-    let index = inputs[1].cast(&DataType::UInt64)?;
-    let name = inputs[0].name().clone();
-    RATE.check_column(&rate)?;
-
-    let rows = binary_param_rows(&rate, index.u64()?, build_dist);
-
-    samples_per_row(name, rows, kwargs.seed, kwargs.size, draw)
+    samples_per_row_binary(inputs, kwargs, &RATE, build_dist, draw)
 }

--- a/src/distributions/geometric.rs
+++ b/src/distributions/geometric.rs
@@ -4,11 +4,11 @@ use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::Geometric;
 
 use crate::distributions::{
-    align_inputs, coerce_f64, expm1, ln_abs_expm1, on_unit_interval, value_keyed_derived_per_row,
-    value_keyed_derived_scalar, ParamDomain, Sides,
+    expm1, ln_abs_expm1, on_unit_interval, validated_param, value_keyed_derived_binary,
+    value_keyed_scalar, ParamDomain, Sides,
 };
 use crate::rng::{
-    binary_param_rows, sample_by_index, sample_per_row_binary, samples_by_index, samples_per_row,
+    sample_by_index, sample_per_row_binary, samples_by_index, samples_per_row_binary,
     samples_u64_output, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
@@ -19,38 +19,35 @@ const P: ParamDomain = ParamDomain {
     accepts: |p| p.is_finite() && p > 0.0 && p <= 1.0,
 };
 
-/// Cannot fail behind [`P`]'s pass; the `statrs` error is kept as the backstop.
-fn build_dist(proba: f64) -> PolarsResult<Geometric> {
-    Geometric::new(proba).map_err(|e| polars_err!(ComputeError: "{e}"))
+fn build_dist(p: f64) -> PolarsResult<Geometric> {
+    Geometric::new(p).map_err(|e| polars_err!(ComputeError: "{e}"))
 }
 
-/// `ln(1 - p)` as `ln_1p(-p)`: the literal `ln(1.0 - p)` inherits the rounding of `1 - p` (a few
-/// parts in `1e9` at `p = 1e-8`) and collapses to `0.0` below `p ~ 1.1e-16`. `-inf` at `p = 1`.
+/// `ln(1 - p)` as `ln_1p(-p)`: the literal `ln(1.0 - p)` inherits the rounding of `1 - p` and
+/// collapses to `0.0` below `p ~ 1.1e-16`. `-inf` at `p = 1`.
 #[inline]
-fn ln_failure(proba: f64) -> f64 {
-    (-proba).ln_1p()
+fn ln_failure(p: f64) -> f64 {
+    (-p).ln_1p()
 }
 
-/// The samplers' per-row state: [`ln_failure`], behind [`build_dist`]'s backstop. Built once per
-/// row, not once per draw: the multi-draw and constant-parameter paths take many draws per state.
-fn build_sampler(proba: f64) -> PolarsResult<f64> {
-    build_dist(proba)?;
-    Ok(ln_failure(proba))
+/// The samplers' per-row state, behind [`build_dist`]'s check.
+fn build_sampler(p: f64) -> PolarsResult<f64> {
+    build_dist(p)?;
+    Ok(ln_failure(p))
 }
 
-/// Geometric's constant success probability, deserialised once per call.
+/// Constant parameter, deserialised once per call; every `_scalar` twin checks it once here.
 #[derive(serde::Deserialize)]
-struct GeometricParamsKwargs {
+struct GeometricParams {
     p: f64,
 }
 
-impl GeometricParamsKwargs {
+impl GeometricParams {
     fn build_sampler(&self) -> PolarsResult<f64> {
         P.check(self.p)?;
         build_sampler(self.p)
     }
 
-    /// Validates once per call, then derives and maps through [`value_keyed_derived_scalar`].
     fn value_keyed<Branches>(
         &self,
         value: &Series,
@@ -58,33 +55,24 @@ impl GeometricParamsKwargs {
         select: impl Fn(&Branches, f64) -> Option<f64>,
     ) -> PolarsResult<Series> {
         P.check(self.p)?;
-        value_keyed_derived_scalar(value, self.p, derive, select)
+        value_keyed_scalar(value, &derive(self.p), select)
     }
 }
 
-/// `p` unchanged after [`P`]'s column pass, `null` included. The moments derive from this so an
-/// invalid `p` raises as it does from `geometric_sample`.
 #[polars_expr(output_type=Float64)]
 fn geometric_p(inputs: &[Series]) -> PolarsResult<Series> {
-    let proba = coerce_f64(&inputs[0])?;
-    P.check_column(&proba)?;
-    Ok(proba.into_series())
+    validated_param(inputs, &P)
 }
 
-/// Crossover of [`derive_cdf`], in units of `ln(sf)`.
-///
-/// Below it `exp(ln_sf)` is small enough that the direct `1 - exp(ln_sf)` rounds no worse than the
-/// `sinh` identity and cannot round above `1`. The identity itself only breaks past `ln_sf ~ -1455`,
-/// where `sinh` overflows, far inside this branch.
+/// Crossover of [`derive_cdf`] in units of `ln(sf)`: below it `exp(ln_sf)` is small enough that the
+/// direct `1 - exp(ln_sf)` rounds no worse than the `sinh` identity and cannot round above `1`.
 const CDF_DIRECT_COMPLEMENT_MAX: f64 = -20.0;
 
-/// Crossover of [`derive_ln_cdf`], in units of `ln(sf)`.
-///
-/// Below it the cdf sits within `0.63` of `1` and `ln_1p(-exp(ln_sf))` carries that difference
-/// exactly, down through the `cdf ~ 1 - 1e-16` zone where `cdf.ln()` reads the tail mass as `0`.
+/// Crossover of [`derive_ln_cdf`] in units of `ln(sf)`: below it the cdf sits within `0.63` of `1`
+/// and `ln_1p(-exp(ln_sf))` carries that difference exactly, where `cdf.ln()` reads the tail as `0`.
 const LN_CDF_LN_1P_MAX: f64 = -1.0;
 
-/// `pmf` / `log_pmf`: the constant off the support (below `1`, or a non-integral point), and the arm
+/// `pmf` / `log_pmf`: a constant off the support (below `1`, or a non-integral point), and the arm
 /// `p` derives on it.
 struct Mass<Arm> {
     off_support: f64,
@@ -92,10 +80,8 @@ struct Mass<Arm> {
 }
 
 impl<Arm: Fn(f64) -> f64> Mass<Arm> {
-    /// Only a positive integer takes the arm, so `pmf(2.5)` is `0`, not the mass at `2`.
     /// `floor(k) == k` rather than an integer cast keeps `1e300` and `+inf` on the support, answering
-    /// `0` through the arm instead of saturating. A `NaN` point never reaches here: both drivers
-    /// short-circuit it.
+    /// `0` through the arm instead of saturating.
     fn at(&self, value: f64) -> Option<f64> {
         Some(if value >= 1.0 && value.floor() == value {
             (self.on_support)(value)
@@ -105,15 +91,11 @@ impl<Arm: Fn(f64) -> f64> Mass<Arm> {
     }
 }
 
-/// `cdf` / `log_cdf` / `sf` / `log_sf`: the tail methods floor a non-integral point onto the support,
-/// so `cdf(2.5)` is `cdf(2)` and needs `p` where [`Mass`] answers its constant; the two cannot share
-/// a table.
+/// The tail methods floor a non-integral point onto the support, so `cdf(2.5)` is `cdf(2)`.
 type Tail<Arm> = Sides<Arm, 1>;
 
-/// `(1 - p)^(k - 1) * p` on the positive integers, `0` elsewhere.
-///
-/// `k = 1` short-circuits the power: its exponent `(k - 1) * ln(1 - p)` is `0 * -inf = NaN` at
-/// `p = 1`, where the whole mass sits on `k = 1`.
+/// `(1 - p)^(k - 1) * p` on the positive integers, `0` elsewhere. `k = 1` short-circuits the power,
+/// whose exponent `(k - 1) * ln(1 - p)` is `0 * -inf = NaN` at `p = 1`.
 fn derive_pmf(p: f64) -> Mass<impl Fn(f64) -> f64> {
     Mass {
         off_support: 0.0,
@@ -130,10 +112,8 @@ fn derive_pmf(p: f64) -> Mass<impl Fn(f64) -> f64> {
     }
 }
 
-/// `(k - 1) * ln(1 - p) + ln(p)` on the positive integers, `-inf` elsewhere.
-///
-/// Not `ln(pmf)`, whose `ln(1 - p)` collapses to `0.0` below `p ~ 1.1e-16`. `k = 1` reads `ln(p)`
-/// alone, for the same `0 * -inf` reason as [`derive_pmf`].
+/// `(k - 1) * ln(1 - p) + ln(p)` on the positive integers, `-inf` elsewhere; same `k = 1` guard as
+/// [`derive_pmf`].
 fn derive_ln_pmf(p: f64) -> Mass<impl Fn(f64) -> f64> {
     Mass {
         off_support: f64::NEG_INFINITY,
@@ -150,10 +130,8 @@ fn derive_ln_pmf(p: f64) -> Mass<impl Fn(f64) -> f64> {
     }
 }
 
-/// `1 - (1 - p)^floor(k)` from `1` up, `0` below, read as `-expm1(ln_sf)`.
-///
-/// Below [`CDF_DIRECT_COMPLEMENT_MAX`] it is the direct `1 - exp(ln_sf)` instead. The literal
-/// `1 - (1 - p)^k` would inherit the rounding of both `1 - p` and the subtraction against `1`.
+/// `1 - (1 - p)^floor(k)` from `1` up, `0` below, as `-expm1(ln_sf)`; the direct complement below
+/// [`CDF_DIRECT_COMPLEMENT_MAX`].
 fn derive_cdf(p: f64) -> Tail<impl Fn(f64) -> f64> {
     Tail {
         below_support: 0.0,
@@ -171,11 +149,8 @@ fn derive_cdf(p: f64) -> Tail<impl Fn(f64) -> f64> {
     }
 }
 
-/// `ln(1 - exp(ln_sf))` from `1` up, `-inf` below.
-///
-/// Split at [`LN_CDF_LN_1P_MAX`], where the answer's own magnitude stops dwarfing the absolute
-/// granularity of the pieces: below it `ln_1p` carries the difference from `1` exactly, above it
-/// [`ln_abs_expm1`] assembles the answer on the log scale so the rounding stays relative.
+/// `ln(1 - exp(ln_sf))` from `1` up, `-inf` below: `ln_1p` below [`LN_CDF_LN_1P_MAX`], where the
+/// difference from `1` is what carries the answer, [`ln_abs_expm1`] above it.
 fn derive_ln_cdf(p: f64) -> Tail<impl Fn(f64) -> f64> {
     Tail {
         below_support: f64::NEG_INFINITY,
@@ -193,10 +168,8 @@ fn derive_ln_cdf(p: f64) -> Tail<impl Fn(f64) -> f64> {
     }
 }
 
-/// `exp(ln_sf)` from `1` up, exactly `1` below.
-///
-/// Never `1 - cdf`, which recomputes `p` as `1 - (1 - p)` and so quantises it to the `1.1e-16`
-/// spacing of `1.0`, reaching `0.0` below that.
+/// `exp(ln_sf)` from `1` up, exactly `1` below; never `1 - cdf`, which quantises `p` to the
+/// `1.1e-16` spacing of `1.0`.
 fn derive_sf(p: f64) -> Tail<impl Fn(f64) -> f64> {
     Tail {
         below_support: 1.0,
@@ -207,7 +180,6 @@ fn derive_sf(p: f64) -> Tail<impl Fn(f64) -> f64> {
     }
 }
 
-/// `ln(sf) = floor(k) * ln(1 - p)` from `1` up, `0` below.
 fn derive_ln_sf(p: f64) -> Tail<impl Fn(f64) -> f64> {
     Tail {
         below_support: 0.0,
@@ -218,17 +190,12 @@ fn derive_ln_sf(p: f64) -> Tail<impl Fn(f64) -> f64> {
     }
 }
 
-/// Smallest `k >= 1` with `k * ln_failure <= log_target`, the shape both inverses share: they differ
-/// only in what they take the log of (`1 - q` against `q`).
+/// Smallest `k >= 1` with `k * ln_failure <= log_target`, shared by both inverses.
 ///
-/// A ratio sitting an ulp above an exact integer overshoots by one support point, so the ceiling
-/// steps back down whenever `k - 1` already satisfies the inequality, compared in the same log domain
-/// both sides entered through. The clip to `1.0` is also where `-0.0` lands at the degenerate
-/// endpoint of either inverse.
-///
-/// `ln_failure` is divided by, never reciprocated: `x * (1 / d)` rounds twice where `x / d` rounds
-/// once, and at a subnormal `ln(1 - p)` the reciprocal overflows to `inf`, turning `q = 0` into `NaN`
-/// and every other quantile into `inf`. So neither inverse hoists it into its `derive`.
+/// A ratio one ulp above an exact integer overshoots by one support point, so the ceiling steps back
+/// whenever `k - 1` already satisfies the inequality, compared in the same log domain. The clip to
+/// `1.0` is also where `-0.0` lands at the degenerate endpoint. `ln_failure` is divided by, never
+/// reciprocated: at a subnormal `ln(1 - p)` the reciprocal overflows to `inf`.
 fn smallest_support_point(log_target: f64, ln_failure: f64) -> f64 {
     let ceiling = (log_target / ln_failure).ceil();
     let overshot = (ceiling - 1.0) * ln_failure <= log_target;
@@ -237,11 +204,8 @@ fn smallest_support_point(log_target: f64, ln_failure: f64) -> f64 {
 }
 
 /// `ceil(ln_1p(-q) / ln(1 - p))`, the smallest `k` with `cdf(k) >= q`; null outside `[0, 1]`.
-///
-/// `ln_1p(-q)`, not `ln(1 - q)`, which collapses to `0.0` below `q ~ 1.1e-16` and answers `0` where
-/// `1` is the only correct answer. `q = 1` runs the ratio off to `+inf`, right for an unbounded
-/// support. `p = 1` short-circuits before [`smallest_support_point`], where the ratio would be
-/// `-inf / -inf = NaN`.
+/// `ln_1p(-q)`, not `ln(1 - q)`, which collapses below `q ~ 1.1e-16`. `p = 1` short-circuits the
+/// `-inf / -inf` ratio.
 fn derive_ppf(p: f64) -> impl Fn(f64) -> f64 {
     let ln_failure = ln_failure(p);
     move |quantile: f64| {
@@ -253,12 +217,8 @@ fn derive_ppf(p: f64) -> impl Fn(f64) -> f64 {
     }
 }
 
-/// `ceil(ln(q) / ln(1 - p))`, the smallest `k` with `sf(k) <= q`; null outside `[0, 1]`.
-///
-/// Entered against `q` itself, never as `ppf(1 - q)`, whose complement throws the tail mass away
-/// before the inverse runs. `q = 1` degenerates to `-0.0` and `q = 0` flows through as `+inf`. At
-/// `p = 1` every survival quantile inverts to `k = 1`, `q = 0` included, since `sf(1) = 0` already
-/// satisfies the inequality.
+/// `ceil(ln(q) / ln(1 - p))`, the smallest `k` with `sf(k) <= q`, solved on `q` itself rather than
+/// as `ppf(1 - q)`; null outside `[0, 1]`.
 fn derive_isf(p: f64) -> impl Fn(f64) -> f64 {
     let ln_failure = ln_failure(p);
     move |quantile: f64| {
@@ -270,188 +230,122 @@ fn derive_isf(p: f64) -> impl Fn(f64) -> f64 {
     }
 }
 
-/// Element-wise pmf; see [`derive_pmf`], and [`Mass::at`] for the support rule.
-/// See [`value_keyed_derived_per_row`] for the null/error contract.
 #[polars_expr(output_type=Float64)]
 fn geometric_pmf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, derive_pmf, Mass::at)
+    value_keyed_derived_binary(inputs, &P, derive_pmf, Mass::at)
 }
 
-/// Element-wise log-pmf; see [`derive_ln_pmf`].
 #[polars_expr(output_type=Float64)]
 fn geometric_ln_pmf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, derive_ln_pmf, Mass::at)
+    value_keyed_derived_binary(inputs, &P, derive_ln_pmf, Mass::at)
 }
 
-/// Element-wise cdf `P(X <= value)`; see [`derive_cdf`] and [`CDF_DIRECT_COMPLEMENT_MAX`].
 #[polars_expr(output_type=Float64)]
 fn geometric_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, derive_cdf, Tail::at)
+    value_keyed_derived_binary(inputs, &P, derive_cdf, Tail::at)
 }
 
-/// Element-wise log-cdf; see [`derive_ln_cdf`] and [`LN_CDF_LN_1P_MAX`].
 #[polars_expr(output_type=Float64)]
 fn geometric_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, derive_ln_cdf, Tail::at)
+    value_keyed_derived_binary(inputs, &P, derive_ln_cdf, Tail::at)
 }
 
-/// Element-wise survival function `P(X > value)`; see [`derive_sf`] for why it is not `1 - cdf`.
 #[polars_expr(output_type=Float64)]
 fn geometric_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, derive_sf, Tail::at)
+    value_keyed_derived_binary(inputs, &P, derive_sf, Tail::at)
 }
 
-/// Element-wise log-sf; see [`derive_ln_sf`].
 #[polars_expr(output_type=Float64)]
 fn geometric_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, derive_ln_sf, Tail::at)
+    value_keyed_derived_binary(inputs, &P, derive_ln_sf, Tail::at)
 }
 
-/// Element-wise ppf (inverse cdf); see [`derive_ppf`] and [`smallest_support_point`].
 #[polars_expr(output_type=Float64)]
 fn geometric_ppf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, derive_ppf, on_unit_interval)
+    value_keyed_derived_binary(inputs, &P, derive_ppf, on_unit_interval)
 }
 
-/// Element-wise inverse survival function; see [`derive_isf`] for why it never forms a complement.
 #[polars_expr(output_type=Float64)]
 fn geometric_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_per_row(inputs, &P, derive_isf, on_unit_interval)
+    value_keyed_derived_binary(inputs, &P, derive_isf, on_unit_interval)
 }
 
-/// Constant-`p` fast path for [`geometric_pmf`].
 #[polars_expr(output_type=Float64)]
-fn geometric_pmf_scalar(inputs: &[Series], kwargs: GeometricParamsKwargs) -> PolarsResult<Series> {
+fn geometric_pmf_scalar(inputs: &[Series], kwargs: GeometricParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_pmf, Mass::at)
 }
 
-/// Constant-`p` fast path for [`geometric_ln_pmf`].
 #[polars_expr(output_type=Float64)]
-fn geometric_ln_pmf_scalar(
-    inputs: &[Series],
-    kwargs: GeometricParamsKwargs,
-) -> PolarsResult<Series> {
+fn geometric_ln_pmf_scalar(inputs: &[Series], kwargs: GeometricParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_ln_pmf, Mass::at)
 }
 
-/// Constant-`p` fast path for [`geometric_cdf`].
 #[polars_expr(output_type=Float64)]
-fn geometric_cdf_scalar(inputs: &[Series], kwargs: GeometricParamsKwargs) -> PolarsResult<Series> {
+fn geometric_cdf_scalar(inputs: &[Series], kwargs: GeometricParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_cdf, Tail::at)
 }
 
-/// Constant-`p` fast path for [`geometric_ln_cdf`].
 #[polars_expr(output_type=Float64)]
-fn geometric_ln_cdf_scalar(
-    inputs: &[Series],
-    kwargs: GeometricParamsKwargs,
-) -> PolarsResult<Series> {
+fn geometric_ln_cdf_scalar(inputs: &[Series], kwargs: GeometricParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_ln_cdf, Tail::at)
 }
 
-/// Constant-`p` fast path for [`geometric_sf`].
 #[polars_expr(output_type=Float64)]
-fn geometric_sf_scalar(inputs: &[Series], kwargs: GeometricParamsKwargs) -> PolarsResult<Series> {
+fn geometric_sf_scalar(inputs: &[Series], kwargs: GeometricParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_sf, Tail::at)
 }
 
-/// Constant-`p` fast path for [`geometric_ln_sf`].
 #[polars_expr(output_type=Float64)]
-fn geometric_ln_sf_scalar(
-    inputs: &[Series],
-    kwargs: GeometricParamsKwargs,
-) -> PolarsResult<Series> {
+fn geometric_ln_sf_scalar(inputs: &[Series], kwargs: GeometricParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_ln_sf, Tail::at)
 }
 
-/// Constant-`p` fast path for [`geometric_ppf`].
 #[polars_expr(output_type=Float64)]
-fn geometric_ppf_scalar(inputs: &[Series], kwargs: GeometricParamsKwargs) -> PolarsResult<Series> {
+fn geometric_ppf_scalar(inputs: &[Series], kwargs: GeometricParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_ppf, on_unit_interval)
 }
 
-/// Constant-`p` fast path for [`geometric_isf`].
 #[polars_expr(output_type=Float64)]
-fn geometric_isf_scalar(inputs: &[Series], kwargs: GeometricParamsKwargs) -> PolarsResult<Series> {
+fn geometric_isf_scalar(inputs: &[Series], kwargs: GeometricParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_isf, on_unit_interval)
 }
 
-/// One Geometric draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
-///
-/// Every Geometric sampler draws through here, per-row and fast path alike, so their bit-equality is
-/// structural rather than only sampled by `sample_test.py`.
-///
-/// The inverse transform `ceil(ln u / ln(1 - p))` takes its log base from [`ln_failure`], not from
-/// `statrs`' `Distribution<u64>`, which forms the literal `1.0 - p`: that rounds to `1.0` at
-/// `p <= 2^-54`, so the base is `0.0`, the ratio `-inf`, and every draw below the threshold casts to
-/// `0` where the true draws are around `1 / p`.
-///
-/// `u` comes from `(0, 1]`, so `u = 1` gives a raw draw of `0`; `.max(1)` lifts it to the support
-/// floor, where that endpoint's mass belongs in the limit. At the other end the cast saturates once
-/// `-ln u` outgrows `u64::MAX * p`, from around `p ~ 2e-18`: a dtype limit, not an algorithm one.
+/// Inverse transform `ceil(ln u / ln(1 - p))` with the log base from [`ln_failure`] rather than
+/// `statrs`' draw, whose literal `1.0 - p` rounds to `1.0` at `p <= 2^-54` and casts every draw to
+/// `0`. `u` is in `(0, 1]`, so `u = 1` gives `0` and `.max(1)` lifts it to the support floor; the
+/// cast saturates once `-ln u` outgrows `u64::MAX * p`, from around `p ~ 2e-18`.
 #[inline]
 fn draw(ln_failure: &f64, rng: &mut impl rand::Rng) -> u64 {
     let uniform: f64 = RandDistribution::sample(&rand::distr::OpenClosed01, rng);
     ((uniform.ln() / ln_failure).ceil() as u64).max(1)
 }
 
-/// Element-wise Geometric sampler over `(p, row_index)`, returning `UInt64`.
-///
-/// Per row, `null` propagates; an invalid `p` raises from [`P`]'s column pass first. Seeding and
-/// chunk-invariance follow [`sample_per_row_binary`].
 #[polars_expr(output_type=UInt64)]
 fn geometric_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let proba = coerce_f64(&inputs[0])?;
-    let index = inputs[1].cast(&DataType::UInt64)?;
-    let name = inputs[0].name().clone();
-    P.check_column(&proba)?;
-
-    sample_per_row_binary(name, &proba, index.u64()?, kwargs.seed, build_sampler, draw)
+    sample_per_row_binary(inputs, kwargs, &P, build_sampler, draw)
 }
 
-/// Constant-parameter fast path for [`geometric_sample`].
 #[polars_expr(output_type=UInt64)]
 fn geometric_sample_scalar(
     inputs: &[Series],
-    kwargs: SampleScalarKwargs<GeometricParamsKwargs>,
+    kwargs: SampleScalarKwargs<GeometricParams>,
 ) -> PolarsResult<Series> {
     let ln_failure = kwargs.params.build_sampler()?;
-    let name = inputs[0].name().clone();
-
-    sample_by_index(name, &inputs[0], kwargs.seed, |rng| draw(&ln_failure, rng))
+    sample_by_index(&inputs[0], kwargs.seed, |rng| draw(&ln_failure, rng))
 }
 
-/// Constant-parameter multi-draw fast path: the `samples` twin of [`geometric_sample_scalar`].
-///
-/// `size` consecutive draws from each row's stream, so `samples(size=1)` matches `sample` bit for
-/// bit. Returns `Array(UInt64, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_u64_output)]
 fn geometric_samples_scalar(
     inputs: &[Series],
-    kwargs: SamplesScalarKwargs<GeometricParamsKwargs>,
+    kwargs: SamplesScalarKwargs<GeometricParams>,
 ) -> PolarsResult<Series> {
     let ln_failure = kwargs.params.build_sampler()?;
-    let name = inputs[0].name().clone();
-
-    samples_by_index(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
+    samples_by_index(&inputs[0], kwargs.seed, kwargs.size, |rng| {
         draw(&ln_failure, rng)
     })
 }
 
-/// Element-wise multi-draw Geometric sampler: `size` draws per row in one call. Returns
-/// `Array(UInt64, size)`.
-///
-/// Seeding and the null/error contract follow [`samples_per_row`] and [`geometric_sample`].
 #[polars_expr(output_type_func_with_kwargs=samples_u64_output)]
 fn geometric_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let proba = coerce_f64(&inputs[0])?;
-    let index = inputs[1].cast(&DataType::UInt64)?;
-    let name = inputs[0].name().clone();
-    P.check_column(&proba)?;
-
-    let rows = binary_param_rows(&proba, index.u64()?, build_sampler);
-
-    samples_per_row(name, rows, kwargs.seed, kwargs.size, draw)
+    samples_per_row_binary(inputs, kwargs, &P, build_sampler, draw)
 }

--- a/src/distributions/lognormal.rs
+++ b/src/distributions/lognormal.rs
@@ -1,15 +1,14 @@
-use polars::prelude::arity::binary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution as RandDistribution;
 use statrs::distribution::{Continuous, ContinuousCDF, LogNormal, Normal};
 
 use crate::distributions::{
-    align_inputs, coerce_f64, normal, value_keyed_per_row, value_keyed_scalar, ParamDomain,
+    coerce_f64, normal, validated_pair, value_keyed_scalar, value_keyed_ternary, ParamDomain,
 };
 use crate::rng::{
-    sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
-    ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
+    sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output,
+    samples_per_row_ternary, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
 const MU: ParamDomain = ParamDomain::finite("mu");
@@ -20,160 +19,107 @@ fn check_params(mu: &Float64Chunked, sigma: &Float64Chunked) -> PolarsResult<()>
     SIGMA.check_column(sigma)
 }
 
-/// `statrs::LogNormal::new` accepts an infinite `mu` or `sigma`, so [`MU`] and [`SIGMA`] are what
-/// refuse them; behind their pass this cannot fail.
 fn build_dist(mu: f64, sigma: f64) -> PolarsResult<LogNormal> {
     LogNormal::new(mu, sigma).map_err(|e| polars_err!(ComputeError: "{e}"))
 }
 
-/// LogNormal's constant parameters, deserialised once per call.
-///
-/// The one place this file spells `(mu, sigma)`: every fast path, sampler or value-keyed, reaches the
-/// constructor through [`Self::build`], so the order cannot drift between them.
+/// Constant parameters, deserialised once per call. Every `_scalar` twin builds through
+/// [`Self::build`], so it cannot rebuild per row.
 #[derive(serde::Deserialize)]
-struct LogNormalParamsKwargs {
+struct LogNormalParams {
     mu: f64,
     sigma: f64,
 }
 
-impl LogNormalParamsKwargs {
+impl LogNormalParams {
     fn build(&self) -> PolarsResult<LogNormal> {
         MU.check(self.mu)?;
         SIGMA.check(self.sigma)?;
         build_dist(self.mu, self.sigma)
     }
 
-    /// Constant-parameter twin of the per-row [`value_keyed`], sharing its `<method>_value`
-    /// bodies: build once per call, then map `f` over the evaluation-point column.
-    fn value_keyed<F>(&self, value: &Series, f: F) -> PolarsResult<Series>
+    fn value_keyed<Body>(&self, value: &Series, body: Body) -> PolarsResult<Series>
     where
-        F: Fn(&LogNormal, f64) -> Option<f64>,
+        Body: Fn(&LogNormal, f64) -> Option<f64>,
     {
-        let dist = self.build()?;
-        value_keyed_scalar(value, |v| f(&dist, v))
+        value_keyed_scalar(value, &self.build()?, body)
     }
 }
 
-/// The underlying `statrs::Normal` (mean `mu`, std-dev `sigma`) a built `LogNormal` wraps,
-/// recovered through the `location()` / `scale()` accessors. Backs the stable `log_cdf` / `log_sf`
-/// / `isf`, which reuse the normal's `ln_erfc` forms on `ln(x)`.
-///
-/// Infallible: any `(location, scale)` a built `LogNormal` carries is a valid `Normal`
-/// parameterisation, so this carries no check of its own.
+fn value_keyed<Body>(inputs: &[Series], body: Body) -> PolarsResult<Series>
+where
+    Body: Fn(&LogNormal, f64) -> Option<f64>,
+{
+    value_keyed_ternary(
+        inputs,
+        coerce_f64,
+        coerce_f64,
+        check_params,
+        build_dist,
+        body,
+    )
+}
+
+/// The `Normal(mu, sigma)` under a built `LogNormal`; infallible because the parameters passed
+/// [`build_dist`].
 fn underlying_normal(dist: &LogNormal) -> Normal {
     Normal::new(dist.location(), dist.scale())
         .expect("Normal::new accepts every (location, scale) a built LogNormal carries")
 }
 
-/// Apply a value-keyed `f(dist, value)` element-wise over `(value, mu, sigma)`; shared by every
-/// Rust-bound value-keyed method. Null and `NaN` contracts in [`value_keyed_per_row`].
-fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
-where
-    F: Fn(&LogNormal, f64) -> Option<f64>,
-{
-    value_keyed_per_row(inputs, coerce_f64, coerce_f64, check_params, build_dist, f)
-}
-
-/// `sigma` where both of `(mu, sigma)` are present, null elsewhere, after [`check_params`].
-///
-/// `inputs[0]` is `mu`, `inputs[1]` is `sigma`. The Python closed-form moments all derive from
-/// this single FFI round-trip, so they raise on an invalid parameterisation exactly like the
-/// value-keyed methods.
 #[polars_expr(output_type=Float64)]
 fn lognormal_sigma(inputs: &[Series]) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let mu = coerce_f64(&inputs[0])?;
-    let sigma = coerce_f64(&inputs[1])?;
-    check_params(&mu, &sigma)?;
-
-    let ca: Float64Chunked =
-        binary_elementwise(&mu, &sigma, |mu: Option<f64>, sigma: Option<f64>| {
-            mu.and(sigma)
-        });
-    Ok(ca.into_series())
+    validated_pair(inputs, coerce_f64, check_params)
 }
 
-/// One LogNormal draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
-///
-/// Every LogNormal sampler draws through here, per-row and fast path alike, so their bit-equality is
-/// structural rather than only sampled by `sample_test.py`.
 #[inline]
 fn draw(dist: &LogNormal, rng: &mut impl rand::Rng) -> f64 {
     RandDistribution::sample(dist, rng)
 }
 
-/// Element-wise LogNormal sampler over `(mu, sigma, row_index)`, returning `Float64`.
-///
-/// Per row, `null` propagates; an invalid parameterisation raises from [`check_params`] first.
-/// Seeding and chunk-invariance follow [`sample_per_row_ternary`].
 #[polars_expr(output_type=Float64)]
 fn lognormal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let mu = coerce_f64(&inputs[0])?;
-    let sigma = coerce_f64(&inputs[1])?;
-    let index = inputs[2].cast(&DataType::UInt64)?;
-    let name = inputs[0].name().clone();
-    check_params(&mu, &sigma)?;
-
     sample_per_row_ternary(
-        name,
-        &mu,
-        &sigma,
-        index.u64()?,
-        kwargs.seed,
+        inputs,
+        kwargs,
+        coerce_f64,
+        coerce_f64,
+        check_params,
         build_dist,
         draw,
     )
 }
 
-/// Constant-parameter fast path for [`lognormal_sample`].
 #[polars_expr(output_type=Float64)]
 fn lognormal_sample_scalar(
     inputs: &[Series],
-    kwargs: SampleScalarKwargs<LogNormalParamsKwargs>,
+    kwargs: SampleScalarKwargs<LogNormalParams>,
 ) -> PolarsResult<Series> {
     let dist = kwargs.params.build()?;
-    let name = inputs[0].name().clone();
-
-    sample_by_index(name, &inputs[0], kwargs.seed, |rng| draw(&dist, rng))
+    sample_by_index(&inputs[0], kwargs.seed, |rng| draw(&dist, rng))
 }
 
-/// Constant-parameter multi-draw fast path: the `samples` twin of [`lognormal_sample_scalar`].
-///
-/// `size` consecutive draws from each row's stream, so `samples(size=1)` matches `sample` bit for
-/// bit and the distribution is built once per call. Returns `Array(Float64, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn lognormal_samples_scalar(
     inputs: &[Series],
-    kwargs: SamplesScalarKwargs<LogNormalParamsKwargs>,
+    kwargs: SamplesScalarKwargs<LogNormalParams>,
 ) -> PolarsResult<Series> {
     let dist = kwargs.params.build()?;
-    let name = inputs[0].name().clone();
-
-    samples_by_index(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
-        draw(&dist, rng)
-    })
+    samples_by_index(&inputs[0], kwargs.seed, kwargs.size, |rng| draw(&dist, rng))
 }
 
-/// Element-wise multi-draw LogNormal sampler: `size` draws per row in one call, the distribution
-/// built once per row. Returns `Array(Float64, size)`.
-///
-/// Seeding and the null/error contract follow [`samples_per_row`] and [`lognormal_sample`].
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn lognormal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let mu = coerce_f64(&inputs[0])?;
-    let sigma = coerce_f64(&inputs[1])?;
-    let index = inputs[2].cast(&DataType::UInt64)?;
-    let name = inputs[0].name().clone();
-    check_params(&mu, &sigma)?;
-
-    let rows = ternary_param_rows(&mu, &sigma, index.u64()?, build_dist);
-
-    samples_per_row(name, rows, kwargs.seed, kwargs.size, draw)
+    samples_per_row_ternary(
+        inputs,
+        kwargs,
+        coerce_f64,
+        coerce_f64,
+        check_params,
+        build_dist,
+        draw,
+    )
 }
-
-// Per-method bodies, shared by the per-row plugins and their `*_scalar` twins.
 
 fn pdf_value(dist: &LogNormal, v: f64) -> Option<f64> {
     Some(dist.pdf(v))
@@ -191,8 +137,7 @@ fn sf_value(dist: &LogNormal, v: f64) -> Option<f64> {
     Some(dist.sf(v))
 }
 
-/// Stable log-cdf: the underlying normal's [`normal::ln_cdf_value`] at `ln(v)`; `-inf` for `v <= 0`
-/// (`cdf = 0` outside the support). See [`underlying_normal`] for the recovery.
+/// The normal's stable log-cdf at `ln(v)`; `-inf` off the support (`v <= 0`).
 fn ln_cdf_value(dist: &LogNormal, v: f64) -> Option<f64> {
     if v <= 0.0 {
         Some(f64::NEG_INFINITY)
@@ -201,8 +146,7 @@ fn ln_cdf_value(dist: &LogNormal, v: f64) -> Option<f64> {
     }
 }
 
-/// Stable log-sf: the underlying normal's [`normal::ln_sf_value`] at `ln(v)`; `0` for `v <= 0`
-/// (`sf = 1` outside the support).
+/// The normal's stable log-sf at `ln(v)`; `0` off the support (`v <= 0`).
 fn ln_sf_value(dist: &LogNormal, v: f64) -> Option<f64> {
     if v <= 0.0 {
         Some(0.0)
@@ -211,8 +155,7 @@ fn ln_sf_value(dist: &LogNormal, v: f64) -> Option<f64> {
     }
 }
 
-/// A quantile outside `[0, 1]` yields `null` (guarding the `statrs` panic). The closed endpoints
-/// map to the support boundaries (`ppf(0) = 0`, `ppf(1) = +inf`), matching `scipy.stats.lognorm.ppf`.
+/// Null outside `[0, 1]`; `statrs` panics there. The endpoints map to `0` and `+inf`.
 fn ppf_value(dist: &LogNormal, q: f64) -> Option<f64> {
     if !(0.0..=1.0).contains(&q) {
         None
@@ -221,126 +164,89 @@ fn ppf_value(dist: &LogNormal, q: f64) -> Option<f64> {
     }
 }
 
-/// Inverse survival function, the underlying normal's [`normal::isf_value`] exponentiated.
-///
-/// Not `ppf(1 - q)`: see [`normal::isf_value`] for why the complement is unrecoverable for a tiny
-/// `q`. Composing through `exp` turns the normal's *absolute* error at the quantile into a
-/// *relative* one here, so a large `sigma` amplifies it.
-///
-/// The endpoints follow from the normal's: `isf(0) = exp(+inf) = +inf` and `isf(1) = exp(-inf) = 0`,
-/// which are the support boundaries `ppf` maps in the other order.
+/// The normal's [`normal::isf_value`] exponentiated, so the tail is solved on `q` itself rather than
+/// through `ppf(1 - q)`. `exp` turns the normal's absolute error at the quantile into a relative one
+/// here, so a large `sigma` amplifies it.
 fn isf_value(dist: &LogNormal, q: f64) -> Option<f64> {
     normal::isf_value(&underlying_normal(dist), q).map(f64::exp)
 }
 
-/// Element-wise pdf via `statrs` `Continuous::pdf`; `0` for `value <= 0` (outside the support).
-/// See [`value_keyed`] for the null/error contract.
 #[polars_expr(output_type=Float64)]
 fn lognormal_pdf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, pdf_value)
 }
 
-/// Element-wise log-pdf via native `Continuous::ln_pdf` (more accurate than `pdf().ln()`);
-/// `-inf` for `value <= 0`.
 #[polars_expr(output_type=Float64)]
 fn lognormal_ln_pdf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, ln_pdf_value)
 }
 
-/// Element-wise cdf via `statrs` `ContinuousCDF::cdf`; `0` for `value <= 0`.
 #[polars_expr(output_type=Float64)]
 fn lognormal_cdf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, cdf_value)
 }
 
-/// Element-wise survival function via native `ContinuousCDF::sf` (accurate in the upper tail);
-/// `1` for `value <= 0`.
 #[polars_expr(output_type=Float64)]
 fn lognormal_sf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, sf_value)
 }
 
-/// Element-wise log-cdf via the underlying normal's stable `ln_erfc` form (finite in the far-left
-/// tail, unlike `cdf().ln()`); `-inf` for `value <= 0`.
 #[polars_expr(output_type=Float64)]
 fn lognormal_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, ln_cdf_value)
 }
 
-/// Element-wise log-sf via the underlying normal's stable `ln_erfc` form (finite in the far-right
-/// tail, unlike `sf().ln()`); `0` for `value <= 0`.
 #[polars_expr(output_type=Float64)]
 fn lognormal_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, ln_sf_value)
 }
 
-/// Element-wise ppf (inverse cdf) via the closed-form `ContinuousCDF::inverse_cdf`.
-/// See [`ppf_value`] for the endpoint and out-of-range contract.
 #[polars_expr(output_type=Float64)]
 fn lognormal_ppf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, ppf_value)
 }
 
-/// Element-wise isf via the underlying normal's symmetry form, not `ppf(1 - q)`.
-/// See [`isf_value`] for why, and for the endpoint and out-of-range contract.
 #[polars_expr(output_type=Float64)]
 fn lognormal_isf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, isf_value)
 }
 
-/// Constant-parameter fast path for [`lognormal_pdf`].
 #[polars_expr(output_type=Float64)]
-fn lognormal_pdf_scalar(inputs: &[Series], kwargs: LogNormalParamsKwargs) -> PolarsResult<Series> {
+fn lognormal_pdf_scalar(inputs: &[Series], kwargs: LogNormalParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], pdf_value)
 }
 
-/// Constant-parameter fast path for [`lognormal_ln_pdf`].
 #[polars_expr(output_type=Float64)]
-fn lognormal_ln_pdf_scalar(
-    inputs: &[Series],
-    kwargs: LogNormalParamsKwargs,
-) -> PolarsResult<Series> {
+fn lognormal_ln_pdf_scalar(inputs: &[Series], kwargs: LogNormalParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], ln_pdf_value)
 }
 
-/// Constant-parameter fast path for [`lognormal_cdf`].
 #[polars_expr(output_type=Float64)]
-fn lognormal_cdf_scalar(inputs: &[Series], kwargs: LogNormalParamsKwargs) -> PolarsResult<Series> {
+fn lognormal_cdf_scalar(inputs: &[Series], kwargs: LogNormalParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], cdf_value)
 }
 
-/// Constant-parameter fast path for [`lognormal_sf`].
 #[polars_expr(output_type=Float64)]
-fn lognormal_sf_scalar(inputs: &[Series], kwargs: LogNormalParamsKwargs) -> PolarsResult<Series> {
+fn lognormal_sf_scalar(inputs: &[Series], kwargs: LogNormalParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], sf_value)
 }
 
-/// Constant-parameter fast path for [`lognormal_ppf`].
 #[polars_expr(output_type=Float64)]
-fn lognormal_ppf_scalar(inputs: &[Series], kwargs: LogNormalParamsKwargs) -> PolarsResult<Series> {
-    kwargs.value_keyed(&inputs[0], ppf_value)
-}
-
-/// Constant-parameter fast path for [`lognormal_ln_cdf`].
-#[polars_expr(output_type=Float64)]
-fn lognormal_ln_cdf_scalar(
-    inputs: &[Series],
-    kwargs: LogNormalParamsKwargs,
-) -> PolarsResult<Series> {
+fn lognormal_ln_cdf_scalar(inputs: &[Series], kwargs: LogNormalParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], ln_cdf_value)
 }
 
-/// Constant-parameter fast path for [`lognormal_ln_sf`].
 #[polars_expr(output_type=Float64)]
-fn lognormal_ln_sf_scalar(
-    inputs: &[Series],
-    kwargs: LogNormalParamsKwargs,
-) -> PolarsResult<Series> {
+fn lognormal_ln_sf_scalar(inputs: &[Series], kwargs: LogNormalParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], ln_sf_value)
 }
 
-/// Constant-parameter fast path for [`lognormal_isf`].
 #[polars_expr(output_type=Float64)]
-fn lognormal_isf_scalar(inputs: &[Series], kwargs: LogNormalParamsKwargs) -> PolarsResult<Series> {
+fn lognormal_ppf_scalar(inputs: &[Series], kwargs: LogNormalParams) -> PolarsResult<Series> {
+    kwargs.value_keyed(&inputs[0], ppf_value)
+}
+
+#[polars_expr(output_type=Float64)]
+fn lognormal_isf_scalar(inputs: &[Series], kwargs: LogNormalParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], isf_value)
 }

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -1,3 +1,22 @@
+//! Shared drivers behind every `#[polars_expr]` in the distribution files.
+//!
+//! A plugin is a one-line shell over one driver here or in `crate::rng`; the driver owns input
+//! alignment, the dtype gate, the parameter domain pass, null propagation and the row loop. Driver
+//! names count plugin inputs: `value_keyed_binary` takes `(value, param)`, `value_keyed_ternary`
+//! takes `(value, a, b)`.
+//!
+//! Contracts every driver keeps:
+//!
+//! * A null in any input nulls the row before the body runs.
+//! * A `NaN` evaluation point is `NaN`, for every method including `ppf`, and never reaches a body:
+//!   the regularized incomplete beta behind `Beta::cdf` panics on `NaN`, and `NaN.floor() as u64` is
+//!   `0`, which would make Binomial answer a confident `P(X <= 0)`.
+//! * An invalid parameter raises `ComputeError` from a pass over the whole column, before any row is
+//!   built, so it raises beside a null or `NaN` point too.
+//! * When every parameter is length 1 ([`params_are_constant`]) it is checked and built once and the
+//!   value column takes [`value_keyed_scalar`], the same path the kwargs `_scalar` twins take. A null
+//!   constant falls through to the row loop, which nulls every row and still runs the value dtype gate.
+
 pub mod bernoulli;
 pub mod beta;
 pub mod binomial;
@@ -10,15 +29,14 @@ pub mod uniform;
 
 use std::borrow::Cow;
 
-use polars::prelude::arity::{
-    binary_elementwise, ternary_elementwise, try_ternary_elementwise, unary_elementwise,
-};
+use polars::prelude::arity::{try_binary_elementwise, try_ternary_elementwise, unary_elementwise};
 use polars::prelude::*;
 
 /// Broadcast every length-1 input up to the call's row count, and reject lengths that cannot align.
 ///
-/// The row count is the one input length that is not 1, so length-1 inputs never set it: an
-/// all-length-1 call stays length 1, and a 0-row frame beside a `pl.lit` stays empty.
+/// Polars broadcasts nothing into a plugin and the `*_elementwise` kernels truncate to their shortest
+/// input, so every multi-input plugin calls this before any cast. Length-1 inputs never set the row
+/// count: an all-length-1 call stays length 1, and a 0-row frame beside a `pl.lit` stays empty.
 pub(crate) fn align_inputs(inputs: &[Series]) -> PolarsResult<Cow<'_, [Series]>> {
     let mut anchor: Option<&Series> = None;
     let mut needs_broadcast = false;
@@ -39,8 +57,6 @@ pub(crate) fn align_inputs(inputs: &[Series]) -> PolarsResult<Cow<'_, [Series]>>
         }
     }
 
-    // Borrow when there is nothing to expand: no anchor means every input is already length 1, and
-    // `!needs_broadcast` means they already agree, which is every call whose parameters are columns.
     let row_count = match anchor {
         Some(anchor) if needs_broadcast => anchor.len(),
         _ => return Ok(Cow::Borrowed(inputs)),
@@ -60,17 +76,16 @@ pub(crate) fn align_inputs(inputs: &[Series]) -> PolarsResult<Cow<'_, [Series]>>
     ))
 }
 
-/// Every parameter (every input after the evaluation point) is a length-1 Series: a `pl.lit`, or an
-/// aggregate whose length polars only knows once it has run. One length-1 parameter beside a column
-/// is not constant; it still aligns, so a mismatched column is still reported by [`align_inputs`].
+/// Every parameter (every input after the evaluation point) is length 1: a `pl.lit`, or an
+/// aggregate whose length polars only knows once it has run.
 pub(crate) fn params_are_constant(inputs: &[Series]) -> bool {
     inputs[1..].iter().all(|param| param.len() == 1)
 }
 
 /// The dtype gate every evaluation point and float parameter passes: `Int*`, `UInt*`, `Float*` and
-/// `Decimal` cast to `Float64`, a `Null`-typed column to all-null, anything else raises `ComputeError`
-/// naming the input. Polars' own cast would read `Boolean` as `0` / `1`, parse `String` and take a
-/// temporal dtype's integer representation.
+/// `Decimal` cast to `Float64`, a `Null`-typed column to all-null, anything else raises. Polars' own
+/// cast would read `Boolean` as `0` / `1`, parse `String` and take a temporal dtype's integer
+/// representation.
 pub(crate) fn coerce_f64(input: &Series) -> PolarsResult<Float64Chunked> {
     let dtype = input.dtype();
     polars_ensure!(
@@ -81,11 +96,8 @@ pub(crate) fn coerce_f64(input: &Series) -> PolarsResult<Float64Chunked> {
     Ok(input.cast(&DataType::Float64)?.f64()?.clone())
 }
 
-/// What one float parameter must satisfy on its own, checked once per call: [`Self::check`] on a
-/// constant, [`Self::check_column`] over the whole column before any row is built.
-///
-/// Every rule spells finiteness because the `statrs` constructors do not (`Normal::new(0.0,
-/// f64::INFINITY)` is `Ok`); behind the pass, the constructor inside a row loop cannot fail.
+/// What one float parameter must satisfy on its own. Every rule spells finiteness because the
+/// `statrs` constructors do not (`Normal::new(0.0, f64::INFINITY)` is `Ok`).
 pub(crate) struct ParamDomain {
     pub(crate) name: &'static str,
     /// Read as "`name` must be {rule}".
@@ -127,13 +139,15 @@ impl ParamDomain {
     }
 
     /// Nulls are skipped: a missing parameter is a missing answer, not an invalid one.
-    pub(crate) fn check_column(&self, ca: &Float64Chunked) -> PolarsResult<()> {
-        ca.iter().flatten().try_for_each(|value| self.check(value))
+    pub(crate) fn check_column(&self, column: &Float64Chunked) -> PolarsResult<()> {
+        column
+            .iter()
+            .flatten()
+            .try_for_each(|value| self.check(value))
     }
 }
 
-/// What two parameters must satisfy together (`Uniform`'s `max > min`, `DiscreteUniform`'s
-/// `min <= max`), checked only where both are present.
+/// What two parameters must satisfy together, checked only where both are present.
 pub(crate) struct PairDomain<N> {
     pub(crate) names: (&'static str, &'static str),
     /// Read as "`names.1` must be {rule}".
@@ -166,173 +180,177 @@ impl<N: Copy + std::fmt::Display> PairDomain<N> {
     }
 }
 
-/// Shared driver for the constant-parameter value-keyed fast paths.
-///
-/// The constant-parameter counterpart of each distribution's `value_keyed` helper: the parameters are
-/// Python scalars in kwargs, or every one is a length-1 Series ([`params_are_constant`]), so the
-/// caller validates them and builds the distribution **once** and this maps `f` over the
-/// evaluation-point column. `f` is the same per-method body the per-row path uses, so the two paths
-/// cannot drift and output is bit-identical.
-///
-/// Null contract: `value` is the only nullable input this driver sees; a null `value` propagates,
-/// and `f` returning `None` nulls the row on the method's own terms (`ppf` outside `[0, 1]`).
-///
-/// `NaN` contract: a `NaN` evaluation point short-circuits to `NaN` (scipy semantics) before `f`
-/// runs, for every method including `ppf`. The short-circuit is central (here and in
-/// [`value_keyed_per_row`]) rather than per body, because two bodies need it and none may be
-/// forgotten: the regularized incomplete beta behind `Beta` `cdf`/`sf` panics on `NaN`, aborting
-/// the whole query, and binomial's support mapping saturates (`NaN.floor() as u64` is `0`),
-/// returning a confident `P(X <= 0)`. Pinned by `tests/distributions/plugin_nan_test.py`.
-pub(crate) fn value_keyed_scalar<F>(value: &Series, f: F) -> PolarsResult<Series>
-where
-    F: Fn(f64) -> Option<f64>,
-{
-    let value = coerce_f64(value)?;
-    let name = value.name().clone();
-
-    let ca: Float64Chunked = unary_elementwise(&value, |opt| {
-        opt.and_then(|v| if v.is_nan() { Some(f64::NAN) } else { f(v) })
-    });
-    Ok(ca.with_name(name).into_series())
+/// The one-parameter validator plugin: the parameter unchanged after `domain`'s column pass, nulls
+/// included. The Python moments derive from it, so an invalid parameter raises there too.
+pub(crate) fn validated_param(inputs: &[Series], domain: &ParamDomain) -> PolarsResult<Series> {
+    let param = coerce_f64(&inputs[0])?;
+    domain.check_column(&param)?;
+    Ok(param.into_series())
 }
 
-/// Constant-parameter twin of [`value_keyed_derived_per_row`], over [`value_keyed_scalar`]: derives
-/// once per call, so the parameter-only terms `derive` hoists (`Bernoulli`'s `1 - p`, `Exponential`'s
-/// `ln(rate)`) are computed once instead of per row. The caller has already checked `param`.
-///
-/// The kwargs plugins and the driver's length-1 branch both call this rather than spelling the two
-/// lines themselves, so the two spellings share one instantiation: same output bit for bit, and the
-/// same machine code (separate copies of the closure measured 7% apart on one method, 28% on another).
-pub(crate) fn value_keyed_derived_scalar<Branches, Derive, Select>(
-    value: &Series,
-    param: f64,
-    derive: Derive,
-    select: Select,
-) -> PolarsResult<Series>
-where
-    Derive: Fn(f64) -> Branches,
-    Select: Fn(&Branches, f64) -> Option<f64>,
-{
-    let branches = derive(param);
-    value_keyed_scalar(value, |v| select(&branches, v))
-}
-
-/// Two-parameter sibling of [`value_keyed_derived_scalar`], shared by the same two spellings for the
-/// same reason. The caller has already checked `(a, b)`.
-pub(crate) fn value_keyed_derived_pair_scalar<Branches, Derive, Select>(
-    value: &Series,
-    a: f64,
-    b: f64,
-    derive: Derive,
-    select: Select,
-) -> PolarsResult<Series>
-where
-    Derive: Fn(f64, f64) -> Branches,
-    Select: Fn(&Branches, f64) -> Option<f64>,
-{
-    let branches = derive(a, b);
-    value_keyed_scalar(value, |v| select(&branches, v))
-}
-
-/// Shared driver for the column-parameter value-keyed per-row paths.
-///
-/// The column-parameter counterpart of [`value_keyed_scalar`]: at least one distribution parameter
-/// is a column, so `build` constructs once per row instead of once per call. `f` is the same named
-/// per-method body the fast path applies (`cdf_value`, `ppf_value`, ...), so the two paths cannot
-/// drift and agree bit for bit.
-///
-/// `coerce_p1` and `coerce_p2` are each parameter's own coercer (`coerce_f64`, `coerce_n`,
-/// `coerce_bound`), which fixes `A` and `B`, so a mixed `(u64, f64)` parameterisation (Binomial's
-/// `UInt64` `n` beside its `Float64` `p`) fits, as in
-/// [`ternary_param_rows`](crate::rng::ternary_param_rows). `S` needs no trait bound: it is whatever
-/// `build` returns.
-///
-/// `check_params` is the caller's pass over the two parameter columns, run once before any row is
-/// built, so `build` cannot fail here; it stays `PolarsResult` because the `statrs` constructors are.
-///
-/// Constant parameters ([`params_are_constant`]) are checked and built once, before any row is read
-/// and even on a 0-row frame, and the value column takes [`value_keyed_scalar`]. A null constant
-/// falls through to the row loop, which nulls every row and keeps the value column's dtype gate.
-///
-/// Null contract: any null among `(value, p1, p2)` nulls the row without calling `build`, matching
-/// the samplers. `NaN` contract: as in [`value_keyed_scalar`].
-///
-/// Keep `build` and `f` generic `Fn`s: they monomorphise into the row loop, where a `&dyn Fn` or a
-/// `fn` pointer would cost an indirect call per row.
-pub(crate) fn value_keyed_per_row<A, B, S, CoerceP1, CoerceP2, CheckParams, Build, F>(
+/// Two parameters and no evaluation point: `body(a, b)` per row, null where either is null, after
+/// `check_params`'s pass over both columns. Backs the two-parameter validators and the moments with
+/// no closed form (`entropy`). The output is named after the first input.
+pub(crate) fn param_keyed<A, B, CoerceA, CoerceB, Check, Body>(
     inputs: &[Series],
-    coerce_p1: CoerceP1,
-    coerce_p2: CoerceP2,
-    check_params: CheckParams,
-    build: Build,
-    f: F,
+    coerce_a: CoerceA,
+    coerce_b: CoerceB,
+    check_params: Check,
+    body: Body,
 ) -> PolarsResult<Series>
 where
     A: PolarsNumericType,
     B: PolarsNumericType,
-    CoerceP1: Fn(&Series) -> PolarsResult<ChunkedArray<A>>,
-    CoerceP2: Fn(&Series) -> PolarsResult<ChunkedArray<B>>,
-    CheckParams: Fn(&ChunkedArray<A>, &ChunkedArray<B>) -> PolarsResult<()>,
-    Build: Fn(A::Native, B::Native) -> PolarsResult<S>,
-    F: Fn(&S, f64) -> Option<f64>,
+    CoerceA: Fn(&Series) -> PolarsResult<ChunkedArray<A>>,
+    CoerceB: Fn(&Series) -> PolarsResult<ChunkedArray<B>>,
+    Check: Fn(&ChunkedArray<A>, &ChunkedArray<B>) -> PolarsResult<()>,
+    Body: Fn(A::Native, B::Native) -> PolarsResult<f64>,
+{
+    let inputs = align_inputs(inputs)?;
+    let a = coerce_a(&inputs[0])?;
+    let b = coerce_b(&inputs[1])?;
+    check_params(&a, &b)?;
+
+    let out: Float64Chunked = try_binary_elementwise(&a, &b, |a, b| match (a, b) {
+        (Some(a), Some(b)) => body(a, b).map(Some),
+        _ => Ok(None),
+    })?;
+    Ok(out.into_series())
+}
+
+/// The two-parameter validator plugin: the second parameter where both are present, null elsewhere.
+pub(crate) fn validated_pair<A, CoerceA, Check>(
+    inputs: &[Series],
+    coerce_a: CoerceA,
+    check_params: Check,
+) -> PolarsResult<Series>
+where
+    A: PolarsNumericType,
+    CoerceA: Fn(&Series) -> PolarsResult<ChunkedArray<A>>,
+    Check: Fn(&ChunkedArray<A>, &Float64Chunked) -> PolarsResult<()>,
+{
+    param_keyed(inputs, coerce_a, coerce_f64, check_params, |_, b| Ok(b))
+}
+
+/// The constant-parameter value-keyed path: `body(state, value)` over the evaluation column, with
+/// `state` built once by the caller. Both the kwargs `_scalar` twins and the drivers' constant branch
+/// call this, so the two spellings of a constant parameterisation run one instantiation.
+pub(crate) fn value_keyed_scalar<State, Body>(
+    value: &Series,
+    state: &State,
+    body: Body,
+) -> PolarsResult<Series>
+where
+    Body: Fn(&State, f64) -> Option<f64>,
+{
+    let value = coerce_f64(value)?;
+    let out: Float64Chunked = unary_elementwise(&value, |point| {
+        point.and_then(|v| {
+            if v.is_nan() {
+                Some(f64::NAN)
+            } else {
+                body(state, v)
+            }
+        })
+    });
+    Ok(out.into_series())
+}
+
+/// Value-keyed driver over `(value, param)`: `build` turns the parameter into the per-row state
+/// (`statrs` distribution or closed-form branch table) and `body` evaluates it at the point.
+///
+/// `build` and `body` stay generic `Fn`s so they monomorphise into the row loop; a `&dyn Fn` or a
+/// `fn` pointer would cost an indirect call per row.
+pub(crate) fn value_keyed_binary<State, Build, Body>(
+    inputs: &[Series],
+    domain: &ParamDomain,
+    build: Build,
+    body: Body,
+) -> PolarsResult<Series>
+where
+    Build: Fn(f64) -> PolarsResult<State>,
+    Body: Fn(&State, f64) -> Option<f64>,
 {
     if params_are_constant(inputs) {
-        let (p1, p2) = (coerce_p1(&inputs[1])?, coerce_p2(&inputs[2])?);
-        check_params(&p1, &p2)?;
-        if let Some((p1, p2)) = p1.get(0).zip(p2.get(0)) {
-            let dist = build(p1, p2)?;
-            return value_keyed_scalar(&inputs[0], |v| f(&dist, v));
+        let param = coerce_f64(&inputs[1])?;
+        domain.check_column(&param)?;
+        if let Some(param) = param.get(0) {
+            return value_keyed_scalar(&inputs[0], &build(param)?, body);
         }
     }
 
     let inputs = align_inputs(inputs)?;
     let value = coerce_f64(&inputs[0])?;
-    let p1 = coerce_p1(&inputs[1])?;
-    let p2 = coerce_p2(&inputs[2])?;
-    let name = inputs[0].name().clone();
-    check_params(&p1, &p2)?;
+    let param = coerce_f64(&inputs[1])?;
+    domain.check_column(&param)?;
 
-    let ca: Float64Chunked = try_ternary_elementwise(
+    let out: Float64Chunked = try_binary_elementwise(
         &value,
-        &p1,
-        &p2,
-        |value_opt, p1_opt, p2_opt| -> PolarsResult<Option<f64>> {
-            let (Some(value), Some(p1), Some(p2)) = (value_opt, p1_opt, p2_opt) else {
+        &param,
+        |value, param| -> PolarsResult<Option<f64>> {
+            let (Some(value), Some(param)) = (value, param) else {
                 return Ok(None);
             };
             if value.is_nan() {
                 return Ok(Some(f64::NAN));
             }
-            Ok(f(&build(p1, p2)?, value))
+            Ok(body(&build(param)?, value))
         },
     )?;
-
-    Ok(ca.with_name(name).into_series())
+    Ok(out.into_series())
 }
 
-/// Shared driver for the value-keyed methods of a **one-parameter** distribution that computes its
-/// own closed form instead of building a `statrs` distribution.
-///
-/// `derive` turns the parameter into that method's branch table and `select` picks the branch the
-/// evaluation point lands on. Each method derives its own type, so pairing one method's `derive`
-/// with another's `select` does not compile. Both run per row here; [`value_keyed_derived_scalar`]
-/// is the twin that runs `derive` once per call.
-///
-/// `domain`'s column pass runs once before any row is built, so nothing inside the row loop
-/// validates.
-///
-/// A constant parameter ([`params_are_constant`]) is checked and derived once, as in
-/// [`value_keyed_per_row`]; a null one falls through to the row loop, which nulls every row.
-///
-/// Null contract: a null parameter nulls the row before the evaluation point is read; then a null
-/// value nulls it. `select` returning `None` nulls it on the method's own terms (`ppf` outside
-/// `[0, 1]`).
-///
-/// `NaN` contract: a `NaN` value short-circuits to `NaN`, as in [`value_keyed_scalar`].
-///
-/// Keep `derive` and `select` generic `Fn`s: they monomorphise into the row loop, where a `&dyn Fn`
-/// or a `fn` pointer would cost an indirect call per row.
-pub(crate) fn value_keyed_derived_per_row<Branches, Derive, Select>(
+/// Value-keyed driver over `(value, a, b)`. Each parameter has its own coercer, so a mixed
+/// `(UInt64, Float64)` parameterisation (Binomial's `n` beside its `p`) fits; `check_params` is the
+/// caller's pass over both columns, each alone and the pair together.
+pub(crate) fn value_keyed_ternary<A, B, State, CoerceA, CoerceB, Check, Build, Body>(
+    inputs: &[Series],
+    coerce_a: CoerceA,
+    coerce_b: CoerceB,
+    check_params: Check,
+    build: Build,
+    body: Body,
+) -> PolarsResult<Series>
+where
+    A: PolarsNumericType,
+    B: PolarsNumericType,
+    CoerceA: Fn(&Series) -> PolarsResult<ChunkedArray<A>>,
+    CoerceB: Fn(&Series) -> PolarsResult<ChunkedArray<B>>,
+    Check: Fn(&ChunkedArray<A>, &ChunkedArray<B>) -> PolarsResult<()>,
+    Build: Fn(A::Native, B::Native) -> PolarsResult<State>,
+    Body: Fn(&State, f64) -> Option<f64>,
+{
+    if params_are_constant(inputs) {
+        let (a, b) = (coerce_a(&inputs[1])?, coerce_b(&inputs[2])?);
+        check_params(&a, &b)?;
+        if let Some((a, b)) = a.get(0).zip(b.get(0)) {
+            return value_keyed_scalar(&inputs[0], &build(a, b)?, body);
+        }
+    }
+
+    let inputs = align_inputs(inputs)?;
+    let value = coerce_f64(&inputs[0])?;
+    let a = coerce_a(&inputs[1])?;
+    let b = coerce_b(&inputs[2])?;
+    check_params(&a, &b)?;
+
+    let out: Float64Chunked =
+        try_ternary_elementwise(&value, &a, &b, |value, a, b| -> PolarsResult<Option<f64>> {
+            let (Some(value), Some(a), Some(b)) = (value, a, b) else {
+                return Ok(None);
+            };
+            if value.is_nan() {
+                return Ok(Some(f64::NAN));
+            }
+            Ok(body(&build(a, b)?, value))
+        })?;
+    Ok(out.into_series())
+}
+
+/// [`value_keyed_binary`] for a closed form: `derive` turns the parameter into the method's branch
+/// table and cannot fail, `select` picks the branch the point lands on. `derive` runs once per call
+/// on a constant parameter and once per row on a column.
+pub(crate) fn value_keyed_derived_binary<Branches, Derive, Select>(
     inputs: &[Series],
     domain: &ParamDomain,
     derive: Derive,
@@ -342,73 +360,59 @@ where
     Derive: Fn(f64) -> Branches,
     Select: Fn(&Branches, f64) -> Option<f64>,
 {
-    if params_are_constant(inputs) {
-        let param = coerce_f64(&inputs[1])?;
-        domain.check_column(&param)?;
-        if let Some(param) = param.get(0) {
-            return value_keyed_derived_scalar(&inputs[0], param, derive, select);
-        }
-    }
-
-    let inputs = align_inputs(inputs)?;
-    let value = coerce_f64(&inputs[0])?;
-    let param = coerce_f64(&inputs[1])?;
-    let name = inputs[0].name().clone();
-    domain.check_column(&param)?;
-
-    let ca: Float64Chunked = binary_elementwise(&value, &param, |value_opt, param_opt| {
-        let param = param_opt?;
-        let value = value_opt?;
-        if value.is_nan() {
-            Some(f64::NAN)
-        } else {
-            select(&derive(param), value)
-        }
-    });
-
-    Ok(ca.with_name(name).into_series())
+    value_keyed_binary(inputs, domain, |param| Ok(derive(param)), select)
 }
 
-/// `exp(t) - 1` through the identity `2 exp(t / 2) sinh(t / 2)`, which has no subtraction to cancel.
-///
-/// Not `f64::exp_m1`, which differs from this identity by one ulp on roughly a fifth of the left
-/// tail. Every expected value in `tests/distributions/exponential/` is this identity's rounding, and
-/// `_base.expm1` spells it the same way for the moments still assembled in Polars.
-///
-/// `sinh(t / 2)` overflows above `|t| ~ 1420`; every caller crosses over to a direct form long before
-/// that (`exponential::CDF_SINH_MAX`, `geometric::CDF_DIRECT_COMPLEMENT_MAX`).
+/// [`value_keyed_ternary`] for a closed form over two float parameters.
+pub(crate) fn value_keyed_derived_ternary<Branches, Check, Derive, Select>(
+    inputs: &[Series],
+    check_params: Check,
+    derive: Derive,
+    select: Select,
+) -> PolarsResult<Series>
+where
+    Check: Fn(&Float64Chunked, &Float64Chunked) -> PolarsResult<()>,
+    Derive: Fn(f64, f64) -> Branches,
+    Select: Fn(&Branches, f64) -> Option<f64>,
+{
+    value_keyed_ternary(
+        inputs,
+        coerce_f64,
+        coerce_f64,
+        check_params,
+        |a, b| Ok(derive(a, b)),
+        select,
+    )
+}
+
+/// `exp(t) - 1` as `2 exp(t / 2) sinh(t / 2)`, which has no subtraction to cancel. Not
+/// `f64::exp_m1`, which differs by one ulp on roughly a fifth of the left tail; `_base.expm1` spells
+/// the same identity for the moments assembled in Polars. `sinh(t / 2)` overflows above `|t| ~ 1420`;
+/// every caller crosses to a direct form long before that.
 #[inline]
 pub(crate) fn expm1(t: f64) -> f64 {
     let half = t / 2.0;
     2.0 * half.exp() * half.sinh()
 }
 
-/// `ln|exp(t) - 1|` as `ln(2) + t / 2 + ln|sinh(t / 2)|`: [`expm1`]'s identity read term by term on
-/// the log scale, so each term is large exactly where the answer is and the rounding stays relative;
-/// `expm1(t).ln()` would round the answer's own magnitude away.
-///
-/// The absolute value carries both signs of `t`: a no-op for `t > 0`, and for `t < 0` the log of the
-/// complement `1 - exp(t)`. Same overflow limit as [`expm1`]; `_base.log_abs_expm1` spells it the same
-/// way for `LogNormal.entropy`.
+/// `ln|exp(t) - 1|` as `ln(2) + t / 2 + ln|sinh(t / 2)|`: [`expm1`] read term by term on the log
+/// scale, so the rounding stays relative where `expm1(t).ln()` would round the answer away. The
+/// absolute value carries `t < 0`, where this is the log of `1 - exp(t)`.
 #[inline]
 pub(crate) fn ln_abs_expm1(t: f64) -> f64 {
     let half = t / 2.0;
     std::f64::consts::LN_2 + half + half.sinh().abs().ln()
 }
 
-/// The two sides of a support whose floor is the integer `FLOOR`, for the value-keyed methods of a
-/// distribution that computes its own closed form: a constant below the floor, the parameter's arm
-/// on it.
+/// A closed form on a support whose floor is the integer `FLOOR`: a constant below it, the
+/// parameter's arm on it.
 pub(crate) struct Sides<Arm, const FLOOR: i8> {
     pub(crate) below_support: f64,
     pub(crate) on_support: Arm,
 }
 
 impl<Arm: Fn(f64) -> f64, const FLOOR: i8> Sides<Arm, FLOOR> {
-    /// `value < FLOOR` takes the constant, everything else the arm, so `-0.0` sits where `0.0` does.
-    ///
-    /// A `NaN` value never reaches here: every driver short-circuits it. That is what lets this be a
-    /// bare `<`; the `!(value >= FLOOR)` a negated predicate would spell puts `NaN` below the support.
+    /// A bare `<`, so `-0.0` sits where `0.0` does; a `NaN` point never reaches here.
     pub(crate) fn at(&self, value: f64) -> Option<f64> {
         Some(if value < f64::from(FLOOR) {
             self.below_support
@@ -418,60 +422,8 @@ impl<Arm: Fn(f64) -> f64, const FLOOR: i8> Sides<Arm, FLOOR> {
     }
 }
 
-/// The `select` every inverse shares: the arm on the closed quantile interval `[0, 1]`, `None`
-/// (null) outside it. `-0.0` is inside, since `-0.0 == 0.0`.
-///
-/// A `NaN` quantile never reaches here: every driver short-circuits it, which is what lets this be a
-/// plain range check.
+/// The `select` every inverse shares: the arm on `[0, 1]`, null outside it. `-0.0` is inside.
 #[inline]
 pub(crate) fn on_unit_interval<Arm: Fn(f64) -> f64>(arm: &Arm, quantile: f64) -> Option<f64> {
     (0.0..=1.0).contains(&quantile).then(|| arm(quantile))
-}
-
-/// Two-parameter sibling of [`value_keyed_derived_per_row`], over `ternary_elementwise`.
-///
-/// "Pair" counts the *distribution parameters* (`Uniform`'s two bounds); the driver itself takes
-/// three `Series`.
-///
-/// `check_params` is the caller's column pass over the two parameter columns, each alone and the
-/// pair together, run once before any row is built. Null, `NaN` and constant-parameter contracts as
-/// in [`value_keyed_derived_per_row`]; a null in either parameter nulls the row.
-pub(crate) fn value_keyed_derived_pair_per_row<Branches, CheckParams, Derive, Select>(
-    inputs: &[Series],
-    check_params: CheckParams,
-    derive: Derive,
-    select: Select,
-) -> PolarsResult<Series>
-where
-    CheckParams: Fn(&Float64Chunked, &Float64Chunked) -> PolarsResult<()>,
-    Derive: Fn(f64, f64) -> Branches,
-    Select: Fn(&Branches, f64) -> Option<f64>,
-{
-    if params_are_constant(inputs) {
-        let (a, b) = (coerce_f64(&inputs[1])?, coerce_f64(&inputs[2])?);
-        check_params(&a, &b)?;
-        if let Some((a, b)) = a.get(0).zip(b.get(0)) {
-            return value_keyed_derived_pair_scalar(&inputs[0], a, b, derive, select);
-        }
-    }
-
-    let inputs = align_inputs(inputs)?;
-    let value = coerce_f64(&inputs[0])?;
-    let param_a = coerce_f64(&inputs[1])?;
-    let param_b = coerce_f64(&inputs[2])?;
-    let name = inputs[0].name().clone();
-    check_params(&param_a, &param_b)?;
-
-    let ca: Float64Chunked =
-        ternary_elementwise(&value, &param_a, &param_b, |value_opt, a_opt, b_opt| {
-            let (a, b) = (a_opt?, b_opt?);
-            let value = value_opt?;
-            if value.is_nan() {
-                Some(f64::NAN)
-            } else {
-                select(&derive(a, b), value)
-            }
-        });
-
-    Ok(ca.with_name(name).into_series())
 }

--- a/src/distributions/normal.rs
+++ b/src/distributions/normal.rs
@@ -1,6 +1,5 @@
 use std::f64::consts::{LN_2, SQRT_2};
 
-use polars::prelude::arity::binary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distr::Distribution as RandDistribution;
@@ -9,11 +8,11 @@ use statrs::function::erf;
 use statrs::statistics::Distribution as StatrsDistribution;
 
 use crate::distributions::{
-    align_inputs, coerce_f64, value_keyed_per_row, value_keyed_scalar, ParamDomain,
+    coerce_f64, validated_pair, value_keyed_scalar, value_keyed_ternary, ParamDomain,
 };
 use crate::rng::{
-    sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
-    ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
+    sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output,
+    samples_per_row_ternary, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
 const MU: ParamDomain = ParamDomain::finite("mu");
@@ -24,149 +23,100 @@ fn check_params(mu: &Float64Chunked, sigma: &Float64Chunked) -> PolarsResult<()>
     SIGMA.check_column(sigma)
 }
 
-/// `statrs::Normal::new` accepts an infinite `mu` or `sigma`, so [`MU`] and [`SIGMA`] are what
-/// refuse them; behind their pass this cannot fail.
 fn build_dist(mu: f64, sigma: f64) -> PolarsResult<Normal> {
     Normal::new(mu, sigma).map_err(|e| polars_err!(ComputeError: "{e}"))
 }
 
-/// Normal's constant parameters, deserialised once per call.
-///
-/// The one place this file spells `(mu, sigma)`: every fast path, sampler or value-keyed, reaches the
-/// constructor through [`Self::build`], so the order cannot drift between them.
+/// Constant parameters, deserialised once per call. Every `_scalar` twin builds through
+/// [`Self::build`], so it cannot rebuild per row.
 #[derive(serde::Deserialize)]
-struct NormalParamsKwargs {
+struct NormalParams {
     mu: f64,
     sigma: f64,
 }
 
-impl NormalParamsKwargs {
+impl NormalParams {
     fn build(&self) -> PolarsResult<Normal> {
         MU.check(self.mu)?;
         SIGMA.check(self.sigma)?;
         build_dist(self.mu, self.sigma)
     }
 
-    /// Constant-parameter twin of the per-row [`value_keyed`], sharing its `<method>_value`
-    /// bodies: build once per call, then map `f` over the evaluation-point column.
-    fn value_keyed<F>(&self, value: &Series, f: F) -> PolarsResult<Series>
+    fn value_keyed<Body>(&self, value: &Series, body: Body) -> PolarsResult<Series>
     where
-        F: Fn(&Normal, f64) -> Option<f64>,
+        Body: Fn(&Normal, f64) -> Option<f64>,
     {
-        let dist = self.build()?;
-        value_keyed_scalar(value, |v| f(&dist, v))
+        value_keyed_scalar(value, &self.build()?, body)
     }
 }
 
-/// `sigma` where both of `(mu, sigma)` are present, null elsewhere, after [`check_params`].
-///
-/// `inputs[0]` is `mu`, `inputs[1]` is `sigma`. The Python closed-form moments all derive from
-/// this single FFI round-trip, so they raise on an invalid parameterisation exactly like the
-/// value-keyed methods.
+fn value_keyed<Body>(inputs: &[Series], body: Body) -> PolarsResult<Series>
+where
+    Body: Fn(&Normal, f64) -> Option<f64>,
+{
+    value_keyed_ternary(
+        inputs,
+        coerce_f64,
+        coerce_f64,
+        check_params,
+        build_dist,
+        body,
+    )
+}
+
 #[polars_expr(output_type=Float64)]
 fn normal_sigma(inputs: &[Series]) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let mu = coerce_f64(&inputs[0])?;
-    let sigma = coerce_f64(&inputs[1])?;
-    check_params(&mu, &sigma)?;
-
-    let ca: Float64Chunked =
-        binary_elementwise(&mu, &sigma, |mu: Option<f64>, sigma: Option<f64>| {
-            mu.and(sigma)
-        });
-    Ok(ca.into_series())
+    validated_pair(inputs, coerce_f64, check_params)
 }
 
-/// Apply a value-keyed `f(dist, value)` element-wise over `(value, mu, sigma)`; shared by `pdf`,
-/// `ln_pdf`, `cdf`, `sf`, `ppf`. Null and `NaN` contracts in [`value_keyed_per_row`].
-fn value_keyed<F>(inputs: &[Series], f: F) -> PolarsResult<Series>
-where
-    F: Fn(&Normal, f64) -> Option<f64>,
-{
-    value_keyed_per_row(inputs, coerce_f64, coerce_f64, check_params, build_dist, f)
-}
-
-/// One Normal draw from a `&mut` per-row RNG already seeded from `(root_seed, index)`.
-///
-/// Every Normal sampler draws through here, per-row and fast path alike, so their bit-equality is
-/// structural rather than only sampled by `sample_test.py`.
 #[inline]
 fn draw(dist: &Normal, rng: &mut impl rand::Rng) -> f64 {
     RandDistribution::sample(dist, rng)
 }
 
-/// Element-wise Normal sampler over `(mu, sigma, row_index)`, returning `Float64`.
-///
-/// Per row, `null` propagates; an invalid parameterisation raises from [`check_params`] first.
-/// Seeding and chunk-invariance follow [`sample_per_row_ternary`].
 #[polars_expr(output_type=Float64)]
 fn normal_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let mu = coerce_f64(&inputs[0])?;
-    let sigma = coerce_f64(&inputs[1])?;
-    let index = inputs[2].cast(&DataType::UInt64)?;
-    let name = inputs[0].name().clone();
-    check_params(&mu, &sigma)?;
-
     sample_per_row_ternary(
-        name,
-        &mu,
-        &sigma,
-        index.u64()?,
-        kwargs.seed,
+        inputs,
+        kwargs,
+        coerce_f64,
+        coerce_f64,
+        check_params,
         build_dist,
         draw,
     )
 }
 
-/// Constant-parameter fast path for [`normal_sample`].
 #[polars_expr(output_type=Float64)]
 fn normal_sample_scalar(
     inputs: &[Series],
-    kwargs: SampleScalarKwargs<NormalParamsKwargs>,
+    kwargs: SampleScalarKwargs<NormalParams>,
 ) -> PolarsResult<Series> {
     let dist = kwargs.params.build()?;
-    let name = inputs[0].name().clone();
-
-    sample_by_index(name, &inputs[0], kwargs.seed, |rng| draw(&dist, rng))
+    sample_by_index(&inputs[0], kwargs.seed, |rng| draw(&dist, rng))
 }
 
-/// Constant-parameter multi-draw fast path: the `samples` twin of [`normal_sample_scalar`].
-///
-/// `size` consecutive draws from each row's stream, so `samples(size=1)` matches `sample` bit for
-/// bit and the distribution is built once per call. Returns `Array(Float64, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn normal_samples_scalar(
     inputs: &[Series],
-    kwargs: SamplesScalarKwargs<NormalParamsKwargs>,
+    kwargs: SamplesScalarKwargs<NormalParams>,
 ) -> PolarsResult<Series> {
     let dist = kwargs.params.build()?;
-    let name = inputs[0].name().clone();
-
-    samples_by_index(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
-        draw(&dist, rng)
-    })
+    samples_by_index(&inputs[0], kwargs.seed, kwargs.size, |rng| draw(&dist, rng))
 }
 
-/// Element-wise multi-draw Normal sampler: `size` draws per row in one call, the distribution
-/// built once per row. Returns `Array(Float64, size)`.
-///
-/// Seeding and the null/error contract follow [`samples_per_row`] and [`normal_sample`].
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn normal_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let mu = coerce_f64(&inputs[0])?;
-    let sigma = coerce_f64(&inputs[1])?;
-    let index = inputs[2].cast(&DataType::UInt64)?;
-    let name = inputs[0].name().clone();
-    check_params(&mu, &sigma)?;
-
-    let rows = ternary_param_rows(&mu, &sigma, index.u64()?, build_dist);
-
-    samples_per_row(name, rows, kwargs.seed, kwargs.size, draw)
+    samples_per_row_ternary(
+        inputs,
+        kwargs,
+        coerce_f64,
+        coerce_f64,
+        check_params,
+        build_dist,
+        draw,
+    )
 }
-
-// Per-method bodies, shared by the per-row plugins and their `*_scalar` twins.
 
 fn pdf_value(dist: &Normal, v: f64) -> Option<f64> {
     Some(dist.pdf(v))
@@ -184,17 +134,13 @@ fn sf_value(dist: &Normal, v: f64) -> Option<f64> {
     Some(dist.sf(v))
 }
 
-/// Point past which `erfc(t)` is close enough to underflowing (`erfc ~ 1e-274` at `t = 25`,
-/// underflow near `t = 26.6`) that we switch `ln_erfc` to the asymptotic series.
+/// Past this `erfc(t)` is close to underflowing (`~1e-274` at `t = 25`, `0` near `t = 26.6`), so
+/// [`ln_erfc`] switches to the asymptotic series. The two branches agree to `~1e-13` here.
 const LN_ERFC_ASYMPTOTIC_MIN: f64 = 25.0;
 
-/// Natural log of the complementary error function, stable in the right tail.
-///
-/// `erfc(t).ln()` returns `-inf` once `erfc(t)` rounds to `0` (`t` above ~26.6), the regime `log_cdf`
-/// / `log_sf` exist to serve. Past [`LN_ERFC_ASYMPTOTIC_MIN`] we switch to the asymptotic expansion
-/// `erfc(t) = exp(-t^2) / (t * sqrt(pi)) * (1 - 1/(2t^2) + 3/(4t^4) - 15/(8t^6) + ...)`, whose log is a
-/// large finite negative number; below it, statrs `erfc` holds full relative precision so the direct
-/// form is exact. The two branches agree to ~1e-13 at the crossover.
+/// `ln(erfc(t))`, finite in the right tail where `erfc(t).ln()` is `-inf`: the direct log below
+/// [`LN_ERFC_ASYMPTOTIC_MIN`], the log of
+/// `exp(-t^2) / (t sqrt(pi)) * (1 - 1/(2t^2) + 3/(4t^4) - 15/(8t^6) + ...)` above it.
 fn ln_erfc(t: f64) -> f64 {
     if t < LN_ERFC_ASYMPTOTIC_MIN {
         erf::erfc(t).ln()
@@ -206,10 +152,9 @@ fn ln_erfc(t: f64) -> f64 {
     }
 }
 
-/// `ln(0.5 * erfc(s))` with full relative precision on both sides: [`ln_erfc`] for the small half
-/// (`s >= 0`), `ln_1p` for the near-one half (`s < 0`, where `erfc(s) = 2 - erfc(-s)` rounds to `2`
-/// and the direct log collapses to `0` instead of the true tiny negative, e.g. `-7.6e-24` at
-/// 10 sigma; scipy's `log_ndtr` takes the same branch).
+/// `ln(0.5 * erfc(s))` with full relative precision on both sides: [`ln_erfc`] for `s >= 0`,
+/// `ln_1p(-0.5 * erfc(-s))` for `s < 0`, where `erfc(s)` rounds to `2` and the direct log collapses
+/// to `0` instead of the true tiny negative (`-7.6e-24` at 10 sigma).
 fn ln_half_erfc(s: f64) -> f64 {
     if s >= 0.0 {
         -LN_2 + ln_erfc(s)
@@ -218,33 +163,27 @@ fn ln_half_erfc(s: f64) -> f64 {
     }
 }
 
-/// Standardise `x` into the `erfc` argument `t = (x - mu) / (sigma * sqrt(2))`, so that
-/// `cdf(x) = 0.5 * erfc(-t)` and `sf(x) = 0.5 * erfc(t)` (statrs' own `cdf` / `sf` definition).
-fn erfc_arg(dist: &Normal, x: f64) -> f64 {
+fn mu_sigma(dist: &Normal) -> (f64, f64) {
     let mu = dist.mean().expect("Normal always has a mean");
     let sigma = dist.std_dev().expect("Normal always has a std_dev");
+    (mu, sigma)
+}
+
+/// `t = (x - mu) / (sigma sqrt 2)`, so that `cdf(x) = 0.5 erfc(-t)` and `sf(x) = 0.5 erfc(t)`.
+fn erfc_arg(dist: &Normal, x: f64) -> f64 {
+    let (mu, sigma) = mu_sigma(dist);
     (x - mu) / (sigma * SQRT_2)
 }
 
-/// Native log-cdf via `ln(0.5 * erfc(-t))`: finite in the left tail (no `cdf().ln()` underflow) and
-/// full relative precision in the right one (see [`ln_half_erfc`]).
-///
-/// `pub(crate)` so `LogNormal` reuses it on the underlying normal at `ln(x)` (log-normal log-cdf is
-/// the underlying normal's log-cdf composed with `ln`).
 pub(crate) fn ln_cdf_value(dist: &Normal, v: f64) -> Option<f64> {
     Some(ln_half_erfc(-erfc_arg(dist, v)))
 }
 
-/// Native log-sf via `ln(0.5 * erfc(t))`: finite in the right tail (no `sf().ln()` underflow) and
-/// full relative precision in the left one (see [`ln_half_erfc`]).
-///
-/// `pub(crate)` for the same reason as [`ln_cdf_value`].
 pub(crate) fn ln_sf_value(dist: &Normal, v: f64) -> Option<f64> {
     Some(ln_half_erfc(erfc_arg(dist, v)))
 }
 
-/// A quantile outside `[0, 1]` yields `null`; the closed endpoints map to the infinite tails
-/// (`ppf(0) = -inf`, `ppf(1) = +inf`), matching `scipy.stats.norm.ppf`.
+/// Null outside `[0, 1]`; the closed endpoints map to the infinite tails.
 fn ppf_value(dist: &Normal, q: f64) -> Option<f64> {
     if !(0.0..=1.0).contains(&q) {
         None
@@ -257,16 +196,9 @@ fn ppf_value(dist: &Normal, q: f64) -> Option<f64> {
     }
 }
 
-/// Inverse survival function, `mu + sigma * sqrt(2) * erfc_inv(2q)`, solved on `q` rather than on
-/// its complement.
-///
-/// Not `ppf(1 - q)`: that composes `statrs`' `inverse_cdf` into `erfc_inv(2 - 2q)`, whose argument
-/// resolves to `2.2e-16` absolute, so the tail mass is quantised before the inverse runs. The
-/// symmetry `z_(1-q) = -z_q` puts the sign on the scale instead, leaving the exact power-of-two `2q`
-/// as the only thing the inverse sees.
-///
-/// Contract mirrors [`ppf_value`]: `null` outside `[0, 1]`, closed endpoints to the infinite tails
-/// (`isf(0) = +inf`, `isf(1) = -inf`, the reverse of `ppf`). `pub(crate)` so `LogNormal` composes it.
+/// `mu + sigma sqrt(2) erfc_inv(2q)`, solved on `q` itself. `ppf(1 - q)` would hand `erfc_inv`
+/// the argument `2 - 2q`, which quantises the tail mass to `2.2e-16` before the inverse runs; the
+/// symmetry `z_(1-q) = -z_q` puts the sign on the scale instead. Endpoints reverse `ppf`'s.
 pub(crate) fn isf_value(dist: &Normal, q: f64) -> Option<f64> {
     if !(0.0..=1.0).contains(&q) {
         None
@@ -275,106 +207,87 @@ pub(crate) fn isf_value(dist: &Normal, q: f64) -> Option<f64> {
     } else if q == 1.0 {
         Some(f64::NEG_INFINITY)
     } else {
-        let mu = dist.mean().expect("Normal always has a mean");
-        let sigma = dist.std_dev().expect("Normal always has a std_dev");
+        let (mu, sigma) = mu_sigma(dist);
         Some(mu + sigma * SQRT_2 * erf::erfc_inv(2.0 * q))
     }
 }
 
-/// Element-wise pdf via `statrs` `Continuous::pdf`. See [`value_keyed`] for the null/error contract.
 #[polars_expr(output_type=Float64)]
 fn normal_pdf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, pdf_value)
 }
 
-/// Element-wise log-pdf via native `Continuous::ln_pdf` (more accurate than `pdf().ln()`).
 #[polars_expr(output_type=Float64)]
 fn normal_ln_pdf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, ln_pdf_value)
 }
 
-/// Element-wise cdf via `statrs` `ContinuousCDF::cdf`.
 #[polars_expr(output_type=Float64)]
 fn normal_cdf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, cdf_value)
 }
 
-/// Element-wise survival function via native `ContinuousCDF::sf` (accurate in the upper tail).
 #[polars_expr(output_type=Float64)]
 fn normal_sf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, sf_value)
 }
 
-/// Element-wise log-cdf via the stable [`ln_erfc`] form (finite in the left tail, unlike `cdf().ln()`).
 #[polars_expr(output_type=Float64)]
 fn normal_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, ln_cdf_value)
 }
 
-/// Element-wise log-sf via the stable [`ln_erfc`] form (finite in the right tail, unlike `sf().ln()`).
 #[polars_expr(output_type=Float64)]
 fn normal_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, ln_sf_value)
 }
 
-/// Element-wise ppf (inverse cdf) via the closed-form `ContinuousCDF::inverse_cdf`.
-/// See [`ppf_value`] for the endpoint and out-of-range contract.
 #[polars_expr(output_type=Float64)]
 fn normal_ppf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, ppf_value)
 }
 
-/// Element-wise isf (inverse survival function) via the symmetry form, not `ppf(1 - q)`.
-/// See [`isf_value`] for why, and for the endpoint and out-of-range contract.
 #[polars_expr(output_type=Float64)]
 fn normal_isf(inputs: &[Series]) -> PolarsResult<Series> {
     value_keyed(inputs, isf_value)
 }
 
-/// Constant-parameter fast path for [`normal_pdf`].
 #[polars_expr(output_type=Float64)]
-fn normal_pdf_scalar(inputs: &[Series], kwargs: NormalParamsKwargs) -> PolarsResult<Series> {
+fn normal_pdf_scalar(inputs: &[Series], kwargs: NormalParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], pdf_value)
 }
 
-/// Constant-parameter fast path for [`normal_ln_pdf`].
 #[polars_expr(output_type=Float64)]
-fn normal_ln_pdf_scalar(inputs: &[Series], kwargs: NormalParamsKwargs) -> PolarsResult<Series> {
+fn normal_ln_pdf_scalar(inputs: &[Series], kwargs: NormalParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], ln_pdf_value)
 }
 
-/// Constant-parameter fast path for [`normal_cdf`].
 #[polars_expr(output_type=Float64)]
-fn normal_cdf_scalar(inputs: &[Series], kwargs: NormalParamsKwargs) -> PolarsResult<Series> {
+fn normal_cdf_scalar(inputs: &[Series], kwargs: NormalParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], cdf_value)
 }
 
-/// Constant-parameter fast path for [`normal_sf`].
 #[polars_expr(output_type=Float64)]
-fn normal_sf_scalar(inputs: &[Series], kwargs: NormalParamsKwargs) -> PolarsResult<Series> {
+fn normal_sf_scalar(inputs: &[Series], kwargs: NormalParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], sf_value)
 }
 
-/// Constant-parameter fast path for [`normal_ln_cdf`].
 #[polars_expr(output_type=Float64)]
-fn normal_ln_cdf_scalar(inputs: &[Series], kwargs: NormalParamsKwargs) -> PolarsResult<Series> {
+fn normal_ln_cdf_scalar(inputs: &[Series], kwargs: NormalParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], ln_cdf_value)
 }
 
-/// Constant-parameter fast path for [`normal_ln_sf`].
 #[polars_expr(output_type=Float64)]
-fn normal_ln_sf_scalar(inputs: &[Series], kwargs: NormalParamsKwargs) -> PolarsResult<Series> {
+fn normal_ln_sf_scalar(inputs: &[Series], kwargs: NormalParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], ln_sf_value)
 }
 
-/// Constant-parameter fast path for [`normal_ppf`].
 #[polars_expr(output_type=Float64)]
-fn normal_ppf_scalar(inputs: &[Series], kwargs: NormalParamsKwargs) -> PolarsResult<Series> {
+fn normal_ppf_scalar(inputs: &[Series], kwargs: NormalParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], ppf_value)
 }
 
-/// Constant-parameter fast path for [`normal_isf`].
 #[polars_expr(output_type=Float64)]
-fn normal_isf_scalar(inputs: &[Series], kwargs: NormalParamsKwargs) -> PolarsResult<Series> {
+fn normal_isf_scalar(inputs: &[Series], kwargs: NormalParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], isf_value)
 }

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -1,29 +1,27 @@
-use polars::prelude::arity::binary_elementwise;
 use polars::prelude::*;
 use pyo3_polars::derive::polars_expr;
 use rand::distr::{Distribution, StandardUniform};
 
 use crate::distributions::{
-    align_inputs, coerce_f64, on_unit_interval, value_keyed_derived_pair_per_row,
-    value_keyed_derived_pair_scalar, PairDomain, ParamDomain,
+    coerce_f64, on_unit_interval, param_keyed, value_keyed_derived_ternary, value_keyed_scalar,
+    PairDomain, ParamDomain,
 };
 use crate::rng::{
-    sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output, samples_per_row,
-    ternary_param_rows, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
+    sample_by_index, sample_per_row_ternary, samples_by_index, samples_f64_output,
+    samples_per_row_ternary, SampleKwargs, SampleScalarKwargs, SamplesKwargs, SamplesScalarKwargs,
 };
 
 const MIN: ParamDomain = ParamDomain::finite("min");
 const MAX: ParamDomain = ParamDomain::finite("max");
 
-/// `max - min` overflows to `inf` for `min=-1e308, max=1e308`, and with it every derived quantity
-/// (`range`, the moments, the draw) would silently be `inf`.
+/// `max - min` overflows to `inf` for `min=-1e308, max=1e308`, and every derived quantity with it.
 const BOUNDS: PairDomain<f64> = PairDomain {
     names: ("min", "max"),
     rule: "strictly greater than min, and max - min must be finite",
     accepts: |min, max| max > min && (max - min).is_finite(),
 };
 
-/// The constant regime's once-per-call check, and the row loops' backstop.
+/// The samplers' per-row state: the bounds themselves, checked.
 fn checked_bounds(min: f64, max: f64) -> PolarsResult<(f64, f64)> {
     MIN.check(min)?;
     MAX.check(max)?;
@@ -37,15 +35,14 @@ fn check_params(min: &Float64Chunked, max: &Float64Chunked) -> PolarsResult<()> 
     BOUNDS.check_columns(min, max)
 }
 
-/// Uniform's constant bounds, deserialised once per call.
+/// Constant parameters, deserialised once per call; every `_scalar` twin checks them once here.
 #[derive(serde::Deserialize)]
-struct UniformParamsKwargs {
+struct UniformParams {
     min: f64,
     max: f64,
 }
 
-impl UniformParamsKwargs {
-    /// Validates once per call, then derives and maps through [`value_keyed_derived_pair_scalar`].
+impl UniformParams {
     fn value_keyed<Branches>(
         &self,
         value: &Series,
@@ -53,17 +50,15 @@ impl UniformParamsKwargs {
         select: impl Fn(&Branches, f64) -> Option<f64>,
     ) -> PolarsResult<Series> {
         checked_bounds(self.min, self.max)?;
-        value_keyed_derived_pair_scalar(value, self.min, self.max, derive, select)
+        value_keyed_scalar(value, &derive(self.min, self.max), select)
     }
 }
 
-/// Where both inverses switch which bound they interpolate from; see [`derive_inverse`].
+/// Where both inverses switch which bound they interpolate from.
 const MEDIAN_QUANTILE: f64 = 0.5;
 
-/// Where the two log methods swap conditioning, as `min + range / 2` rather than `(min + max) / 2`.
-///
-/// The two round differently on a span that straddles zero, and `min + max` can overflow where
-/// `range / 2` cannot: `range` is already known finite.
+/// `min + range / 2` rather than `(min + max) / 2`: `min + max` can overflow where `range` is
+/// already known finite.
 fn midpoint(min: f64, range: f64) -> f64 {
     min + range / 2.0
 }
@@ -77,7 +72,6 @@ struct Density {
 }
 
 impl Density {
-    /// `1 / range` on the support, `0` off it.
     fn pdf(min: f64, max: f64) -> Self {
         Density {
             min,
@@ -87,8 +81,8 @@ impl Density {
         }
     }
 
-    /// `-ln(range)` on the support, `-inf` off it. From the width rather than as `ln(pdf)`, so it
-    /// stays exact where the density itself has underflowed or overflowed.
+    /// `-ln(range)` from the width rather than `ln(pdf)`, so it stays exact where the density has
+    /// under- or overflowed.
     fn ln_pdf(min: f64, max: f64) -> Self {
         Density {
             min,
@@ -98,11 +92,8 @@ impl Density {
         }
     }
 
-    /// The support is closed at both ends, so `max` is on it (`pdf(max) == 1 / range`) and only
-    /// `value > max` is outside. scipy's convention, and the one asymmetry with `uniform_sample`,
-    /// which draws on the half-open `[min, max)`.
-    ///
-    /// A `NaN` point never reaches here: both drivers short-circuit it.
+    /// Closed at both ends (scipy's convention), so `pdf(max) == 1 / range`; the one asymmetry with
+    /// the sampler, which draws on `[min, max)`.
     fn at(&self, value: f64) -> Option<f64> {
         Some(if value < self.min || value > self.max {
             self.off_support
@@ -112,10 +103,8 @@ impl Density {
     }
 }
 
-/// `cdf` / `log_cdf` / `sf` / `log_sf`: the three places an evaluation point lands, and the answer
-/// at each.
-///
-/// These saturate from `max` up, so `max` takes `at_or_above_max` rather than the interior.
+/// `cdf` / `log_cdf` / `sf` / `log_sf`: the three places a point lands. These saturate from `max`
+/// up, so `max` takes `at_or_above_max`.
 struct Regions<Arm> {
     min: f64,
     max: f64,
@@ -136,7 +125,6 @@ impl<Arm: Fn(f64) -> f64> Regions<Arm> {
     }
 }
 
-/// `(value - min) / range` on the support, clamped to `0` below and `1` from `max` up.
 fn derive_cdf(min: f64, max: f64) -> Regions<impl Fn(f64) -> f64> {
     Regions {
         min,
@@ -150,12 +138,9 @@ fn derive_cdf(min: f64, max: f64) -> Regions<impl Fn(f64) -> f64> {
     }
 }
 
-/// `ln(cdf)` below the midpoint, `ln_1p(-sf)` above it; `-inf` below `min`, `0` from `max` up.
-///
-/// Approaching `max` the cdf ratio rounds to exactly `1` and its log to `0`, where the truth is a
-/// small negative, so the near-certain half reads the *survival* fraction through `ln_1p` instead.
-/// The other half is well conditioned and takes the plain log, the same branch `normal.rs`'s
-/// `ln_half_erfc` takes.
+/// `ln(cdf)` below the midpoint, `ln_1p(-sf)` above it. Approaching `max` the cdf ratio rounds to
+/// exactly `1` and its log to `0` where the truth is a small negative, so the near-certain half reads
+/// the survival fraction through `ln_1p`.
 fn derive_ln_cdf(min: f64, max: f64) -> Regions<impl Fn(f64) -> f64> {
     Regions {
         min,
@@ -176,10 +161,8 @@ fn derive_ln_cdf(min: f64, max: f64) -> Regions<impl Fn(f64) -> f64> {
     }
 }
 
-/// `(max - value) / range` on the support, `1` below `min` and `0` from `max` up.
-///
-/// The closed form, never `1 - cdf`: the complement quantises the upper tail to the `1.1e-16`
-/// spacing of `1.0` and reaches `0.0` below that.
+/// `(max - value) / range`; never `1 - cdf`, which quantises the upper tail to the `1.1e-16` spacing
+/// of `1.0`.
 fn derive_sf(min: f64, max: f64) -> Regions<impl Fn(f64) -> f64> {
     Regions {
         min,
@@ -193,8 +176,8 @@ fn derive_sf(min: f64, max: f64) -> Regions<impl Fn(f64) -> f64> {
     }
 }
 
-/// The mirror of [`derive_ln_cdf`]: `0` below `min`, `-inf` from `max` up, and the `ln_1p` branch on
-/// the **lower** half, which is where the survival function is the near-certain one.
+/// The mirror of [`derive_ln_cdf`]: `ln_1p` on the lower half, where the survival function is the
+/// near-certain one.
 fn derive_ln_sf(min: f64, max: f64) -> Regions<impl Fn(f64) -> f64> {
     Regions {
         min,
@@ -215,17 +198,11 @@ fn derive_ln_sf(min: f64, max: f64) -> Regions<impl Fn(f64) -> f64> {
     }
 }
 
-/// `ppf` and `isf`, interpolating from whichever bound the answer is nearest.
-///
-/// Both inverses are one multiply-add, and both lose the answer when they interpolate from the
-/// *far* bound: `min + quantile * range` is a difference of nearly equal numbers once the result
-/// lands near `max`. Anchoring to the near bound makes the addition well conditioned, and the
-/// `1 - quantile` it needs is formed only above [`MEDIAN_QUANTILE`], where Sterbenz makes it
-/// exact.
-///
-/// `ascending` is `true` for `ppf`, whose quantile `0` sits at `min`, and `false` for `isf`, whose
-/// sits at `max`. Mirroring rather than `ppf(1 - q)`: below `q ~ 1.1e-16` that complement rounds to
-/// `1.0` and the whole tail collapses onto one bound.
+/// `ppf` (`ascending`) and `isf`, interpolating from whichever bound the answer is nearest:
+/// `min + q * range` is a difference of nearly equal numbers once the result lands near `max`, so
+/// above [`MEDIAN_QUANTILE`] the answer anchors to the far bound through `1 - q`, which Sterbenz
+/// makes exact there. Mirroring rather than `ppf(1 - q)`: below `q ~ 1.1e-16` that complement rounds
+/// to `1.0`.
 fn derive_inverse(min: f64, max: f64, ascending: bool) -> impl Fn(f64) -> f64 {
     let range = max - min;
     let (at_zero, at_one, step) = if ascending {
@@ -242,132 +219,99 @@ fn derive_inverse(min: f64, max: f64, ascending: bool) -> impl Fn(f64) -> f64 {
     }
 }
 
-/// `min + quantile * range`, from `max` down above the median; null outside `[0, 1]`.
 fn derive_ppf(min: f64, max: f64) -> impl Fn(f64) -> f64 {
     derive_inverse(min, max, true)
 }
 
-/// `max - quantile * range`, from `min` up above the median; null outside `[0, 1]`.
 fn derive_isf(min: f64, max: f64) -> impl Fn(f64) -> f64 {
     derive_inverse(min, max, false)
 }
 
-/// Element-wise pdf; see [`Density::at`] for why the support is closed at `max`.
-/// See [`value_keyed_derived_pair_per_row`] for the null/error contract.
 #[polars_expr(output_type=Float64)]
 fn uniform_pdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, check_params, Density::pdf, Density::at)
+    value_keyed_derived_ternary(inputs, check_params, Density::pdf, Density::at)
 }
 
-/// Element-wise log-pdf; see [`Density::ln_pdf`].
 #[polars_expr(output_type=Float64)]
 fn uniform_ln_pdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, check_params, Density::ln_pdf, Density::at)
+    value_keyed_derived_ternary(inputs, check_params, Density::ln_pdf, Density::at)
 }
 
-/// Element-wise cdf `P(X <= value)`; see [`derive_cdf`].
 #[polars_expr(output_type=Float64)]
 fn uniform_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, check_params, derive_cdf, Regions::at)
+    value_keyed_derived_ternary(inputs, check_params, derive_cdf, Regions::at)
 }
 
-/// Element-wise log-cdf; see [`derive_ln_cdf`].
 #[polars_expr(output_type=Float64)]
 fn uniform_ln_cdf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, check_params, derive_ln_cdf, Regions::at)
+    value_keyed_derived_ternary(inputs, check_params, derive_ln_cdf, Regions::at)
 }
 
-/// Element-wise survival function `P(X > value)`; see [`derive_sf`] for why it is not `1 - cdf`.
 #[polars_expr(output_type=Float64)]
 fn uniform_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, check_params, derive_sf, Regions::at)
+    value_keyed_derived_ternary(inputs, check_params, derive_sf, Regions::at)
 }
 
-/// Element-wise log-sf; see [`derive_ln_sf`].
 #[polars_expr(output_type=Float64)]
 fn uniform_ln_sf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, check_params, derive_ln_sf, Regions::at)
+    value_keyed_derived_ternary(inputs, check_params, derive_ln_sf, Regions::at)
 }
 
-/// Element-wise ppf (inverse cdf); see [`derive_inverse`].
 #[polars_expr(output_type=Float64)]
 fn uniform_ppf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, check_params, derive_ppf, on_unit_interval)
+    value_keyed_derived_ternary(inputs, check_params, derive_ppf, on_unit_interval)
 }
 
-/// Element-wise inverse survival function; see [`derive_inverse`] for why it never forms a
-/// complement.
 #[polars_expr(output_type=Float64)]
 fn uniform_isf(inputs: &[Series]) -> PolarsResult<Series> {
-    value_keyed_derived_pair_per_row(inputs, check_params, derive_isf, on_unit_interval)
+    value_keyed_derived_ternary(inputs, check_params, derive_isf, on_unit_interval)
 }
 
-/// Constant-bounds fast path for [`uniform_pdf`].
 #[polars_expr(output_type=Float64)]
-fn uniform_pdf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
+fn uniform_pdf_scalar(inputs: &[Series], kwargs: UniformParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], Density::pdf, Density::at)
 }
 
-/// Constant-bounds fast path for [`uniform_ln_pdf`].
 #[polars_expr(output_type=Float64)]
-fn uniform_ln_pdf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
+fn uniform_ln_pdf_scalar(inputs: &[Series], kwargs: UniformParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], Density::ln_pdf, Density::at)
 }
 
-/// Constant-bounds fast path for [`uniform_cdf`].
 #[polars_expr(output_type=Float64)]
-fn uniform_cdf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
+fn uniform_cdf_scalar(inputs: &[Series], kwargs: UniformParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_cdf, Regions::at)
 }
 
-/// Constant-bounds fast path for [`uniform_ln_cdf`].
 #[polars_expr(output_type=Float64)]
-fn uniform_ln_cdf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
+fn uniform_ln_cdf_scalar(inputs: &[Series], kwargs: UniformParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_ln_cdf, Regions::at)
 }
 
-/// Constant-bounds fast path for [`uniform_sf`].
 #[polars_expr(output_type=Float64)]
-fn uniform_sf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
+fn uniform_sf_scalar(inputs: &[Series], kwargs: UniformParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_sf, Regions::at)
 }
 
-/// Constant-bounds fast path for [`uniform_ln_sf`].
 #[polars_expr(output_type=Float64)]
-fn uniform_ln_sf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
+fn uniform_ln_sf_scalar(inputs: &[Series], kwargs: UniformParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_ln_sf, Regions::at)
 }
 
-/// Constant-bounds fast path for [`uniform_ppf`].
 #[polars_expr(output_type=Float64)]
-fn uniform_ppf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
+fn uniform_ppf_scalar(inputs: &[Series], kwargs: UniformParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_ppf, on_unit_interval)
 }
 
-/// Constant-bounds fast path for [`uniform_isf`].
 #[polars_expr(output_type=Float64)]
-fn uniform_isf_scalar(inputs: &[Series], kwargs: UniformParamsKwargs) -> PolarsResult<Series> {
+fn uniform_isf_scalar(inputs: &[Series], kwargs: UniformParams) -> PolarsResult<Series> {
     kwargs.value_keyed(&inputs[0], derive_isf, on_unit_interval)
 }
 
-/// One half-open `[lo, hi)` draw: `lo + (hi - lo) * U[0, 1)`, matching scipy's
-/// `loc + scale * U[0, 1)`.
-///
-/// Uniform's counterpart of the other distributions' `fn draw`: every Uniform sampler draws through
-/// here, per-row and fast path alike, so their bit-equality is structural rather than only sampled
-/// by `sample_test.py`.
-///
-/// This deliberately bypasses `statrs`' `Distribution::sample`, which rebuilds a
-/// `rand::distr::Uniform` float sampler (scale/bias/rejection-zone setup) on *every* call: that
-/// fixed per-draw cost dwarfs the single multiply-add here, enough to leave the sampler slower
-/// than scipy.
-///
-/// `u < 1` does not survive the multiply-add's rounding: `lo + (hi - lo) * u` can land exactly on
-/// `hi` (or one ulp above) when `u` is close to 1, so the result is nudged back to the largest
-/// float below `hi` to keep the documented half-open contract. `lo < hi` guarantees
-/// `hi.next_down() >= lo`.
+/// One `[lo, hi)` draw, `lo + (hi - lo) * U[0, 1)`, bypassing `statrs`' `sample`, which rebuilds a
+/// `rand::distr::Uniform` sampler on every call. The multiply-add can round onto `hi` when `u` is
+/// close to `1`, so the result is nudged back below `hi`; `lo < hi` guarantees `hi.next_down() >= lo`.
 #[inline]
-fn draw_half_open(lo: f64, hi: f64, rng: &mut impl rand::Rng) -> f64 {
+fn draw(&(lo, hi): &(f64, f64), rng: &mut impl rand::Rng) -> f64 {
     let u: f64 = StandardUniform.sample(rng);
     let x = lo + (hi - lo) * u;
     if x < hi {
@@ -377,101 +321,56 @@ fn draw_half_open(lo: f64, hi: f64, rng: &mut impl rand::Rng) -> f64 {
     }
 }
 
-/// Element-wise continuous Uniform sampler over `[min, max)`, taking `(min, max, row_index)` and
-/// returning `Float64`.
-///
-/// Per row, `null` propagates; an invalid parameterisation (`max <= min`, non-finite bounds, or a
-/// width overflowing `f64`) raises from [`check_params`] before any row is drawn. Seeding and
-/// chunk-invariance follow [`sample_per_row_ternary`].
 #[polars_expr(output_type=Float64)]
 fn uniform_sample(inputs: &[Series], kwargs: SampleKwargs) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let min = coerce_f64(&inputs[0])?;
-    let max = coerce_f64(&inputs[1])?;
-    let index = inputs[2].cast(&DataType::UInt64)?;
-    let name = inputs[0].name().clone();
-    check_params(&min, &max)?;
-
     sample_per_row_ternary(
-        name,
-        &min,
-        &max,
-        index.u64()?,
-        kwargs.seed,
+        inputs,
+        kwargs,
+        coerce_f64,
+        coerce_f64,
+        check_params,
         checked_bounds,
-        |&(lo, hi), rng| draw_half_open(lo, hi, rng),
+        draw,
     )
 }
 
-/// Constant-bounds fast path for [`uniform_sample`].
 #[polars_expr(output_type=Float64)]
 fn uniform_sample_scalar(
     inputs: &[Series],
-    kwargs: SampleScalarKwargs<UniformParamsKwargs>,
+    kwargs: SampleScalarKwargs<UniformParams>,
 ) -> PolarsResult<Series> {
-    let (lo, hi) = checked_bounds(kwargs.params.min, kwargs.params.max)?;
-    let name = inputs[0].name().clone();
-
-    sample_by_index(name, &inputs[0], kwargs.seed, |rng| {
-        draw_half_open(lo, hi, rng)
-    })
+    let bounds = checked_bounds(kwargs.params.min, kwargs.params.max)?;
+    sample_by_index(&inputs[0], kwargs.seed, |rng| draw(&bounds, rng))
 }
 
-/// Constant-bounds multi-draw fast path: the `samples` twin of [`uniform_sample_scalar`].
-///
-/// `size` consecutive draws from each row's stream, so `samples(size=1)` matches `sample` bit for
-/// bit and the bounds are validated once per call. Returns `Array(Float64, size)`.
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn uniform_samples_scalar(
     inputs: &[Series],
-    kwargs: SamplesScalarKwargs<UniformParamsKwargs>,
+    kwargs: SamplesScalarKwargs<UniformParams>,
 ) -> PolarsResult<Series> {
-    let (lo, hi) = checked_bounds(kwargs.params.min, kwargs.params.max)?;
-    let name = inputs[0].name().clone();
-
-    samples_by_index(name, &inputs[0], kwargs.seed, kwargs.size, |rng| {
-        draw_half_open(lo, hi, rng)
+    let bounds = checked_bounds(kwargs.params.min, kwargs.params.max)?;
+    samples_by_index(&inputs[0], kwargs.seed, kwargs.size, |rng| {
+        draw(&bounds, rng)
     })
 }
 
-/// Element-wise multi-draw Uniform sampler over `[min, max)`: `size` draws per row in one call.
-/// Returns `Array(Float64, size)`.
-///
-/// Seeding and the null/error contract follow [`samples_per_row`] and [`uniform_sample`]; the
-/// draw is the shared [`draw_half_open`].
 #[polars_expr(output_type_func_with_kwargs=samples_f64_output)]
 fn uniform_samples(inputs: &[Series], kwargs: SamplesKwargs) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let min = coerce_f64(&inputs[0])?;
-    let max = coerce_f64(&inputs[1])?;
-    let index = inputs[2].cast(&DataType::UInt64)?;
-    let name = inputs[0].name().clone();
-    check_params(&min, &max)?;
-
-    let rows = ternary_param_rows(&min, &max, index.u64()?, checked_bounds);
-
-    samples_per_row(name, rows, kwargs.seed, kwargs.size, |&(lo, hi), rng| {
-        draw_half_open(lo, hi, rng)
-    })
+    samples_per_row_ternary(
+        inputs,
+        kwargs,
+        coerce_f64,
+        coerce_f64,
+        check_params,
+        checked_bounds,
+        draw,
+    )
 }
 
-/// Element-wise support width `max - min`, behind [`check_params`].
-///
-/// `inputs[0]` is the lower bound, `inputs[1]` the upper bound. `null` in either propagates;
-/// `max <= min`, non-finite bounds, or a width overflowing `f64` raise `ComputeError`.
-///
-/// Every closed-form Python method derives from this width, so routing it through Rust is what
-/// lets them report an invalid parameterisation consistently with `uniform_sample`, instead of
-/// silently producing a negative or infinite result.
+/// The support width `max - min`, which the Python moments derive from.
 #[polars_expr(output_type=Float64)]
 fn uniform_range(inputs: &[Series]) -> PolarsResult<Series> {
-    let inputs = align_inputs(inputs)?;
-    let min = coerce_f64(&inputs[0])?;
-    let max = coerce_f64(&inputs[1])?;
-    check_params(&min, &max)?;
-
-    let ca: Float64Chunked = binary_elementwise(&min, &max, |lo: Option<f64>, hi: Option<f64>| {
-        Some(hi? - lo?)
-    });
-    Ok(ca.into_series())
+    param_keyed(inputs, coerce_f64, coerce_f64, check_params, |lo, hi| {
+        Ok(hi - lo)
+    })
 }

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,25 +1,16 @@
-//! Shared per-row RNG foundation for all distribution samplers.
+//! Per-row RNG foundation shared by every sampler.
 //!
-//! Every sampler needs the same property: a deterministic, independent random stream
-//! per row, derived only from `(root_seed, row_index)`. Because the seed is a function
-//! of the row index (not of position within a chunk), the output is invariant to how
-//! Polars chunks or threads the input.
+//! Row `i` draws from a `Pcg64Mcg` seeded from `(root_seed, i)` alone, so output does not depend on
+//! how polars chunks or threads the input, and the constant-parameter and column-parameter paths
+//! agree bit for bit for the same seed. `Pcg64Mcg` costs a handful of integer ops to construct, passes
+//! TestU01 BigCrush, and is stable across `rand_pcg` releases and platforms.
 //!
-//! The generator is [`Pcg64Mcg`]: construction is a handful of integer ops (no key
-//! schedule, no keystream block), it passes TestU01 BigCrush, and its output is stable
-//! across `rand_pcg` releases and platforms (so seeded results stay reproducible). That
-//! makes it a safe default for any distribution, including rejection/Ziggurat samplers
-//! that consume an unbounded number of words per draw.
-//!
-//! A one-shot hash-to-uniform would be cheaper but only serves distributions needing a
-//! single uniform per draw, so it is deliberately not the foundation; see
-//! `docs/explanation/design.md` for the alternatives that were rejected and why.
-//!
-//! Every sampler plugin is a shell over one of the drivers below; none resolves a seed or writes a
-//! row loop itself. They share one argument order, `name, inputs, seed, [size], closures`, and take
-//! their output dtype from the drawn value through [`DrawValue`]. The constant-parameter drivers
-//! cast the index `Series` themselves; the per-row drivers take it pre-cast as `&UInt64Chunked`,
-//! since [`binary_param_rows`] returns an iterator borrowing its inputs and cannot own the cast.
+//! Every sampler plugin is a one-line shell over a driver here: [`sample_by_index`] /
+//! [`samples_by_index`] when every parameter is constant (only the row index crosses FFI),
+//! `sample_per_row_*` / `samples_per_row_*` when one is a column. Driver names count plugin inputs:
+//! `_binary` takes `(param, row_index)`, `_ternary` takes `(a, b, row_index)`. A distribution supplies
+//! `build` (a row's draw state from its parameters) and `draw` (one value from that state); the output
+//! dtype follows the drawn value through [`DrawValue`]. A null in any input nulls the row.
 
 use polars::prelude::arity::{try_binary_elementwise, try_ternary_elementwise};
 use polars::prelude::*;
@@ -33,11 +24,10 @@ use rand::TryRng;
 use rand_pcg::Pcg64Mcg;
 use serde::Deserialize;
 
-/// splitmix64 finalizer: full-avalanche mixing of a single 64-bit word.
-///
-/// Used to decorrelate adjacent `(root_seed, index)` pairs before they seed the
-/// generator, so neighbouring rows get well-separated states rather than nearly
-/// identical ones.
+use crate::distributions::{align_inputs, coerce_f64, ParamDomain};
+
+/// splitmix64 finalizer: full-avalanche mixing of one 64-bit word, so neighbouring
+/// `(root_seed, index)` pairs seed well-separated states.
 #[inline]
 fn splitmix64(mut z: u64) -> u64 {
     z = z.wrapping_add(0x9E37_79B9_7F4A_7C15);
@@ -46,95 +36,37 @@ fn splitmix64(mut z: u64) -> u64 {
     z ^ (z >> 31)
 }
 
-/// Resolve the root seed for a sampler call: the caller's seed if given, otherwise a
-/// fresh OS-entropy draw. Called once per plugin invocation, never per row.
-///
-/// An OS-entropy failure (`SysRng` is fallible) surfaces as a `ComputeError` and fails the
-/// evaluation, the same contract as an invalid parameter: it is a per-call error, deliberately
-/// not a panic out of the plugin.
-#[inline]
-fn resolve_root_seed(seed: Option<u64>) -> PolarsResult<u64> {
-    match seed {
-        Some(seed) => Ok(seed),
-        None => SysRng.try_next_u64().map_err(|e| {
-            PolarsError::ComputeError(
-                format!("failed to draw OS entropy for the sampler root seed: {e}").into(),
-            )
-        }),
+/// Per-call source of per-row RNGs. The root seed is resolved once per plugin call, so OS entropy is
+/// drawn at most once and every [`Self::row_rng`] is a few integer ops.
+struct RowRngs {
+    root_seed: u64,
+}
+
+impl RowRngs {
+    /// The caller's seed, or one OS-entropy draw; an entropy failure is a `ComputeError`, never a
+    /// panic out of the plugin.
+    fn new(seed: Option<u64>) -> PolarsResult<Self> {
+        let root_seed = match seed {
+            Some(seed) => seed,
+            None => SysRng.try_next_u64().map_err(|e| {
+                polars_err!(ComputeError: "failed to draw OS entropy for the sampler root seed: {e}")
+            })?,
+        };
+        Ok(Self { root_seed })
+    }
+
+    /// Identical `(seed, index)` pairs always yield identical streams. Two splitmix64 draws fold both
+    /// inputs into the 128-bit state; the low bit is forced odd for the MCG's full period.
+    #[inline]
+    fn row_rng(&self, index: u64) -> Pcg64Mcg {
+        let lo = splitmix64(self.root_seed ^ index.wrapping_mul(0x9E37_79B9_7F4A_7C15));
+        let hi = splitmix64(lo);
+        Pcg64Mcg::new((((hi as u128) << 64) | lo as u128) | 1)
     }
 }
 
-/// Per-row RNG seeded by `(root_seed, index)`.
-///
-/// Identical inputs always yield identical streams, so a sampler built on this is
-/// genuinely elementwise: chunking and thread scheduling cannot change its output.
-#[inline]
-fn row_rng(root_seed: u64, index: u64) -> Pcg64Mcg {
-    // Fold both inputs into a 128-bit state via two splitmix64 draws. The low bit is
-    // forced odd to give the MCG its full period.
-    let lo = splitmix64(root_seed ^ index.wrapping_mul(0x9E37_79B9_7F4A_7C15));
-    let hi = splitmix64(lo);
-    let state = (((hi as u128) << 64) | lo as u128) | 1;
-    Pcg64Mcg::new(state)
-}
-
-/// Kwargs shared by every per-row sampler plugin.
-///
-/// A sampler's only static input is an optional root seed: the per-row index travels as
-/// a regular input `Series`, not a kwarg. So every distribution deserialises the *same*
-/// shape, and they share this one struct rather than each declaring an identical copy.
-#[derive(Deserialize)]
-pub(crate) struct SampleKwargs {
-    pub(crate) seed: Option<u64>,
-}
-
-/// Resolve a root seed **once** and hand back a per-row RNG source.
-///
-/// Every sampler reaches this through a driver, once per plugin invocation and never inside the
-/// row loop: OS entropy is drawn at most once here (only when `seed` is `None`), after which every
-/// [`RowRngs::rng`] is a few integer ops. That single entry point is why seeded output is identical
-/// across the scalar and column paths. Errs only when the OS entropy source fails (see
-/// [`resolve_root_seed`]).
-#[inline]
-fn row_rngs(seed: Option<u64>) -> PolarsResult<RowRngs> {
-    Ok(RowRngs {
-        root_seed: resolve_root_seed(seed)?,
-    })
-}
-
-/// Shared driver for the constant-parameter sampler fast paths.
-///
-/// When every distribution parameter is a Python scalar, the parameters are validated **once** by
-/// the caller and passed as kwargs, so the only FFI input is the per-row index produced by
-/// `pl.int_range(0, len)`. That index is dense and non-null by construction, which lets this skip
-/// the per-row `Option`/validity bookkeeping the general `try_*_elementwise` paths must carry.
-///
-/// `draw` takes one value from a `&mut` per-row RNG already seeded `(root_seed, i)`, the same draw
-/// the distribution's per-row plugin performs, so seeded output is identical between the two.
-#[inline]
-pub(crate) fn sample_by_index<V, Draw>(
-    name: PlSmallStr,
-    index: &Series,
-    seed: Option<u64>,
-    draw: Draw,
-) -> PolarsResult<Series>
-where
-    V: DrawValue,
-    ChunkedArray<V::Data>: NewChunkedArray<V::Data, V> + IntoSeries,
-    Draw: Fn(&mut Pcg64Mcg) -> V,
-{
-    let index = index.cast(&DataType::UInt64)?;
-    let index_ca = index.u64()?;
-    let rngs = row_rngs(seed)?;
-
-    let ca = ChunkedArray::<V::Data>::from_iter_values(
-        name,
-        index_ca.into_no_null_iter().map(|i| {
-            let mut rng = rngs.rng(i);
-            draw(&mut rng)
-        }),
-    );
-    Ok(ca.into_series())
+fn coerce_index(index: &Series) -> PolarsResult<UInt64Chunked> {
+    Ok(index.cast(&DataType::UInt64)?.u64()?.clone())
 }
 
 /// The output column dtype a drawn value collects into.
@@ -158,77 +90,110 @@ impl DrawValue for bool {
     type Data = BooleanType;
 }
 
-/// Shared driver for the column-parameter single-draw (`sample`) per-row paths: one parameter
-/// column plus the row index.
-///
-/// The column-parameter counterpart of [`sample_by_index`], and the single-draw counterpart of
-/// [`samples_per_row`]. `build` constructs the row's draw state once per row; `draw` takes one
-/// value from that row's stream. Any null input nulls the row without calling `build`; the caller
-/// has run the parameter columns through their domain pass, so `build` cannot fail here.
-///
-/// Seeding follows [`sample_by_index`]: row `i` draws from a stream keyed `(root_seed, i)`, a
-/// function of position only, never of the parameters, so the scalar and column paths stay
-/// bit-identical for the same parameters.
-///
-/// Takes `ChunkedArray`s, not the [`binary_param_rows`] iterator its multi-draw twin consumes:
-/// `try_*_elementwise` walks each concrete arrow chunk, while chaining `ChunkedArray::iter()`s
-/// across chunks costs more per row than the single draw. One draw per row also does not pay for a
-/// fork-join dispatch, so this fills serially and [`PARALLEL_FILL_MIN_DRAWS`] is the multi-draw
-/// path's concern alone.
+/// Kwargs of every column-parameter single-draw plugin. The row index travels as a regular input.
+#[derive(Deserialize)]
+pub(crate) struct SampleKwargs {
+    pub(crate) seed: Option<u64>,
+}
+
+/// Kwargs of every column-parameter multi-draw plugin; `size` is the output `Array` width. The
+/// output-dtype functions read the `_scalar` variants' kwargs into this too: serde skips the extra
+/// parameter keys.
+#[derive(Deserialize)]
+pub(crate) struct SamplesKwargs {
+    pub(crate) seed: Option<u64>,
+    pub(crate) size: usize,
+}
+
+/// Single-draw fast-path kwargs: the distribution's constant parameters `P`, flattened next to
+/// `seed` so the wire shape stays one flat mapping.
+#[derive(Deserialize)]
+pub(crate) struct SampleScalarKwargs<P> {
+    pub(crate) seed: Option<u64>,
+    #[serde(flatten)]
+    pub(crate) params: P,
+}
+
+/// Multi-draw counterpart of [`SampleScalarKwargs`].
+#[derive(Deserialize)]
+pub(crate) struct SamplesScalarKwargs<P> {
+    pub(crate) seed: Option<u64>,
+    pub(crate) size: usize,
+    #[serde(flatten)]
+    pub(crate) params: P,
+}
+
+/// Constant-parameter single-draw driver: the caller has built the draw state once, and the only
+/// input is the dense, non-null row index. Row `i` draws from the stream keyed `(root_seed, i)`, the
+/// one the per-row drivers use.
+pub(crate) fn sample_by_index<V, Draw>(
+    index: &Series,
+    seed: Option<u64>,
+    draw: Draw,
+) -> PolarsResult<Series>
+where
+    V: DrawValue,
+    ChunkedArray<V::Data>: NewChunkedArray<V::Data, V> + IntoSeries,
+    Draw: Fn(&mut Pcg64Mcg) -> V,
+{
+    let indices = coerce_index(index)?;
+    let rngs = RowRngs::new(seed)?;
+
+    let out = ChunkedArray::<V::Data>::from_iter_values(
+        index.name().clone(),
+        indices
+            .into_no_null_iter()
+            .map(|i| draw(&mut rngs.row_rng(i))),
+    );
+    Ok(out.into_series())
+}
+
+/// Column-parameter single-draw driver over `(param, row_index)`. `domain`'s column pass runs before
+/// any row is built, so `build` cannot fail in the loop. Output is named after the parameter column.
 ///
 /// Keep `build` and `draw` generic `Fn`s: they monomorphise into the row loop, where a `&dyn Fn` or
 /// a `fn` pointer would cost an indirect call per row.
-#[inline]
-pub(crate) fn sample_per_row_binary<V, A, S, Build, Draw>(
-    name: PlSmallStr,
-    param: &ChunkedArray<A>,
-    index: &UInt64Chunked,
-    seed: Option<u64>,
+pub(crate) fn sample_per_row_binary<V, State, Build, Draw>(
+    inputs: &[Series],
+    kwargs: SampleKwargs,
+    domain: &ParamDomain,
     build: Build,
     draw: Draw,
 ) -> PolarsResult<Series>
 where
     V: DrawValue,
     ChunkedArray<V::Data>: IntoSeries,
-    A: PolarsNumericType,
-    Build: Fn(A::Native) -> PolarsResult<S>,
-    Draw: Fn(&S, &mut Pcg64Mcg) -> V,
+    Build: Fn(f64) -> PolarsResult<State>,
+    Draw: Fn(&State, &mut Pcg64Mcg) -> V,
 {
-    let rngs = row_rngs(seed)?;
+    let inputs = align_inputs(inputs)?;
+    let param = coerce_f64(&inputs[0])?;
+    let index = coerce_index(&inputs[1])?;
+    domain.check_column(&param)?;
+    let rngs = RowRngs::new(kwargs.seed)?;
 
-    let ca: ChunkedArray<V::Data> = try_binary_elementwise(
-        param,
-        index,
-        |param_opt, index_opt| -> PolarsResult<Option<V>> {
-            match (param_opt, index_opt) {
+    let out: ChunkedArray<V::Data> =
+        try_binary_elementwise(&param, &index, |param, index| -> PolarsResult<Option<V>> {
+            match (param, index) {
                 (Some(param), Some(index)) => {
-                    let state = build(param)?;
-                    let mut rng = rngs.rng(index);
-                    Ok(Some(draw(&state, &mut rng)))
+                    Ok(Some(draw(&build(param)?, &mut rngs.row_rng(index))))
                 },
                 _ => Ok(None),
             }
-        },
-    )?;
-
-    Ok(ca.with_name(name).into_series())
+        })?;
+    Ok(out.with_name(inputs[0].name().clone()).into_series())
 }
 
-/// Two-parameter counterpart of [`sample_per_row_binary`] (e.g. `(mu, sigma)`, `(n, p)`), same
-/// contracts throughout.
-///
-/// The two parameter dtypes are independent, so a mixed `(u64, f64)` parameterisation (Binomial's
-/// `UInt64` `n` beside its `Float64` `p`) fits, as in [`ternary_param_rows`]: each parameter arrives
-/// through its own coercer, which fixes `A` and `B`. `S` is whatever `build` returns, the built
-/// distribution for most callers but Uniform's raw `(f64, f64)` bounds for the one that validates
-/// then discards.
-#[inline]
-pub(crate) fn sample_per_row_ternary<V, A, B, S, Build, Draw>(
-    name: PlSmallStr,
-    a: &ChunkedArray<A>,
-    b: &ChunkedArray<B>,
-    index: &UInt64Chunked,
-    seed: Option<u64>,
+/// Two-parameter counterpart of [`sample_per_row_binary`], over `(a, b, row_index)`. Each parameter
+/// has its own coercer, so a mixed `(UInt64, Float64)` parameterisation fits; `check_params` is the
+/// caller's pass over both columns. `State` is whatever `build` returns: the built distribution for
+/// most callers, Uniform's checked `(min, max)` for the one that draws directly.
+pub(crate) fn sample_per_row_ternary<V, A, B, State, CoerceA, CoerceB, Check, Build, Draw>(
+    inputs: &[Series],
+    kwargs: SampleKwargs,
+    coerce_a: CoerceA,
+    coerce_b: CoerceB,
+    check_params: Check,
     build: Build,
     draw: Draw,
 ) -> PolarsResult<Series>
@@ -237,41 +202,38 @@ where
     ChunkedArray<V::Data>: IntoSeries,
     A: PolarsNumericType,
     B: PolarsNumericType,
-    Build: Fn(A::Native, B::Native) -> PolarsResult<S>,
-    Draw: Fn(&S, &mut Pcg64Mcg) -> V,
+    CoerceA: Fn(&Series) -> PolarsResult<ChunkedArray<A>>,
+    CoerceB: Fn(&Series) -> PolarsResult<ChunkedArray<B>>,
+    Check: Fn(&ChunkedArray<A>, &ChunkedArray<B>) -> PolarsResult<()>,
+    Build: Fn(A::Native, B::Native) -> PolarsResult<State>,
+    Draw: Fn(&State, &mut Pcg64Mcg) -> V,
 {
-    let rngs = row_rngs(seed)?;
+    let inputs = align_inputs(inputs)?;
+    let a = coerce_a(&inputs[0])?;
+    let b = coerce_b(&inputs[1])?;
+    let index = coerce_index(&inputs[2])?;
+    check_params(&a, &b)?;
+    let rngs = RowRngs::new(kwargs.seed)?;
 
-    let ca: ChunkedArray<V::Data> = try_ternary_elementwise(
-        a,
-        b,
-        index,
-        |a_opt, b_opt, index_opt| -> PolarsResult<Option<V>> {
-            match (a_opt, b_opt, index_opt) {
+    let out: ChunkedArray<V::Data> =
+        try_ternary_elementwise(&a, &b, &index, |a, b, index| -> PolarsResult<Option<V>> {
+            match (a, b, index) {
                 (Some(a), Some(b), Some(index)) => {
-                    let state = build(a, b)?;
-                    let mut rng = rngs.rng(index);
-                    Ok(Some(draw(&state, &mut rng)))
+                    Ok(Some(draw(&build(a, b)?, &mut rngs.row_rng(index))))
                 },
                 _ => Ok(None),
             }
-        },
-    )?;
-
-    Ok(ca.with_name(name).into_series())
+        })?;
+    Ok(out.with_name(inputs[0].name().clone()).into_series())
 }
 
-/// Total draw count below which the multi-draw row fill runs serially: a fork-join dispatch
-/// costs more than drawing this few values, and elementwise plugins run once per
-/// `group_by` / `over` partition, so tiny calls are common.
+/// Total draw count below which the multi-draw fill runs serially: a fork-join dispatch costs more
+/// than this few draws, and elementwise plugins run once per `group_by` / `over` partition.
 const PARALLEL_FILL_MIN_DRAWS: usize = 4096;
 
-/// Fill the row-major multi-draw buffer: `fill_row(i, slot)` writes row `i`'s `size` draws into
-/// its own disjoint `size`-wide slice.
-///
-/// Rows fill in parallel on the polars thread pool when the total work justifies it. That is
-/// deterministic because a row's draws depend only on `(root_seed, row_index)`, never on other
-/// rows or on visit order, so the parallel fill is bit-identical to the serial one.
+/// Fill the row-major multi-draw buffer: `fill_row(i, slot)` writes row `i`'s `size` draws into its
+/// own slice. Rows fill in parallel when the total justifies it, which is deterministic because a
+/// row's draws depend only on `(root_seed, row_index)`.
 fn fill_rows<V, F>(flat: &mut [V], size: usize, fill_row: F)
 where
     V: Send,
@@ -290,18 +252,11 @@ where
     }
 }
 
-/// Shared driver for the constant-parameter multi-draw (`samples`) fast paths.
-///
-/// The multi-draw counterpart of [`sample_by_index`]: one plugin call returns the
-/// `Array(width=size)` column directly, rather than `size` `sample` calls glued by `concat_arr`.
-///
-/// Row `i`'s `size` draws are **consecutive values from one per-row stream** seeded
-/// `(root_seed, i)`, the same stream `sample` takes its single draw from. So `samples(size=1)` is
-/// bit-identical to `sample` for the same seed, and growing `size` extends each row's array without
-/// changing the existing draws. Rows can fill in parallel (see [`fill_rows`]).
-#[inline]
+/// Constant-parameter multi-draw driver: one call returns the `Array(width=size)` column. Row `i`'s
+/// `size` draws are consecutive values from the stream keyed `(root_seed, i)`, the one `sample` takes
+/// its single draw from, so `samples(size=1)` is bit-identical to `sample` and growing `size` extends
+/// each row without changing the existing draws.
 pub(crate) fn samples_by_index<V, Draw>(
-    name: PlSmallStr,
     index: &Series,
     seed: Option<u64>,
     size: usize,
@@ -312,43 +267,28 @@ where
     ChunkedArray<V::Data>: NewChunkedArray<V::Data, V> + IntoSeries,
     Draw: Fn(&mut Pcg64Mcg) -> V + Sync,
 {
-    // The Python layer rejects `size <= 0` before registering the plugin; this guards the
-    // zero-width `Array` reshape against any other caller.
-    if size == 0 {
-        return Err(PolarsError::InvalidOperation(
-            "samples requires a positive size".into(),
-        ));
-    }
-    let index = index.cast(&DataType::UInt64)?;
-    let indices: Vec<u64> = index.u64()?.into_no_null_iter().collect();
-    let rngs = row_rngs(seed)?;
+    polars_ensure!(size > 0, InvalidOperation: "samples requires a positive size");
+    let indices: Vec<u64> = coerce_index(index)?.into_no_null_iter().collect();
+    let rngs = RowRngs::new(seed)?;
 
     let mut flat = vec![V::default(); indices.len() * size];
     fill_rows(&mut flat, size, |row, slot| {
-        let mut rng = rngs.rng(indices[row]);
+        let mut rng = rngs.row_rng(indices[row]);
         for value in slot {
             *value = draw(&mut rng);
         }
     });
 
-    ChunkedArray::<V::Data>::from_iter_values(name, flat.into_iter())
+    ChunkedArray::<V::Data>::from_iter_values(index.name().clone(), flat.into_iter())
         .into_series()
         .reshape_array(&[ReshapeDimension::Infer, ReshapeDimension::new(size as i64)])
 }
 
-/// Shared driver for the column-parameter multi-draw (`samples`) per-row paths.
-///
-/// The column-parameter counterpart of [`samples_by_index`]. `rows` yields, per row, the index and
-/// a ready-to-draw state (typically the built distribution, so it is constructed once per row
-/// rather than once per draw). A `None` row (any null input) becomes a null `Array` element with
-/// its inner slots also null, the same two-layer shape as `pl.lit(None, dtype=Array(...))`; an
-/// invalid parameterisation `?`-raises out of the row iterator.
-///
-/// Seeding follows [`samples_by_index`]. The per-draw *consumption* of a row's stream does depend
-/// on its parameters (rejection samplers draw a variable number of words), which is fine: the
-/// stream is private to the row.
-#[inline]
-pub(crate) fn samples_per_row<V, S, Rows, Draw>(
+/// Column-parameter multi-draw driver. `rows` yields, per row, the index and a ready-to-draw state
+/// (built once per row, not once per draw); a `None` row (any null input) becomes a null `Array`
+/// element whose inner slots are also null, the two-layer shape of `pl.lit(None, dtype=Array(...))`.
+/// Seeding as in [`samples_by_index`].
+fn samples_per_row<V, State, Rows, Draw>(
     name: PlSmallStr,
     rows: Rows,
     seed: Option<u64>,
@@ -358,25 +298,21 @@ pub(crate) fn samples_per_row<V, S, Rows, Draw>(
 where
     V: DrawValue + Default + Clone + Send,
     ChunkedArray<V::Data>: NewChunkedArray<V::Data, V> + IntoSeries,
-    S: Sync,
-    Rows: Iterator<Item = PolarsResult<Option<(u64, S)>>>,
-    Draw: Fn(&S, &mut Pcg64Mcg) -> V + Sync,
+    State: Sync,
+    Rows: Iterator<Item = PolarsResult<Option<(u64, State)>>>,
+    Draw: Fn(&State, &mut Pcg64Mcg) -> V + Sync,
 {
-    if size == 0 {
-        return Err(PolarsError::InvalidOperation(
-            "samples requires a positive size".into(),
-        ));
-    }
-    // Materialising the states up front separates the sequential part (parameter validation,
-    // which can raise) from the draw loop, whose rows then fill independently. A null row keeps
-    // its `V::default()` slice; it is masked by the validity bitmaps below, never read.
-    let states: Vec<Option<(u64, S)>> = rows.collect::<PolarsResult<_>>()?;
-    let rngs = row_rngs(seed)?;
+    polars_ensure!(size > 0, InvalidOperation: "samples requires a positive size");
+    // Materialising the states first separates the part that can raise (building) from the draw
+    // loop, whose rows then fill independently. A null row keeps its `V::default()` slice, masked by
+    // the validity bitmaps below and never read.
+    let states: Vec<Option<(u64, State)>> = rows.collect::<PolarsResult<_>>()?;
+    let rngs = RowRngs::new(seed)?;
 
     let mut flat = vec![V::default(); states.len() * size];
     fill_rows(&mut flat, size, |row, slot| {
         if let Some((index, state)) = &states[row] {
-            let mut rng = rngs.rng(*index);
+            let mut rng = rngs.row_rng(*index);
             for value in slot {
                 *value = draw(state, &mut rng);
             }
@@ -391,9 +327,6 @@ where
     if outer_validity.unset_bits() == 0 {
         return flat.reshape_array(&shape);
     }
-    // A null row nulls both layers, matching `pl.lit(None, dtype=Array(...))`: the outer bit makes
-    // the element null, and the inner bits keep value-level reads (`arr.first`, `explode`, ...)
-    // from leaking the placeholder defaults behind it.
     let inner_validity: Bitmap = states
         .iter()
         .flat_map(|state| std::iter::repeat_n(state.is_some(), size))
@@ -404,87 +337,87 @@ where
     Series::from_arrow(name, masked)
 }
 
-/// Build the per-row state iterator a single-parameter column `samples` plugin feeds to
-/// [`samples_per_row`]: zip the parameter column with the row index and, on a fully-non-null row,
-/// run `build` once to make the row's draw state.
-///
-/// Any null input nulls the whole row, matching the single-draw paths.
-pub(crate) fn binary_param_rows<'a, A, S, F>(
-    param: &'a ChunkedArray<A>,
-    index: &'a UInt64Chunked,
-    build: F,
-) -> impl Iterator<Item = PolarsResult<Option<(u64, S)>>> + 'a
+/// [`samples_per_row`] over `(param, row_index)`: `domain`'s column pass, then one `build` per
+/// fully-non-null row.
+pub(crate) fn samples_per_row_binary<V, State, Build, Draw>(
+    inputs: &[Series],
+    kwargs: SamplesKwargs,
+    domain: &ParamDomain,
+    build: Build,
+    draw: Draw,
+) -> PolarsResult<Series>
 where
-    A: PolarsNumericType,
-    F: Fn(A::Native) -> PolarsResult<S> + 'a,
-    S: 'a,
+    V: DrawValue + Default + Clone + Send,
+    ChunkedArray<V::Data>: NewChunkedArray<V::Data, V> + IntoSeries,
+    State: Sync,
+    Build: Fn(f64) -> PolarsResult<State>,
+    Draw: Fn(&State, &mut Pcg64Mcg) -> V + Sync,
 {
-    param
+    let inputs = align_inputs(inputs)?;
+    let param = coerce_f64(&inputs[0])?;
+    let index = coerce_index(&inputs[1])?;
+    domain.check_column(&param)?;
+
+    let rows = param
         .iter()
         .zip(index.iter())
-        .map(move |(p_opt, i_opt)| match (p_opt, i_opt) {
-            (Some(p), Some(i)) => Ok(Some((i, build(p)?))),
+        .map(|(param, index)| match (param, index) {
+            (Some(param), Some(index)) => Ok(Some((index, build(param)?))),
             _ => Ok(None),
-        })
+        });
+    samples_per_row(
+        inputs[0].name().clone(),
+        rows,
+        kwargs.seed,
+        kwargs.size,
+        draw,
+    )
 }
 
-/// Two-parameter counterpart of [`binary_param_rows`] (e.g. `(mu, sigma)`, `(n, p)`): zip both
-/// parameter columns with the row index and, on a fully-non-null row, run `build` once. The two
-/// parameter dtypes are independent, so a mixed `(u64, f64)` parameterisation (Binomial) fits.
-pub(crate) fn ternary_param_rows<'a, A, B, S, F>(
-    a: &'a ChunkedArray<A>,
-    b: &'a ChunkedArray<B>,
-    index: &'a UInt64Chunked,
-    build: F,
-) -> impl Iterator<Item = PolarsResult<Option<(u64, S)>>> + 'a
+/// Two-parameter counterpart of [`samples_per_row_binary`], over `(a, b, row_index)`; coercers and
+/// `check_params` as in [`sample_per_row_ternary`].
+pub(crate) fn samples_per_row_ternary<V, A, B, State, CoerceA, CoerceB, Check, Build, Draw>(
+    inputs: &[Series],
+    kwargs: SamplesKwargs,
+    coerce_a: CoerceA,
+    coerce_b: CoerceB,
+    check_params: Check,
+    build: Build,
+    draw: Draw,
+) -> PolarsResult<Series>
 where
+    V: DrawValue + Default + Clone + Send,
+    ChunkedArray<V::Data>: NewChunkedArray<V::Data, V> + IntoSeries,
     A: PolarsNumericType,
     B: PolarsNumericType,
-    F: Fn(A::Native, B::Native) -> PolarsResult<S> + 'a,
-    S: 'a,
+    State: Sync,
+    CoerceA: Fn(&Series) -> PolarsResult<ChunkedArray<A>>,
+    CoerceB: Fn(&Series) -> PolarsResult<ChunkedArray<B>>,
+    Check: Fn(&ChunkedArray<A>, &ChunkedArray<B>) -> PolarsResult<()>,
+    Build: Fn(A::Native, B::Native) -> PolarsResult<State>,
+    Draw: Fn(&State, &mut Pcg64Mcg) -> V + Sync,
 {
-    a.iter()
+    let inputs = align_inputs(inputs)?;
+    let a = coerce_a(&inputs[0])?;
+    let b = coerce_b(&inputs[1])?;
+    let index = coerce_index(&inputs[2])?;
+    check_params(&a, &b)?;
+
+    let rows = a
+        .iter()
         .zip(b.iter())
         .zip(index.iter())
-        .map(move |((a_opt, b_opt), i_opt)| match (a_opt, b_opt, i_opt) {
-            (Some(a), Some(b), Some(i)) => Ok(Some((i, build(a, b)?))),
+        .map(|((a, b), index)| match (a, b, index) {
+            (Some(a), Some(b), Some(index)) => Ok(Some((index, build(a, b)?))),
             _ => Ok(None),
-        })
-}
-
-/// Kwargs shared by every column-parameter multi-draw plugin, and the slice the shared
-/// output-dtype functions read from the scalar variants' kwargs (serde skips their extra
-/// parameter fields): the optional root seed and the draw count, which is the output `Array`
-/// width.
-#[derive(Deserialize)]
-pub(crate) struct SamplesKwargs {
-    pub(crate) seed: Option<u64>,
-    pub(crate) size: usize,
-}
-
-/// Single-draw fast-path kwargs: a distribution's constant parameters `P` plus the optional root seed.
-///
-/// `P` is flattened, so the wire shape is one flat mapping with `seed` next to the parameter keys.
-/// Composing keeps each distribution's parameter list, and its constructor order, in the one struct
-/// its value-keyed fast paths already use.
-#[derive(Deserialize)]
-pub(crate) struct SampleScalarKwargs<P> {
-    pub(crate) seed: Option<u64>,
-    #[serde(flatten)]
-    pub(crate) params: P,
-}
-
-/// Multi-draw counterpart of [`SampleScalarKwargs`], plus the draw count `size` (the output `Array`
-/// width).
-///
-/// `seed` and `size` sit outside `P` and flatten alongside the parameter keys, so the shared output
-/// functions can read `size` by deserialising the same bytes into [`SamplesKwargs`].
-#[derive(Deserialize)]
-pub(crate) struct SamplesScalarKwargs<P> {
-    pub(crate) seed: Option<u64>,
-    pub(crate) size: usize,
-    #[serde(flatten)]
-    pub(crate) params: P,
+        });
+    samples_per_row(
+        inputs[0].name().clone(),
+        rows,
+        kwargs.seed,
+        kwargs.size,
+        draw,
+    )
 }
 
 fn samples_output(fields: &[Field], width: usize, inner: DataType) -> PolarsResult<Field> {
@@ -494,40 +427,18 @@ fn samples_output(fields: &[Field], width: usize, inner: DataType) -> PolarsResu
     ))
 }
 
-/// Output dtype of a float-valued multi-draw plugin: `Array(Float64, size)`.
 pub(crate) fn samples_f64_output(fields: &[Field], kwargs: SamplesKwargs) -> PolarsResult<Field> {
     samples_output(fields, kwargs.size, DataType::Float64)
 }
 
-/// Output dtype of an integer-valued multi-draw plugin: `Array(UInt64, size)`.
 pub(crate) fn samples_u64_output(fields: &[Field], kwargs: SamplesKwargs) -> PolarsResult<Field> {
     samples_output(fields, kwargs.size, DataType::UInt64)
 }
 
-/// Output dtype of a signed-integer-valued multi-draw plugin: `Array(Int64, size)`.
 pub(crate) fn samples_i64_output(fields: &[Field], kwargs: SamplesKwargs) -> PolarsResult<Field> {
     samples_output(fields, kwargs.size, DataType::Int64)
 }
 
-/// Output dtype of a boolean-valued multi-draw plugin: `Array(Boolean, size)`.
 pub(crate) fn samples_bool_output(fields: &[Field], kwargs: SamplesKwargs) -> PolarsResult<Field> {
     samples_output(fields, kwargs.size, DataType::Boolean)
-}
-
-/// Per-call source of per-row RNGs, all derived from one already-resolved root seed.
-///
-/// The resolve-once step happens at construction (via [`row_rngs`]), so the
-/// type enforces the invariant every elementwise sampler depends on: resolve per call,
-/// derive per row.
-pub(crate) struct RowRngs {
-    root_seed: u64,
-}
-
-impl RowRngs {
-    /// The deterministic, independent RNG for `index`. Identical `(seed, index)` pairs
-    /// always yield identical streams, so output is invariant to Polars chunking/threading.
-    #[inline]
-    pub(crate) fn rng(&self, index: u64) -> Pcg64Mcg {
-        row_rng(self.root_seed, index)
-    }
 }

--- a/tests/distributions/bernoulli/sample_test.py
+++ b/tests/distributions/bernoulli/sample_test.py
@@ -124,9 +124,8 @@ def test_sample_with_series_p_seed_reproducible(rng: np.random.Generator, seed: 
 
 @pytest.mark.parametrize("bad_p", [-0.1, 1.5, float("nan")])
 def test_sample_with_column_p_out_of_range_raises(bad_p: float, seed: int) -> None:
-    # Plugin-side errors are always wrapped in ComputeError by the polars FFI
-    # layer (the underlying PolarsError::InvalidOperation variant is lost at
-    # the plugin boundary). The message is preserved.
+    # Plugin-side errors are always wrapped in ComputeError by the polars FFI layer.
+    # The message is preserved.
     dframe = pl.DataFrame({"p": [0.5, bad_p, 0.7]})
     with pytest.raises(pl.exceptions.ComputeError, match="p must be in"):
         dframe.with_columns(b=Bernoulli(p=pl.col("p")).sample(seed=seed))

--- a/tests/distributions/bernoulli/samples_test.py
+++ b/tests/distributions/bernoulli/samples_test.py
@@ -43,7 +43,7 @@ def test_samples_columns_are_not_all_equal(
     result = dframe.select(s=Bernoulli(p=0.5).samples(size=size, seed=seed))["s"]
     columns = [result.arr.get(i) for i in range(size)]
     distinct = {tuple(c.to_list()) for c in columns}
-    assert len(distinct) == size  # 8 truly independent draws → 8 distinct rasters
+    assert len(distinct) == size
 
 
 def test_samples_mean_close_to_p_for_large_total(

--- a/tests/distributions/beta/log_pdf_test.py
+++ b/tests/distributions/beta/log_pdf_test.py
@@ -17,9 +17,8 @@ def test_log_pdf_equals_log_of_pdf(value_grid: list[float]) -> None:
 
 def test_log_pdf_finite_in_the_upper_1e9_band() -> None:
     # The log-density is finite right up to the endpoint (positive for small shapes), so no value
-    # below 1 may return -inf. statrs 0.19.0 collapsed this whole band to -inf by comparing the
-    # evaluation point to 1.0 with an absolute epsilon; 0.19.1 restored the exact comparison. The
-    # expectation is the closed form rather than a recorded number, so this stays a live check.
+    # below 1 may return -inf. The expectation is the closed form rather than a recorded number,
+    # so this stays a live check.
     x = 1.0 - 1e-9
     df = pl.DataFrame({"x": [x]})
     for a, b in [(2.0, 3.0), (0.05, 0.05), (5.0, 1e-3)]:

--- a/tests/distributions/binomial/validation_test.py
+++ b/tests/distributions/binomial/validation_test.py
@@ -178,10 +178,10 @@ def test_null_dtype_n_column_propagates() -> None:
     # null-in-null-out like every other parameter instead of hitting the dtype gate.
     df = pl.DataFrame({"n": [None, None], "p": [0.5, 0.5]})  # n dtype: Null
     b = Binomial(pl.col("n"), pl.col("p"))
-    # `pmf(1.0)`, not `pmf(pl.lit(1.0))`: a Python scalar is row-aligned by `_coerce`'s
-    # `pl.repeat`, where a caller-built length-1 literal expr is passed to the plugin as-is and
-    # `try_ternary_elementwise` zips it to length 1 (the truncation `_coerce` documents). The
-    # in-memory engine exposes that; the streaming engine broadcasts upstream and hides it.
+    # `pmf(1.0)`, not `pmf(pl.lit(1.0))`: a Python scalar is row-aligned to the column length,
+    # where a caller-built length-1 literal expr would take a different broadcast path and hide
+    # the same truncation. The in-memory engine exposes it; the streaming engine broadcasts
+    # upstream and hides it.
     got = df.select(mean=b.mean(), pmf=b.pmf(1.0), draw=b.sample(seed=0))
     assert got["mean"].to_list() == [None, None]
     assert got["pmf"].to_list() == [None, None]

--- a/tests/distributions/broadcast_test.py
+++ b/tests/distributions/broadcast_test.py
@@ -294,10 +294,10 @@ def test_mismatched_lengths_raise() -> None:
     """Lengths that are neither equal nor 1 have no defined broadcast, so they raise.
 
     *Which layer* rejects the shape is a polars scheduling detail that moves with the version and the engine:
-    `align_inputs` names both lengths, while polars' own zip node reports `non-equal length inputs` when it
-    gets there first. Both are correct rejections, so the message is matched loosely and the raise itself,
-    which is the contract, is asserted strictly. `engine=` is deliberately not passed: `"in-memory"` is not a
-    valid engine name on the oldest supported polars.
+    this library's own alignment check names both lengths, while polars' own zip node reports `non-equal
+    length inputs` when it gets there first. Both are correct rejections, so the message is matched loosely
+    and the raise itself, which is the contract, is asserted strictly. `engine=` is deliberately not passed:
+    `"in-memory"` is not a valid engine name on the oldest supported polars.
     """
     frame = pl.DataFrame({"x": [0.0, 1.0, 2.0, 3.0], "p": [0.5] * 4})
     mismatched = Binomial(n=pl.Series("n", [1, 2, 3]), p=pl.col("p")).pmf(pl.col("x"))
@@ -347,8 +347,8 @@ def test_partition_contexts_keep_sampler_bit_equality(spec: DistSpec) -> None:
 def test_multi_chunk_frame_broadcasts() -> None:
     """A broadcast input is single-chunk; the column it is zipped against need not be.
 
-    `try_*_elementwise` calls `align_chunks_*` itself and the `*_param_rows` iterators walk chunks in order,
-    so length alignment is all the funnels owe. Nothing else pinned that.
+    The elementwise funnel aligns chunks itself before zipping, so length alignment is all it owes.
+    Nothing else pinned that.
     """
     parts = [pl.DataFrame({"x": [float(i) for i in range(k, k + 8)]}) for k in (0, 8, 16)]
     chunked = pl.concat(parts, rechunk=False)

--- a/tests/distributions/exponential/construct_test.py
+++ b/tests/distributions/exponential/construct_test.py
@@ -9,15 +9,15 @@ from polars_stats import Exponential
 @pytest.mark.parametrize("bad", [None, True, False, 1, 0, [1.0], (1.0,), {"rate": 1.0}])
 def test_construct_invalid_rate_type_raises(bad: object) -> None:
     # `rate` is a float (or IntoExprColumn): an `int` / `bool` is rejected by type, like every
-    # float parameter (`coerce_param`).
+    # float parameter.
     with pytest.raises(TypeError, match="rate should be a float or IntoExprColumn"):
         Exponential(rate=bad)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize("bad_rate", [0.0, -1.0, -2.5, float("nan")])
 def test_construct_scalar_invalid_rate_defers_to_eval(bad_rate: float) -> None:
-    # No early Python validation: construction succeeds (matching Uniform / Bernoulli's deferral);
-    # the invalid rate surfaces as a ComputeError when a method is evaluated, not a ValueError here.
+    # No early Python validation: construction succeeds; the invalid rate surfaces as a
+    # ComputeError when a method is evaluated, not a ValueError.
     Exponential(rate=bad_rate)
     with pytest.raises(pl.exceptions.ComputeError, match="rate must be finite and strictly positive"):
         pl.DataFrame({"x": [0.5]}).select(r=Exponential(rate=bad_rate).pdf(pl.col("x")))

--- a/tests/distributions/exponential/log_cdf_test.py
+++ b/tests/distributions/exponential/log_cdf_test.py
@@ -13,7 +13,7 @@ def test_log_cdf_stable_in_deep_right_tail() -> None:
     # At `rate * x = 40`, `1 - exp(-rate * x)` rounds to exactly `1.0`, so the naive `log(cdf)`
     # collapses to `0.0`. The `log1p(-sf)` form keeps the true value `log(1 - exp(-40)) ~= -exp(-40)`.
     result = pl.DataFrame({"x": [40.0]}).select(r=Exponential(rate=1.0).log_cdf(pl.col("x")))["r"].item()
-    assert result < 0.0  # not collapsed to 0.0 like the naive form
+    assert result < 0.0
     assert result == pytest.approx(-math.exp(-40.0), rel=1e-6)
 
 

--- a/tests/distributions/geometric/entropy_test.py
+++ b/tests/distributions/geometric/entropy_test.py
@@ -30,7 +30,6 @@ def test_entropy_at_half_equals_two_log_two(unit_frame: pl.DataFrame) -> None:
 
 @pytest.mark.parametrize("p", [0.1, 0.3, 0.7])
 def test_entropy_grows_as_p_shrinks(p: float, unit_frame: pl.DataFrame) -> None:
-    # The geometric distribution spreads out as success becomes rarer.
     smaller = unit_frame.select(v=Geometric(p=p / 2).entropy()).item(0, "v")
     larger = unit_frame.select(v=Geometric(p=p).entropy()).item(0, "v")
     assert smaller > larger

--- a/tests/distributions/geometric/samples_test.py
+++ b/tests/distributions/geometric/samples_test.py
@@ -43,7 +43,7 @@ def test_samples_columns_are_not_all_equal(
     result = dframe.select(s=Geometric(p=0.5).samples(size=size, seed=seed))["s"]
     columns = [result.arr.get(i) for i in range(size)]
     distinct = {tuple(c.to_list()) for c in columns}
-    assert len(distinct) == size  # 8 truly independent draws -> 8 distinct rasters
+    assert len(distinct) == size
 
 
 def test_samples_mean_close_to_inverse_p_for_large_total(

--- a/tests/distributions/lognormal/construct_test.py
+++ b/tests/distributions/lognormal/construct_test.py
@@ -26,8 +26,8 @@ def test_construct_defaults_to_standard_lognormal() -> None:
 
 @pytest.mark.parametrize("bad_sigma", [0.0, -1.0, -1e-9])
 def test_construct_scalar_non_positive_sigma_defers_to_eval(bad_sigma: float) -> None:
-    # No early Python validation (matching Bernoulli / Uniform / Normal): construction succeeds; the
-    # invalid scale surfaces as a ComputeError when a method is evaluated, not a ValueError here.
+    # No early Python validation: construction succeeds; the invalid scale surfaces as a
+    # ComputeError when a method is evaluated, not a ValueError.
     LogNormal(mu=0.0, sigma=bad_sigma)
     with pytest.raises(pl.exceptions.ComputeError, match="sigma must be finite and strictly positive"):
         pl.DataFrame({"x": [0.5]}).select(r=LogNormal(mu=0.0, sigma=bad_sigma).pdf(pl.col("x")))

--- a/tests/distributions/lognormal/sample_test.py
+++ b/tests/distributions/lognormal/sample_test.py
@@ -21,7 +21,6 @@ def test_sample_basic_properties(size: int, frame: Callable[..., pl.DataFrame], 
 
 
 def test_sample_is_positive(frame: Callable[..., pl.DataFrame], seed: int) -> None:
-    # The LogNormal support is (0, inf): every draw is strictly positive.
     s = frame(size=10_000).with_columns(z=LogNormal(mu=0.0, sigma=1.5).sample(seed=seed))["z"]
     assert s.min() > 0.0  # type: ignore[operator]
 

--- a/tests/distributions/lognormal/support_test.py
+++ b/tests/distributions/lognormal/support_test.py
@@ -5,8 +5,7 @@ from polars.testing import assert_series_equal
 
 from polars_stats import LogNormal
 
-# The LogNormal support is `x > 0`. For `x <= 0` the density and cdf are 0 and the survival function
-# is 1, matching `scipy.stats.lognorm`. The boundary `x == 0` is included in the "outside" branch.
+# Matches `scipy.stats.lognorm`: `x == 0` falls in the off-support branch, not the support `x > 0`.
 
 
 def test_pdf_is_zero_at_or_below_zero() -> None:

--- a/tests/distributions/moment_fast_path_test.py
+++ b/tests/distributions/moment_fast_path_test.py
@@ -1,18 +1,17 @@
 """Validation contract of the constant-parameter moment fast path.
 
-Every moment validates its parameters through a Rust plugin (`normal_sigma`, `uniform_range`,
-`bernoulli_proba`, ..., or the `beta_entropy` / `binomial_entropy` formula itself). With all-scalar
-parameters that plugin runs once on length-1 `pl.lit` inputs instead of per row.
-`tests/property/moment_test.py` pins bit-equality against the per-row path for *valid* parameters; this
-module pins what that test does not reach:
+Every moment validates its parameters through a Rust plugin call. With all-scalar parameters that
+plugin runs once on length-1 `pl.lit` inputs instead of per row. `tests/property/moment_test.py`
+pins bit-equality against the per-row path for *valid* parameters; this module pins what that test
+does not reach:
 
 * both paths raise the same `ComputeError` on an invalid scalar parameterisation, a non-finite
   parameter included (finiteness is the library's own check, whether or not `statrs` accepts the value);
 * the validator runs whatever the frame height, so an empty frame still raises on the scalar path
   and yields one row on a valid one, while the per-row path returns empty.
 
-A Python `None` parameter and a negative scalar `n` are rejected at construction (`coerce_param`,
-`coerce_n`), so neither has a case here.
+A Python `None` parameter and a negative scalar `n` are rejected at construction, so neither has a
+case here.
 """
 
 from __future__ import annotations
@@ -47,9 +46,9 @@ def _col(value: float, dtype: pl.DataType | None = None) -> pl.Expr:
 
 
 # id -> (scalar instance, equivalent per-row instance). `variance` is the representative
-# moment: it routes through the parameter validator for every distribution (Normal/LogNormal/Binomial
-# via `_moment`, Uniform via `range`). The `inf` cases guard that the fast
-# path applies the library's own finiteness check where `statrs` alone would accept the value.
+# moment: it routes through the parameter validator for every distribution. The `inf` cases guard
+# that the fast path applies the library's own finiteness check where `statrs` alone would accept
+# the value.
 _CASES: dict[str, tuple[_UnivariateDistribution, _UnivariateDistribution]] = {
     "normal mu=nan": (Normal(_NAN, 1.0), Normal(_col(_NAN), _col(1.0))),
     "normal mu=inf": (Normal(_INF, 1.0), Normal(_col(_INF), _col(1.0))),

--- a/tests/distributions/normal/construct_test.py
+++ b/tests/distributions/normal/construct_test.py
@@ -26,8 +26,8 @@ def test_construct_defaults_to_standard_normal() -> None:
 
 @pytest.mark.parametrize("bad_std", [0.0, -1.0, -1e-9])
 def test_construct_scalar_non_positive_std_defers_to_eval(bad_std: float) -> None:
-    # No early Python validation (matching Bernoulli / Uniform): construction succeeds; the invalid
-    # scale surfaces as a ComputeError when a method is evaluated, not a ValueError here.
+    # No early Python validation: construction succeeds; the invalid scale surfaces as a
+    # ComputeError when a method is evaluated, not a ValueError.
     Normal(mu=0.0, sigma=bad_std)
     with pytest.raises(pl.exceptions.ComputeError, match="sigma must be finite and strictly positive"):
         pl.DataFrame({"x": [0.5]}).select(r=Normal(mu=0.0, sigma=bad_std).pdf(pl.col("x")))

--- a/tests/distributions/normal/sample_test.py
+++ b/tests/distributions/normal/sample_test.py
@@ -74,8 +74,7 @@ def test_sample_null_param_row_is_null(seed: int) -> None:
 
 
 def test_sample_non_positive_std_row_raises(seed: int) -> None:
-    # An invalid scale on a row raises (no early Python validation), the same way Bernoulli reports an
-    # out-of-range `p`. Plugin errors surface as `ComputeError`.
+    # An invalid scale on a row raises (no early Python validation); plugin errors surface as `ComputeError`.
     dframe = pl.DataFrame({"mu": [0.0, 1.0, -1.0], "sigma": [1.0, -2.0, 3.0]})  # row 1: sigma = -2.0
     with pytest.raises(pl.exceptions.ComputeError, match="sigma must be finite and strictly positive"):
         dframe.with_columns(z=Normal(mu=pl.col("mu"), sigma=pl.col("sigma")).sample(seed=seed))

--- a/tests/distributions/plugin_nan_test.py
+++ b/tests/distributions/plugin_nan_test.py
@@ -1,19 +1,17 @@
 """Every value-keyed method propagates a `NaN` evaluation point as `NaN`, `ppf` / `isf` included.
 
-The `NaN` short-circuit lives in the shared drivers (`value_keyed_scalar` / `value_keyed_per_row` in
-`src/distributions/mod.rs`) and is load-bearing in two places:
+The `NaN` short-circuit lives in the shared drivers in `src/distributions/mod.rs` (`value_keyed_scalar`
+for constant parameters, `value_keyed_binary` and `value_keyed_ternary` for column parameters) and is
+load-bearing in two places:
 
 * `Beta` `cdf` / `sf`: statrs' regularized incomplete beta panics on a `NaN` evaluation point, so
   without the short-circuit the whole query aborts.
 * `Binomial`: `NaN < 0.0` is false and `NaN.floor() as u64` saturates to `0`, so unguarded bodies
   would return a confident `P(X <= 0)` (and a `pmf` of `0.0`).
 
-`Bernoulli`, `Exponential` and `Geometric` take a third driver (`value_keyed_derived_per_row`) and
-`Uniform` its two-parameter sibling; both repeat the short-circuit rather than share one, so every
-case here runs against all four and the drivers cannot drift apart.
-
-Both plugin shapes are covered: scalar-parameter instances route to the `<method>_scalar` twins,
-column-parameter instances to the per-row plugins.
+Each driver repeats the short-circuit rather than sharing one, so every case here runs against all
+three and the drivers cannot drift apart. Both plugin shapes are covered: scalar-parameter instances
+route to the `<method>_scalar` twins, column-parameter instances to the per-row plugins.
 """
 
 from __future__ import annotations

--- a/tests/distributions/uniform/construct_test.py
+++ b/tests/distributions/uniform/construct_test.py
@@ -20,8 +20,8 @@ def test_construct_invalid_max_type_raises(bad: object) -> None:
 
 @pytest.mark.parametrize(("mn", "mx"), [(1.0, 1.0), (2.0, 1.0), (0.0, -1.0)])
 def test_construct_scalar_max_le_min_defers_to_eval(mn: float, mx: float) -> None:
-    # No early Python validation: construction succeeds (matching Bernoulli's deferral); the invalid
-    # parameterisation surfaces as a ComputeError when a method is evaluated, not a ValueError here.
+    # No early Python validation: construction succeeds; the invalid parameterisation surfaces as a
+    # ComputeError when a method is evaluated, not a ValueError.
     Uniform(min=mn, max=mx)
     with pytest.raises(pl.exceptions.ComputeError, match="max must be strictly greater than min"):
         pl.DataFrame({"x": [0.5]}).select(r=Uniform(min=mn, max=mx).pdf(pl.col("x")))

--- a/tests/distributions/uniform/sample_test.py
+++ b/tests/distributions/uniform/sample_test.py
@@ -92,8 +92,8 @@ def test_sample_null_bound_row_is_null(seed: int) -> None:
 
 
 def test_sample_max_le_min_row_raises(seed: int) -> None:
-    # An invalid parameterisation on a row raises (no early Python validation), the same way
-    # Bernoulli reports an out-of-range `p`. Plugin errors surface as `ComputeError`.
+    # An invalid parameterisation on a row raises (no early Python validation); plugin errors surface
+    # as `ComputeError`.
     dframe = pl.DataFrame({"lo": [0.0, 5.0, -1.0], "hi": [1.0, 2.0, 3.0]})  # row 1: hi (2.0) <= lo (5.0)
     with pytest.raises(pl.exceptions.ComputeError, match="max must be strictly greater than min"):
         dframe.with_columns(u=Uniform(min=pl.col("lo"), max=pl.col("hi")).sample(seed=seed))

--- a/tests/distributions/value_keyed_fast_path_test.py
+++ b/tests/distributions/value_keyed_fast_path_test.py
@@ -12,8 +12,8 @@ bit-equality against the per-row path for *valid* parameters; this module pins w
   zero-row frame; an empty parameter column has no values to reject and returns empty. One constant beside
   a column still aligns, and a mismatched column is still reported.
 
-A Python `None` parameter and a negative scalar `n` are rejected at construction (`coerce_param`, `coerce_n`),
-so neither has a case here.
+A Python `None` parameter and a negative scalar `n` are rejected at construction, so neither has a
+case here.
 """
 
 from __future__ import annotations

--- a/tests/scipy_parity/geometric_test.py
+++ b/tests/scipy_parity/geometric_test.py
@@ -105,8 +105,7 @@ def test_isf_deep_tail_keeps_full_precision() -> None:
 
     Asserted against the exact closed form only: scipy's discrete inverse goes through
     `ppf(1 - q)`, whose complement saturates here (`log1p(0)` divides by zero and scipy answers
-    `inf`), so it is not a usable oracle in this regime — which is the defect this override exists
-    to avoid.
+    `inf`), so it is not a usable oracle in this regime.
     """
     p = 0.5
     q = 1e-300


### PR DESCRIPTION
Collapses the Rust plugin scaffolding to one row loop per input arity: `value_keyed_scalar` / `value_keyed_binary` / `value_keyed_ternary` serve the statrs-backed and closed-form families alike (the latter through two thin `derived_*` wrappers), and `param_keyed` replaces the hand-written validators, `*_range` and `entropy` bodies. Every plugin is a one-line shell; no macros, no traits, and a 3-parameter distribution needs one new loop, not a new pattern.
